### PR TITLE
Only use block sized operations

### DIFF
--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -149,7 +149,10 @@ fn main() -> Result<()> {
 
             for i in 0..len {
                 if verify_vec[i as usize] != 0 {
-                    bail!("Not isolated! non-zero byte at {}", (offset + bsz as u64) + i);
+                    bail!(
+                        "Not isolated! non-zero byte at {}",
+                        (offset + bsz as u64) + i
+                    );
                 }
             }
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1562,8 +1562,6 @@ impl BlockReq {
 /**
  * When BlockOps are sent to a guest, the calling function receives a
  * waiter that it can block on.
- *
- * BlockReqWaiters can wait on more than one BlockOp, and/or can be chained together.
  */
 pub struct BlockReqWaiter {
     recv: std_mpsc::Receiver<i32>,
@@ -1809,6 +1807,10 @@ impl Guest {
             /*
              * Note: if only submitting block sized writes to Upstairs, do read+modify+write here.
              */
+
+            // XXX: RMW here has atomicity problem
+            println!("atomicity fail! write of {} size {}", offset, data.len());
+
             let mut waiter = span.read_affected_blocks_from_guest(self);
             waiter.block_wait();
 


### PR DESCRIPTION
The Upstairs can now specify that it requires block sized operations only, and the Guest queries this and chunks non-block-aligned and/or non-block-sized operations accordingly.

Changed BlockReqWaiter to instead wait on a list of receivers, and added the ability to chain together BlockReqWaiters. This is used to wait on several chunks being written back to Upstairs. During the multi-chunk read, a "no-op" BlockReqWaiter is returned because the read function has to wait on all the chunked reads returning before it can properly fill the buffer.