### PR TITLE
Add more info to ExtentVersions message

### DIFF
--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -581,7 +581,7 @@ impl Region {
         self.def
     }
 
-    pub fn versions(&self) -> Result<Vec<u64>> {
+    pub fn flush_numbers(&self) -> Result<Vec<u64>> {
         let mut ver = self
             .extents
             .iter()
@@ -596,6 +596,19 @@ impl Region {
         self.extents
             .iter()
             .map(|e| e.inner().flush_number())
+            .collect::<Result<Vec<_>>>()
+    }
+
+    pub fn gen_numbers(&self) -> Result<Vec<u64>> {
+        self.extents
+            .iter()
+            .map(|e| e.inner().gen_number())
+            .collect::<Result<Vec<_>>>()
+    }
+    pub fn dirty(&self) -> Result<Vec<bool>> {
+        self.extents
+            .iter()
+            .map(|e| e.inner().dirty())
             .collect::<Result<Vec<_>>>()
     }
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -37,7 +37,7 @@ pub enum Message {
     ExtentVersionsPlease,
     LastFlush(u64),
     LastFlushAck(u64),
-    ExtentVersions(Vec<u64>),
+    ExtentVersions(Vec<u64>, Vec<u64>, Vec<bool>),
 
     Write(Uuid, u64, u64, Vec<u64>, Block, bytes::Bytes),
     WriteAck(Uuid, u64, Result<(), CrucibleError>),
@@ -198,14 +198,18 @@ mod tests {
 
     #[test]
     fn rt_ev_0() -> Result<()> {
-        let input = Message::ExtentVersions(vec![]);
+        let input = Message::ExtentVersions(vec![], vec![], vec![]);
         assert_eq!(input, round_trip(&input)?);
         Ok(())
     }
 
     #[test]
     fn rt_ev_7() -> Result<()> {
-        let input = Message::ExtentVersions(vec![1, 2, 3, 4, u64::MAX, 1, 0]);
+        let input = Message::ExtentVersions(
+            vec![1, 2, 3, 4, u64::MAX, 1, 0],
+            vec![1, 2, 3, 4, u64::MAX, 1, 0],
+            vec![true, true, false, true, true, false, true],
+        );
         assert_eq!(input, round_trip(&input)?);
         Ok(())
     }

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -96,6 +96,32 @@ else
     fi
 fi
 
+args=()
+for (( i = 0; i < 3; i++ )); do
+    (( port = 3801 + i ))
+    dir="${testdir}/$port"
+    args+=( -d "$dir" )
+done
+echo cargo run -p crucible-downstairs -- dump "${args[@]}"
+if ! cargo run -p crucible-downstairs -- dump "${args[@]}"; then
+    res=1
+    echo ""
+    echo "Failed crucible-client dump test"
+    echo ""
+else
+    echo "dump test passed"
+fi
+
+args+=( -e 1 )
+echo cargo run -p crucible-downstairs -- dump "${args[@]}"
+if ! cargo run -p crucible-downstairs -- dump "${args[@]}"; then
+    res=1
+    echo ""
+    echo "Failed crucible-client dump test 2"
+    echo ""
+else
+    echo "dump test 2 passed"
+fi
 
 echo "Tests have completed, stopping all downstairs"
 for pid in ${downstairs[*]}; do


### PR DESCRIPTION
Added the generation number and dirty bit vectors to the
ExtentVersions message. Added two more methods to the region
impl to create and provide this information.

Made a new test for crucible-client that will leave modified extents
without a final flush.
Fixed some new cargo clippy complaints also in crucible-client.

Added the display of generation numbers and dirty bits when a
downstairs connects, but they are not connected to anything yet.

Future commits will make use of generation numbers and the dirty
bits for comparing downstairs.

Added a downstairs dump test to the test_up.sh script.  Not really
anything do to with the rest of this commit.