### PR TITLE
More stall (+ panic) fixes

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -310,8 +310,6 @@ fn main() -> Result<()> {
         }
 
         Workload::Generic => {
-            println!("Run Generic test in 5 seconds");
-            std::thread::sleep(std::time::Duration::from_secs(5));
             runtime.block_on(generic_workload(
                 &guest,
                 5000,
@@ -1113,7 +1111,7 @@ async fn dep_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
         /*
          * Generate some number of operations
          */
-        for ioc in 0..20 {
+        for ioc in 0..200 {
             my_offset = (my_offset + ri.block_size) % final_offset;
             if random() {
                 /*

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1107,7 +1107,7 @@ async fn dep_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
     let final_offset = ri.total_size - ri.block_size;
 
     let mut my_offset: u64 = 0;
-    for my_count in 1..15 {
+    for my_count in 1..150 {
         let mut waiterlist = Vec::new();
 
         /*
@@ -1153,9 +1153,11 @@ async fn dep_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
         }
 
         guest.show_work()?;
-        println!("Loop:{} send a final flush and wait", my_count);
-        let mut flush_waiter = guest.flush()?;
-        flush_waiter.block_wait()?;
+        if random() && random() {
+            println!("Loop:{} send a final flush and wait", my_count);
+            let mut flush_waiter = guest.flush()?;
+            flush_waiter.block_wait()?;
+        }
 
         println!("Loop:{} loop over {} waiters", my_count, waiterlist.len());
         for wa in waiterlist.iter_mut() {

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1151,11 +1151,13 @@ async fn dep_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
         }
 
         guest.show_work()?;
-        if random() && random() {
-            println!("Loop:{} send a final flush and wait", my_count);
-            let mut flush_waiter = guest.flush()?;
-            flush_waiter.block_wait()?;
-        }
+
+        // The final flush is to help prevent the pause that we get when the
+        // last command is a write or read and we have to wait x seconds for the
+        // flush check to trigger.
+        println!("Loop:{} send a final flush and wait", my_count);
+        let mut flush_waiter = guest.flush()?;
+        flush_waiter.block_wait()?;
 
         println!("Loop:{} loop over {} waiters", my_count, waiterlist.len());
         for wa in waiterlist.iter_mut() {

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -1359,11 +1359,7 @@ impl Work {
                 None
             }
         } else {
-            /*
-             * This ID is no longer a valid job id.  That would be ok
-             * if there a multiple things running at the same time.
-             */
-            None
+            panic!("This ID is no longer a valid job id");
         }
     }
 

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -1277,6 +1277,8 @@ impl Work {
             }
         }
 
+        result.sort_unstable();
+
         result
     }
 

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -1026,7 +1026,7 @@ impl Downstairs {
         };
 
         let mut work = self.work_lock(upstairs_uuid).await?;
-        work.active.insert(ds_id, dsw);
+        work.add_work(ds_id, dsw);
 
         Ok(())
     }
@@ -1280,10 +1280,15 @@ impl Work {
         result
     }
 
+    fn add_work(&mut self, ds_id: u64, dsw: DownstairsWork) {
+        self.active.insert(ds_id, dsw);
+    }
+
     /**
      * If the requested job is still new, and the dependencies are all met,
      * return the DownstairsWork struct and let the caller take action
      * with it, leaving the state as InProgress.
+     *
      * If this job is not new, then just return none.  This can be okay as
      * we build or work list with the new_work fn above, but we drop and
      * re-aquire the Work mutex and things can change.

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -1307,24 +1307,7 @@ impl Work {
                  * holding this locked, check the dep list if there is one
                  * and make sure all dependencies are completed.
                  */
-                let dep_list = match &job.work {
-                    IOop::Write {
-                        dependencies,
-                        eid: _eid,
-                        offset: _offset,
-                        data: _data,
-                    } => dependencies,
-                    IOop::Flush {
-                        dependencies,
-                        flush_number: _flush_number,
-                    } => dependencies,
-                    IOop::Read {
-                        dependencies,
-                        eid: _eid,
-                        offset: _offset,
-                        num_blocks: _num_blocks,
-                    } => dependencies,
-                };
+                let dep_list = job.work.deps();
 
                 /*
                  * See which of our dependencies are met.

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -232,4 +232,30 @@ mod tests {
         assert_eq!(input, round_trip(&input)?);
         Ok(())
     }
+
+    #[test]
+    fn correctly_detect_truncated_message() -> Result<()> {
+        let mut encoder = CrucibleEncoder::new();
+        let mut decoder = CrucibleDecoder::new();
+
+        let input = Message::HereIAm(0, Uuid::new_v4());
+        let mut buffer = BytesMut::new();
+
+        encoder.encode(input, &mut buffer)?;
+
+        buffer.truncate(buffer.len() - 1);
+
+        let result = decoder.decode(&mut buffer);
+
+        match result {
+            Err(_) => {
+                result?;
+            }
+            Ok(v) => {
+                assert_eq!(v, None);
+            }
+        };
+
+        Ok(())
+    }
 }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -841,27 +841,23 @@ async fn cmd_loop(
         let up_coms_c = up_coms.clone();
 
         tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    x = rx.recv() => {
-                        match x {
-                            Some(m) => {
-                                /*
-                                 * TODO: Add a check here to make sure we are
-                                 * connected and in the proper state before we
-                                 * accept any commands.
-                                 */
-                                let _result =
-                                    process_message(
-                                        &up_c,
-                                        &m,
-                                        up_coms_c.clone()
-                                    ).await;
-                            }
-                            None => {
-                                break;
-                            }
-                        }
+            while let Some(x) = rx.recv().await {
+                match x {
+                    Some(m) => {
+                        /*
+                         * TODO: Add a check here to make sure we are
+                         * connected and in the proper state before we
+                         * accept any commands.
+                         */
+                        let _result =
+                            process_message(
+                                &up_c,
+                                &m,
+                                up_coms_c.clone()
+                            ).await;
+                    }
+                    None => {
+                        break;
                     }
                 }
             }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2626,6 +2626,29 @@ pub enum IOop {
     },
 }
 
