### PR TITLE
Update write message to take EID and block offset.

### DIFF
--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -60,8 +60,8 @@ async fn proc_frame(
             fw.send(Message::ExtentVersions(bs, es, ec, d.disk.versions()))
                 .await
         }
-        Message::Write(rn, block_offset, data) => {
-            d.disk.disk_write(*block_offset, data)?;
+        Message::Write(rn, eid, block_offset, data) => {
+            d.disk.disk_write(*eid, *block_offset, data)?;
             fw.send(Message::WriteAck(*rn)).await
         }
         Message::Flush(rn, dependencies, flush) => {


### PR DESCRIPTION
Change the write message and functions to take the Extent ID and
the block offset into the extent instead of a real offset in the LBA.
This means the work of determining which EID and block offset a
request coming into Upstairs will have to be determined before putting
that write on the work queue.  This is okay as we need to know the
EID Upstairs so we can set dirty bits for later flush commands.

Moved the offset to extent test into Upstairs as well.

Cleaned up a comment or two.