### PR TITLE
Panic upstairs if downstairs flush numbers mismatch

### DIFF
--- a/downstairs/src/disk.rs
+++ b/downstairs/src/disk.rs
@@ -469,7 +469,7 @@ impl Disk {
 
     pub fn versions(&self) -> Vec<u64> {
         println!(
-            "Current flush_numbers {:?}",
+            "Current flush_numbers: {:?}",
             self.extents
                 .iter()
                 .map(|e| e.flush_number())

--- a/upstairs/Cargo.toml
+++ b/upstairs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crucible-upstairs"
 version = "0.0.0"
-authors = ["Joshua M. Clulow <jmc@oxide.computer>"]
+authors = ["Joshua M. Clulow <jmc@oxide.computer>", "Alan Hanson <alan@oxide.computer"]
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
Moved the logic that looks at extent flush numbers and disk info
to a new function.  Now we panic the upstairs if it encounters a
downstairs that returns flush numbers that don't match with what it
expects to find.