+impl IOop {
+    pub fn deps(&self) -> &Vec<u64> {
+        match &self {
+            IOop::Write {
+                dependencies,
+                eid: _eid,
+                offset: _offset,
+                data: _data,
+            } => dependencies,
+            IOop::Flush {
+                dependencies,
+                flush_number: _flush_number,
+            } => dependencies,
+            IOop::Read {
+                dependencies,
+                eid: _eid,
+                offset: _offset,
+                num_blocks: _num_blocks,
+            } => dependencies,
+        }
+    }
+}
+
 /*
  * The various states an IO can be in when it is on the work hashmap.
  * There is a state that is unique to each downstairs task we have and

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -834,32 +834,21 @@ async fn cmd_loop(
     let mut ping_interval = deadline_secs(10);
     let mut timeout_deadline = deadline_secs(50);
 
-    let (tx, mut rx) = mpsc::channel(100);
+    let (tx, mut rx) = mpsc::channel::<Message>(100);
 
     {
         let up_c = up.clone();
         let up_coms_c = up_coms.clone();
 
         tokio::spawn(async move {
-            while let Some(x) = rx.recv().await {
-                match x {
-                    Some(m) => {
-                        /*
-                         * TODO: Add a check here to make sure we are
-                         * connected and in the proper state before we
-                         * accept any commands.
-                         */
-                        let _result =
-                            process_message(
-                                &up_c,
-                                &m,
-                                up_coms_c.clone()
-                            ).await;
-                    }
-                    None => {
-                        break;
-                    }
-                }
+            while let Some(m) = rx.recv().await {
+                /*
+                 * TODO: Add a check here to make sure we are
+                 * connected and in the proper state before we
+                 * accept any commands.
+                 */
+                let _result =
+                    process_message(&up_c, &m, up_coms_c.clone()).await;
             }
         });
     }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -842,7 +842,7 @@ async fn cmd_loop(
 
         tokio::spawn(async move {
             loop {
-                tokio::select!{
+                tokio::select! {
                     x = rx.recv() => {
                         match x {
                             Some(m) => {


### PR DESCRIPTION
Summary of downstairs changes:

- combine do_work_task and ack_sender task
- only unblocks jobs for the active UUID
- removed "Unblock any stuck jobs. XXX how does this happen?" branch
- unblock jobs if their deps are about to run (+ add verification that deps are fulfilled)
- unit tests!