### PR TITLE
improve image import

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -10,7 +10,9 @@ use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;
 
 mod region;
-pub use region::{Block, RegionDefinition, RegionOptions};
+pub use region::{
+    Block, RegionDefinition, RegionOptions, MAX_BLOCK_SIZE, MIN_BLOCK_SIZE,
+};
 
 #[derive(thiserror::Error, Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum CrucibleError {

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -2,7 +2,6 @@
 use futures::lock::Mutex;
 use std::collections::HashMap;
 use std::fmt;
-use std::fs;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::net::{Ipv4Addr, SocketAddrV4};
@@ -11,7 +10,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crucible::*;
-use crucible_common::{Block, CrucibleError};
+use crucible_common::{Block, CrucibleError, MAX_BLOCK_SIZE};
 use crucible_protocol::*;
 
 use anyhow::{bail, Result};
@@ -202,19 +201,12 @@ fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
     import_path: P,
 ) -> Result<()> {
     /*
-     * We are only allowing the import on an empty Region, i.e.
-     * one that has just been created.  If you want to overwrite
-     * an existing region, write more code: TODO
+     * Open the file to import and determine how many extents we will need
+     * based on the length.
      */
-    assert!(region.def().extent_count() == 0);
-
-    /*
-     * Get some information about our file and the region defaults
-     * and figure out how many extents we will need to import
-     * this file.
-     */
-    let file_size = fs::metadata(&import_path)?.len();
-    let (block_size, extent_size, _) = region.region_def();
+    let mut f = File::open(&import_path)?;
+    let file_size = f.metadata()?.len();
+    let (_, extent_size, _) = region.region_def();
     let space_per_extent = extent_size.byte_value();
 
     let mut extents_needed = file_size / space_per_extent;
@@ -222,52 +214,85 @@ fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
         extents_needed += 1;
     }
     println!(
-        "Import file_size: {}  Extent size:{}  Total extents:{}",
+        "Import file_size: {}  Extent size: {}  Needed extents: {}",
         file_size, space_per_extent, extents_needed
     );
 
-    /*
-     * Create the number of extents the file will require
-     */
-    region.extend(extents_needed as u32)?;
+    if extents_needed > region.def().extent_count().into() {
+        /*
+         * The file to import would require more extents than we have.
+         * Extend the region to fit the file.
+         */
+        println!("Extending region to fit image");
+        region.extend(extents_needed as u32)?;
+    } else {
+        println!("Region already large enough for image");
+    }
+
+    println!("Importing {:?} to region", import_path);
     let rm = region.def();
 
-    println!("Importing {:?} to new region", import_path);
+    /*
+     * We want to read and write large chunks of data, rather than individual
+     * blocks, to improve import performance.  The chunk buffer must be a
+     * whole number of the largest block size we are able to support.
+     */
+    const CHUNK_SIZE: usize = 32 * 1024 * 1024;
+    assert_eq!(CHUNK_SIZE % MAX_BLOCK_SIZE, 0);
+    let mut buffer = vec![0; CHUNK_SIZE];
 
-    let mut buffer = vec![0; block_size as usize];
-    buffer.resize(block_size as usize, 0);
-
-    let mut fp = File::open(import_path)?;
     let mut offset = Block::new_with_ddef(0, &region.def());
