### PR TITLE
Add simple integrity test to crucible client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
  "futures",
  "futures-core",
  "rand",
+ "rand_chacha",
  "ringbuffer",
  "serde",
  "serde_json",
@@ -867,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -16,6 +16,7 @@ futures = "0.3"
 futures-core = "0.3"
 ringbuffer = "0.7"
 rand = "0.8.4"
+rand_chacha = "0.3.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 structopt = "0.3"

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -22,7 +22,7 @@ arg_enum! {
         Big,
         Dep,
         Rand,
-        Baloon,
+        Balloon,
     }
 }
 
@@ -164,9 +164,9 @@ fn main() -> Result<()> {
             println!("Run random test");
             runtime.block_on(rand_workload(&guest))?;
         }
-        Workload::Baloon => {
-            println!("Run baloon test");
-            runtime.block_on(baloon_workload(&guest))?;
+        Workload::Balloon => {
+            println!("Run balloon test");
+            runtime.block_on(balloon_workload(&guest))?;
         }
     }
 
@@ -304,10 +304,10 @@ fn validate_vec(
 /*
  * Write then read (and verify) to every possible block, with every size that
  * block can possibly support.
- * I named it baloon because each loop on a block "baloons" from the minimum
+ * I named it balloon because each loop on a block "balloons" from the minimum
  * IO size to the largest possible.
  */
-async fn baloon_workload(guest: &Arc<Guest>) -> Result<()> {
+async fn balloon_workload(guest: &Arc<Guest>) -> Result<()> {
     /*
      * These query requests have the side effect of preventing the test from
      * starting before the upstairs is ready.
@@ -318,7 +318,7 @@ async fn baloon_workload(guest: &Arc<Guest>) -> Result<()> {
     let total_blocks = (total_size / block_size) as usize;
 
     println!(
-        "Baloon workload starting with  es: {}  bs:{}  ts:{}  tb:{}",
+        "Balloon workload starting with  es: {}  bs:{}  ts:{}  tb:{}",
         extent_size, block_size, total_size, total_blocks
     );
 
@@ -394,7 +394,7 @@ fn print_write_count(
 
 /*
  * Generate a random offset and length, and write to then read from
- * that offset/lenght.  Verify the data is what we expect.
+ * that offset/length.  Verify the data is what we expect.
  */
 async fn rand_workload(guest: &Arc<Guest>) -> Result<()> {
     /*

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -602,9 +602,7 @@ mod test {
     }
 
     pub fn test_cleanup() {
-        if Path::new("/tmp/ds_test").exists() {
-            remove_dir_all("/tmp/ds_test").unwrap();
-        }
+        let _ = remove_dir_all("/tmp/ds_test");
     }
 
     #[test]

--- a/tools/README.md
+++ b/tools/README.md
@@ -66,4 +66,11 @@ dtrace: script 'tools/perfgw.d' matched 6 probes
         67108864 |@@@@@@@@@@@@@@@@@@@@@@@@@@               647
        134217728 |
 ```
+
+## test_up.sh
+A simple script that will start three downstairs, then run through some tests in
+client/src/main.  It's an easy way to quickly run some simple tests without
+having to spin up a bunch of things.  These tests are limited in their scope and
+should not be considered substantial.
+
 That's all for now!

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Simple script to start three downstairs, then run through all the tests
+# that exist on the crucible client program.  This should eventually either
+# move to some common test framework, or be thrown away.
+
+set -o pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+
+echo "$ROOT"
+cd "$ROOT"
+
+if pgrep -fl target/debug/crucible-downstairs; then
+    echo 'Downstairs already running?' >&2
+    exit 1
+fi
+
+if ! cargo build; then
+    echo "Initial Build failed, no tests ran"
+    exit 1
+fi
+
+cds="./target/debug/crucible-downstairs"
+cc="./target/debug/crucible-client"
+if [[ ! -f ${cds} ]] || [[ ! -f ${cc} ]]; then
+    echo "Can't find crucible binary at $cds or $cc"
+    exit 1
+fi
+
+testdir="/tmp/ds_test"
+if [[ -d ${testdir} ]]; then
+    rm -rf ${testdir}
+fi
+
+args=()
+downstairs=()
+for (( i = 0; i < 3; i++ )); do
+    (( port = 3801 + i ))
+    dir="${testdir}/$port"
+    args+=( -t "127.0.0.1:$port" )
+    echo ${cds} -c -p "$port" -d "$dir" --extent-count 5 --extent-size 10
+    set -o errexit
+    ${cds} -c -p "$port" -d "$dir" --extent-count 5 --extent-size 10 &
+    downstairs[$i]=$!
+    set +o errexit
+done
+
+res=0
+test_list="one big dep rand baloon"
+for tt in ${test_list}; do
+    echo ""
+    echo "Running test: $tt"
+    echo cargo run -p crucible-client -- -q -w "$tt" "${args[@]}"
+    if ! cargo run -p crucible-client -- -q -w "$tt" "${args[@]}"; then
+        res=1
+        echo ""
+        echo "Failed crucible-client $tt test"
+        echo ""
+    else
+        echo "Completed test: $tt"
+    fi
+done
+
+echo "Tests have completed, stopping all downstairs"
+for pid in ${downstairs[*]}; do
+    kill $pid >/dev/null 2>&1
+    wait $pid
+done
+
+echo ""
+if [[ $res != 0 ]]; then
+    echo "Tests have failed"
+else
+    echo "All Tests have passed"
+fi
+exit $res

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -47,7 +47,7 @@ for (( i = 0; i < 3; i++ )); do
 done
 
 res=0
-test_list="one big dep rand baloon"
+test_list="one big dep rand balloon"
 for tt in ${test_list}; do
     echo ""
     echo "Running test: $tt"


### PR DESCRIPTION
Updated the crucible-client program to have a real simple data integrity
test.  Added a random and a sequential tests as options to the client
program.

Updated the workload option to expect an enum of valid test names using
the arg_enum macro.

Fixed a bug where the dep_workload test would create offsets too large.

Added tests for the integrity checker.

Fixed a bug where sometimes the downstairs region test would fail.

Made a silly test script to start up three downstairs, then run through
the tests in crucible-client.