### PR TITLE
dtrace probes and fewer versions

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -69,8 +69,8 @@ fn main() -> Result<()> {
      * get in its own way.
      */
     std::thread::sleep(std::time::Duration::from_secs(5));
-    _run_single_workload(&guest)?;
-    //run_big_workload(&guest, 1)?;
+    //_run_single_workload(&guest)?;
+    _run_big_workload(&guest, 1)?;
     /*
     for _ in 0..1000 {
         _run_single_workload(&guest)?;

--- a/tools/README.md
+++ b/tools/README.md
@@ -18,11 +18,52 @@ Here is an example of how it might look:
 final:crucible alan$ sudo dtrace -s tools/tracegw.d
 dtrace: system integrity protection is on, some features will not be available
 
-dtrace: script 'tools/tracegw.d' matched 5 probes
 ^C
-CPU     ID                    FUNCTION:NAME
-  8      2                             :END gw_start:3000   gw_end:3000
+ read_start:1000    read_end:1000
+ write_start:1000   write_end:1000
+ flush_start:1000   flush_end:1000
+```
 
+## tracegw.d
+This is a simple dtrace script that measures latency times for when a r/w/f
+job is submitted to the internal upstairs work queue, to when that job has
+completed and the notification was sent back to the guest.
+```
+sudo dtrace -s tools/perfgw.d
+```
 
+Here is an example of how it might look:
+```
+$ sudo dtrace -s tools/perfgw.d
+dtrace: system integrity protection is on, some features will not be available
+
+dtrace: script 'tools/perfgw.d' matched 6 probes
+^C
+
+  write
+           value  ------------- Distribution ------------- count
+        16777216 |                                         0
+        33554432 |@@@@@@@@@@@@@@                           355
+        67108864 |@@@@@@@@@@@@@@@@@@@@@@@@@@               645
+       134217728 |                                         0
+
+  read
+           value  ------------- Distribution ------------- count
+        16777216 |                                         0
+        33554432 |@@@@@@@@@@@@@@                           353
+        67108864 |@@@@@@@@@@@@@@@@@@@@@@@@@@               647
+       134217728 |                                         0
+
+  flush
+           value  ------------- Distribution ------------- count
+          524288 |                                         0
+         1048576 |                                         1
+         2097152 |                                         0
+         4194304 |                                         0
+         8388608 |                                         0
+        16777216 |                                         0
+        33554432 |@@@@@@@@@@@@@@                           353
+        67108864 |@@@@@@@@@@@@@@@@@@@@@@@@@@               647
+       134217728 |
 ```
 That's all for now!

--- a/tools/perfgw.d
+++ b/tools/perfgw.d
@@ -1,0 +1,24 @@
+// Trace all the guest submitted and completed IOs.
+// Note, the way dtrace works with Rust means you have to start crucible
+// running before you can run this.
+crutrace*:::gw_read_start,
+crutrace*:::gw_write_start,
+crutrace*:::gw_flush_start
+{
+    start[arg0] = timestamp;
+}
+crutrace*:::gw_read_end
+{
+    @time["read"] = quantize(timestamp - start[arg0]);
+    start[arg0] = 0;
+}
+crutrace*:::gw_write_end
+{
+    @time["write"] = quantize(timestamp - start[arg0]);
+    start[arg0] = 0;
+}
+crutrace*:::gw_flush_end
+{
+    @time["flush"] = quantize(timestamp - start[arg0]);
+    start[arg0] = 0;
+}

--- a/tools/tracegw.d
+++ b/tools/tracegw.d
@@ -1,16 +1,35 @@
 // Trace all the guest submitted and completed IOs.
 // Note, the way dtrace works with Rust means you have to start crucible
 // running before you can run this.
-crutrace*:::gw_start
+#pragma D option quiet
+crutrace*:::gw_read_start
 {
-    @start = count();
+    @read_start = count();
 }
-crutrace*:::gw_end
+crutrace*:::gw_read_end
 {
-    @end = count();
+    @read_end = count();
+}
+crutrace*:::gw_write_start
+{
+    @write_start = count();
+}
+crutrace*:::gw_write_end
+{
+    @write_end = count();
+}
+crutrace*:::gw_flush_start
+{
+    @flush_start = count();
+}
+crutrace*:::gw_flush_end
+{
+    @flush_end = count();
 }
 
 END
 {
-    printa("gw_start:%@d   gw_end:%@d", @start, @end);
+    printa(" read_start:%@d    read_end:%@d\n", @read_start, @read_end);
+    printa("write_start:%@d   write_end:%@d\n", @write_start, @write_end);
+    printa("flush_start:%@d   flush_end:%@d\n", @flush_start, @flush_end);
 }

--- a/upstairs/crutrace.d
+++ b/upstairs/crutrace.d
@@ -1,4 +1,8 @@
 provider crutrace {
-    probe gw_start(uint64_t);
-    probe gw_end(uint64_t);
+    probe gw_read_start(uint64_t);
+    probe gw_write_start(uint64_t);
+    probe gw_flush_start(uint64_t);
+    probe gw_read_end(uint64_t);
+    probe gw_write_end(uint64_t);
+    probe gw_flush_end(uint64_t);
 };


### PR DESCRIPTION
Added and updated the dtrace probe points, we now have an entry/exit
point for each IO type: Read, Write, and Flush.  The current points are
when an IO lands on the internal upstairs queue, and when that IO has
been completed and that completion was sent back to the guest.

Cleaned up the flush number information that is printed on startup to only
print the value for the first 12 extents.

Added another dtrace script and updated the tools README.