### PR TITLE
Errors!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror",
  "toml",
 ]
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,3 +11,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.5"
 tempfile = "3"
+thiserror = "1.0"

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -314,7 +314,7 @@ async fn do_work(
              * back to the upstairs.
              */
             let data = data.freeze();
-            fw.send(Message::ReadResponse(job.ds_id, data.clone()))
+            fw.send(Message::ReadResponse(job.ds_id, data.clone(), Ok(())))
                 .await?;
             ds.complete_work(job.ds_id, false);
             Ok(())
@@ -326,7 +326,7 @@ async fn do_work(
             data,
         } => {
             ds.region.region_write(eid, offset, &data)?;
-            fw.send(Message::WriteAck(job.ds_id)).await?;
+            fw.send(Message::WriteAck(job.ds_id, Ok(()))).await?;
             ds.complete_work(job.ds_id, false);
             Ok(())
         }
@@ -335,7 +335,7 @@ async fn do_work(
             flush_number,
         } => {
             ds.region.region_flush(flush_number)?;
-            fw.send(Message::FlushAck(job.ds_id)).await?;
+            fw.send(Message::FlushAck(job.ds_id, Ok(()))).await?;
             ds.complete_work(job.ds_id, true);
             Ok(())
         }

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -317,6 +317,7 @@ async fn do_work(
              * back to the upstairs.
              */
             let result = if ds.return_errors && random() && random() {
+                println!("returning error on read!");
                 Err(CrucibleError::GenericError("test error".to_string()))
             } else {
                 ds.region.region_read(eid, offset, &mut data)
@@ -334,6 +335,7 @@ async fn do_work(
             data,
         } => {
             let result = if ds.return_errors && random() && random() {
+                println!("returning error on write!");
                 Err(CrucibleError::GenericError("test error".to_string()))
             } else {
                 ds.region.region_write(eid, offset, &data)
@@ -347,6 +349,7 @@ async fn do_work(
             flush_number,
         } => {
             let result = if ds.return_errors && random() && random() {
+                println!("returning error on flush!");
                 Err(CrucibleError::GenericError("test error".to_string()))
             } else {
                 ds.region.region_flush(flush_number)
@@ -637,7 +640,7 @@ async fn proc(ds: &Arc<Downstairs>, mut sock: TcpStream) -> Result<()> {
 struct Downstairs {
     region: Region,
     work: Mutex<Work>,
-    lossy: bool, // Test flag, enables pauses and skipped jobs
+    lossy: bool,         // Test flag, enables pauses and skipped jobs
     return_errors: bool, // Test flag
 }
 

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -99,11 +99,11 @@ fn main() -> Result<()> {
     runtime.spawn(up_main(crucible_opts, guest.clone()));
     println!("Crucible runtime is spawned");
 
-    let bs = guest.query_block_size() as u64;
-    let sz = guest.query_total_size() as u64;
+    let bs = guest.query_block_size()? as u64;
+    let sz = guest.query_total_size()? as u64;
     println!("advertised size as {} bytes ({} byte blocks)", sz, bs);
 
-    let mut cpf = crucible::CruciblePseudoFile::from_guest(guest);
+    let mut cpf = crucible::CruciblePseudoFile::from_guest(guest)?;
 
     use rand::Rng;
     let mut rng = rand::thread_rng();

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -116,7 +116,7 @@ fn main() -> Result<()> {
         }
     }
 
-    for _ in 0..5000 {
+    for _ in 0..25000 {
         let mut offset: u64 = rng.gen::<u64>() % sz;
         let mut bsz: usize = rng.gen::<usize>() % 4096;
 
@@ -190,6 +190,14 @@ fn main() -> Result<()> {
             // Once done, zero out the write
             cpf.seek(SeekFrom::Start(offset))?;
             cpf.write_all(&vec![0; bsz])?;
+        }
+    }
+
+    loop {
+        let wc = cpf.show_work();
+        println!("Up:{} ds:{}", wc.up_count, wc.ds_count);
+        if wc.up_count + wc.ds_count == 0 {
+            break;
         }
     }
 

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -33,7 +33,7 @@ pub struct Opt {
     #[structopt(short, long)]
     verify_isolation: bool,
 
-    #[structopt(short, long)]
+    #[structopt(long)]
     tracing_endpoint: Option<String>,
 
     #[structopt(short, long)]

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -85,7 +85,7 @@ fn main() -> Result<()> {
     // NBD server
 
     let listener = TcpListener::bind("127.0.0.1:10809").unwrap();
-    let mut cpf = crucible::CruciblePseudoFile::from_guest(guest);
+    let mut cpf = crucible::CruciblePseudoFile::from_guest(guest)?;
 
     // sent to NBD client during handshake through Export struct
     println!("NBD advertised size as {} bytes", cpf.sz());

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -6,7 +6,7 @@ use tokio_util::codec::{Decoder, Encoder};
 
 const MAX_FRM_LEN: usize = 1024 * 1024;
 
-use crucible_common::Block;
+use crucible_common::{Block, CrucibleError};
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum Message {
@@ -17,11 +17,11 @@ pub enum Message {
     ExtentVersionsPlease,
     ExtentVersions(u64, u64, u32, Vec<u64>),
     Write(u64, u64, Vec<u64>, Block, bytes::Bytes),
-    WriteAck(u64),
+    WriteAck(u64, Result<(), CrucibleError>),
     Flush(u64, Vec<u64>, u64),
-    FlushAck(u64),
+    FlushAck(u64, Result<(), CrucibleError>),
     ReadRequest(u64, Vec<u64>, u64, Block, u64),
-    ReadResponse(u64, bytes::Bytes),
+    ReadResponse(u64, bytes::Bytes, Result<(), CrucibleError>),
     Unknown(u32, BytesMut),
 }
 

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -39,9 +39,19 @@ for (( i = 0; i < 3; i++ )); do
     (( port = 3801 + i ))
     dir="${testdir}/$port"
     args+=( -t "127.0.0.1:$port" )
-    echo ${cds} -c -p "$port" -d "$dir" --extent-count 5 --extent-size 10
+    if [[ $i -eq 0 ]];
+    then
+        echo ${cds} -c -p "$port" -d "$dir" --extent-count 5 --extent-size 10 --return-errors
+    else
+        echo ${cds} -c -p "$port" -d "$dir" --extent-count 5 --extent-size 10
+    fi
     set -o errexit
-    ${cds} -c -p "$port" -d "$dir" --extent-count 5 --extent-size 10 &
+    if [[ $i -eq 0 ]];
+    then
+        ${cds} -c -p "$port" -d "$dir" --extent-count 5 --extent-size 10 --return-errors &
+    else
+        ${cds} -c -p "$port" -d "$dir" --extent-count 5 --extent-size 10 &
+    fi;
     downstairs[$i]=$!
     set +o errexit
 done
@@ -61,6 +71,9 @@ for tt in ${test_list}; do
         echo "Completed test: $tt"
     fi
 done
+
+echo "Running hammer"
+./hammer.sh
 
 echo "Tests have completed, stopping all downstairs"
 for pid in ${downstairs[*]}; do

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -39,19 +39,9 @@ for (( i = 0; i < 3; i++ )); do
     (( port = 3801 + i ))
     dir="${testdir}/$port"
     args+=( -t "127.0.0.1:$port" )
-    if [[ $i -eq 0 ]];
-    then
-        echo ${cds} -c -p "$port" -d "$dir" --extent-count 5 --extent-size 10 --return-errors
-    else
-        echo ${cds} -c -p "$port" -d "$dir" --extent-count 5 --extent-size 10
-    fi
+    echo ${cds} -c -p "$port" -d "$dir" --extent-count 5 --extent-size 10
     set -o errexit
-    if [[ $i -eq 0 ]];
-    then
-        ${cds} -c -p "$port" -d "$dir" --extent-count 5 --extent-size 10 --return-errors &
-    else
-        ${cds} -c -p "$port" -d "$dir" --extent-count 5 --extent-size 10 &
-    fi;
+    ${cds} -c -p "$port" -d "$dir" --extent-count 5 --extent-size 10 &
     downstairs[$i]=$!
     set +o errexit
 done

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -969,7 +969,7 @@ impl Work {
 
         if let Some(oldstate) = oldstate {
             // we shouldn't be transitioning a state that was already transitioned
-            assert!(matches!(oldstate, IOState::New | IOState::InProgress));
+            assert_eq!(oldstate, IOState::InProgress);
         } else {
             panic!("no old state! that's bad!");
         }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2039,10 +2039,6 @@ impl GuestWork {
      * arrived from all the downstairs jobs we created, then we
      * can move forward with finishing up the guest work operation.
      * This may include moving/decrypting data buffers from completed reads.
-     *
-     * TODO: Error handling case needs to come through here in a way that
-     * won't break if enough of the IO completed to satisfy the upstairs, but
-     * will be handled if all the downstairs have returned error.
      */
     #[instrument]
     fn ds_complete(

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -4002,8 +4002,7 @@ mod test {
         assert!(work.downstairs_errors.get(&1).is_some());
         assert!(work.downstairs_errors.get(&2).is_none());
 
-        // another read. make sure:
-        // - even if previously bad downstairs reutrn ok this time, the results are not used
+        // another read. make sure only client 2 returns data. the others should be skipped.
 
         let next_id = work.next_id();
         let op = create_read_eob(next_id, vec![], 10, 0, Block::new_512(7), 2);

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -71,7 +71,7 @@ async fn proc_frame(
 ) -> Result<()> {
     match m {
         Message::Imok => Ok(()),
-        Message::WriteAck(ds_id) => Ok(io_completed(
+        Message::WriteAck(ds_id, _result) => Ok(io_completed(
             u,
             *ds_id,
             up_coms.client_id,
@@ -79,7 +79,7 @@ async fn proc_frame(
             up_coms.ds_done_tx,
         )
         .await?),
-        Message::FlushAck(ds_id) => Ok(io_completed(
+        Message::FlushAck(ds_id, _result) => Ok(io_completed(
             u,
             *ds_id,
             up_coms.client_id,
@@ -87,7 +87,7 @@ async fn proc_frame(
             up_coms.ds_done_tx,
         )
         .await?),
-        Message::ReadResponse(ds_id, data) => Ok(io_completed(
+        Message::ReadResponse(ds_id, data, _result) => Ok(io_completed(
             u,
             *ds_id,
             up_coms.client_id,

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -856,13 +856,16 @@ impl Work {
             .get_mut(&ds_id)
             .ok_or_else(|| anyhow!("reqid {} is not active", ds_id))?;
 
+        /*
+         * XXX: this code assumes that 3 downstairs is the max that we'll ever support.
+         */
         let bad_job = match &job.work {
             IOop::Read {
                 dependencies: _dependencies,
                 eid: _eid,
                 offset: _offset,
                 num_blocks: _num_blocks,
-            } => wc.error >= 3,
+            } => wc.error == 3,
             IOop::Write {
                 dependencies: _dependencies,
                 eid: _eid,

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2460,7 +2460,7 @@ async fn up_ds_listen(up: &Arc<Upstairs>, mut ds_done_rx: mpsc::Receiver<u64>) {
             // Verify we did find an AckReady downstairs IO
             assert!(work.ack(ds_id));
 
-            gw.ds_complete(gw_id, ds_id, data, work.result(_ds_id));
+            gw.ds_complete(gw_id, ds_id, data, work.result(ds_id));
 
             work.crutrace_gw_work_done(ds_id, gw_id);
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -3024,6 +3024,10 @@ impl CruciblePseudoFile {
     pub fn sz(&self) -> u64 {
         self.sz
     }
+
+    pub fn show_work(&self) -> WQCounts {
+        self.guest.show_work()
+    }
 }
 
 /*

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1701,12 +1701,8 @@ impl DownstairsIO {
             match state {
                 IOState::New | IOState::InProgress => wc.active += 1,
                 IOState::Error(_) => wc.error += 1,
-                IOState::Skipped => {
-                    wc.skipped += 1;
-                }
-                IOState::Done => {
-                    wc.done += 1;
-                }
+                IOState::Skipped => wc.skipped += 1,
+                IOState::Done => wc.done += 1,
             }
         }
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1341,7 +1341,6 @@ impl Upstairs {
          */
         let mut gw = self.guest.guest_work.lock().unwrap();
         let mut ds_work = self.ds_work.lock().unwrap();
-        let gw_id: u64 = gw.next_gw_id();
 
         /*
          * Given the offset and buffer size, figure out what extent and
@@ -1353,8 +1352,13 @@ impl Upstairs {
             *ddef,
             offset,
             data.len() as u64 / ddef.block_size(),
-        )
-        .unwrap();
+        )?;
+
+        /*
+         * Grab this ID after extent_from_offset: in case of Err we don't want to create a gap in
+         * the IDs.
+         */
+        let gw_id: u64 = gw.next_gw_id();
 
         /*
          * Now create a downstairs work job for each (eid, bi, len) returned
@@ -1449,7 +1453,6 @@ impl Upstairs {
          */
         let mut gw = self.guest.guest_work.lock().unwrap();
         let mut ds_work = self.ds_work.lock().unwrap();
-        let gw_id: u64 = gw.next_gw_id();
 
         /*
          * Given the offset and buffer size, figure out what extent and
@@ -1461,8 +1464,13 @@ impl Upstairs {
             *ddef,
             offset,
             data.len() as u64 / ddef.block_size(),
-        )
-        .unwrap();
+        )?;
+
+        /*
+         * Grab this ID after extent_from_offset: in case of Err we don't want to create a gap in
+         * the IDs.
+         */
+        let gw_id: u64 = gw.next_gw_id();
 
         /*
          * Create the tracking info for downstairs request numbers (ds_id) we

--- a/upstairs/src/main.rs
+++ b/upstairs/src/main.rs
@@ -157,17 +157,21 @@ fn run_single_workload(guest: &Arc<Guest>) -> Result<()> {
     }
 
     println!("send a write");
-    guest.write_to_byte_offset(my_offset, data.freeze());
+    guest
+        .write_to_byte_offset(my_offset, data.freeze())?
+        .block_wait()?;
 
     println!("send a flush");
-    guest.flush();
+    guest.flush().block_wait()?;
 
     let read_offset = my_offset;
     const READ_SIZE: usize = 1024;
     let data = crucible::Buffer::from_slice(&[0x99; READ_SIZE]);
 
     println!("send a read");
-    guest.read_from_byte_offset(read_offset, data);
+    guest
+        .read_from_byte_offset(read_offset, data)?
+        .block_wait()?;
 
     Ok(())
 }


### PR DESCRIPTION
This commit defines a new CrucibleError enum and returns `Result<(), CrucibleError>` from the Guest functions and also from the BlockReqWaiter's `block_wait`.

Downstairs errors are returned in the WriteAck, FlushAck, and ReadResponse messages, and eventually to the Guest's BlockReqWaiter channel.

Note: I don't usually submit PRs with wip commits, but when I do, it's because we always squash and merge :)