### PR TITLE
Add nonces and tags to protocol

### DIFF
--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -244,8 +244,8 @@ fn show_extent(
          * A,B,C all represent unique values in a block. If blocks match,
          * they will share the same letter.
          *
-         * Each row is a new block and the values are unrelated to the previous
-         * block.
+         * Each row is a new block and the values are unrelated to the
+         * previous block.
          */
 
         let mut diff_found = false;
@@ -281,10 +281,7 @@ fn show_extent(
             }
         }
 
-        print!("{0:^11} {1:^11} ",
-            status_letters[0],
-            status_letters[1],
-        );
+        print!("{0:^11} {1:^11} ", status_letters[0], status_letters[1],);
         if dir_count > 2 {
             print!("{0:^11} ", status_letters[2]);
         }
@@ -320,10 +317,7 @@ fn show_extent(
             }
         }
 
-        print!("{0:^11} {1:^11} ",
-            status_letters[0],
-            status_letters[1],
-        );
+        print!("{0:^11} {1:^11} ", status_letters[0], status_letters[1],);
         if dir_count > 2 {
             print!("{0:^11} ", status_letters[2]);
         }
@@ -359,10 +353,7 @@ fn show_extent(
             }
         }
 
-        print!("{0:^11} {1:^11} ",
-            status_letters[0],
-            status_letters[1],
-        );
+        print!("{0:^11} {1:^11} ", status_letters[0], status_letters[1],);
         if dir_count > 2 {
             print!("{0:^11} ", status_letters[2]);
         }

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -105,7 +105,7 @@ pub fn dump_region(
     let mut ext_num = all_extents.keys().collect::<Vec<&u32>>();
     ext_num.sort_unstable();
 
-    print!("  N");
+    print!("EXT");
     for _ in 0..dir_count {
         print!("      GEN FLUSH_ID D");
     }
@@ -193,19 +193,33 @@ fn show_extent(
         }
     }
     println!();
