### PR TITLE
Refactor client test, save verify information to file

### DIFF
--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -75,6 +75,28 @@ if ! time cargo run -p crucible-hammer -- \
     res=1
 fi
 
+echo ""
+echo "Running verify test: $tt"
+vfile="${testdir}/verify"
+echo cargo run -p crucible-client -- -q -w rand --verify-out "$vfile" "${args[@]}"
+if ! cargo run -p crucible-client -- -q -w rand --verify-out "$vfile" "${args[@]}"; then
+    res=1
+    echo ""
+    echo "Failed crucible-client rand verify test"
+    echo ""
+else
+    echo cargo run -p crucible-client -- -q -w rand --verify-in "$vfile" "${args[@]}"
+    if ! cargo run -p crucible-client -- -q -w rand --verify-in "$vfile" "${args[@]}"; then
+        res=1
+        echo ""
+        echo "Failed crucible-client rand verify part 2 test"
+        echo ""
+    else
+        echo "Verify test passed"
+    fi
+fi
+
+
 echo "Tests have completed, stopping all downstairs"
 for pid in ${downstairs[*]}; do
     kill $pid >/dev/null 2>&1


### PR DESCRIPTION
To verify that a downstairs has left then returned and has all the expected
data, I needed to write a simple verify test that could remember across
restarts what it had written.  This work is to enable that.


Added the ability for some (most) of the tests in the client program
to save their internal write counter to a file. Added the ability
to load the internal write counter from a file. This allows us to
run a test in the client program, then record what we think each
block should contain. We can then verify a previous run, and build
on that with the next test.

Made a common function to get region info from the upstairs on
startup, and, if requested, load and verify a write count for
expected data.

Refactored all the client tests to take a region info struct.

Made a few more of the client tests actually verify the data they were
writing out and reading back.

Added a verify in/out test to test_up.sh