### PR TITLE
Serialize and deserialize Message using serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,9 @@ name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cfg-if"
@@ -299,8 +302,10 @@ name = "crucible-protocol"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bincode",
  "bytes",
  "crucible-common",
+ "serde",
  "tokio-util",
 ]
 
@@ -525,9 +530,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "lock_api"
@@ -1182,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.7.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb2ed024293bb19f7a5dc54fe83bf86532a44c12a2bb8ba40d64a4509395ca2"
+checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
 dependencies = [
  "autocfg",
  "bytes",

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -112,7 +112,7 @@ fn main() -> Result<()> {
         }
     }
 
-    loop {
+    for _ in 0..5000 {
         let mut offset: u64 = rng.gen::<u64>() % sz;
         let mut bsz: usize = rng.gen::<usize>() % 4096;
 
@@ -121,7 +121,7 @@ fn main() -> Result<()> {
             bsz = rng.gen::<usize>() % 4096;
         }
 
-        println!("testing: offset {} sz {}", offset, bsz);
+        // println!("testing {}: offset {} sz {}", idx, offset, bsz);
 
         let vec: Vec<u8> = (0..bsz)
             .map(|_| rng.sample(rand::distributions::Standard))
@@ -188,4 +188,6 @@ fn main() -> Result<()> {
             cpf.write_all(&vec![0; bsz])?;
         }
     }
+
+    Ok(())
 }

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 
 [dependencies]
 tokio-util = { version = "0.6", features = [ "codec" ] }
-bytes = "1"
+bytes = { version = "1", features = ["serde"] }
 anyhow = "1"
 crucible-common = { path = "../common" }
+serde = "1.0"
+bincode = "1.3.3"


### PR DESCRIPTION
Derive Serialize and Deserialize for Message, and put that on the wire
automatically. Keep the length part of the frame.

I chose bincode after benchmarking[1] each binary based encoding that serde
supports (and JSON for reference):

    $ ministat -s -w 70 bench_*
    x bench_bendy
    + bench_bincode
    * bench_cbor
    % bench_flexbuffers
    # bench_postcard
    @ bench_rmp_serde
    O bench_serde_json
    +----------------------------------------------------------------------+
    |    +OO O@x                                           O    O          |
    |+ O*OOO*OOOO# * xO+x  %    *   #@   %    x     O     OO OOOO         O|
    |     |______M___A__________|                                          |
    ||_____M_A________|                                                    |
    |  |_____MA______|                                                     |
    |   |______M__A________|                                               |
    | |____M___A_______|                                                   |
    |  |______M_A_______|                                                  |
    |                                                   |_____A____|       |
    +----------------------------------------------------------------------+
	N           Min           Max        Median           Avg        Stddev
    x  10          9.24          9.99          9.36         9.443    0.23466525
    +  10           9.1          9.68          9.23         9.283    0.17346469
    No difference proven at 95.0% confidence
    *  10          9.15          9.69          9.27         9.294    0.15882905
    No difference proven at 95.0% confidence
    %  10           9.2          9.87          9.32         9.376    0.20233086
    No difference proven at 95.0% confidence
    #  10          9.18          9.76          9.23         9.306    0.18025907
    No difference proven at 95.0% confidence
    @  10          9.15           9.8          9.29         9.327    0.18427335
    No difference proven at 95.0% confidence
    O  10         10.12         10.59         10.34        10.325    0.12167808
    Difference at 95.0% confidence
	    0.882 +/- 0.175623
	    9.34025% +/- 1.85982%
	    (Student's t, pooled s = 0.186914)

It looks like each encoding is the same (according to ministat), so I chose
bincode because it's "zero-fluff" and should perform some simple compression.

[1]: Using m5d.xlarge, one upstairs, three downstairs, running 5000 iterations
     of hammer and measuring the time in seconds required.