### PR TITLE
Fixes for propolis

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1817,15 +1817,6 @@ pub async fn up_main(opt: Opt, guest: Arc<Guest>) -> Result<()> {
     // That part is not connected yet. XXX
     let mut ds_count = 0u32;
     loop {
-        match register_probes() {
-            Ok(()) => {
-                println!("In loop, DTrace probes registered ok");
-            }
-            Err(e) => {
-                println!("In loop, error registering DTrace probes: {:?}", e);
-            }
-        }
-
         let c = crx.recv().await.unwrap();
         if c.connected {
             ds_count += 1;


### PR DESCRIPTION
- add ability to construct upstairs Opt from options string
- fixed bug with Buffer::new not allocating to capacity
- register_probes might fail, don't panic
- add ability to construct Buffer from a vector