### PR TITLE
Generation number part 1

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -68,6 +68,9 @@ pub struct Opt {
     #[structopt(short, long)]
     key: Option<String>,
 
+    #[structopt(short, long, default_value = "0")]
+    gen: u64,
+
     /*
      * For tests that support it, load the expected write count from
      * the provided file.
@@ -234,7 +237,7 @@ fn main() -> Result<()> {
     runtime.spawn(up_main(crucible_opts, guest.clone()));
     println!("Crucible runtime is spawned");
 
-    guest.activate()?;
+    guest.activate(opt.gen)?;
 
     std::thread::sleep(std::time::Duration::from_secs(2));
 

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -38,6 +38,9 @@ pub struct Opt {
 
     #[structopt(short, long)]
     key: Option<String>,
+
+    #[structopt(short, long, default_value = "0")]
+    gen: u64,
 }
 
 pub fn opts() -> Result<Opt> {
@@ -58,6 +61,7 @@ fn main() -> Result<()> {
         lossy: false,
         key: opt.key,
     };
+    let mut generation_number = opt.gen;
 
     if let Some(tracing_endpoint) = opt.tracing_endpoint {
         let tracer = opentelemetry_jaeger::new_pipeline()
@@ -114,7 +118,8 @@ fn main() -> Result<()> {
     let mut cpf_idx = 0;
 
     println!("Handing off to CPF {}", cpf_idx);
-    cpfs[cpf_idx].activate()?;
+    cpfs[cpf_idx].activate(generation_number)?;
+    generation_number += 1;
     println!(
         "Handed off to CPF {} {:?}",
         cpf_idx,
@@ -143,7 +148,8 @@ fn main() -> Result<()> {
             println!("Handing off to CPF {}", cpf_idx);
 
             let cpf = &mut cpfs[cpf_idx];
-            cpf.activate()?;
+            cpf.activate(generation_number)?;
+            generation_number += 1;
 
             println!("Handed off to CPF {} {:?}", cpf_idx, cpf.upstairs_uuid());
 

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -38,6 +38,9 @@ pub struct Opt {
 
     #[structopt(short, long)]
     key: Option<String>,
+
+    #[structopt(short, long, default_value = "0")]
+    gen: u64,
 }
 
 pub fn opts() -> Result<Opt> {
@@ -87,7 +90,7 @@ fn main() -> Result<()> {
     let listener = TcpListener::bind("127.0.0.1:10809").unwrap();
     let mut cpf = crucible::CruciblePseudoFile::from_guest(guest)?;
 
-    cpf.activate()?;
+    cpf.activate(opt.gen)?;
 
     // sent to NBD client during handshake through Export struct
     println!("NBD advertised size as {} bytes", cpf.sz());

--- a/upstairs/src/main.rs
+++ b/upstairs/src/main.rs
@@ -20,6 +20,9 @@ pub struct Opt {
 
     #[structopt(short, long)]
     key: Option<String>,
+
+    #[structopt(short, long, default_value = "0")]
+    gen: u64,
 }
 
 pub fn opts() -> Result<Opt> {
@@ -137,7 +140,7 @@ fn main() -> Result<()> {
     runtime.spawn(up_main(crucible_opts, guest.clone()));
     println!("runtime is spawned");
 
-    guest.activate()?;
+    guest.activate(opt.gen)?;
 
     /*
      * The rest of this is just test code

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -147,8 +147,8 @@ impl CruciblePseudoFile {
         self.sz
     }
 
-    pub fn activate(&mut self) -> Result<(), CrucibleError> {
-        self.guest.activate()?;
+    pub fn activate(&mut self, gen: u64) -> Result<(), CrucibleError> {
+        self.guest.activate(gen)?;
 
         self.sz = self.guest.query_total_size()? as u64;
         self.block_size = self.guest.query_block_size()? as u64;


### PR DESCRIPTION
This is part one of maybe two for support of generation numbers in
the upstairs.  This will allow reconciliation as well as help with migration
transfers between upstairs.

Added a generation number field to the activate command to allow a guest
to specify the generation number for an activate request.  Right now
this is not passed to the downstairs, but that will come soon.