### PR TITLE
V1 flow control and region matching

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -151,7 +151,12 @@ fn main() -> Result<()> {
         }
         Workload::Demo => {
             println!("Run Demo test");
-            runtime.block_on(demo_workload(&guest, 10))?;
+            /*
+             * The count provided here should be greater than the flow
+             * control limit if we wish to test flow control.  Also, set
+             * lossy on a downstairs otherwise it will probably keep up.
+             */
+            runtime.block_on(demo_workload(&guest, 200))?;
         }
         Workload::Dep => {
             println!("Run dep test");
@@ -576,7 +581,6 @@ async fn demo_workload(guest: &Arc<Guest>, count: u32) -> Result<()> {
     };
     println!("loop over {} waiters", waiterlist.len());
     for wa in waiterlist.iter_mut() {
-        wc = guest.show_work();
         wa.block_wait()?;
     }
     /*
@@ -585,7 +589,7 @@ async fn demo_workload(guest: &Arc<Guest>, count: u32) -> Result<()> {
     println!("All submitted jobs completed, waiting for downstairs");
     while wc.up_count + wc.ds_count > 0 {
         wc = guest.show_work();
-        std::thread::sleep(std::time::Duration::from_secs(3));
+        std::thread::sleep(std::time::Duration::from_secs(5));
     }
     println!("All downstairs jobs completed.");
 

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -475,14 +475,8 @@ async fn proc_frame(
             fw.send(Message::RegionInfo(rd)).await?;
         }
         Message::ExtentVersionsPlease => {
-            let (bs, es, ec) = d.region.region_def();
-            fw.send(Message::ExtentVersions(
-                bs,
-                es.value,
-                ec,
-                d.region.versions(),
-            ))
-            .await?;
+            fw.send(Message::ExtentVersions(d.region.versions()))
+                .await?;
         }
         Message::Write(ds_id, eid, dependencies, offset, data) => {
             let new_write = IOop::Write {

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -17,7 +17,7 @@ pub enum Message {
     RegionInfoPlease,
     RegionInfo(RegionDefinition),
     ExtentVersionsPlease,
-    ExtentVersions(u64, u64, u32, Vec<u64>),
+    ExtentVersions(Vec<u64>),
     Write(u64, u64, Vec<u64>, Block, bytes::Bytes),
     WriteAck(u64, Result<(), CrucibleError>),
     Flush(u64, Vec<u64>, u64),
@@ -177,15 +177,14 @@ mod tests {
 
     #[test]
     fn rt_ev_0() -> Result<()> {
-        let input = Message::ExtentVersions(2, 4, 6, vec![]);
+        let input = Message::ExtentVersions(vec![]);
         assert_eq!(input, round_trip(&input)?);
         Ok(())
     }
 
     #[test]
     fn rt_ev_7() -> Result<()> {
-        let input =
-            Message::ExtentVersions(2, 4, 6, vec![1, 2, 3, 4, u64::MAX, 1, 0]);
+        let input = Message::ExtentVersions(vec![1, 2, 3, 4, u64::MAX, 1, 0]);
         assert_eq!(input, round_trip(&input)?);
         Ok(())
     }

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -68,8 +68,9 @@ done
 
 echo "Running hammer"
 if ! time cargo run -p crucible-hammer -- \
-    "${args[@]}" \
-    --key "$(openssl rand -base64 32)"; then
+  "${args[@]}" \
+  --key "$(openssl rand -base64 32)"; then
+
 	echo "Failed hammer test"
     res=1
 fi


### PR DESCRIPTION
This is required before a downstairs can go away and come back.
But, as that will be a bunch of work all on it's own, I'm breaking it up into "bite size"
pieces for review.  This one ended up being a little bigger than I wanted.

Broke the initial upstairs downstairs negotiation into a different
function.  Moved the loop for new work and responses from downstairs
into its own function.

Added a basic flow control to avoid the current situation where the
upstairs would overwhelm the downstairs with work and not check for
any responses until all the work it had was sent.  This initial flow
control should work until we add credits, or do some more profiling.

Moved the downstairs region passing to the RegionInfo command.  Made
the add_downstairs() method responsible for it and remove it from
both the ExtentVersions command and the process_downstairs()
function.

More polishing of the show_all_work() function.