### PR TITLE
Move upstairs work queue processing to new function.

### DIFF
--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -82,10 +82,6 @@ async fn proc_frame(
              */
             let mut data = BytesMut::with_capacity(512);
             data.put(&[1; 512][..]);
-            println!(
-                "Read rn:{} eid:{} block_offset:{}",
-                rn, eid, block_offset
-            );
             d.disk.disk_read(*eid, *block_offset, &mut data)?;
             let data = data.freeze();
             fw.send(Message::ReadResponse(*rn, data.clone())).await
@@ -129,7 +125,6 @@ async fn proc(id: u64, d: &Arc<Downstairs>, mut sock: TcpStream) -> Result<()> {
                             bail!("expected version 1, got {}", version);
                         }
                         negotiated = true;
-                        println!("{}: version {}", id, version);
                         fw.send(Message::YesItsMe(1)).await?;
                     }
                     Some(m) => {


### PR DESCRIPTION
Break out what the async task does when new work has landed on
the work hashmap.  This is really just prep for changing the flow
from a single job being processed each time, to having the ability
to have several jobs all land at the same time.

Also cleaned up some status messages that are no longer wanted