### PR TITLE
Several fixes while adding support to Propolis

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -12,7 +12,6 @@ use structopt::StructOpt;
 use tokio::runtime::Builder;
 
 use crucible::*;
-use crucible_common::*;
 
 /*
  * The various tests this program supports.

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -60,6 +60,14 @@ impl From<std::io::Error> for CrucibleError {
     }
 }
 
+// Clippy complains but code won't compile without the Into!
+#[allow(clippy::from_over_into)]
+impl Into<std::io::Error> for CrucibleError {
+    fn into(self) -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::Other, self)
+    }
+}
+
 impl From<anyhow::Error> for CrucibleError {
     fn from(e: anyhow::Error) -> Self {
         CrucibleError::GenericError(format!("{:?}", e))

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -82,12 +82,12 @@ fn main() -> Result<()> {
     runtime.spawn(up_main(crucible_opts, guest.clone()));
     println!("Crucible runtime is spawned");
 
-    guest.activate()?;
-
     // NBD server
 
     let listener = TcpListener::bind("127.0.0.1:10809").unwrap();
     let mut cpf = crucible::CruciblePseudoFile::from_guest(guest)?;
+
+    cpf.activate()?;
 
     // sent to NBD client during handshake through Export struct
     println!("NBD advertised size as {} bytes", cpf.sz());

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use tokio_util::codec::{Decoder, Encoder};
 use uuid::Uuid;
 
-const MAX_FRM_LEN: usize = 1024 * 1024;
+const MAX_FRM_LEN: usize = 100 * 1024 * 1024; // 100M
 
 use crucible_common::{Block, CrucibleError, RegionDefinition};
 


### PR DESCRIPTION
Add `byte_offset_to_block` function to compute Block from a u64 byte
offset.

Increase MAX_FRM_LEN, otherwise f3write + f3read test crashes.

Add ability to query Upstairs UUID from Guest.

Fix non-functional nbd server - activate should occur in
CruciblePseudoFile, not Guest.