### PR TITLE
Plumb the generation number all the way to storage

### DIFF
--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -70,7 +70,7 @@ pub enum Message {
     Write(Uuid, u64, Vec<u64>, Vec<Write>),
     WriteAck(Uuid, u64, Result<(), CrucibleError>),
 
-    Flush(Uuid, u64, Vec<u64>, u64),
+    Flush(Uuid, u64, Vec<u64>, u64, u64),
     FlushAck(Uuid, u64, Result<(), CrucibleError>),
 
     /*

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -356,7 +356,7 @@ mod test {
 
         let next_id = work.next_id();
 
-        let op = create_flush(next_id, vec![], 10, 0);
+        let op = create_flush(next_id, vec![], 10, 0, 0);
 
         work.enqueue(op);
 
@@ -389,7 +389,7 @@ mod test {
 
         let next_id = work.next_id();
 
-        let op = create_flush(next_id, vec![], 10, 0);
+        let op = create_flush(next_id, vec![], 10, 0, 0);
 
         work.enqueue(op);
 
@@ -431,7 +431,7 @@ mod test {
 
         let next_id = work.next_id();
 
-        let op = create_flush(next_id, vec![], 10, 0);
+        let op = create_flush(next_id, vec![], 10, 0, 0);
 
         work.enqueue(op);
 
@@ -1110,7 +1110,7 @@ mod test {
         // A flush is required to move work to completed
         // Create the flush then send it to all downstairs.
         let next_id = work.next_id();
-        let op = create_flush(next_id, vec![], 10, 0);
+        let op = create_flush(next_id, vec![], 10, 0, 0);
 
         work.enqueue(op);
 
@@ -1197,7 +1197,7 @@ mod test {
 
         // Create the flush, put on the work queue
         let flush_id = work.next_id();
-        let op = create_flush(flush_id, vec![], 10, 0);
+        let op = create_flush(flush_id, vec![], 10, 0, 0);
         work.enqueue(op);
 
         // Simulate sending the flush to downstairs 0 and 1
@@ -1287,7 +1287,7 @@ mod test {
 
         // Create the flush IO
         let next_id = work.next_id();
-        let op = create_flush(next_id, vec![], 10, 0);
+        let op = create_flush(next_id, vec![], 10, 0, 0);
         work.enqueue(op);
 
         // Submit the flush to all three downstairs.
@@ -1371,7 +1371,7 @@ mod test {
 
         // Create and enqueue the flush.
         let flush_id = work.next_id();
-        let op = create_flush(flush_id, vec![], 10, 0);
+        let op = create_flush(flush_id, vec![], 10, 0, 0);
         work.enqueue(op);
 
         // Send the flush to two downstairs.


### PR DESCRIPTION
This is part two (of ??) for support of generation number (AKA attach
number) in Crucible.  The generation number supplied during the
attach request for a guest is now passed down through the flush
command all the way to storage.

There is still more to do here, and part of that is design work.

You can specify the generation number on the command line for crucible-client, here is some
example output showing both generation 9 and 1 on extents:
```
final:generation$ cargo run  -p crucible-downstairs -- dump -d var/3801 -d var/3802 -d var/3803
    Finished dev [unoptimized + debuginfo] target(s) in 0.29s
     Running `target/debug/crucible-downstairs dump -d var/3801 -d var/3802 -d var/3803`
  N      GEN FLUSH_ID D      GEN FLUSH_ID D      GEN FLUSH_ID D
  0        9      119          9      119          9      119   
  1        9      127          9      127          9      127   
  2        9      131          9      131          9      131   
  3        9      131          9      131          9      131   
  4        9      123          9      123          9      123   
  5        9      131          9      131          9      131   
  6        9      131          9      131          9      131   
  7        9      128          9      128          9      128   
  8        9      122          9      122          9      122   
  9        9      130          9      130          9      130   
 10        9      131          9      131          9      131   
 11        9      130          9      130          9      130   
 12        1      132          1      132          1      132   
 13        9      128          9      128          9      128   
 14        9      128          9      128          9      128   
 15        9      124          9      124          9      124   
 16        9      131          9      131          9      131   
 17        9      131          9      131          9      131   
 18        1      132          1      132          1      132   
 19        9      124          9      124          9      124 
```