### PR TITLE
This PR is not a PR.  WIP for the ack task

### DIFF
--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -399,7 +399,7 @@ async fn do_work(
                 Err(CrucibleError::GenericError("test error".to_string()))
             } else if !ds.is_active(job.upstairs_uuid) {
                 Err(CrucibleError::UpstairsInactive)
-            } else{
+            } else {
                 ds.region.region_flush(*flush_number)
             };
 
@@ -849,26 +849,26 @@ async fn ack_sender(
             println!("Ack job {:#?}", job);
         }
 
-    /*
-            fw.send(Message::ReadResponse(
-                job.upstairs_uuid,
-                job.ds_id,
-                data.freeze(),
-                result,
-            ))
+        /*
+        fw.send(Message::ReadResponse(
+            job.upstairs_uuid,
+            job.ds_id,
+            data.freeze(),
+            result,
+        ))
+        .await?;
+        ds.complete_work(job.ds_id, false);
+
+        /* Write */
+
+        fw.send(Message::WriteAck(job.upstairs_uuid, job.ds_id, result))
             .await?;
-            ds.complete_work(job.ds_id, false);
+        ds.complete_work(job.ds_id, false);
 
-            /* Write */
-
-            fw.send(Message::WriteAck(job.upstairs_uuid, job.ds_id, result))
-                .await?;
-            ds.complete_work(job.ds_id, false);
-
-            fw.send(Message::FlushAck(job.upstairs_uuid, job.ds_id, result))
-                .await?;
-            ds.complete_work(job.ds_id, true);
-            */
+        fw.send(Message::FlushAck(job.upstairs_uuid, job.ds_id, result))
+            .await?;
+        ds.complete_work(job.ds_id, true);
+        */
     }
 }
 
@@ -883,7 +883,6 @@ async fn resp_loop(
     mut another_upstairs_active_rx: mpsc::Receiver<u64>,
     upstairs_uuid: Uuid,
 ) -> Result<()> {
-
     // Spawn async task to ACK work
     let (ack_ready_tx, ack_ready_rx) = mpsc::channel(1);
     let adsc = Arc::clone(&ads);
@@ -1303,7 +1302,9 @@ impl Work {
                 panic!("Old Upstairs Job in ack_work!");
             }
 
-            if job.state == WorkState::AckReady || job.state == WorkState::BadUUID {
+            if job.state == WorkState::AckReady
+                || job.state == WorkState::BadUUID
+            {
                 result.push(job.ds_id);
             }
         }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -437,6 +437,7 @@ async fn io_send(
                 eid,
                 offset,
                 num_blocks,
+                data: _data,
             } => {
                 fw.send(Message::ReadRequest(
                     u.uuid,
@@ -1351,6 +1352,7 @@ impl Downstairs {
                 eid: _eid,
                 offset: _offset,
                 num_blocks: _num_blocks,
+                data: _data,
             } => wc.error == 3,
             IOop::Write {
                 dependencies: _dependencies,
@@ -1391,6 +1393,7 @@ impl Downstairs {
                 eid: _,
                 offset: _,
                 num_blocks: _,
+                data: _,
             } => {
                 cdt_gw_read_end!(|| (gw_id));
             }
@@ -1508,6 +1511,7 @@ impl Downstairs {
                     eid: _eid,
                     offset: _offset,
                     num_blocks: _num_blocks,
+                    data: _data,
                 } => {
                     assert!(read_data.is_some());
                     if jobs_completed_ok == 1 {
@@ -1643,6 +1647,7 @@ impl Downstairs {
                 eid: _eid,
                 offset: _offset,
                 num_blocks: _num_blocks,
+                data: _data,
             } => Ok(true),
             _ => Ok(false),
         }
@@ -2622,6 +2627,7 @@ pub enum IOop {
         eid: u64,
         offset: Block,
         num_blocks: u64,
+        data: Option<Bytes>,
     },
     Flush {
         dependencies: Vec<u64>, // Jobs that must finish before this
@@ -4152,6 +4158,7 @@ fn create_read_eob(
         eid,
         offset,
         num_blocks,
+        data: None,
     };
 
     let mut state = HashMap::new();
@@ -4237,6 +4244,7 @@ fn show_all_work(up: &Arc<Upstairs>) -> WQCounts {
                     eid,
                     offset,
                     num_blocks,
+                    data: _data,
                 } => {
                     job_type = "Read ".to_string();
                     io_eid = *eid;


### PR DESCRIPTION
The two commits here are where I got to with this.

The first one, I made the framed write an onwed frame write and then passed that
everywhere the old one was.

I also broke proc into to functions, the first that did the negotiation, and the 2nd that
does the main work loop.  With that commit, everything still worked.

The 2nd commit is more progress breaking out the ack into a separate task with the `fw` it will need, but it's not compete, and if you run it now, it will hang as it is not actually sending
an ack back to the upstairs.  

To continue down this path, I'm considering making a "work to ack" hashmap, and using a new struct to create the work that goes on it.  When an IO is finished, the work would
come off active, then go onto a new queue to ack.  Having a different queue would also
enable us to add ping responses to the work the ack task should do, and possibly the UUID
mismatch message as well. 