+    println!();
+
+    print!("{0:10}", "");
+    for (index, _) in region_dir.iter().enumerate() {
+        print!(" {0:^11}", format!("Data {}", index));
+    }
+    for (index, _) in region_dir.iter().enumerate() {
+        print!(" {0:^11}", format!("Nonce {}", index));
+    }
+    for (index, _) in region_dir.iter().enumerate() {
+        print!(" {0:^11}", format!("Tag {}", index));
+    }
+    print!(" {0:^7}", "DIFF");
+    println!();
 
     /*
      * Compare the data from each block.
      * Print a letter representing the data for each block.
      */
     for block in 0..blocks_per_extent {
-        print!("Block {:3}", block);
+        print!("Block {:4}", block);
 
         /*
-         * Build a Vector to hold our data buffers, one for each
+         * Build a Vector to hold our responses, one for each
          * region we are comparing.
          */
-        let mut dvec: Vec<BytesMut> = Vec::with_capacity(dir_count);
+        let mut dvec: Vec<ReadResponse> = Vec::with_capacity(dir_count);
 
         /*
          * Read the requested block in from the extent.  Store it
@@ -225,35 +239,136 @@ fn show_extent(
         }
 
         /*
-         * Compare all the data buffers to each other.
-         * A,B,C all represent unique values in a block.  If blocks match,
+         * Compare all the responses to each other.
+         *
+         * A,B,C all represent unique values in a block. If blocks match,
          * they will share the same letter.
-         * Each row is a new block and the values are unrelated to the
-         * data in the previous block.
+         *
+         * Each row is a new block and the values are unrelated to the previous
+         * block.
          */
-        if dvec[0] == dvec[1] {
-            print!("{0:>8} {0:>8} ", "A".to_string());
+
+        let mut diff_found = false;
+
+        // first compare data
+        let mut status_letters = vec![String::new(); 3];
+
+        if dvec[0].data == dvec[1].data {
+            status_letters[0] += "A";
+            status_letters[1] += "A";
 
             if dir_count > 2 {
-                if dvec[0] == dvec[2] {
-                    print!("{:>8}", "A".to_string());
+                if dvec[0].data == dvec[2].data {
+                    status_letters[2] += "A";
                 } else {
-                    print!("{:>8}", "C".to_string());
+                    status_letters[2] += "C";
+                    diff_found = true;
                 }
             }
         } else {
-            print!("{:>8} {:>8} ", "A".to_string(), "B".to_string());
+            diff_found = true;
+            status_letters[0] += "A";
+            status_letters[1] += "B";
 
             if dir_count > 2 {
-                if dvec[0] == dvec[2] {
-                    print!("{:>8}", "A".to_string());
-                } else if dvec[1] == dvec[2] {
-                    print!("{:>8}", "B".to_string());
+                if dvec[0].data == dvec[2].data {
+                    status_letters[2] += "A";
+                } else if dvec[1].data == dvec[2].data {
+                    status_letters[2] += "B";
                 } else {
-                    print!("{:>8}", "C".to_string());
+                    status_letters[2] += "C";
                 }
             }
         }
+
+        print!("{0:^11} {1:^11} ",
+            status_letters[0],
+            status_letters[1],
+        );
+        if dir_count > 2 {
+            print!("{0:^11} ", status_letters[2]);
+        }
+
+        // then, compare nonces
+        let mut status_letters = vec![String::new(); 3];
+
+        if dvec[0].nonce == dvec[1].nonce {
+            status_letters[0] += "A";
+            status_letters[1] += "A";
+
+            if dir_count > 2 {
+                if dvec[0].nonce == dvec[2].nonce {
+                    status_letters[2] += "A";
+                } else {
+                    status_letters[2] += "C";
+                    diff_found = true;
+                }
+            }
+        } else {
+            diff_found = true;
+            status_letters[0] += "A";
+            status_letters[1] += "B";
+
+            if dir_count > 2 {
+                if dvec[0].nonce == dvec[2].nonce {
+                    status_letters[2] += "A";
+                } else if dvec[1].nonce == dvec[2].nonce {
+                    status_letters[2] += "B";
+                } else {
+                    status_letters[2] += "C";
+                }
+            }
+        }
+
+        print!("{0:^11} {1:^11} ",
+            status_letters[0],
+            status_letters[1],
+        );
+        if dir_count > 2 {
+            print!("{0:^11} ", status_letters[2]);
+        }
+
+        // then, compare tags
+        let mut status_letters = vec![String::new(); 3];
+
+        if dvec[0].tag == dvec[1].tag {
+            status_letters[0] += "A";
+            status_letters[1] += "A";
+
+            if dir_count > 2 {
+                if dvec[0].tag == dvec[2].tag {
+                    status_letters[2] += "A";
+                } else {
+                    status_letters[2] += "C";
+                    diff_found = true;
+                }
+            }
+        } else {
+            diff_found = true;
+            status_letters[0] += "A";
+            status_letters[1] += "B";
+
+            if dir_count > 2 {
+                if dvec[0].tag == dvec[2].tag {
+                    status_letters[2] += "A";
+                } else if dvec[1].tag == dvec[2].tag {
+                    status_letters[2] += "B";
+                } else {
+                    status_letters[2] += "C";
+                }
+            }
+        }
+
+        print!("{0:^11} {1:^11} ",
+            status_letters[0],
+            status_letters[1],
+        );
+        if dir_count > 2 {
+            print!("{0:^11} ", status_letters[2]);
+        }
+
+        print!("{0:^7}", if diff_found { "<-------" } else { "" });
+
         println!();
     }
 

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -169,13 +169,13 @@ fn downstairs_export<P: AsRef<Path> + std::fmt::Debug>(
             if (extent_offset + block_offset) >= start_block {
                 blocks_copied += 1;
 
-                let data = region.single_block_region_read(ReadRequest {
+                let response = region.single_block_region_read(ReadRequest {
                     eid: eid as u64,
                     offset: Block::new_with_ddef(block_offset, &region.def()),
                     num_blocks: 1,
                 })?;
 
-                out_file.write_all(&data).unwrap();
+                out_file.write_all(&response.data).unwrap();
 
                 if blocks_copied >= count {
                     break 'eid_loop;

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -169,11 +169,15 @@ fn downstairs_export<P: AsRef<Path> + std::fmt::Debug>(
             if (extent_offset + block_offset) >= start_block {
                 blocks_copied += 1;
 
-                let response = region.single_block_region_read(ReadRequest {
-                    eid: eid as u64,
-                    offset: Block::new_with_ddef(block_offset, &region.def()),
-                    num_blocks: 1,
-                })?;
+                let response =
+                    region.single_block_region_read(ReadRequest {
+                        eid: eid as u64,
+                        offset: Block::new_with_ddef(
+                            block_offset,
+                            &region.def(),
+                        ),
+                        num_blocks: 1,
+                    })?;
 
                 out_file.write_all(&response.data).unwrap();
 

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -460,7 +460,6 @@ impl Extent {
 
         inner.file.seek(SeekFrom::Start(byte_offset))?;
         inner.file.write_all(&write.data)?;
-        inner.file.flush()?;
 
         if write.nonce.is_some() && write.tag.is_some() {
             inner.set_encryption_context(

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -6,7 +6,6 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard};
 
 use anyhow::{bail, Result};
-use bytes::BytesMut;
 use crucible_common::*;
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
@@ -722,11 +721,11 @@ impl Region {
     pub fn single_block_region_read(
         &self,
         request: crucible_protocol::ReadRequest,
-    ) -> Result<BytesMut, CrucibleError> {
+    ) -> Result<crucible_protocol::ReadResponse, CrucibleError> {
         let mut responses = self.region_read(&[request])?;
         let response = responses.pop().unwrap();
         drop(responses);
-        Ok(response.data)
+        Ok(response)
     }
 
     #[instrument]

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -760,10 +760,9 @@ impl Region {
 
 #[cfg(test)]
 mod test {
-    use super::extent_path;
     use super::*;
     use crate::dump::dump_region;
-    use bytes::BufMut;
+    use bytes::{BufMut, BytesMut};
     use rand::Rng;
     use std::path::PathBuf;
     use tempfile::tempdir;

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -109,6 +109,57 @@ impl Inner {
             .execute("UPDATE metadata SET value=1 WHERE name='dirty'", [])?;
         Ok(())
     }
+
+    fn get_encryption_context(
+        &self,
+        block: u64,
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
+        let mut stmt = self.metadb.prepare(
+            &[
+                "SELECT nonce, tag FROM encryption_context",
+                "where block=?1",
+            ]
+            .join(" "),
+        )?;
+
+        let stmt_iter = stmt.query_map(params![block], |row| {
+            Ok(Some((row.get(0)?, row.get(1)?)))
+        })?;
+
+        let mut results = Vec::new();
+
+        for row in stmt_iter {
+            results.push(row);
+        }
+
+        if results.is_empty() {
+            Ok(None)
+        } else {
+            assert_eq!(results.len(), 1);
+            let result = results.pop().unwrap();
+            drop(results);
+            result.map_err(anyhow::Error::new)
+        }
+    }
+
+    fn set_encryption_context(
+        &self,
+        block: u64,
+        nonce: &[u8],
+        tag: &[u8],
+    ) -> Result<()> {
+        let mut stmt = self.metadb.prepare(
+            &[
+                "INSERT OR REPLACE INTO encryption_context",
+                "(block, nonce, tag) values (?1, ?2, ?3)",
+            ]
+            .join(" "),
+        )?;
+
+        let _rows_affected = stmt.execute(params![block, nonce, tag])?;
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -299,6 +350,15 @@ impl Extent {
             params!["dirty", meta.dirty],
         )?;
 
+        metadb.execute(
+            "CREATE TABLE encryption_context (
+                block INTEGER PRIMARY KEY,
+                nonce BLOB NOT NULL,
+                tag BLOB NOT NULL
+            )",
+            [],
+        )?;
+
         /*
          * Complete the construction of our new extent
          */
@@ -321,12 +381,16 @@ impl Extent {
     #[instrument]
     pub fn read(
         &self,
-        offset: Block,
-        data: &mut BytesMut,
-    ) -> Result<(), CrucibleError> {
-        self.check_input(offset, data)?;
+        request: &crucible_protocol::ReadRequest,
+    ) -> Result<crucible_protocol::ReadResponse, CrucibleError> {
+        let mut response = crucible_protocol::ReadResponse::from_request(
+            request,
+            self.block_size as usize,
+        );
 
-        let byte_offset = offset.value * self.block_size;
+        self.check_input(request.offset, &response.data)?;
+
+        let byte_offset = request.offset.value * self.block_size;
 
         let mut inner = self.inner.lock().unwrap();
         inner.file.seek(SeekFrom::Start(byte_offset))?;
@@ -336,9 +400,15 @@ impl Extent {
          * with data ahead of time.  If we want to use an uninitialized
          * buffer, then we need a different read or type for the destination
          */
-        inner.file.read_exact(data)?;
+        inner.file.read_exact(&mut response.data)?;
 
-        Ok(())
+        let ctx = inner.get_encryption_context(request.offset.value)?;
+        if let Some((nonce, tag)) = ctx {
+            response.nonce = Some(nonce);
+            response.tag = Some(tag);
+        }
+
+        Ok(response)
     }
 
     /**
@@ -378,20 +448,27 @@ impl Extent {
     #[instrument]
     pub fn write(
         &self,
-        offset: Block,
-        data: &[u8],
+        write: &crucible_protocol::Write,
     ) -> Result<(), CrucibleError> {
         let mut inner = self.inner.lock().unwrap();
 
-        self.check_input(offset, data)?;
+        self.check_input(write.offset, &write.data)?;
 
         inner.set_dirty()?;
 
-        let byte_offset = offset.value * self.block_size;
+        let byte_offset = write.offset.value * self.block_size;
 
         inner.file.seek(SeekFrom::Start(byte_offset))?;
-        inner.file.write_all(data)?;
+        inner.file.write_all(&write.data)?;
         inner.file.flush()?;
+
+        if write.nonce.is_some() && write.tag.is_some() {
+            inner.set_encryption_context(
+                write.offset.value,
+                write.nonce.as_ref().unwrap(),
+                write.tag.as_ref().unwrap(),
+            )?;
+        }
 
         Ok(())
     }
@@ -618,8 +695,16 @@ impl Region {
         eid: u64,
         offset: Block,
         data: bytes::Bytes,
+        nonce: Option<Vec<u8>>,
+        tag: Option<Vec<u8>>,
     ) -> Result<(), CrucibleError> {
-        self.region_write(&[crucible_protocol::Write { eid, offset, data }])
+        self.region_write(&[crucible_protocol::Write {
+            eid,
+            offset,
+            data,
+            nonce,
+            tag,
+        }])
     }
 
     #[instrument]
@@ -629,7 +714,7 @@ impl Region {
     ) -> Result<(), CrucibleError> {
         for write in writes {
             let extent = &self.extents[write.eid as usize];
-            extent.write(write.offset, &write.data)?;
+            extent.write(write)?;
         }
         Ok(())
     }
@@ -639,30 +724,25 @@ impl Region {
         &self,
         request: crucible_protocol::ReadRequest,
     ) -> Result<BytesMut, CrucibleError> {
-        let block_size = self.def.block_size() as usize;
-
-        let mut data = BytesMut::with_capacity(block_size);
-        data.resize(block_size, 1);
-
-        let mut responses = vec![(request, data)];
-        self.region_read(&mut responses)?;
-
-        let (_, data) = responses.pop().unwrap();
+        let mut responses = self.region_read(&[request])?;
+        let response = responses.pop().unwrap();
         drop(responses);
-
-        Ok(data)
+        Ok(response.data)
     }
 
     #[instrument]
     pub fn region_read(
         &self,
-        responses: &mut Vec<(crucible_protocol::ReadRequest, BytesMut)>,
-    ) -> Result<(), CrucibleError> {
-        for (request, data) in responses {
+        requests: &[crucible_protocol::ReadRequest],
+    ) -> Result<Vec<crucible_protocol::ReadResponse>, CrucibleError> {
+        let mut responses = Vec::with_capacity(requests.len());
+
+        for request in requests {
             let extent = &self.extents[request.eid as usize];
-            extent.read(request.offset, data)?;
+            responses.push(extent.read(request)?);
         }
-        Ok(())
+
+        Ok(responses)
     }
 
     /*
@@ -686,6 +766,7 @@ mod test {
     use super::*;
     use crate::dump::dump_region;
     use bytes::BufMut;
+    use rand::Rng;
     use std::path::PathBuf;
     use tempfile::tempdir;
     use uuid::Uuid;
@@ -960,6 +1041,48 @@ mod test {
          * Dump the region
          */
         dump_region(dvec, Some(2))?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn encryption_context() -> Result<()> {
+        let dir = tempdir()?;
+        let mut region = Region::create(&dir, new_region_options())?;
+        region.extend(1)?;
+
+        let ext = &region.extents[0];
+        let inner = ext.inner();
+
+        // Encryption context for blocks 0 and 1 should start blank
+
+        assert!(inner.get_encryption_context(0)?.is_none());
+        assert!(inner.get_encryption_context(1)?.is_none());
+
+        // Set and verify block 0's context
+
+        inner.set_encryption_context(0, &[1, 2, 3], &[4, 5, 6, 7])?;
+
+        let ctx = inner.get_encryption_context(0)?.unwrap();
+
+        assert_eq!(ctx.0, vec![1, 2, 3]);
+        assert_eq!(ctx.1, vec![4, 5, 6, 7]);
+
+        // Block 1 should still be blank
+
+        assert!(inner.get_encryption_context(1)?.is_none());
+
+        // Set and verify a new context for block 0
+
+        let blob1 = rand::thread_rng().gen::<[u8; 32]>();
+        let blob2 = rand::thread_rng().gen::<[u8; 32]>();
+
+        inner.set_encryption_context(0, &blob1, &blob2)?;
+
+        let ctx = inner.get_encryption_context(0)?.unwrap();
+
+        assert_eq!(ctx.0, blob1);
+        assert_eq!(ctx.1, blob2);
 
         Ok(())
     }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -171,7 +171,11 @@ async fn process_message(
  *
  *     Extent number (EID), Block offset, Length in Blocks
  *
- * - length in blocks can be up to the region size
+ * Note: length in blocks can be up to the region size
+ *
+ * If performing authenticated encryption, nonce and tags must be sent per
+ * block. This means extent_from_offset must return a list of single blocks
+ * only, hence the boolean argument `single_blocks_only`.
  */
 pub fn extent_from_offset(
     ddef: RegionDefinition,


### PR DESCRIPTION
Add nonce and tag to both reads and writes. A separate ReadResponse is
created to differentiate between a request and response.

ReadResponse now returns a Result<Vec<Response>> instead of returning
result separately in another field. This obviates some code and makes
one of the failures currently being tested unable to happen. Empty
vectors are used in io_complete for WriteAck and FlushAck.

Nonces and tags are stored in SQLite as blobs. SQLite only uses variable
length records [1] so no optimization can occur by fixing the byte size
here.

If performing authenticated encryption, nonce and tags must be sent per
block. This means `extent_from_offset` must return a list of single
blocks only, and has had an extra boolean added to its arguments as a
result.

Encryption context is now passed around as an Arc, obviating the clone
code that was there before.

Note that this commit *does not add authenticated encryption*, that will
come separately.

[1]: https://www.sqlite.org/different.html