### PR TITLE
Submit operations to Crucible from a NBD server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +152,28 @@ dependencies = [
  "futures",
  "futures-core",
  "serde",
+ "structopt",
+ "tokio",
+ "tokio-util",
+ "toml",
+]
+
+[[package]]
+name = "crucible-nbd-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "crucible",
+ "crucible-common",
+ "crucible-protocol",
+ "crucible-scope",
+ "futures",
+ "futures-core",
+ "nbd",
+ "ringbuffer",
+ "serde",
+ "serde_json",
  "structopt",
  "tokio",
  "tokio-util",
@@ -371,6 +399,15 @@ checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
  "winapi",
+]
+
+[[package]]
+name = "nbd"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36b0aee27117ae0bc775511be136ac58692704b8650da1e6afee816394a11a"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ members = [
 	"protocol",
 	"scope",
 	"upstairs",
+	"nbd_server",
 ]

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -92,9 +92,9 @@ fn run_single_workload(guest: &Arc<Guest>) -> Result<()> {
     let read_offset = my_offset;
     const READ_SIZE: usize = 1024;
     println!("generate a read 1");
-    let mut data = BytesMut::with_capacity(READ_SIZE);
-    data.put(&[0x99; READ_SIZE][..]);
-    println!("send read, data at {:p}", data.as_ptr());
+    let data = crucible::Buffer::from_slice(&[0x99; READ_SIZE]);
+
+    println!("send read");
     let rio = BlockOp::Read {
         offset: read_offset,
         data,
@@ -128,14 +128,12 @@ fn _run_big_workload(guest: &Arc<Guest>, loops: u32) -> Result<()> {
 
                 let read_offset = my_offset;
                 const READ_SIZE: usize = 512;
-                let mut data = BytesMut::with_capacity(READ_SIZE);
-                data.put(&[0x99; READ_SIZE][..]);
+                let data = crucible::Buffer::from_slice(&[0x99; READ_SIZE]);
                 println!(
-                    "[{}][{}] send read   offset:{}, data at {:p}",
+                    "[{}][{}] send read   offset:{}",
                     olc,
                     lc,
                     read_offset,
-                    data.as_ptr()
                 );
                 let rio = BlockOp::Read {
                     offset: read_offset,
@@ -179,9 +177,9 @@ async fn _run_scope(guest: Arc<Guest>) -> Result<()> {
         let mut read_offset = 512 * 99;
         const READ_SIZE: usize = 4096;
         for _ in 0..4 {
-            let mut data = BytesMut::with_capacity(READ_SIZE);
-            data.put(&[0x99; READ_SIZE][..]);
-            println!("send read, data at {:p}", data.as_ptr());
+            let data = crucible::Buffer::from_slice(&[0x99; READ_SIZE]);
+
+            println!("send a read");
             let rio = BlockOp::Read {
                 offset: read_offset,
                 data,

--- a/nbd_server/Cargo.toml
+++ b/nbd_server/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "crucible-nbd-server"
+version = "0.1.0"
+authors = ["Joshua M. Clulow <jmc@oxide.computer>", "Alan Hanson <alan@oxide.computer>", "James MacMahon <james@oxide.computer>"]
+edition = "2018"
+
+[dependencies]
+anyhow = "1"
+bytes = "1"
+crucible = { path = "../upstairs" }
+crucible-common = { path = "../common" }
+crucible-protocol = { path = "../protocol" }
+crucible-scope = { path = "../scope" }
+futures = "0.3"
+futures-core = "0.3"
+ringbuffer = "0.7"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+structopt = "0.3"
+tokio = { version = "1.7.1", features = ["full"] }
+tokio-util = { version = "0.6", features = ["codec"]}
+toml = "0.5"
+nbd = "0.2.3"

--- a/nbd_server/src/README.md
+++ b/nbd_server/src/README.md
@@ -1,0 +1,44 @@
+To spin up a NBD server to issue work to Crucible, do the following:
+
+1. Start up three separate crucible-downstairs:
+
+    $ cargo run -p crucible-downstairs -- -p 3801 -d "$PWD/disks/d1"
+    $ cargo run -p crucible-downstairs -- -p 3802 -d "$PWD/disks/d2"
+    $ cargo run -p crucible-downstairs -- -p 3803 -d "$PWD/disks/d3"
+
+1. Start up crucible-nbd-server:
+
+    $ cargo run -p crucible-nbd-server -- -t 127.0.0.1:3801 -t 127.0.0.1:3802 -t 127.0.0.1:3803
+
+1. Connect nbd-client to the crucible-nbd-server:
+
+    $ sudo nbd-client 127.0.0.1 10809 /dev/nbd0
+    Warning: the oldstyle protocol is no longer supported.
+    This method now uses the newstyle protocol with a default export
+    Negotiation: ..size = 0MB
+    Connected /dev/nbd0
+
+1. From here, use nbd0 as normal:
+
+    $ sudo mkfs.vfat -F 32 /dev/nbd0
+    mkfs.fat 4.2 (2021-01-31)
+    WARNING: Number of clusters for 32 bit FAT is less then suggested minimum.
+
+    (if your OS does not auto mount, run "sudo mount /dev/nbd0 /mnt/")
+
+    $ date | tee /media/jwm/9287-806A/date
+    Fri 23 Jul 2021 03:33:06 PM EDT
+
+    $ df -h /media/jwm/9287-806A/
+    Filesystem      Size  Used Avail Use% Mounted on
+    /dev/nbd0p1     472K  1.0K  471K   1% /media/jwm/9287-806A
+
+   You should see crucible-downstairs and crucible-nbd-server activity in the other terminal windows.
+
+1. To clean up:
+
+    $ sudo umount /media/jwm/9287-806A/
+    $ sudo nbd-client -d /dev/nbd0
+
+Important: when developing, make sure to disconnect and reconnect nbd-client every time crucible-nbd-server is restarted!
+

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -1,0 +1,217 @@
+use std::sync::{Arc};
+
+use anyhow::Result;
+use bytes::{BufMut, BytesMut};
+use tokio::runtime::Builder;
+
+use crucible::*;
+use crucible_common::{RegionOptions, RegionDefinition};
+
+use std::io::{Result as IOResult};
+use std::net::{TcpListener, TcpStream as NetTcpStream};
+use nbd::server::{handshake, transmission, Export};
+use std::io::{Read, Write, Seek, SeekFrom};
+
+/*
+ * NBD server commands translate through the CruciblePseudoFile and turn
+ * into Guest work ops.
+ */
+
+struct CruciblePseudoFile {
+    guest: Arc<Guest>,
+    block_size: usize,
+    offset: u64,
+    sz: u64,
+}
+
+impl CruciblePseudoFile {
+    fn _read(&mut self, buf: &mut [u8]) -> IOResult<usize> {
+        let data = crucible::Buffer::from_slice(buf);
+
+        let rio = BlockOp::Read {
+            offset: self.offset,
+            data: data.clone(),
+        };
+
+        let mut waiter = self.guest.send(rio);
+        waiter.block_wait();
+
+        // TODO: for block devices, we can't increment offset past the
+        // device size but we're supposed to be pretending to be a proper
+        // file here
+        self.offset += buf.len() as u64;
+
+        // TODO: is there a better way to do this fill?
+        {
+            let vec = data.as_vec();
+            for i in 0..buf.len() {
+                buf[i] = vec[i];
+            }
+        }
+
+        Ok(buf.len())
+    }
+
+    fn _write(&mut self, buf: &[u8]) -> IOResult<usize> {
+        let mut data = BytesMut::with_capacity(buf.len());
+        data.put_slice(buf);
+
+        let wio = BlockOp::Write {
+            offset: self.offset,
+            data: data.freeze(),
+        };
+
+        let mut waiter = self.guest.send(wio);
+        waiter.block_wait();
+
+        // TODO: can't increment offset past the device size
+        self.offset += buf.len() as u64;
+
+        Ok(buf.len())
+    }
+}
+
+/*
+ * The Read + Write impls here translate arbitrary sized operations into
+ * sector size calls for the underlying Crucible API.
+ */
+impl Read for CruciblePseudoFile {
+    fn read(&mut self, buf: &mut [u8]) -> IOResult<usize> {
+        let mut i = 0;
+        let mut sz = buf.len();
+        let orig_sz = buf.len();
+        let mut result: usize = 0;
+
+        while sz > self.block_size {
+            result += self._read(&mut buf[i..(i + self.block_size)])?;
+            sz -= self.block_size;
+            i += self.block_size;
+        }
+
+        result += self._read(&mut buf[i..orig_sz])?;
+
+        Ok(result)
+    }
+
+}
+
+impl Write for CruciblePseudoFile {
+    fn write(&mut self, buf: &[u8]) -> IOResult<usize> {
+        let mut i = 0;
+        let mut sz = buf.len();
+        let orig_sz = buf.len();
+        let mut result: usize = 0;
+
+        while sz > self.block_size {
+            result += self._write(&buf[i..(i + self.block_size)])?;
+            sz -= self.block_size;
+            i += self.block_size;
+        }
+
+        result += self._write(&buf[i..orig_sz])?;
+
+        Ok(result)
+    }
+
+    fn flush(&mut self) -> IOResult<()> {
+        let mut waiter = self.guest.send(BlockOp::Flush);
+        waiter.block_wait();
+
+        Ok(())
+    }
+}
+
+impl Seek for CruciblePseudoFile {
+    fn seek(&mut self, pos: SeekFrom) -> IOResult<u64> {
+        // TODO: does not check against block device size
+        match pos {
+            SeekFrom::Start(v) => {
+                self.offset = v as u64;
+            },
+            SeekFrom::Current(v) => {
+                // TODO: as checked add?
+                self.offset += v as u64;
+            },
+            SeekFrom::End(v) => {
+                // TODO: as checked subtract?
+                self.offset = self.sz - v as u64;
+            }
+        }
+        Ok(self.offset)
+    }
+
+    fn stream_position(&mut self) -> IOResult<u64> {
+        Ok(self.offset)
+    }
+}
+
+fn handle_nbd_client(cpf: &mut CruciblePseudoFile, mut stream: NetTcpStream) -> Result<()> {
+    let e = Export {
+        size: cpf.sz,
+        readonly: false,
+        ..Default::default()
+    };
+    handshake(&mut stream, &e)?;
+    transmission(&mut stream, cpf)?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opt = opts()?;
+
+    /*
+     * Crucible needs a runtime as it will create several async tasks to
+     * handle adding new IOs, communication with the three downstairs
+     * instances, and completing IOs.
+     */
+    let runtime = Builder::new_multi_thread()
+        .worker_threads(10)
+        .thread_name("crucible-tokio")
+        .enable_all()
+        .build()
+        .unwrap();
+
+    /*
+     * The structure we use to send work from outside crucible into the
+     * Upstairs main task.
+     * We create this here instead of inside up_main() so we can use
+     * the methods provided by guest to interact with Crucible.
+     */
+    let guest = Arc::new(Guest::new());
+
+    runtime.spawn(up_main(opt, guest.clone()));
+    println!("Crucible runtime is spawned");
+
+    // TODO: read this from somewhere, instead of defaults
+    let mut region = RegionDefinition::from_options(&RegionOptions::default()).unwrap();
+    region.set_extent_count(10);
+
+    let sz = region.block_size() * region.extent_size() * (region.extent_count() as u64);
+    println!("NBD advertised size as {} bytes", sz);
+
+    // NBD server
+    let listener = TcpListener::bind("127.0.0.1:10809").unwrap();
+    let mut cpf = CruciblePseudoFile{
+        guest: guest,
+        block_size: region.block_size() as usize,
+        offset: 0,
+        sz: sz, // sent to NBD client during handshake through Export struct
+    };
+
+    for stream in listener.incoming() {
+        println!("waiting on nbd traffic");
+        match stream {
+            Ok(stream) => match handle_nbd_client(&mut cpf, stream) {
+                Ok(_) => {}
+                Err(e) => {
+                    eprintln!("handle_nbd_client error: {}", e);
+                }
+            },
+            Err(_) => {
+                println!("Error");
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/upstairs/src/main.rs
+++ b/upstairs/src/main.rs
@@ -61,12 +61,12 @@ fn run_single_workload(guest: &Arc<Guest>) -> Result<()> {
 
     let read_offset = my_offset;
     const READ_SIZE: usize = 1024;
-    let mut data = BytesMut::with_capacity(READ_SIZE);
-    data.put(&[0x99; READ_SIZE][..]);
-    println!("send read, data at {:p}", data.as_ptr());
+    let data = crucible::Buffer::from_slice(&[0x99; READ_SIZE]);
+
+    println!("send a read");
     let rio = BlockOp::Read {
         offset: read_offset,
-        data,
+        data: data.clone(),
     };
     guest.send(rio);
 


### PR DESCRIPTION
Spin up a nbd server (courtesy of the rust-nbd crate) and send the operations to crucible.

Implement a notification system - sending an operation to a Guest now returns a Receiver object, and clients can block on the completion of that operation.

A notable difference here is that BytesMut is not longer used as the data field in BlockOp::Read - it does not guarantee that memory will be shared between cloned objects. A new Buffer type is used.

See nbd_server/src/README.md for instructions.