### PR TITLE
UUIDs for downstairs, and new arg parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,7 @@ dependencies = [
  "toml",
  "tracing",
  "usdt",
+ "uuid",
  "xts-mode",
 ]
 
@@ -270,6 +271,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "toml",
+ "uuid",
 ]
 
 [[package]]
@@ -296,6 +298,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -1453,6 +1456,16 @@ dependencies = [
  "serde_tokenstream",
  "syn",
  "usdt-impl",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
+ "serde",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,3 +11,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.5"
 tempfile = "3"
+uuid = { version = "0.8", features = [ "serde", "v4" ] }

--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -1,6 +1,7 @@
 // Copyright 2021 Oxide Computer Company
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /*
  * Where the unit is blocks, not bytes, make sure to reflect that in the types used.
@@ -66,6 +67,11 @@ pub struct RegionDefinition {
      * How many whole extents comprise this region?
      */
     extent_count: u32,
+
+    /**
+     * UUID for this region
+     */
+    uuid: Uuid,
 }
 
 impl RegionDefinition {
@@ -75,6 +81,7 @@ impl RegionDefinition {
             block_size: opts.block_size,
             extent_size: opts.extent_size,
             extent_count: 0,
+            uuid: opts.uuid,
         })
     }
 
@@ -105,6 +112,14 @@ impl RegionDefinition {
     pub fn total_size(&self) -> u64 {
         self.block_size * self.extent_size.value * (self.extent_count as u64)
     }
+
+    pub fn uuid(&self) -> Uuid {
+        self.uuid
+    }
+
+    pub fn set_uuid(&mut self, uuid: Uuid) {
+        self.uuid = uuid;
+    }
 }
 
 /**
@@ -117,6 +132,7 @@ impl Default for RegionDefinition {
             block_size: 0,
             extent_size: Block::new(0, 9),
             extent_count: 0,
+            uuid: Uuid::nil(),
         }
     }
 }
@@ -132,6 +148,11 @@ pub struct RegionOptions {
      * How many blocks should appear in each extent?
      */
     extent_size: Block,