-    let mut blocks_copied = 0;
-    while let Ok(n) = fp.read(&mut buffer[..]) {
-        if n == 0 {
+    loop {
+        buffer.resize(CHUNK_SIZE, 0);
+
+        /*
+         * Read data into the buffer until it is full, or we hit EOF.
+         */
+        let mut total = 0;
+        loop {
+            assert!(total <= CHUNK_SIZE);
+            if total == CHUNK_SIZE {
+                break;
+            }
+
+            let n = f.read(&mut buffer[total..(CHUNK_SIZE - total)])?;
+
+            if n == 0 {
+                /*
+                 * We have hit EOF.  Extend the read buffer with zeroes until
+                 * it is a multiple of the block size.
+                 */
+                while !Block::is_valid_byte_size(total, &rm) {
+                    buffer[total] = 0;
+                    total += 1;
+                }
+                break;
+            }
+
+            total += n;
+        }
+
+        if total == 0 {
             /*
-             * If we read 0 without error, then we are done
+             * If we read zero bytes without error, then we are done.
              */
             break;
         }
-
-        blocks_copied += 1;
 
         /*
          * Use the same function upsairs uses to decide where to put the
          * data based on the LBA offset.
          */
-        let nwo = extent_from_offset(rm, offset, 1).unwrap();
-        assert_eq!(nwo.len(), 1);
-        let (eid, block_offset, _) = nwo[0];
-
-        if n != (block_size as usize) {
-            if n != 0 {
-                let rest = &buffer[0..n];
-                region.region_write(eid, block_offset, rest)?;
-            }
-            break;
-        } else {
-            region.region_write(eid, block_offset, &buffer)?;
-            offset.value += 1;
+        let nblocks = Block::from_bytes(total, &rm);
+        let mut pos = Block::from_bytes(0, &rm);
+        for (eid, offset, len) in extent_from_offset(rm, offset, nblocks)? {
+            let data = &buffer[pos.bytes()..(pos.bytes() + len.bytes())];
+            region.region_write(eid, offset, data)?;
+            pos.advance(len);
         }
+        assert_eq!(nblocks, pos);
+        assert_eq!(total, pos.bytes());
+        offset.advance(nblocks);
     }
 
     /*
@@ -276,8 +301,10 @@ fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
      * want, use that to extract just this imported file.
      */
     println!(
-        "Created {} extents and Copied {} blocks",
-        extents_needed, blocks_copied
+        "Populated {} extents by copying {} bytes ({} blocks)",
+        extents_needed,
+        offset.byte_value(),
+        offset.value,
     );
 
     Ok(())
@@ -1040,6 +1067,7 @@ async fn main() -> Result<()> {
             region_options.set_uuid(uuid);
 
             region = Region::create(&data, region_options)?;
+            region.extend(extent_count as u32)?;
 
             if let Some(ref ip) = import_path {
                 downstairs_import(&mut region, ip).unwrap();
@@ -1048,8 +1076,6 @@ async fn main() -> Result<()> {
                  * new data and inital flush number is written to disk.
                  */
                 region.region_flush(1)?;
-            } else {
-                region.extend(extent_count as u32)?;
             }
 
             println!("UUID: {:?}", region.def().uuid());

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -145,11 +145,11 @@ async fn process_message(
 pub fn extent_from_offset(
     ddef: RegionDefinition,
     offset: Block,
-    num_blocks: u64,
-) -> Result<Vec<(u64, Block, u64)>> {
-    assert!(num_blocks > 0);
+    num_blocks: Block,
+) -> Result<Vec<(u64, Block, Block)>> {
+    assert!(num_blocks.value > 0);
     assert!(
-        (offset.value + num_blocks)
+        (offset.value + num_blocks.value)
             <= (ddef.extent_size().value * ddef.extent_count() as u64)
     );
     assert_eq!(offset.block_size_in_bytes() as u64, ddef.block_size());
@@ -165,7 +165,7 @@ pub fn extent_from_offset(
      */
     let mut result = Vec::new();
     let mut o: u64 = offset.value;
-    let mut blocks_left: u64 = num_blocks;
+    let mut blocks_left: u64 = num_blocks.value;
 
     while blocks_left > 0 {
         /*
@@ -183,7 +183,11 @@ pub fn extent_from_offset(
             sz = blocks_left;
         }
 
-        result.push((eid, Block::new_with_ddef(extent_offset, &ddef), sz));
+        result.push((
+            eid,
+            Block::new_with_ddef(extent_offset, &ddef),
+            Block::new_with_ddef(sz, &ddef),
+        ));
 
         match blocks_left.checked_sub(sz) {
             Some(v) => {
@@ -200,9 +204,9 @@ pub fn extent_from_offset(
     {
         let mut blocks = 0;
         for r in &result {
-            blocks += r.2;
+            blocks += r.2.value;
         }
-        assert_eq!(blocks, num_blocks);
+        assert_eq!(blocks, num_blocks.value);
     }
 
     Ok(result)
@@ -1932,7 +1936,7 @@ impl Upstairs {
         let nwo = extent_from_offset(
             *ddef,
             offset,
-            data.len() as u64 / ddef.block_size(),
+            Block::from_bytes(data.len(), &ddef),
         )?;
 
         /*
@@ -1962,7 +1966,7 @@ impl Upstairs {
             }
 
             let byte_len: usize =
-                num_blocks as usize * ddef.block_size() as usize;
+                num_blocks.value as usize * ddef.block_size() as usize;
 
             let sub_data = if let Some(context) = &self.encryption_context {
                 // Encrypt here
@@ -1975,7 +1979,7 @@ impl Upstairs {
                 data.slice(cur_offset..(cur_offset + byte_len))
             };
 
-            sub.insert(next_id, num_blocks);
+            sub.insert(next_id, num_blocks.value);
 
             let wr = create_write_eob(
                 next_id,
@@ -2048,7 +2052,7 @@ impl Upstairs {
         let nwo = extent_from_offset(
             *ddef,
             offset,
-            data.len() as u64 / ddef.block_size(),
+            Block::from_bytes(data.len(), &ddef),
         )?;
 
         /*
@@ -2084,7 +2088,7 @@ impl Upstairs {
              * that the lower offset corresponds to the lower next_id.
              * The ID's don't need to be sequential.
              */
-            sub.insert(next_id, num_blocks);
+            sub.insert(next_id, num_blocks.value);
             downstairs_buffer_sector_index.insert(next_id, bo.value as u128);
             let wr = create_read_eob(
                 next_id,
@@ -2092,7 +2096,7 @@ impl Upstairs {
                 gw_id,
                 eid,
                 bo,
-                num_blocks,
+                num_blocks.value,
             );
             new_ds_work.push(wr);
         }


### PR DESCRIPTION
This change allows the creation of a region from an image file that is
smaller than the target region size.  If the file is not an exact
multiple of the target block size, the final short block will be
extended with zeroes.

The change also improves the performance of image import by reading a
32MB chunk of the import file at a time, and writing as much of that as
we are allowed into the target extents.

Finally, a small improvement to type safety: using the Block object to
represent the block count we pass to "extent_from_offset()" and adding
some routines for converting to and from byte sizes.