### PR TITLE
New structures methods and functions for Guest to Crucible IO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [workspace]
 members = [
-	"protocol",
-	"downstairs",
-	"upstairs",
 	"common",
+	"downstairs",
+	"protocol",
 	"scope",
+	"upstairs",
 ]

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -69,7 +69,8 @@ async fn proc_frame(
                 rn, dependencies, flush
             );
             //let dep = Vec::new();
-            d.region.region_flush(dependencies.to_vec(), flush.to_vec())?;
+            d.region
+                .region_flush(dependencies.to_vec(), flush.to_vec())?;
             fw.send(Message::FlushAck(*rn)).await
         }
         Message::ReadRequest(rn, eid, block_offset, blocks) => {

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -32,6 +32,11 @@ impl CrucibleEncoder {
 impl Encoder<Message> for CrucibleEncoder {
     type Error = anyhow::Error;
 
+    /*
+     * XXX Is there some Rusty way to auto generate this?  It seems like
+     * there could be some code generator that will produce the desired
+     * sequence, as it is the same for every command.
+     */
     fn encode(
         &mut self,
         m: Message,


### PR DESCRIPTION
Crucible now has a Guest structure as part of the Upstairs.  This
structure with methods and new functions supports IO operations
coming from outside with an offset and buffer.  Crucible can now
translate these into the required downstairs information and handle
creating and submitting work to the downstairs connections.

A few other misc comments and some fmt and clippy changes to other
files, but nothing that should change any functionality.