### PR TITLE
Use only block sized operations

### DIFF
--- a/hammer/src/hammer.c
+++ b/hammer/src/hammer.c
@@ -9,7 +9,11 @@
 int main() {
   srandom(clock());
 
-  const size_t total_size = 512*100*1000; // TODO: get from region.json
+  // TODO: get from region.json
+  const size_t block_size = 512;
+  const size_t extent_size = 512;
+  const size_t extent_count = 32768;
+  const size_t total_size = block_size * extent_size * extent_count;
 
   while (1) {
     size_t offset = random() % total_size;
@@ -28,7 +32,7 @@ int main() {
     size_t r;
 
     // get some random data
-    fp = fopen("/dev/random", "rb");
+    fp = fopen("/dev/urandom", "rb");
     fn = fileno(fp);
 
     if (sz != read(fn, buf, sz)) {


### PR DESCRIPTION
Perform RMW Upstairs if read and write operations are not block aligned and block sized. This currently means an atomicity failure, but in testing with propolis I haven't seen this yet. I have seen it with nbd and hammer testing though.

Put all the logic that handles turning arbitrary reads and writes into block aligned and block sized operations into a new struct IOSpan. Guest::read and Guest::write now uses IOSpan.

This commit also adds more instrumentation, and switches to non-blocking random to generate data for the C version of hammer.