### PR TITLE
Change protocol from arbitrary sized operation to list of block sized operations

### DIFF
--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -388,7 +388,7 @@ async fn proc_frame(
             fw.send(Message::Imok).await?;
         }
         // Regular work path
-        Message::Write(uuid, ds_id, eid, dependencies, offset, data) => {
+        Message::Write(uuid, ds_id, dependencies, eid, offset, data) => {
             if upstairs_uuid != *uuid {
                 let mut fw = fw.lock().await;
                 fw.send(Message::UuidMismatch(upstairs_uuid)).await?;

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -283,11 +283,10 @@ fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
         let nblocks = Block::from_bytes(total, &rm);
         let mut pos = Block::from_bytes(0, &rm);
         for (eid, offset, len) in extent_from_offset(rm, offset, nblocks)? {
-            let mut data = bytes::BytesMut::with_capacity(len.bytes());
-            data.copy_from_slice(
-                &buffer[pos.bytes()..(pos.bytes() + len.bytes())],
-            );
-            region.single_block_region_write(eid, offset, data.freeze())?;
+            let data = &buffer[pos.bytes()..(pos.bytes() + len.bytes())];
+            let mut buffer = BytesMut::with_capacity(data.len());
+            buffer.copy_from_slice(data);
+            region.single_block_region_write(eid, offset, buffer.freeze())?;
 
             pos.advance(len);
         }

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -1315,7 +1315,9 @@ impl Work {
                  */
                 let (bs, _, _) = ds.region.region_def();
 
-                let mut responses: Vec<(ReadRequest, BytesMut)> = vec![];
+                let mut responses: Vec<(ReadRequest, BytesMut)> =
+                    Vec::with_capacity(requests.len());
+
                 for request in requests {
                     let sz = request.num_blocks as usize * bs as usize;
                     let mut data = BytesMut::with_capacity(sz);

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -282,24 +282,15 @@ fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
          */
         let nblocks = Block::from_bytes(total, &rm);
         let mut pos = Block::from_bytes(0, &rm);
-        let mut writes: Vec<crucible_protocol::Write> = vec![];
         for (eid, offset, len) in extent_from_offset(rm, offset, nblocks)? {
             let mut data = bytes::BytesMut::with_capacity(len.bytes());
             data.copy_from_slice(
                 &buffer[pos.bytes()..(pos.bytes() + len.bytes())],
             );
+            region.single_block_region_write(eid, offset, data.freeze())?;
 
-            let write = crucible_protocol::Write {
-                eid,
-                offset,
-                data: data.freeze(),
-            };
-
-            writes.push(write);
             pos.advance(len);
         }
-
-        region.region_write(&writes)?;
 
         assert_eq!(nblocks, pos);
         assert_eq!(total, pos.bytes());

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -579,7 +579,7 @@ async fn proc(ads: &mut Arc<Mutex<Downstairs>>, sock: TcpStream) -> Result<()> {
                     ds.active_upstairs().unwrap()
                 };
                 let mut fw = fw.lock().await;
-                fw.send(Message::UuidMismatch(active_upstairs)).await?;
+                fw.send(Message::YouAreNoLongerActive(active_upstairs)).await?;
 
                 return Ok(());
             }
@@ -824,7 +824,7 @@ async fn resp_loop(
                 };
 
                 let mut fw = fw.lock().await;
-                fw.send(Message::UuidMismatch(active_upstairs)).await?;
+                fw.send(Message::YouAreNoLongerActive(active_upstairs)).await?;
 
                 return Ok(());
             }

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -613,6 +613,16 @@ impl Region {
     }
 
     #[instrument]
+    pub fn single_block_region_write(
+        &self,
+        eid: u64,
+        offset: Block,
+        data: bytes::Bytes,
+    ) -> Result<(), CrucibleError> {
+        self.region_write(&[crucible_protocol::Write { eid, offset, data }])
+    }
+
+    #[instrument]
     pub fn region_write(
         &self,
         writes: &[crucible_protocol::Write],

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -615,12 +615,12 @@ impl Region {
     #[instrument]
     pub fn region_write(
         &self,
-        eid: u64,
-        offset: Block,
-        data: &[u8],
+        writes: &[crucible_protocol::Write],
     ) -> Result<(), CrucibleError> {
-        let extent = &self.extents[eid as usize];
-        extent.write(offset, data)?;
+        for write in writes {
+            let extent = &self.extents[write.eid as usize];
+            extent.write(write.offset, &write.data)?;
+        }
         Ok(())
     }
 

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -92,6 +92,16 @@ fn main() -> Result<()> {
         .build()
         .unwrap();
 
+    /*
+     * If any of our async tasks in our runtime panic, then we should
+     * exit the program right away.
+     */
+    let default_panic = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        default_panic(info);
+        std::process::exit(1);
+    }));
+
     // Create 5 CruciblePseudoFiles to test activation handoff.
     let mut cpfs: Vec<crucible::CruciblePseudoFile> = Vec::with_capacity(5);
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -11,6 +11,9 @@ use crucible_common::{Block, CrucibleError, RegionDefinition};
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum Message {
+    /*
+     * Initial negotiation
+     */
     HereIAm(u32, Uuid),
     YesItsMe(u32),
 
@@ -29,9 +32,15 @@ pub enum Message {
      */
     UuidMismatch(Uuid),
 
+    /*
+     * Ping related
+     */
     Ruok,
     Imok,
 
+    /*
+     * Metadata exchange
+     */
     RegionInfoPlease,
     RegionInfo(RegionDefinition),
     ExtentVersionsPlease,
@@ -39,12 +48,25 @@ pub enum Message {
     LastFlushAck(u64),
     ExtentVersions(Vec<u64>, Vec<u64>, Vec<bool>),
 
+    /*
+     * Write: Uuid, job id, extent id, dependencies, extent offset, data to
+     *        write
+     * WriteAck: Uuid, job id, result
+     */
     Write(Uuid, u64, u64, Vec<u64>, Block, bytes::Bytes),
     WriteAck(Uuid, u64, Result<(), CrucibleError>),
+
     Flush(Uuid, u64, Vec<u64>, u64),
     FlushAck(Uuid, u64, Result<(), CrucibleError>),
+
+    /*
+     * ReadRequest: Uuid, job id, dependencies, extent id, extent offset, number
+     *              of blocks
+     * ReadResponse: Uuid, job id, block of data, result
+     */
     ReadRequest(Uuid, u64, Vec<u64>, u64, Block, u64),
     ReadResponse(Uuid, u64, bytes::Bytes, Result<(), CrucibleError>),
+
     Unknown(u32, BytesMut),
 }
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -49,19 +49,19 @@ pub enum Message {
     ExtentVersions(Vec<u64>, Vec<u64>, Vec<bool>),
 
     /*
-     * Write: Uuid, job id, extent id, dependencies, extent offset, data to
+     * Write: Uuid, job id, dependencies, extent id, extent offset, data to
      *        write
      * WriteAck: Uuid, job id, result
      */
-    Write(Uuid, u64, u64, Vec<u64>, Block, bytes::Bytes),
+    Write(Uuid, u64, Vec<u64>, u64, Block, bytes::Bytes),
     WriteAck(Uuid, u64, Result<(), CrucibleError>),
 
     Flush(Uuid, u64, Vec<u64>, u64),
     FlushAck(Uuid, u64, Result<(), CrucibleError>),
 
     /*
-     * ReadRequest: Uuid, job id, dependencies, extent id, extent offset, number
-     *              of blocks
+     * ReadRequest: Uuid, job id, dependencies, extent id, extent offset,
+     *              number of blocks
      * ReadResponse: Uuid, job id, block of data, result
      */
     ReadRequest(Uuid, u64, Vec<u64>, u64, Block, u64),

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -39,6 +39,7 @@ pub enum Message {
      */
     PromoteToActive(Uuid),
     YouAreNowActive(Uuid),
+    YouAreNoLongerActive(Uuid), // UUID of new active Upstairs
 
     /*
      * If downstairs sees a UUID that doesn't match what was negotiated, it

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -16,6 +16,13 @@ pub struct Write {
     pub data: bytes::Bytes,
 }
 
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
+pub struct ReadRequest {
+    pub eid: u64,
+    pub offset: Block,
+    pub num_blocks: u64,
+}
+
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum Message {
     /*
@@ -66,12 +73,16 @@ pub enum Message {
     FlushAck(Uuid, u64, Result<(), CrucibleError>),
 
     /*
-     * ReadRequest: Uuid, job id, dependencies, extent id, extent offset,
-     *              number of blocks
-     * ReadResponse: Uuid, job id, block of data, result
+     * ReadRequest: Uuid, job id, dependencies, [ReadRequest]
+     * ReadResponse: Uuid, job id, [(ReadRequest, block)], result
      */
-    ReadRequest(Uuid, u64, Vec<u64>, u64, Block, u64),
-    ReadResponse(Uuid, u64, bytes::Bytes, Result<(), CrucibleError>),
+    ReadRequest(Uuid, u64, Vec<u64>, Vec<ReadRequest>),
+    ReadResponse(
+        Uuid,
+        u64,
+        Vec<(ReadRequest, bytes::Bytes)>,
+        Result<(), CrucibleError>,
+    ),
 
     Unknown(u32, BytesMut),
 }

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -10,6 +10,13 @@ const MAX_FRM_LEN: usize = 100 * 1024 * 1024; // 100M
 use crucible_common::{Block, CrucibleError, RegionDefinition};
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct Write {
+    pub eid: u64,
+    pub offset: Block,
+    pub data: bytes::Bytes,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum Message {
     /*
      * Initial negotiation
@@ -49,11 +56,10 @@ pub enum Message {
     ExtentVersions(Vec<u64>, Vec<u64>, Vec<bool>),
 
     /*
-     * Write: Uuid, job id, dependencies, extent id, extent offset, data to
-     *        write
+     * Write: Uuid, job id, dependencies, [Write]
      * WriteAck: Uuid, job id, result
      */
-    Write(Uuid, u64, Vec<u64>, u64, Block, bytes::Bytes),
+    Write(Uuid, u64, Vec<u64>, Vec<Write>),
     WriteAck(Uuid, u64, Result<(), CrucibleError>),
 
     Flush(Uuid, u64, Vec<u64>, u64),

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -657,6 +657,11 @@ async fn proc(
                         negotiated = 2;
                         fw.send(Message::RegionInfoPlease).await?;
                     }
+                    Some(Message::YouAreNoLongerActive(new_active_uuid)) => {
+                        if up.uuid != new_active_uuid {
+                            up.set_inactive();
+                        }
+                    }
                     Some(Message::RegionInfo(region_def)) => {
                         if negotiated != 2 {
                             bail!("Received RegionInfo out of order!");
@@ -879,6 +884,11 @@ async fn cmd_loop(
                     None => {
                         return Ok(())
                     },
+                    Some(Message::YouAreNoLongerActive(new_active_uuid)) => {
+                        if up.uuid != new_active_uuid {
+                            up.set_inactive();
+                        }
+                    }
                     Some(Message::UuidMismatch(expected_uuid)) => {
                         up.set_inactive();
                         bail!(

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -413,8 +413,8 @@ async fn io_send(
                 fw.send(Message::Write(
                     u.uuid,
                     *new_id,
-                    eid,
                     dependencies.clone(),
+                    eid,
                     offset,
                     data.clone(),
                 ))

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -4285,7 +4285,7 @@ fn show_all_work(up: &Arc<Upstairs>) -> WQCounts {
                 let state = job.state.get(&cid);
                 match state {
                     Some(state) => {
-                        // XX I have no idea why this is two spaces instead of
+                        // XXX I have no idea why this is two spaces instead of
                         // one...
                         print!("  {0:>5}", state);
                         iosc.incr(state, cid);

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -4283,17 +4283,37 @@ fn show_all_work(up: &Arc<Upstairs>) -> WQCounts {
                         offset.value,
                         *num_blocks as usize,
                     );
+
+                    for cid in 0..3 {
+                        let state = job.state.get(&cid);
+                        match state {
+                            Some(state) => {
+                                print!("{} ", state);
+                                iosc.incr(state, cid);
+                            }
+                            _x => {
+                                print!("???? ");
+                            }
+                        }
+                    }
+
+                    println!();
                 }
                 IOop::Write {
                     dependencies: _dependencies,
                     writes,
                 } => {
                     let job_type = "Write".to_string();
+                    let mut first_line = true;
 
                     for write in writes {
                         print!(
-                            " {:4}  {:8}  {:4}   {}   {:4}   {:4}   {:4} ",
-                            job.guest_id,
+                            " {}  {:8}  {:4}   {}   {:4}   {:4}   {:4} ",
+                            if first_line {
+                                format!("{:4}", job.guest_id)
+                            } else {
+                                "   |".to_string()
+                            },
                             ack,
                             id,
                             job_type,
@@ -4301,6 +4321,22 @@ fn show_all_work(up: &Arc<Upstairs>) -> WQCounts {
                             write.offset.value,
                             write.data.len() / (1 << write.offset.shift),
                         );
+                        first_line = false;
+
+                        for cid in 0..3 {
+                            let state = job.state.get(&cid);
+                            match state {
+                                Some(state) => {
+                                    print!("{} ", state);
+                                    iosc.incr(state, cid);
+                                }
+                                _x => {
+                                    print!("???? ");
+                                }
+                            }
+                        }
+
+                        println!();
                     }
                 }
                 IOop::Flush {
@@ -4313,22 +4349,24 @@ fn show_all_work(up: &Arc<Upstairs>) -> WQCounts {
                         " {:4}  {:8}  {:4}   {}   {:4}   {:4}   {:4} ",
                         job.guest_id, ack, id, job_type, 0, 0, 0,
                     );
+
+                    for cid in 0..3 {
+                        let state = job.state.get(&cid);
+                        match state {
+                            Some(state) => {
+                                print!("{} ", state);
+                                iosc.incr(state, cid);
+                            }
+                            _x => {
+                                print!("???? ");
+                            }
+                        }
+                    }
+
+                    println!();
                 }
             };
 
-            for cid in 0..3 {
-                let state = job.state.get(&cid);
-                match state {
-                    Some(state) => {
-                        print!("{} ", state);
-                        iosc.incr(state, cid);
-                    }
-                    _x => {
-                        print!("???? ");
-                    }
-                }
-            }
-            println!();
         }
         iosc.show_all();
         print!("Last Flush: ");

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2159,13 +2159,6 @@ impl Upstairs {
         let mut requests: Vec<ReadRequest> = Vec::with_capacity(nwo.len());
 
         for (eid, bo, num_blocks) in nwo {
-            /*
-             * When multiple operations are needed to satisfy a read, The
-             * offset and length will be divided across two downstairs
-             * requests. It is required (for re-assembly on the other side)
-             * that the lower offset corresponds to the lower next_id.
-             * The ID's don't need to be sequential.
-             */
             requests.push(ReadRequest {
                 eid,
                 offset: bo,

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1072,6 +1072,7 @@ async fn looper(
             proc(&target, up, tcp, &mut connected, &mut up_coms, lossy).await
         {
             eprintln!("ERROR: {}: proc: {:?}", target, e);
+            panic!("{:?}", e);
         }
 
         /*

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1072,7 +1072,8 @@ async fn looper(
             proc(&target, up, tcp, &mut connected, &mut up_coms, lossy).await
         {
             eprintln!("ERROR: {}: proc: {:?}", target, e);
-            panic!("{:?}", e);
+            // XXX proc can return fatal and non-fatal errors, figure out what
+            // to do here
         }
 
         /*

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -4296,7 +4296,7 @@ fn show_all_work(up: &Arc<Upstairs>) -> WQCounts {
                 }
             }
 
-            println!("");
+            println!();
         }
         iosc.show_all();
         print!("Last Flush: ");

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -814,9 +814,11 @@ mod test {
             next_id,
             vec![],
             10,
-            0,
-            Block::new_512(7),
-            Bytes::from(vec![1]),
+            vec![crucible_protocol::Write {
+                eid: 0,
+                offset: Block::new_512(7),
+                data: Bytes::from(vec![1]),
+            }],
         );
 
         work.enqueue(op);
@@ -1087,9 +1089,11 @@ mod test {
             id1,
             vec![],
             10,
-            0,
-            Block::new_512(7),
-            Bytes::from(vec![1]),
+            vec![crucible_protocol::Write {
+                eid: 0,
+                offset: Block::new_512(7),
+                data: Bytes::from(vec![1]),
+            }],
         );
         work.enqueue(op);
 
@@ -1097,9 +1101,11 @@ mod test {
             id2,
             vec![],
             1,
-            0,
-            Block::new_512(7),
-            Bytes::from(vec![1]),
+            vec![crucible_protocol::Write {
+                eid: 0,
+                offset: Block::new_512(7),
+                data: Bytes::from(vec![1]),
+            }],
         );
         work.enqueue(op);
 
@@ -1186,9 +1192,11 @@ mod test {
             next_id,
             vec![],
             10,
-            0,
-            Block::new_512(7),
-            Bytes::from(vec![1]),
+            vec![crucible_protocol::Write {
+                eid: 0,
+                offset: Block::new_512(7),
+                data: Bytes::from(vec![1]),
+            }],
         );
         // Put the write on the queue.
         work.enqueue(op);
@@ -1253,9 +1261,11 @@ mod test {
             id1,
             vec![],
             10,
-            0,
-            Block::new_512(7),
-            Bytes::from(vec![1]),
+            vec![crucible_protocol::Write {
+                eid: 0,
+                offset: Block::new_512(7),
+                data: Bytes::from(vec![1]),
+            }],
         );
         work.enqueue(op);
 
@@ -1263,9 +1273,11 @@ mod test {
             id2,
             vec![],
             1,
-            0,
-            Block::new_512(7),
-            Bytes::from(vec![1]),
+            vec![crucible_protocol::Write {
+                eid: 0,
+                offset: Block::new_512(7),
+                data: Bytes::from(vec![1]),
+            }],
         );
         work.enqueue(op);
 
@@ -1487,9 +1499,11 @@ mod test {
             id1,
             vec![],
             10,
-            0,
-            Block::new_512(7),
-            Bytes::from(vec![1]),
+            vec![crucible_protocol::Write {
+                eid: 0,
+                offset: Block::new_512(7),
+                data: Bytes::from(vec![1]),
+            }],
         );
         work.enqueue(op);
 
@@ -1534,9 +1548,11 @@ mod test {
             id1,
             vec![],
             10,
-            0,
-            Block::new_512(7),
-            Bytes::from(vec![1]),
+            vec![crucible_protocol::Write {
+                eid: 0,
+                offset: Block::new_512(7),
+                data: Bytes::from(vec![1]),
+            }],
         );
         work.enqueue(op);
 

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -478,7 +478,12 @@ mod test {
 
         let next_id = work.next_id();
 
-        let op = create_read_eob(next_id, vec![], 10, 0, Block::new_512(7), 2);
+        let request = ReadRequest {
+            eid: 0,
+            offset: Block::new_512(7),
+            num_blocks: 2,
+        };
+        let op = create_read_eob(next_id, vec![], 10, vec![request]);
 
         work.enqueue(op);
 
@@ -486,9 +491,9 @@ mod test {
         work.in_progress(next_id, 1);
         work.in_progress(next_id, 2);
 
-        let bytes = Some(Bytes::from(vec![]));
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
 
-        assert_eq!(work.complete(next_id, 0, bytes, Ok(())).unwrap(), true);
+        assert_eq!(work.complete(next_id, 0, response, Ok(())).unwrap(), true);
         assert_eq!(work.ackable_work().len(), 1);
         assert_eq!(work.completed.len(), 0);
 
@@ -496,15 +501,15 @@ mod test {
         assert_eq!(state, AckStatus::AckReady);
         work.ack(next_id);
 
-        let bytes = Some(Bytes::from(vec![]));
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
 
-        assert_eq!(work.complete(next_id, 1, bytes, Ok(())).unwrap(), false);
+        assert_eq!(work.complete(next_id, 1, response, Ok(())).unwrap(), false);
         assert_eq!(work.ackable_work().len(), 0);
         assert_eq!(work.completed.len(), 0);
 
-        let bytes = Some(Bytes::from(vec![]));
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
 
-        assert_eq!(work.complete(next_id, 2, bytes, Ok(())).unwrap(), false);
+        assert_eq!(work.complete(next_id, 2, response, Ok(())).unwrap(), false);
         assert_eq!(work.ackable_work().len(), 0);
         // A flush is required to move work to completed
         assert_eq!(work.completed.len(), 0);
@@ -517,7 +522,12 @@ mod test {
 
         let next_id = work.next_id();
 
-        let op = create_read_eob(next_id, vec![], 10, 0, Block::new_512(7), 2);
+        let request = ReadRequest {
+            eid: 0,
+            offset: Block::new_512(7),
+            num_blocks: 2,
+        };
+        let op = create_read_eob(next_id, vec![], 10, vec![request]);
 
         work.enqueue(op);
 
@@ -525,13 +535,13 @@ mod test {
         work.in_progress(next_id, 1);
         work.in_progress(next_id, 2);
 
-        let bytes = Some(Bytes::from(vec![]));
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
 
         assert_eq!(
             work.complete(
                 next_id,
                 0,
-                bytes,
+                response,
                 Err(CrucibleError::GenericError(format!("bad")))
             )
             .unwrap(),
@@ -540,9 +550,9 @@ mod test {
         assert_eq!(work.ackable_work().len(), 0);
         assert_eq!(work.completed.len(), 0);
 
-        let bytes = Some(Bytes::from(vec![]));
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
 
-        assert_eq!(work.complete(next_id, 1, bytes, Ok(())).unwrap(), true);
+        assert_eq!(work.complete(next_id, 1, response, Ok(())).unwrap(), true);
         assert_eq!(work.ackable_work().len(), 1);
         assert_eq!(work.completed.len(), 0);
 
@@ -550,9 +560,9 @@ mod test {
         assert_eq!(state, AckStatus::AckReady);
         work.ack(next_id);
 
-        let bytes = Some(Bytes::from(vec![]));
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
 
-        assert_eq!(work.complete(next_id, 2, bytes, Ok(())).unwrap(), false);
+        assert_eq!(work.complete(next_id, 2, response, Ok(())).unwrap(), false);
         assert_eq!(work.ackable_work().len(), 0);
         // A flush is required to move work to completed
         // That this is still zero is part of the test
@@ -566,7 +576,12 @@ mod test {
 
         let next_id = work.next_id();
 
-        let op = create_read_eob(next_id, vec![], 10, 0, Block::new_512(7), 2);
+        let request = ReadRequest {
+            eid: 0,
+            offset: Block::new_512(7),
+            num_blocks: 2,
+        };
+        let op = create_read_eob(next_id, vec![], 10, vec![request]);
 
         work.enqueue(op);
 
@@ -574,13 +589,13 @@ mod test {
         work.in_progress(next_id, 1);
         work.in_progress(next_id, 2);
 
-        let bytes = Some(Bytes::from(vec![]));
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
 
         assert_eq!(
             work.complete(
                 next_id,
                 0,
-                bytes,
+                response,
                 Err(CrucibleError::GenericError(format!("bad")))
             )
             .unwrap(),
@@ -589,13 +604,13 @@ mod test {
         assert_eq!(work.ackable_work().len(), 0);
         assert_eq!(work.completed.len(), 0);
 
-        let bytes = Some(Bytes::from(vec![]));
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
 
         assert_eq!(
             work.complete(
                 next_id,
                 1,
-                bytes,
+                response,
                 Err(CrucibleError::GenericError(format!("bad")))
             )
             .unwrap(),
@@ -604,9 +619,9 @@ mod test {
         assert_eq!(work.ackable_work().len(), 0);
         assert_eq!(work.completed.len(), 0);
 
-        let bytes = Some(Bytes::from(vec![]));
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
 
-        assert_eq!(work.complete(next_id, 2, bytes, Ok(())).unwrap(), true);
+        assert_eq!(work.complete(next_id, 2, response, Ok(())).unwrap(), true);
         assert_eq!(work.ackable_work().len(), 1);
 
         work.ack(next_id);
@@ -624,7 +639,12 @@ mod test {
 
         let next_id = work.next_id();
 
-        let op = create_read_eob(next_id, vec![], 10, 0, Block::new_512(7), 2);
+        let request = ReadRequest {
+            eid: 0,
+            offset: Block::new_512(7),
+            num_blocks: 2,
+        };
+        let op = create_read_eob(next_id, vec![], 10, vec![request]);
 
         work.enqueue(op);
 
@@ -632,13 +652,13 @@ mod test {
         work.in_progress(next_id, 1);
         work.in_progress(next_id, 2);
 
-        let bytes = Some(Bytes::from(vec![]));
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
 
         assert_eq!(
             work.complete(
                 next_id,
                 0,
-                bytes,
+                response,
                 Err(CrucibleError::GenericError(format!("bad")))
             )
             .unwrap(),
@@ -647,13 +667,13 @@ mod test {
         assert_eq!(work.ackable_work().len(), 0);
         assert_eq!(work.completed.len(), 0);
 
-        let bytes = Some(Bytes::from(vec![]));
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
 
         assert_eq!(
             work.complete(
                 next_id,
                 1,
-                bytes,
+                response,
                 Err(CrucibleError::GenericError(format!("bad")))
             )
             .unwrap(),
@@ -662,13 +682,13 @@ mod test {
         assert_eq!(work.ackable_work().len(), 0);
         assert_eq!(work.completed.len(), 0);
 
-        let bytes = Some(Bytes::from(vec![]));
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
 
         assert_eq!(
             work.complete(
                 next_id,
                 2,
-                bytes,
+                response,
                 Err(CrucibleError::GenericError(format!("bad")))
             )
             .unwrap(),
@@ -687,13 +707,18 @@ mod test {
     fn work_read_two_ok_one_bad() {
         let upstairs = Upstairs::default();
 
+        let request = ReadRequest {
+            eid: 0,
+            offset: Block::new_512(7),
+            num_blocks: 2,
+        };
+
         let next_id = {
             let mut work = upstairs.downstairs.lock().unwrap();
 
             let next_id = work.next_id();
 
-            let op =
-                create_read_eob(next_id, vec![], 10, 0, Block::new_512(7), 2);
+            let op = create_read_eob(next_id, vec![], 10, vec![request]);
 
             work.enqueue(op);
 
@@ -704,12 +729,15 @@ mod test {
             next_id
         };
 
-        let bytes = Some(Bytes::from(vec![]));
-        assert_eq!(upstairs.complete(next_id, 2, bytes, Ok(())).unwrap(), true);
-
-        let bytes = Some(Bytes::from(vec![]));
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
         assert_eq!(
-            upstairs.complete(next_id, 0, bytes, Ok(())).unwrap(),
+            upstairs.complete(next_id, 2, response, Ok(())).unwrap(),
+            true
+        );
+
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
+        assert_eq!(
+            upstairs.complete(next_id, 0, response, Ok(())).unwrap(),
             false
         );
 
@@ -724,13 +752,13 @@ mod test {
             work.retire_check(next_id);
         }
 
-        let bytes = Some(Bytes::from(vec![]));
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
         assert_eq!(
             upstairs
                 .complete(
                     next_id,
                     1,
-                    bytes,
+                    response,
                     Err(CrucibleError::GenericError(format!("bad")))
                 )
                 .unwrap(),
@@ -752,7 +780,12 @@ mod test {
 
         let next_id = work.next_id();
 
-        let op = create_read_eob(next_id, vec![], 10, 0, Block::new_512(7), 2);
+        let request = ReadRequest {
+            eid: 0,
+            offset: Block::new_512(7),
+            num_blocks: 2,
+        };
+        let op = create_read_eob(next_id, vec![], 10, vec![request]);
 
         work.enqueue(op);
 
@@ -760,13 +793,13 @@ mod test {
         work.in_progress(next_id, 1);
         work.in_progress(next_id, 2);
 
-        let bytes = Some(Bytes::from(vec![1]));
+        let response = Some(vec![(request, Bytes::from(vec![1]))]);
 
         assert_eq!(
             work.complete(
                 next_id,
                 0,
-                bytes,
+                response,
                 Err(CrucibleError::GenericError(format!("bad")))
             )
             .unwrap(),
@@ -775,13 +808,13 @@ mod test {
 
         assert!(work.active.get(&next_id).unwrap().data.is_none());
 
-        let bytes = Some(Bytes::from(vec![2]));
+        let response = Some(vec![(request, Bytes::from(vec![2]))]);
 
         assert_eq!(
             work.complete(
                 next_id,
                 1,
-                bytes,
+                response,
                 Err(CrucibleError::GenericError(format!("bad")))
             )
             .unwrap(),
@@ -790,14 +823,14 @@ mod test {
 
         assert!(work.active.get(&next_id).unwrap().data.is_none());
 
-        let bytes = Some(Bytes::from(vec![3]));
+        let response = Some(vec![(request, Bytes::from(vec![3]))]);
 
-        assert_eq!(work.complete(next_id, 2, bytes, Ok(()),).unwrap(), true);
+        assert_eq!(work.complete(next_id, 2, response, Ok(()),).unwrap(), true);
 
         assert!(work.active.get(&next_id).unwrap().data.is_some());
         assert_eq!(
             work.active.get(&next_id).unwrap().data,
-            Some(Bytes::from(vec![3]))
+            Some(vec![(request, Bytes::from(vec![3]))])
         );
     }
 
@@ -863,7 +896,12 @@ mod test {
         // The others should be skipped.
 
         let next_id = work.next_id();
-        let op = create_read_eob(next_id, vec![], 10, 0, Block::new_512(7), 2);
+        let request = ReadRequest {
+            eid: 0,
+            offset: Block::new_512(7),
+            num_blocks: 2,
+        };
+        let op = create_read_eob(next_id, vec![], 10, vec![request]);
 
         work.enqueue(op);
 
@@ -871,14 +909,14 @@ mod test {
         assert!(work.in_progress(next_id, 1).is_none());
         assert!(work.in_progress(next_id, 2).is_some());
 
-        let bytes = Some(Bytes::from(vec![3]));
+        let response = Some(vec![(request, Bytes::from(vec![3]))]);
 
-        assert_eq!(work.complete(next_id, 2, bytes, Ok(()),).unwrap(), true);
+        assert_eq!(work.complete(next_id, 2, response, Ok(()),).unwrap(), true);
 
         assert!(work.active.get(&next_id).unwrap().data.is_some());
         assert_eq!(
             work.active.get(&next_id).unwrap().data,
-            Some(Bytes::from(vec![3]))
+            Some(vec![(request, Bytes::from(vec![3]))])
         );
     }
 
@@ -891,7 +929,12 @@ mod test {
 
         // send a read, and clients 0 and 1 will return errors
 
-        let op = create_read_eob(next_id, vec![], 10, 0, Block::new_512(7), 2);
+        let request = ReadRequest {
+            eid: 0,
+            offset: Block::new_512(7),
+            num_blocks: 2,
+        };
+        let op = create_read_eob(next_id, vec![], 10, vec![request]);
 
         work.enqueue(op);
 
@@ -899,13 +942,13 @@ mod test {
         assert!(work.in_progress(next_id, 1).is_some());
         assert!(work.in_progress(next_id, 2).is_some());
 
-        let bytes = Some(Bytes::from(vec![1]));
+        let response = Some(vec![(request, Bytes::from(vec![1]))]);
 
         assert_eq!(
             work.complete(
                 next_id,
                 0,
-                bytes,
+                response,
                 Err(CrucibleError::GenericError(format!("bad")))
             )
             .unwrap(),
@@ -914,13 +957,13 @@ mod test {
 
         assert!(work.active.get(&next_id).unwrap().data.is_none());
 
-        let bytes = Some(Bytes::from(vec![2]));
+        let response = Some(vec![(request, Bytes::from(vec![2]))]);
 
         assert_eq!(
             work.complete(
                 next_id,
                 1,
-                bytes,
+                response,
                 Err(CrucibleError::GenericError(format!("bad")))
             )
             .unwrap(),
@@ -929,14 +972,14 @@ mod test {
 
         assert!(work.active.get(&next_id).unwrap().data.is_none());
 
-        let bytes = Some(Bytes::from(vec![3]));
+        let response = Some(vec![(request, Bytes::from(vec![3]))]);
 
-        assert_eq!(work.complete(next_id, 2, bytes, Ok(()),).unwrap(), true);
+        assert_eq!(work.complete(next_id, 2, response, Ok(()),).unwrap(), true);
 
         assert!(work.active.get(&next_id).unwrap().data.is_some());
         assert_eq!(
             work.active.get(&next_id).unwrap().data,
-            Some(Bytes::from(vec![3]))
+            Some(vec![(request, Bytes::from(vec![3]))])
         );
 
         assert!(work.downstairs_errors.get(&0).is_none());
@@ -947,7 +990,12 @@ mod test {
         // (reads shouldn't cause a Failed transition)
 
         let next_id = work.next_id();
-        let op = create_read_eob(next_id, vec![], 10, 0, Block::new_512(7), 2);
+        let request = ReadRequest {
+            eid: 0,
+            offset: Block::new_512(7),
+            num_blocks: 2,
+        };
+        let op = create_read_eob(next_id, vec![], 10, vec![request]);
 
         work.enqueue(op);
 
@@ -955,13 +1003,13 @@ mod test {
         assert!(work.in_progress(next_id, 1).is_some());
         assert!(work.in_progress(next_id, 2).is_some());
 
-        let bytes = Some(Bytes::from(vec![4]));
+        let response = Some(vec![(request, Bytes::from(vec![4]))]);
 
         assert_eq!(
             work.complete(
                 next_id,
                 0,
-                bytes,
+                response,
                 Err(CrucibleError::GenericError(format!("bad")))
             )
             .unwrap(),
@@ -970,13 +1018,13 @@ mod test {
 
         assert!(work.active.get(&next_id).unwrap().data.is_none());
 
-        let bytes = Some(Bytes::from(vec![5]));
+        let response = Some(vec![(request, Bytes::from(vec![5]))]);
 
         assert_eq!(
             work.complete(
                 next_id,
                 1,
-                bytes,
+                response,
                 Err(CrucibleError::GenericError(format!("bad")))
             )
             .unwrap(),
@@ -985,14 +1033,14 @@ mod test {
 
         assert!(work.active.get(&next_id).unwrap().data.is_none());
 
-        let bytes = Some(Bytes::from(vec![6]));
+        let response = Some(vec![(request, Bytes::from(vec![6]))]);
 
-        assert_eq!(work.complete(next_id, 2, bytes, Ok(()),).unwrap(), true);
+        assert_eq!(work.complete(next_id, 2, response, Ok(()),).unwrap(), true);
 
         assert!(work.active.get(&next_id).unwrap().data.is_some());
         assert_eq!(
             work.active.get(&next_id).unwrap().data,
-            Some(Bytes::from(vec![6]))
+            Some(vec![(request, Bytes::from(vec![6]))])
         );
     }
 
@@ -1006,7 +1054,12 @@ mod test {
         // Build our read, put it into the work queue
         let next_id = work.next_id();
 
-        let op = create_read_eob(next_id, vec![], 10, 0, Block::new_512(7), 2);
+        let request = ReadRequest {
+            eid: 0,
+            offset: Block::new_512(7),
+            num_blocks: 2,
+        };
+        let op = create_read_eob(next_id, vec![], 10, vec![request]);
 
         work.enqueue(op);
 
@@ -1016,17 +1069,17 @@ mod test {
         work.in_progress(next_id, 2);
 
         // Downstairs 0 now has completed this work.
-        let bytes = Some(Bytes::from(vec![]));
-        assert_eq!(work.complete(next_id, 0, bytes, Ok(())).unwrap(), true);
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
+        assert_eq!(work.complete(next_id, 0, response, Ok(())).unwrap(), true);
 
         // One completion of a read means we can ACK
         assert_eq!(work.ackable_work().len(), 1);
 
         // Complete downstairs 1 and 2
-        let bytes = Some(Bytes::from(vec![]));
-        assert_eq!(work.complete(next_id, 1, bytes, Ok(())).unwrap(), false);
-        let bytes = Some(Bytes::from(vec![]));
-        assert_eq!(work.complete(next_id, 2, bytes, Ok(())).unwrap(), false);
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
+        assert_eq!(work.complete(next_id, 1, response, Ok(())).unwrap(), false);
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
+        assert_eq!(work.complete(next_id, 2, response, Ok(())).unwrap(), false);
 
         // Make sure the job is still active
         assert_eq!(work.completed.len(), 0);
@@ -1357,7 +1410,12 @@ mod test {
 
         // Build our read IO and submit it to the work queue.
         let next_id = work.next_id();
-        let op = create_read_eob(next_id, vec![], 10, 0, Block::new_512(7), 2);
+        let request = ReadRequest {
+            eid: 0,
+            offset: Block::new_512(7),
+            num_blocks: 2,
+        };
+        let op = create_read_eob(next_id, vec![], 10, vec![request]);
         work.enqueue(op);
 
         // Submit the read to all three downstairs
@@ -1366,8 +1424,8 @@ mod test {
         work.in_progress(next_id, 2);
 
         // Complete the read on one downstairs.
-        let bytes = Some(Bytes::from(vec![]));
-        assert_eq!(work.complete(next_id, 0, bytes, Ok(())).unwrap(), true);
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
+        assert_eq!(work.complete(next_id, 0, response, Ok(())).unwrap(), true);
 
         // One completion should allow for an ACK
         assert_eq!(work.ackable_work().len(), 1);
@@ -1392,7 +1450,12 @@ mod test {
 
         // Build a read and put it on the work queue.
         let next_id = work.next_id();
-        let op = create_read_eob(next_id, vec![], 10, 0, Block::new_512(7), 2);
+        let request = ReadRequest {
+            eid: 0,
+            offset: Block::new_512(7),
+            num_blocks: 2,
+        };
+        let op = create_read_eob(next_id, vec![], 10, vec![request]);
         work.enqueue(op);
 
         // Submit the read to each downstairs.
@@ -1401,15 +1464,15 @@ mod test {
         work.in_progress(next_id, 2);
 
         // Complete the read on one downstairs, verify it is ack ready.
-        let bytes = Some(Bytes::from(vec![]));
-        assert_eq!(work.complete(next_id, 0, bytes, Ok(())).unwrap(), true);
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
+        assert_eq!(work.complete(next_id, 0, response, Ok(())).unwrap(), true);
         assert_eq!(work.ackable_work().len(), 1);
         let state = work.active.get_mut(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
 
         // Complete the read on a 2nd downstairs.
-        let bytes = Some(Bytes::from(vec![]));
-        assert_eq!(work.complete(next_id, 1, bytes, Ok(())).unwrap(), false);
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
+        assert_eq!(work.complete(next_id, 1, response, Ok(())).unwrap(), false);
 
         // Now, take the first downstairs offline.
         work.re_new(0);
@@ -1424,9 +1487,9 @@ mod test {
         assert_eq!(state, AckStatus::NotAcked);
 
         // Redo the read on DS 0, IO should go back to ackable.
-        let bytes = Some(Bytes::from(vec![]));
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
         work.in_progress(next_id, 0);
-        assert_eq!(work.complete(next_id, 0, bytes, Ok(())).unwrap(), true);
+        assert_eq!(work.complete(next_id, 0, response, Ok(())).unwrap(), true);
         assert_eq!(work.ackable_work().len(), 1);
         let state = work.active.get_mut(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
@@ -1441,7 +1504,12 @@ mod test {
 
         // Create the read and put it on the work queue.
         let next_id = work.next_id();
-        let op = create_read_eob(next_id, vec![], 10, 0, Block::new_512(7), 2);
+        let request = ReadRequest {
+            eid: 0,
+            offset: Block::new_512(7),
+            num_blocks: 2,
+        };
+        let op = create_read_eob(next_id, vec![], 10, vec![request]);
         work.enqueue(op);
 
         // Submit the read to each downstairs.
@@ -1450,8 +1518,8 @@ mod test {
         work.in_progress(next_id, 2);
 
         // Complete the read on one downstairs.
-        let bytes = Some(Bytes::from(vec![]));
-        assert_eq!(work.complete(next_id, 0, bytes, Ok(())).unwrap(), true);
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
+        assert_eq!(work.complete(next_id, 0, response, Ok(())).unwrap(), true);
 
         // Verify the read is now AckReady
         assert_eq!(work.ackable_work().len(), 1);
@@ -1477,9 +1545,9 @@ mod test {
         assert_eq!(state, AckStatus::Acked);
 
         // Redo on DS 0, IO should remain acked.
-        let bytes = Some(Bytes::from(vec![]));
+        let response = Some(vec![(request, Bytes::from(vec![]))]);
         work.in_progress(next_id, 0);
-        assert_eq!(work.complete(next_id, 0, bytes, Ok(())).unwrap(), false);
+        assert_eq!(work.complete(next_id, 0, response, Ok(())).unwrap(), false);
         assert_eq!(work.ackable_work().len(), 0);
         let state = work.active.get_mut(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::Acked);


### PR DESCRIPTION
This is required for storing a per-block HMAC for AEAD.

Write changes:
```
    -    Write(Uuid, u64, Vec<u64>, u64, Block, bytes::Bytes),
    +    Write(Uuid, u64, Vec<u64>, Vec<Write>),

pub struct Write {
    pub eid: u64,
    pub offset: Block,
    pub data: bytes::Bytes,
}
```

Read changes:
```
    -    ReadRequest(Uuid, u64, Vec<u64>, u64, Block, u64),
    -    ReadResponse(Uuid, u64, bytes::Bytes, Result<(), CrucibleError>),
    +    ReadRequest(Uuid, u64, Vec<u64>, Vec<ReadRequest>),
    +    ReadResponse(
    +        Uuid,
    +        u64,
    +        Vec<(ReadRequest, bytes::Bytes)>,
    +        Result<(), CrucibleError>,
    +    ),

pub struct ReadRequest {
    pub eid: u64,
    pub offset: Block,
    pub num_blocks: u64,
}
```

By bundling the ReadRequest into the response, this simplifies the processing on the Upstairs side. One example is that `downstairs_buffer_sector_index` is no longer required.

In AWS testing, this protocol change caused a hammer benchmark speedup (measuring illumos ptime output):

unencrypted benchmark showed 1.38% faster for sys, 2.35% faster for user:
```
real
x before.val
+ after.val
+----------------------------------------------------------------------+
|                                                            +         |
| +  x +xxx xx++  +    x x+  x+                              + +      x|
||___________M______A___________________|                              |
|     |___________________M___A______________________|                 |
+----------------------------------------------------------------------+
    N           Min           Max        Median           Avg        Stddev
x  10     14.673433     15.743631     14.804038     14.931771    0.31581653
+  10     14.636076     15.629443     15.024965     15.083366    0.38305231
No difference proven at 95.0% confidence
sys
x before.val
+ after.val
+----------------------------------------------------------------------+
|                            +                                         |
|                            +                                x  x     |
|+                   +   +  x+   ++  +   +           x     xx x xxx    |
|                                              |__________A___M_______||
|                |__________AM_________|                               |
+----------------------------------------------------------------------+
    N           Min           Max        Median           Avg        Stddev
x  10     1.9706256     2.0052229     2.0021461     1.9985865   0.010467791
+  10     1.9462727     1.9824126     1.9721712      1.970913   0.010074588
Difference at 95.0% confidence
	-0.0276735 +/- 0.00965253
	-1.38465% +/- 0.482968%
	(Student's t, pooled s = 0.0102731)
user
x before.val
+ after.val
+----------------------------------------------------------------------+
|+   +       +  +  + +    ++    +   +                 x  x xxx x x    x|
|                                                        |___MA____|   |
|       |___________AM_________|                                       |
+----------------------------------------------------------------------+
    N           Min           Max        Median           Avg        Stddev
x  10     2.0737353     2.0925247     2.0825709     2.0831995  0.0059731274
+  10     2.0125575     2.0529298     2.0358676     2.0341238     0.0130916
Difference at 95.0% confidence
	-0.0490758 +/- 0.00956055
	-2.35579% +/- 0.458936%
	(Student's t, pooled s = 0.0101752)
```

encrypted benchmark showed 0.48& faster for sys, 1.60% faster for user:

```
real
x before.val
+ after.val
+----------------------------------------------------------------------+
|         +                                                            |
|         +x                                                           |
|     +  ++*  x x  x*++ x  x x                                    +   x|
|      |____________M___A________________|                             |
||_________M_______A________________|                                  |
+----------------------------------------------------------------------+
    N           Min           Max        Median           Avg        Stddev
x  10     14.721541     15.735178      14.87558     14.949124    0.29576212
+  10     14.642579      15.66278     14.735282     14.856211     0.2995154
No difference proven at 95.0% confidence
sys
x before.val
+ after.val
+----------------------------------------------------------------------+
|+       ++ +  + x      +  x    + +  x x * +      x   x x             x|
|                           |____________M_A______________|            |
|      |______________A_M____________|                                 |
+----------------------------------------------------------------------+
    N           Min           Max        Median           Avg        Stddev
x  10       1.97723     2.0018994     1.9883818     1.9893851   0.007031637
+  10     1.9698362     1.9891536     1.9804605     1.9796399  0.0068266116
Difference at 95.0% confidence
	-0.00974524 +/- 0.00651129
	-0.489862% +/- 0.327302%
	(Student's t, pooled s = 0.00692988)
user
x before.val
+ after.val
+----------------------------------------------------------------------+
|        +                                            x                |
|+      ++    +++     +    ++                        xxx   x x x    xxx|
|                                                     |______A_____|   |
|     |________A________|                                              |
+----------------------------------------------------------------------+
    N           Min           Max        Median           Avg        Stddev
x  10     2.0920509     2.1041988     2.0978368     2.0974367  0.0047919885
+  10     2.0537706     2.0731476     2.0637777     2.0638825  0.0063399792
Difference at 95.0% confidence
	-0.0335541 +/- 0.0052801
	-1.59977% +/- 0.25174%
	(Student's t, pooled s = 0.00561954)
```

fio measurements on my Ubuntu workstation also showed an improvement:

![crucible_bw](https://user-images.githubusercontent.com/2858890/141375643-d843fe96-d334-4f60-ae0e-4272b794ab10.png)

![crucible_lat](https://user-images.githubusercontent.com/2858890/141375657-c2e39296-c336-4383-b541-73d0d2e3f2f6.png)

Notice the red marks finishing "earlier" in the graph.

Additionally, note that in case of another upstairs activation, this commit changes to return a new YouAreNoLongerActive message. This differentiates between a programmer error resulting in a Uuid mismatch and business as normal when another upstairs is Promoted to Active.