### PR TITLE
Scope USDT probes in Upstairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "dtrace-parser"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b6ae072fe941bb529d87dc78d18a1a5693da8245a99eef1f22cb2b3a1735a3"
+checksum = "5bbb93fb1a0c517bf20f37caaf5d1f7d20f144c6c35a7d751ecad077b6c042e8"
 dependencies = [
  "pest",
  "pest_derive",
@@ -1277,6 +1277,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-id"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fdfe0627923f7411a43ec9ec9c39c3a9b4151be313e0922042581fb6c9b717f"
+dependencies = [
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,12 +1492,13 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "usdt"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9520f6ffcd471d285809a69bd10dd62a783c9e662630aba6387c68dc3861160a"
+checksum = "9aba50f80946d1ef9b21f40e46b74dd211b9ff5e603ad028c0d58871835ada4f"
 dependencies = [
  "dof",
  "dtrace-parser",
+ "serde",
  "usdt-attr-macro",
  "usdt-impl",
  "usdt-macro",
@@ -1494,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "usdt-attr-macro"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee18d68aa617f5d6f220b6504aaabd5505daf0a64b61dc9a3f6850e9db202322"
+checksum = "dd55281622053408612f20f3d92df0db533d4b15ec4842883e94c23b1e9351f2"
 dependencies = [
  "dtrace-parser",
  "proc-macro2",
@@ -1508,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "usdt-impl"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda7cc788bd91a8d7024965378f24fd565cf8153488fc3835b7c36c7f1657062"
+checksum = "e71989deee492038dec04ea3e5ad68bd876947b5ba35562d0bee04e784557f6a"
 dependencies = [
  "byteorder",
  "dof",
@@ -1519,15 +1531,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
+ "serde_json",
  "syn",
  "thiserror",
+ "thread-id",
 ]
 
 [[package]]
 name = "usdt-macro"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a3f03dad02b54d7859e939b25e10f81538604f3a970441b938a77b9f748e15"
+checksum = "95e4feae7fabf18bc31413acb5bdeb52581c093e2578e80ab7c2a8402ad4e039"
 dependencies = [
  "dtrace-parser",
  "proc-macro2",

--- a/upstairs/Cargo.toml
+++ b/upstairs/Cargo.toml
@@ -38,6 +38,6 @@ tokio = { version = "1.7.1", features = ["full"] }
 tokio-util = { version = "0.6", features = ["codec"]}
 toml = "0.5"
 tracing = "0.1.26"
-usdt = "0.1.17"
+usdt = "0.1.19"
 uuid = { version = "0.8", features = [ "serde", "v4" ] }
 xts-mode = "0.4.0"

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1389,7 +1389,7 @@ impl Downstairs {
                 offset: _,
                 num_blocks: _,
             } => {
-                cdt_gw_read_end!(|| (gw_id));
+                cdt::gw_read_end!(|| (gw_id));
             }
             IOop::Write {
                 dependencies: _,
@@ -1397,13 +1397,13 @@ impl Downstairs {
                 offset: _,
                 data: _,
             } => {
-                cdt_gw_write_end!(|| (gw_id));
+                cdt::gw_write_end!(|| (gw_id));
             }
             IOop::Flush {
                 dependencies: _,
                 flush_number: _,
             } => {
-                cdt_gw_flush_end!(|| (gw_id));
+                cdt::gw_flush_end!(|| (gw_id));
             }
         }
     }
@@ -1956,7 +1956,7 @@ impl Upstairs {
             None,
         );
         gw.active.insert(gw_id, new_gtos);
-        cdt_gw_flush_start!(|| (gw_id));
+        cdt::gw_flush_start!(|| (gw_id));
 
         downstairs.enqueue(fl);
 
@@ -2071,7 +2071,7 @@ impl Upstairs {
         {
             gw.active.insert(gw_id, new_gtos);
         }
-        cdt_gw_write_start!(|| (gw_id));
+        cdt::gw_write_start!(|| (gw_id));
 
         for wr in new_ds_work {
             downstairs.enqueue(wr);
@@ -2182,7 +2182,7 @@ impl Upstairs {
         {
             gw.active.insert(gw_id, new_gtos);
         }
-        cdt_gw_read_start!(|| (gw_id));
+        cdt::gw_read_start!(|| (gw_id));
 
         for wr in new_ds_work {
             downstairs.enqueue(wr);
@@ -3786,7 +3786,7 @@ pub struct Arg {
  */
 #[inline]
 fn stat_update(up: &Arc<Upstairs>, msg: &str) {
-    cdt_up_status!(|| {
+    cdt::up_status!(|| {
         let arg = Arg {
             up_count: up.up_work_active(),
             ds_count: up.ds_work_active(),


### PR DESCRIPTION
The latest version of `usdt` allows probes to be module-scoped, rather
than calling them from a global namespace.