+
+    /**
+     * UUID for this region
+     */
+    uuid: Uuid,
 }
 
 impl RegionOptions {
@@ -172,6 +193,10 @@ impl RegionOptions {
     pub fn set_extent_size(&mut self, es: Block) {
         self.extent_size = es;
     }
+
+    pub fn set_uuid(&mut self, uuid: Uuid) {
+        self.uuid = uuid;
+    }
 }
 
 impl Default for RegionOptions {
@@ -180,6 +205,7 @@ impl Default for RegionOptions {
         RegionOptions {
             block_size: 512,
             extent_size: Block::new(100, 9),
+            uuid: Uuid::nil(),
         }
     }
 }

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -26,3 +26,5 @@ opentelemetry = "0.15.0"
 opentelemetry-jaeger = { version = "0.14.0" }
 tracing-subscriber = "0.2.19"
 tracing-opentelemetry = "0.14.0"
+uuid = { version = "0.8", features = [ "serde", "v4" ] }
+

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -580,11 +580,10 @@ impl Region {
 mod test {
     use super::extent_path;
     use super::*;
-    use crate::Opt;
     use bytes::BufMut;
     use std::fs::remove_dir_all;
     use std::path::PathBuf;
-    use structopt::StructOpt;
+    use uuid::Uuid;
 
     fn p(s: &str) -> PathBuf {
         PathBuf::from(s)
@@ -608,32 +607,43 @@ mod test {
         }
     }
 
-    pub fn opt_from_string(args: String) -> Result<Opt> {
-        let opt: Opt = Opt::from_iter(args.split(' '));
-        Ok(opt)
+    static TEST_UUID_STR: &str = "12345678-1111-2222-3333-123456789999";
+
+    fn test_uuid() -> Uuid {
+        TEST_UUID_STR.parse().unwrap()
     }
 
     pub fn test_cleanup() {
         let _ = remove_dir_all("/tmp/ds_test");
     }
 
+    fn new_region_options() -> crucible_common::RegionOptions {
+        let mut region_options: crucible_common::RegionOptions =
+            Default::default();
+        let block_size = 512;
+        region_options.set_block_size(block_size);
+        region_options
+            .set_extent_size(Block::new(10, block_size.trailing_zeros()));
+        region_options.set_uuid(test_uuid());
+        region_options
+    }
+
     #[test]
     fn new_region() -> Result<()> {
         test_cleanup();
-        let my_arg = "-- -c -p 3801 -d /tmp/ds_test/1".to_string();
-        let opt = opt_from_string(my_arg).unwrap();
-        //let opt = Opt::from_string(my_arg).unwrap();
-        let _ = Region::create(&opt.data, Default::default()).unwrap();
+
+        let data = p("/tmp/ds_test/1");
+        let _ = Region::create(&data, new_region_options());
         remove_dir_all("/tmp/ds_test/1").unwrap();
         Ok(())
     }
     #[test]
     fn new_existing_region() -> Result<()> {
         test_cleanup();
-        let my_arg = "-- -c -p 3801 -d /tmp/ds_test/2".to_string();
-        let opt = opt_from_string(my_arg).unwrap();
-        let _ = Region::create(&opt.data, Default::default()).unwrap();
-        let _ = Region::open(&opt.data, Default::default());
+
+        let data = p("/tmp/ds_test/2");
+        let _ = Region::create(&data, new_region_options());
+        let _ = Region::open(&data, new_region_options());
         remove_dir_all("/tmp/ds_test/2").unwrap();
         Ok(())
     }
@@ -641,13 +651,12 @@ mod test {
     #[should_panic]
     fn bad_import_region() -> () {
         test_cleanup();
-        let my_arg = "-- -c -p 3801 -d /tmp/ds_test/3".to_string();
-        let opt = opt_from_string(my_arg).unwrap();
-        let _ = Region::open(&opt.data, Default::default()).unwrap();
+
+        let data = p("/tmp/ds_test/3");
+        let _ = Region::open(&data, new_region_options());
         remove_dir_all("/tmp/ds_test/3").unwrap();
         ()
     }
-
     #[test]
     fn extent_io_valid() {
         let ext = new_extent();

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -6,7 +6,7 @@ use tokio_util::codec::{Decoder, Encoder};
 
 const MAX_FRM_LEN: usize = 1024 * 1024;
 
-use crucible_common::Block;
+use crucible_common::{Block, RegionDefinition};
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum Message {
@@ -14,6 +14,8 @@ pub enum Message {
     YesItsMe(u32),
     Ruok,
     Imok,
+    RegionInfoPlease,
+    RegionInfo(RegionDefinition),
     ExtentVersionsPlease,
     ExtentVersions(u64, u64, u32, Vec<u64>),
     Write(u64, u64, Vec<u64>, Block, bytes::Bytes),

--- a/tools/start_ds.sh
+++ b/tools/start_ds.sh
@@ -6,6 +6,7 @@ set -o xtrace
 
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 
+echo "$ROOT"
 cd "$ROOT"
 
 if pgrep -fl target/debug/crucible-downstairs; then
@@ -13,10 +14,15 @@ if pgrep -fl target/debug/crucible-downstairs; then
 	exit 1
 fi
 
+testdir=/tmp/ds_test
+if [[ -d ${testdir} ]]; then
+    rm -rf ${testdir}
+fi
+
 for (( i = 0; i < 3; i++ )); do
 	(( port = 3801 + i ))
-	dir="$ROOT/var/$port"
-	mkdir -p "$dir"
+	dir="${testdir}/$port"
+	cargo run -p crucible-downstairs -- create -u $(uuidgen) -d "$dir"
 	cargo run -p crucible-downstairs -- run -p "$port" -d "$dir" &
 	disown
 done

--- a/tools/test_ds.sh
+++ b/tools/test_ds.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Simple script to start three downstairs, then run through all the tests
+# that exist on the crucible client program.  This should eventually either
+# move to some common test framework, or be thrown away.
+
+set -o pipefail
+
+ulimit -n 16384
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+
+echo "$ROOT"
+cd "$ROOT"
+
+if pgrep -fl target/debug/crucible-downstairs; then
+    echo 'Downstairs already running?' >&2
+    exit 1
+fi
+
+if ! cargo build; then
+    echo "Initial Build failed, no tests ran"
+    exit 1
+fi
+
+cds="./target/debug/crucible-downstairs"
+if [[ ! -f ${cds} ]]; then
+    echo "Can't find crucible binary at $cds or $cc"
+    exit 1
+fi
+
+testdir="/tmp/ds_test"
+if [[ -d ${testdir} ]]; then
+    rm -rf ${testdir}
+fi
+mkdir "${testdir}"
+
+set -o errexit
+uuid="12345678-1234-1234-1234-000000000001"
+dir="${testdir}/export"
+exp="${testdir}/exported_file"
+imp="${testdir}/import"
+echo "Create file for import"
+dd if=/dev/urandom of="$imp" bs=512 count=300
+
+echo "Import region"
+${cds} create -i "$imp" -u $uuid -d "$dir"
+echo "Export region"
+${cds} export -d "$dir" -e "$exp" --count 280576
+
+diff $imp $exp
+
+echo "Import Export test passed"
+rm -rf ${testdir}

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -33,15 +33,19 @@ if [[ -d ${testdir} ]]; then
     rm -rf ${testdir}
 fi
 
+uuidprefix="12345678-1234-1234-1234-00000000"
 args=()
 downstairs=()
 for (( i = 0; i < 3; i++ )); do
     (( port = 3801 + i ))
     dir="${testdir}/$port"
+    uuid="${uuidprefix}${port}"
     args+=( -t "127.0.0.1:$port" )
-    echo ${cds} -c -p "$port" -d "$dir" --extent-count 5 --extent-size 10
+    echo ${cds} create -u "$uuid" -p "$port" -d "$dir" --extent-count 5 --extent-size 10
     set -o errexit
-    ${cds} -c -p "$port" -d "$dir" --extent-count 5 --extent-size 10 &
+    ${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10
+    echo ${cds} run -p "$port" -d "$dir"
+    ${cds} run -p "$port" -d "$dir" &
     downstairs[$i]=$!
     set +o errexit
 done

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -68,9 +68,7 @@ done
 
 echo "Running hammer"
 if ! time cargo run -p crucible-hammer -- \
-    -t 127.0.0.1:3801 \
-    -t 127.0.0.1:3802 \
-    -t 127.0.0.1:3803 \
+    "${args[@]}" \
     --key "$(openssl rand -base64 32)"; then
 	echo "Failed hammer test"
     res=1

--- a/upstairs/Cargo.toml
+++ b/upstairs/Cargo.toml
@@ -39,4 +39,5 @@ tokio-util = { version = "0.6", features = ["codec"]}
 toml = "0.5"
 tracing = "0.1.26"
 usdt = "0.1.13"
+uuid = { version = "0.8", features = [ "serde", "v4" ] }
 xts-mode = "0.4.0"

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -25,6 +25,7 @@ use tokio::time::{sleep_until, Instant};
 use tokio_util::codec::{FramedRead, FramedWrite};
 use tracing::{instrument, span, Level};
 use usdt::register_probes;
+use uuid::Uuid;
 
 use aes::cipher::generic_array::GenericArray;
 use aes::{Aes128, NewBlockCipher};
@@ -281,7 +282,6 @@ fn process_downstairs(
  * This function is called when the upstairs task is notified that
  * a downstairs operation has completed.  We add the read buffer to the
  * IOop struct for later processing if required.
- *
  */
 #[instrument]
 async fn io_completed(
@@ -521,10 +521,18 @@ async fn proc(
                         deadline = deadline_secs(50);
 
                         /*
+                         * Get region info.
+                         */
+                        fw.send(Message::RegionInfoPlease).await?;
+                    }
+                    Some(Message::RegionInfo(region_def)) => {
+
+                        up.add_downstairs(up_coms.client_id, region_def)?;
+                        /*
                          * Ask for the current version of all extents.
                          */
                         fw.send(Message::ExtentVersionsPlease).await?;
-                    }
+                    },
                     Some(Message::ExtentVersions(bs, es, ec, versions)) => {
                         if !negotiated {
                             bail!("expected YesItsMe first");
@@ -1011,6 +1019,11 @@ pub struct Upstairs {
     ds_state: Mutex<Vec<DsState>>,
 
     /*
+     * UUID for each downstairs, index by client ID
+     */
+    ds_uuid: Mutex<HashMap<u8, Uuid>>,
+
+    /*
      * This Work struct keeps track of IO operations going between upstairs
      * and downstairs.  New work for downstairs is generated inside the
      * upstairs on behalf of IO requests coming from the guest.
@@ -1074,6 +1087,7 @@ impl Upstairs {
         Arc::new(Upstairs {
             guest,
             ds_state: Mutex::new(ds_state),
+            ds_uuid: Mutex::new(HashMap::new()),
             ds_work: Mutex::new(Work {
                 active: HashMap::new(),
                 completed: AllocRingBuffer::with_capacity(2048),
@@ -1403,6 +1417,46 @@ impl Upstairs {
                 }
             }
         });
+    }
+
+    /*
+     * Check the region information for a downstairs and decide if we should
+     * allow this downstairs to be added.
+     * TODO: Still a bunch to do here around reconnecting.
+     */
+    fn add_downstairs(
+        &self,
+        client_id: u8,
+        rdef: RegionDefinition,
+    ) -> Result<()> {
+        println!("[{}] Got region def {:?}", client_id, rdef);
+
+        let mut uuid_hm = self.ds_uuid.lock().unwrap();
+        if let Some(uuid) = uuid_hm.get(&client_id) {
+            if *uuid != rdef.uuid() {
+                panic!(
+                    "New client:{} uuid:{}  does not match existing {}",
+                    client_id,
+                    rdef.uuid(),
+                    uuid
+                );
+            } else {
+                println!(
+                    "Returning clientL{} UUID:{} matches",
+                    client_id, uuid
+                );
+            }
+        } else {
+            uuid_hm.insert(client_id, rdef.uuid());
+        }
+
+        println!("UUIDS: {:?}", uuid_hm);
+
+        // TODO: move the logic for the block size, extent size, and extent
+        // count to this location.  Determine here if this downstairs
+        // matches what we expect.
+        //
+        Ok(())
     }
 }
 
@@ -3120,6 +3174,7 @@ mod test {
         Arc::new(Upstairs {
             guest: Arc::new(Guest::new()),
             ds_state: Mutex::new(vec![DsState::New; 3]),
+            ds_uuid: Mutex::new(HashMap::new()),
             ds_work: Mutex::new(Work {
                 active: HashMap::new(),
                 completed: AllocRingBuffer::with_capacity(2),

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1442,7 +1442,7 @@ impl Upstairs {
                 );
             } else {
                 println!(
-                    "Returning clientL{} UUID:{} matches",
+                    "Returning client:{} UUID:{} matches",
                     client_id, uuid
                 );
             }


### PR DESCRIPTION
Updated the way the downstairs is started.  You now provide a subcommand
and then options for that subcommand, which results in less global
options that are silently ignored when not used.  This makes both the
starting syntax (and the code I stole, ah, was inspired by) similar to
Omicron sled-agent.

Added a UUID to the downstairs region struct.  This is recorded in the
region.json file for each downstairs.

Added two new messages to the upstairs/downstairs initial communication
that requests the RegionDefinition information, including the new
UUID from each downstairs.  Each downstairs UUID is now recorded in the
Upstairs struct.  More coming here later along with processing the rest
of the region information.

Updated all the READMEs I could find that show how to run the
downstairs.  Updated any test scripts or tools I could find as well.