### PR TITLE
Revert Crucible back to only block operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "crucible-common",
  "tokio-util",
 ]
 

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -507,7 +507,7 @@ fn single_workload(guest: &Arc<Guest>) -> Result<()> {
     let data = Bytes::from(vec);
 
     println!("Sending a write spanning two extents");
-    let mut waiter = guest.bwrite(my_offset, data);
+    let mut waiter = guest.write_to_byte_offset(my_offset, data);
     waiter.block_wait();
 
     println!("Sending a flush");
@@ -518,7 +518,7 @@ fn single_workload(guest: &Arc<Guest>) -> Result<()> {
     let data = crucible::Buffer::from_vec(vec);
 
     println!("Sending a read spanning two extents");
-    waiter = guest.bread(my_offset, data);
+    waiter = guest.read_from_byte_offset(my_offset, data);
     waiter.block_wait();
 
     Ok(())
@@ -554,7 +554,7 @@ fn big_workload(guest: &Arc<Guest>) -> Result<()> {
             my_offset,
             data.len()
         );
-        let mut waiter = guest.bwrite(my_offset, data);
+        let mut waiter = guest.write_to_byte_offset(my_offset, data);
         waiter.block_wait();
 
         /*
@@ -575,7 +575,7 @@ fn big_workload(guest: &Arc<Guest>) -> Result<()> {
             my_offset,
             data.len(),
         );
-        waiter = guest.bread(my_offset, data);
+        waiter = guest.read_from_byte_offset(my_offset, data);
         waiter.block_wait();
 
         my_offset += block_size;
@@ -634,7 +634,7 @@ async fn dep_workload(guest: &Arc<Guest>) -> Result<()> {
                     my_offset,
                     data.len()
                 );
-                let waiter = guest.bwrite(my_offset, data);
+                let waiter = guest.write_to_byte_offset(my_offset, data);
                 waiterlist.push(waiter);
             } else {
                 let vec: Vec<u8> = vec![0; block_size as usize];
@@ -647,7 +647,7 @@ async fn dep_workload(guest: &Arc<Guest>) -> Result<()> {
                     my_offset,
                     data.len()
                 );
-                let waiter = guest.bread(my_offset, data);
+                let waiter = guest.read_from_byte_offset(my_offset, data);
                 waiterlist.push(waiter);
             }
         }
@@ -681,7 +681,7 @@ async fn _run_scope(guest: Arc<Guest>) -> Result<()> {
         scope.wait_for("write 1").await;
 
         println!("send write 1");
-        guest.bwrite(my_offset, data.freeze());
+        guest.write_to_byte_offset(my_offset, data.freeze());
 
         scope.wait_for("show work").await;
         guest.show_work();
@@ -693,7 +693,7 @@ async fn _run_scope(guest: Arc<Guest>) -> Result<()> {
 
             println!("send a read");
             // scope.wait_for("send Read").await;
-            guest.bread(read_offset, data);
+            guest.read_from_byte_offset(read_offset, data);
             read_offset += READ_SIZE as u64;
             // scope.wait_for("show work").await;
             guest.show_work();
@@ -708,7 +708,7 @@ async fn _run_scope(guest: Arc<Guest>) -> Result<()> {
 
         // scope.wait_for("write 2").await;
         println!("send write 2");
-        guest.bwrite(my_offset, data.freeze());
+        guest.write_to_byte_offset(my_offset, data.freeze());
         my_offset += 512;
         // scope.wait_for("show work").await;
         guest.show_work();

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -11,6 +11,7 @@ use structopt::StructOpt;
 use tokio::runtime::Builder;
 
 use crucible::*;
+use crucible_common::Block;
 
 /*
  * The various tests this program supports.
@@ -318,7 +319,7 @@ async fn balloon_workload(guest: &Arc<Guest>) -> Result<()> {
     let total_blocks = (total_size / block_size) as usize;
 
     println!(
-        "Balloon workload starting with  es: {}  bs:{}  ts:{}  tb:{}",
+        "Balloon workload starting with  es: {:?}  bs:{}  ts:{}  tb:{}",
         extent_size, block_size, total_size, total_blocks
     );
 
@@ -347,7 +348,8 @@ async fn balloon_workload(guest: &Arc<Guest>) -> Result<()> {
             /*
              * Convert block_index to its byte value.
              */
-            let offset = (block_index as u64 * block_size) as u64;
+            let offset =
+                Block::new(block_index as u64, block_size.trailing_zeros());
 
             let mut waiter = guest.write(offset, data);
             waiter.block_wait();
@@ -380,13 +382,13 @@ async fn balloon_workload(guest: &Arc<Guest>) -> Result<()> {
 fn print_write_count(
     write_count: Vec<u32>,
     total_blocks: usize,
-    extent_size: u64,
+    extent_size: Block,
 ) {
     println!(" Write IO count to each extent");
     println!("###############################");
     for (i, wc) in write_count.iter().enumerate().take(total_blocks) {
         print!("{:5} ", wc);
-        if (i + 1) % (extent_size as usize) == 0 {
+        if (i + 1) % (extent_size.value as usize) == 0 {
             println!();
         }
     }
@@ -407,7 +409,7 @@ async fn rand_workload(guest: &Arc<Guest>) -> Result<()> {
     let total_blocks = (total_size / block_size) as usize;
 
     println!(
-        "Random workload starting with  es: {}  bs:{}  ts:{}  tb:{}",
+        "Random workload starting with  es: {:?}  bs:{}  ts:{}  tb:{}",
         extent_size, block_size, total_size, total_blocks
     );
 
@@ -443,7 +445,8 @@ async fn rand_workload(guest: &Arc<Guest>) -> Result<()> {
         /*
          * Convert offset and length to their byte values.
          */
-        let offset = (block_index as u64 * block_size) as u64;
+        let offset =
+            Block::new(block_index as u64, block_size.trailing_zeros());
 
         /*
          * Update the write count for all blocks we plan to write to.
@@ -485,11 +488,11 @@ fn single_workload(guest: &Arc<Guest>) -> Result<()> {
     println!("Run single workload");
     let block_size = guest.query_block_size();
     let extent_size = guest.query_extent_size();
-    println!("bs: {}  es:{}", extent_size, block_size);
+    println!("bs: {:?}  es:{}", extent_size, block_size);
     /*
      * Pick the last block in the first extent
      */
-    let my_offset = (block_size * extent_size) - block_size;
+    let my_offset = block_size * (extent_size.value - 1);
     let my_length: usize = block_size as usize * 2;
 
     let mut vec: Vec<u8> = Vec::with_capacity(my_length);
@@ -504,7 +507,7 @@ fn single_workload(guest: &Arc<Guest>) -> Result<()> {
     let data = Bytes::from(vec);
 
     println!("Sending a write spanning two extents");
-    let mut waiter = guest.write(my_offset, data);
+    let mut waiter = guest.bwrite(my_offset, data);
     waiter.block_wait();
 
     println!("Sending a flush");
@@ -515,7 +518,7 @@ fn single_workload(guest: &Arc<Guest>) -> Result<()> {
     let data = crucible::Buffer::from_vec(vec);
 
     println!("Sending a read spanning two extents");
-    waiter = guest.read(my_offset, data);
+    waiter = guest.bread(my_offset, data);
     waiter.block_wait();
 
     Ok(())
@@ -551,7 +554,7 @@ fn big_workload(guest: &Arc<Guest>) -> Result<()> {
             my_offset,
             data.len()
         );
-        let mut waiter = guest.write(my_offset, data);
+        let mut waiter = guest.bwrite(my_offset, data);
         waiter.block_wait();
 
         /*
@@ -572,12 +575,12 @@ fn big_workload(guest: &Arc<Guest>) -> Result<()> {
             my_offset,
             data.len(),
         );
-        waiter = guest.read(my_offset, data);
+        waiter = guest.bread(my_offset, data);
         waiter.block_wait();
 
         my_offset += block_size;
         cur_block += 1;
-        if cur_block >= extent_size {
+        if cur_block >= extent_size.value {
             cur_extent += 1;
             cur_block = 0;
             println!("[{}][{}] send flush", cur_extent, cur_block);
@@ -631,7 +634,7 @@ async fn dep_workload(guest: &Arc<Guest>) -> Result<()> {
                     my_offset,
                     data.len()
                 );
-                let waiter = guest.write(my_offset, data);
+                let waiter = guest.bwrite(my_offset, data);
                 waiterlist.push(waiter);
             } else {
                 let vec: Vec<u8> = vec![0; block_size as usize];
@@ -644,7 +647,7 @@ async fn dep_workload(guest: &Arc<Guest>) -> Result<()> {
                     my_offset,
                     data.len()
                 );
-                let waiter = guest.read(my_offset, data);
+                let waiter = guest.bread(my_offset, data);
                 waiterlist.push(waiter);
             }
         }
@@ -678,7 +681,7 @@ async fn _run_scope(guest: Arc<Guest>) -> Result<()> {
         scope.wait_for("write 1").await;
 
         println!("send write 1");
-        guest.write(my_offset, data.freeze());
+        guest.bwrite(my_offset, data.freeze());
 
         scope.wait_for("show work").await;
         guest.show_work();
@@ -690,7 +693,7 @@ async fn _run_scope(guest: Arc<Guest>) -> Result<()> {
 
             println!("send a read");
             // scope.wait_for("send Read").await;
-            guest.read(read_offset, data);
+            guest.bread(read_offset, data);
             read_offset += READ_SIZE as u64;
             // scope.wait_for("show work").await;
             guest.show_work();
@@ -705,7 +708,7 @@ async fn _run_scope(guest: Arc<Guest>) -> Result<()> {
 
         // scope.wait_for("write 2").await;
         println!("send write 2");
-        guest.write(my_offset, data.freeze());
+        guest.bwrite(my_offset, data.freeze());
         my_offset += 512;
         // scope.wait_for("show work").await;
         guest.show_work();

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;
 
 mod region;
-pub use region::{RegionDefinition, RegionOptions};
+pub use region::{Block, RegionDefinition, RegionOptions};
 
 pub fn read_json_maybe<P, T>(file: P) -> Result<Option<T>>
 where

--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -2,17 +2,64 @@
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 
+/*
+ * Where the unit is blocks, not bytes, make sure to reflect that in the types used.
+ *
+ * Consumers of this API should know when to use bytes (rarely), and when to use blocks.
+ *
+ * Blocks have a shift field to ensure that consumers and the upstairs agree on what a block is. It
+ * wouldn't make sense to pass Block { 2, 9 } when the downstairs expects Block { 2, 12 }.
+ */
+#[derive(Deserialize, Serialize, Copy, Clone, Debug, PartialEq, PartialOrd)]
+pub struct Block {
+    // Value could mean a size or offset
+    pub value: u64,
+
+    // block size as a power of 2
+    // shift  9 -> 512
+    // shift 12 -> 4096
+    pub shift: u32,
+}
+
+impl Block {
+    pub fn new(value: u64, shift: u32) -> Block {
+        // are you sure you need blocks that big?
+        assert!(shift <= 16);
+
+        Block { value, shift }
+    }
+
+    pub fn new_512(value: u64) -> Block {
+        Block::new(value, 9)
+    }
+
+    pub fn new_with_ddef(value: u64, ddef: &RegionDefinition) -> Block {
+        Block {
+            value,
+            shift: ddef.block_size().trailing_zeros(),
+        }
+    }
+
+    pub fn block_size_in_bytes(&self) -> u32 {
+        1 << self.shift
+    }
+
+    pub fn byte_value(&self) -> u64 {
+        self.value * self.block_size_in_bytes() as u64
+    }
+}
+
 #[derive(Deserialize, Serialize, Copy, Clone, Debug, PartialEq)]
 pub struct RegionDefinition {
     /**
-     * The size of each block in bytes.  Must be a power of 2, minimum 512.
+     * The size of each block in bytes. Must be a power of 2, minimum 512.
      */
     block_size: u64,
 
     /**
      * How many blocks should appear in each extent?
      */
-    extent_size: u64,
+    extent_size: Block,
 
     /**
      * How many whole extents comprise this region?
@@ -33,14 +80,16 @@ impl RegionDefinition {
     pub fn block_size(&self) -> u64 {
         self.block_size
     }
+
     pub fn set_block_size(&mut self, bs: u64) {
         self.block_size = bs;
     }
 
-    pub fn extent_size(&self) -> u64 {
+    pub fn extent_size(&self) -> Block {
         self.extent_size
     }
-    pub fn set_extent_size(&mut self, es: u64) {
+
+    pub fn set_extent_size(&mut self, es: Block) {
         self.extent_size = es;
     }
 
@@ -53,7 +102,7 @@ impl RegionDefinition {
     }
 
     pub fn total_size(&self) -> u64 {
-        self.block_size * self.extent_size * (self.extent_count as u64)
+        self.block_size * self.extent_size.value * (self.extent_count as u64)
     }
 }
 
@@ -65,7 +114,7 @@ impl Default for RegionDefinition {
     fn default() -> RegionDefinition {
         RegionDefinition {
             block_size: 0,
-            extent_size: 0,
+            extent_size: Block::new(0, 0),
             extent_count: 0,
         }
     }
@@ -81,7 +130,7 @@ pub struct RegionOptions {
     /**
      * How many blocks should appear in each extent?
      */
-    extent_size: u64,
+    extent_size: Block,
 }
 
 impl RegionOptions {
@@ -94,18 +143,18 @@ impl RegionOptions {
             bail!("minimum block size is 512 bytes, not {}", self.block_size);
         }
 
-        if self.extent_size < 1 {
+        if self.extent_size.value < 1 {
             bail!("extent size must be at least 1 block");
         }
 
-        let bs = self.extent_size.saturating_mul(self.block_size);
+        let bs = self.extent_size.value.saturating_mul(self.block_size);
         if bs > 10 * 1024 * 1024 {
             /*
              * For now, make sure we don't accidentally try to use a gigantic
              * extent.
              */
             bail!(
-                "extent size {} x {} bytes = {}MB, bigger than 10MB",
+                "extent size {:?} x {} bytes = {}MB, bigger than 10MB",
                 self.extent_size,
                 self.block_size,
                 bs / 1024 / 1024
@@ -119,16 +168,17 @@ impl RegionOptions {
         self.block_size = bs;
     }
 
-    pub fn set_extent_size(&mut self, es: u64) {
+    pub fn set_extent_size(&mut self, es: Block) {
         self.extent_size = es;
     }
 }
 
 impl Default for RegionOptions {
     fn default() -> Self {
+        /* XXX bigger? */
         RegionOptions {
-            block_size: 512,  /* XXX bigger? */
-            extent_size: 100, /* XXX bigger? */
+            block_size: 512,
+            extent_size: Block::new(100, 9),
         }
     }
 }

--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -23,8 +23,9 @@ pub struct Block {
 
 impl Block {
     pub fn new(value: u64, shift: u32) -> Block {
+        // are you sure you need blocks that small?
         // are you sure you need blocks that big?
-        assert!(shift <= 16);
+        assert!((9..16).contains(&shift));
 
         Block { value, shift }
     }
@@ -114,7 +115,7 @@ impl Default for RegionDefinition {
     fn default() -> RegionDefinition {
         RegionDefinition {
             block_size: 0,
-            extent_size: Block::new(0, 0),
+            extent_size: Block::new(0, 9),
             extent_count: 0,
         }
     }

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2018"
 tokio-util = { version = "0.6", features = [ "codec" ] }
 bytes = "1"
 anyhow = "1"
+crucible-common = { path = "../common" }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1942,7 +1942,7 @@ impl Guest {
     }
 
     pub fn query_extent_size(&self) -> Block {
-        let data = Arc::new(Mutex::new(Block::new(0, 0)));
+        let data = Arc::new(Mutex::new(Block::new(0, 9)));
         let extent_query = BlockOp::QueryExtentSize { data: data.clone() };
         self.send(extent_query).block_wait();
         return *data.lock().unwrap();

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2504,7 +2504,7 @@ impl IOSpan {
     }
 
     #[cfg(test)]
-    fn number_of_affected_blocks(&self) -> usize {
+    fn affected_block_count(&self) -> usize {
         self.affected_block_numbers.len()
     }
 
@@ -2745,39 +2745,39 @@ mod test {
     fn test_iospan() {
         let span = IOSpan::new(512, 1024, 512);
         assert!(span.is_block_aligned_and_block_sized());
-        assert_eq!(span.number_of_affected_blocks(), 2);
+        assert_eq!(span.affected_block_count(), 2);
 
         let span = IOSpan::new(513, 1024, 512);
         assert!(!span.is_block_aligned_and_block_sized());
-        assert_eq!(span.number_of_affected_blocks(), 3);
+        assert_eq!(span.affected_block_count(), 3);
 
         let span = IOSpan::new(512, 500, 512);
         assert!(!span.is_block_aligned_and_block_sized());
-        assert_eq!(span.number_of_affected_blocks(), 1);
+        assert_eq!(span.affected_block_count(), 1);
 
         let span = IOSpan::new(512, 512, 4096);
         assert!(!span.is_block_aligned_and_block_sized());
-        assert_eq!(span.number_of_affected_blocks(), 1);
+        assert_eq!(span.affected_block_count(), 1);
 
         let span = IOSpan::new(500, 4096 * 10, 4096);
         assert!(!span.is_block_aligned_and_block_sized());
-        assert_eq!(span.number_of_affected_blocks(), 10 + 1);
+        assert_eq!(span.affected_block_count(), 10 + 1);
 
         let span = IOSpan::new(500, 4096 * 3 + (4096 - 500 + 1), 4096);
         assert!(!span.is_block_aligned_and_block_sized());
-        assert_eq!(span.number_of_affected_blocks(), 3 + 2);
+        assert_eq!(span.affected_block_count(), 3 + 2);
 
         // Some from hammer
         let span = IOSpan::new(137690, 1340, 512);
         assert!(!span.is_block_aligned_and_block_sized());
-        assert_eq!(span.number_of_affected_blocks(), 4);
+        assert_eq!(span.affected_block_count(), 4);
         assert_eq!(span.affected_block_numbers, vec![268, 269, 270, 271]);
     }
 
     #[test]
     fn test_iospan_buffer_read_write() {
         let span = IOSpan::new(500, 64, 512);
-        assert_eq!(span.number_of_affected_blocks(), 2);
+        assert_eq!(span.affected_block_count(), 2);
         assert_eq!(span.affected_block_numbers, vec![0, 1]);
 
         span.write_from_buffer_into_blocks(&Bytes::from(vec![1; 64]));

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1906,18 +1906,27 @@ impl Guest {
     }
 
     /*
-     * `bread` and `bwrite` accept a byte offset, and data must be a multiple of block size.
+     * `read_from_byte_offset` and `write_to_byte_offset` accept a byte offset, and data must be a
+     * multiple of block size.
      *
      * note these functions assert that the byte offset is divisible by the block size and should
      * only be used in non-production code.
      */
-    pub fn bread(&self, offset: u64, data: Buffer) -> BlockReqWaiter {
+    pub fn read_from_byte_offset(
+        &self,
+        offset: u64,
+        data: Buffer,
+    ) -> BlockReqWaiter {
         let bs = self.query_block_size();
         assert!((offset % bs) == 0);
         self.read(Block::new(offset / bs, bs.trailing_zeros()), data)
     }
 
-    pub fn bwrite(&self, offset: u64, data: Bytes) -> BlockReqWaiter {
+    pub fn write_to_byte_offset(
+        &self,
+        offset: u64,
+        data: Bytes,
+    ) -> BlockReqWaiter {
         let bs = self.query_block_size();
         assert!((offset % bs) == 0);
         self.write(Block::new(offset / bs, bs.trailing_zeros()), data)

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2613,12 +2613,12 @@ impl Write for CruciblePseudoFile {
             IOSpan::new(self.offset, buf.len() as u64, self.block_size);
 
         /*
-         * Crucible's dependency system will properly resolve requests in the order they're sent
-         * but if the request is not block aligned and block sized we need to do read-modify-write
-         * (RMW) here. Use a reader-writer lock, and grab the write portion of the lock when doing
-         * RMW to cause all other operations (which only grab the read portion of the lock) to
-         * pause. Otherwise all operations can use the read portion of this lock and Crucible will
-         * sort it out.
+         * Crucible's dependency system will properly resolve requests in the order they are
+         * received but if the request is not block aligned and block sized we need to do
+         * read-modify-write (RMW) here. Use a reader-writer lock, and grab the write portion of
+         * the lock when doing RMW to cause all other operations (which only grab the read portion
+         * of the lock) to pause. Otherwise all operations can use the read portion of this lock
+         * and Crucible will sort it out.
          */
         if !span.is_block_regular() {
             let _guard = self.rmw_lock.write().unwrap();

--- a/upstairs/src/main.rs
+++ b/upstairs/src/main.rs
@@ -119,7 +119,7 @@ fn run_single_workload(guest: &Arc<Guest>) -> Result<()> {
     }
 
     println!("send a write");
-    guest.write(my_offset, data.freeze());
+    guest.bwrite(my_offset, data.freeze());
 
     println!("send a flush");
     guest.flush();
@@ -129,7 +129,7 @@ fn run_single_workload(guest: &Arc<Guest>) -> Result<()> {
     let data = crucible::Buffer::from_slice(&[0x99; READ_SIZE]);
 
     println!("send a read");
-    guest.read(read_offset, data);
+    guest.bread(read_offset, data);
 
     Ok(())
 }

--- a/upstairs/src/main.rs
+++ b/upstairs/src/main.rs
@@ -119,7 +119,7 @@ fn run_single_workload(guest: &Arc<Guest>) -> Result<()> {
     }
 
     println!("send a write");
-    guest.bwrite(my_offset, data.freeze());
+    guest.write_to_byte_offset(my_offset, data.freeze());
 
     println!("send a flush");
     guest.flush();
@@ -129,7 +129,7 @@ fn run_single_workload(guest: &Arc<Guest>) -> Result<()> {
     let data = crucible::Buffer::from_slice(&[0x99; READ_SIZE]);
 
     println!("send a read");
-    guest.bread(read_offset, data);
+    guest.read_from_byte_offset(read_offset, data);
 
     Ok(())
 }


### PR DESCRIPTION
Revert https://github.com/oxidecomputer/crucible/pull/44/, and go back to only block sized + block offset operations. Importantly, introduce the "Block" type. Attempting to pass just a u64 into Upstairs is no longer supported - users must clearly state they want block X where blocks are size Y in order to avoid passing the wrong offset.

Downstairs will register with a certain Block shift, and then Upstairs operations will fail if passed a different Block shift.

CruciblePseudoFile now uses IOSpan and performs RMW. It uses RwLock so that there isn't an atomicity failure.

Tested with:
- hammer
- import + nbd + md5sum
- all client workloads
- propolis (patched)

Alan and I talked about error handling today and I think the next PR will be to clean up some of the error related TODOs.