### PR TITLE
[#109] Use Authenticated Encryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aead"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "aes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,6 +21,21 @@ dependencies = [
  "cipher",
  "cpufeatures",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm-siv"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589c637f0e68c877bbd59a4599bbe849cac8e5f3e4b5a3ebae8f528cd218dcdc"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "polyval",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -228,6 +252,7 @@ name = "crucible"
 version = "0.0.1"
 dependencies = [
  "aes",
+ "aes-gcm-siv",
  "anyhow",
  "base64",
  "bytes",
@@ -237,6 +262,7 @@ dependencies = [
  "futures",
  "futures-core",
  "rand",
+ "rand_chacha",
  "ringbuffer",
  "serde",
  "serde_json",
@@ -380,6 +406,15 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+]
+
+[[package]]
+name = "ctr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -920,6 +955,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
+name = "polyval"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug 0.3.0",
+ "universal-hash",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1259,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "syn"
 version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +1545,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "universal-hash"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle",
+]
+
+[[package]]
 name = "usdt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,3 +1755,9 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -54,6 +54,9 @@ pub enum CrucibleError {
 
     #[error("Saw a UUID that wasn't ours!")]
     UuidMismatch,
+
+    #[error("Decryption failed!")]
+    DecryptionError,
 }
 
 impl From<std::io::Error> for CrucibleError {

--- a/upstairs/Cargo.toml
+++ b/upstairs/Cargo.toml
@@ -38,3 +38,6 @@ tracing = "0.1.26"
 usdt = "0.2.0"
 uuid = { version = "0.8", features = [ "serde", "v4" ] }
 xts-mode = "0.4.0"
+aes-gcm-siv = "0.10.3"
+rand_chacha = "0.3.1"
+

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2813,7 +2813,8 @@ impl Upstairs {
                 );
 
                 // XXX reconciliation needs to occur, but do we trust that
-                // Downstairs anymore? once could imagine:
+                // Downstairs anymore? One could imagine setting that untrusted
+                // here:
                 //
                 // self.ds_transition(client_id, DsState::Untrusted);
             }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -30,9 +30,9 @@ use tracing::{instrument, span, Level};
 use usdt::register_probes;
 use uuid::Uuid;
 
-use aes::cipher::generic_array::GenericArray;
-use aes::{Aes128, NewBlockCipher};
-use xts_mode::{get_tweak_default, Xts128};
+use aes_gcm_siv::aead::{AeadInPlace, NewAead};
+use aes_gcm_siv::{Aes256GcmSiv, Key, Nonce, Tag};
+use rand_chacha::ChaCha20Rng;
 
 mod pseudo_file;
 mod test;
@@ -1544,7 +1544,8 @@ impl Downstairs {
         &mut self,
         ds_id: u64,
         client_id: u8,
-        read_data: &Result<Vec<ReadResponse>, CrucibleError>,
+        responses: Result<Vec<ReadResponse>, CrucibleError>,
+        encryption_context: &Option<Arc<EncryptionContext>>,
     ) -> Result<bool> {
         /*
          * Assume we don't have enough completed jobs, and only change
@@ -1566,6 +1567,52 @@ impl Downstairs {
             .get_mut(&ds_id)
             .ok_or_else(|| anyhow!("reqid {} is not active", ds_id))?;
 
+        // With AE, responses can come back that are invalid given an encryption
+        // context. Test this here. It will allow us to determine if the
+        // decryption is bad and set the job result to error accordingly.
+        let read_data: Result<Vec<ReadResponse>, CrucibleError> =
+            if let Some(context) = &encryption_context {
+                if let Ok(mut responses) = responses {
+                    let mut decryption_error = None;
+
+                    for response in &mut responses {
+                        // XXX if we haven't encrypted it yet, is this an
+                        // attack?  block generation number would tell us
+                        if response.nonce.is_some() && response.tag.is_some() {
+                            let _nonce = response.nonce.as_ref().unwrap();
+                            let nonce = Nonce::from_slice(_nonce);
+
+                            let _tag = response.tag.as_ref().unwrap();
+                            let tag = Tag::from_slice(_tag);
+
+                            let decryption_result = context.decrypt_in_place(
+                                &mut response.data[..],
+                                nonce,
+                                tag,
+                            );
+
+                            if decryption_result.is_err() {
+                                decryption_error =
+                                    Some(Err(CrucibleError::DecryptionError));
+                                break;
+                            }
+                        }
+                    }
+
+                    if let Some(decryption_error) = decryption_error {
+                        decryption_error
+                    } else {
+                        Ok(responses)
+                    }
+                } else {
+                    // bad responses
+                    responses
+                }
+            } else {
+                // no encryption context
+                responses
+            };
+
         let newstate = if let Err(ref e) = read_data {
             IOState::Error(e.clone())
         } else {
@@ -1574,6 +1621,7 @@ impl Downstairs {
         };
 
         let oldstate = job.state.insert(client_id, newstate.clone()).unwrap();
+
         /*
          * Verify the job was InProgress
          */
@@ -1626,7 +1674,12 @@ impl Downstairs {
             assert_eq!(newstate, IOState::Done);
             assert_ne!(job.ack_status, AckStatus::Acked);
 
-            let read_data = read_data.as_ref().unwrap();
+            let read_data: Vec<ReadResponse> = read_data.unwrap();
+
+            let mut bytes: Vec<Bytes> = Vec::with_capacity(read_data.len());
+            for response in read_data {
+                bytes.push(response.data.freeze());
+            }
 
             /*
              * Transition this job from Done to AckReady if enough have
@@ -1637,10 +1690,10 @@ impl Downstairs {
                     dependencies: _dependencies,
                     requests: _,
                 } => {
-                    assert!(!read_data.is_empty());
+                    assert!(!bytes.is_empty());
                     if jobs_completed_ok == 1 {
                         assert!(job.data.is_none());
-                        job.data = Some(read_data.to_vec());
+                        job.data = Some(bytes);
                         notify_guest = true;
                         assert_eq!(job.ack_status, AckStatus::NotAcked);
                         job.ack_status = AckStatus::AckReady;
@@ -1650,7 +1703,7 @@ impl Downstairs {
                     dependencies: _,
                     writes: _,
                 } => {
-                    assert!(read_data.is_empty());
+                    assert!(bytes.is_empty());
                     if jobs_completed_ok == 2 {
                         notify_guest = true;
                         job.ack_status = AckStatus::AckReady;
@@ -1661,7 +1714,7 @@ impl Downstairs {
                     flush_number: _flush_number,
                     gen_number: _gen_number,
                 } => {
-                    assert!(read_data.is_empty());
+                    assert!(bytes.is_empty());
                     if jobs_completed_ok == 2 {
                         notify_guest = true;
                         job.ack_status = AckStatus::AckReady;
@@ -1774,14 +1827,33 @@ impl Downstairs {
             _ => Ok(false),
         }
     }
+
+    fn client_error(
+        &self,
+        ds_id: u64,
+        client_id: u8,
+    ) -> Result<(), CrucibleError> {
+        let job = self
+            .active
+            .get(&ds_id)
+            .ok_or_else(|| anyhow!("reqid {} is not active", ds_id))?;
+
+        let state = job
+            .state
+            .get(&client_id)
+            .ok_or_else(|| anyhow!("state for client {} missing", client_id))?;
+
+        if let IOState::Error(e) = state {
+            Err(e.clone())
+        } else {
+            Ok(())
+        }
+    }
 }
 
-/// Implement XTS encryption
-/// See: https://en.wikipedia.org/wiki/Disk_encryption_theory#XEX-based_\
-/// tweaked-codebook_mode_with_ciphertext_stealing_(XTS)
+/// Implement AES-GCM-SIV encryption
 pub struct EncryptionContext {
-    xts: Xts128<Aes128>,
-    key: Vec<u8>,
+    cipher: Aes256GcmSiv,
     block_size: usize,
 }
 
@@ -1793,56 +1865,55 @@ impl Debug for EncryptionContext {
     }
 }
 
-impl Clone for EncryptionContext {
-    fn clone(&self) -> Self {
-        EncryptionContext::new(self.key.clone(), self.block_size)
-    }
-
-    fn clone_from(&mut self, source: &Self) {
-        *self = EncryptionContext::new(source.key.clone(), source.block_size);
-    }
-}
-
 impl EncryptionContext {
     pub fn new(key: Vec<u8>, block_size: usize) -> EncryptionContext {
         assert!(key.len() == 32);
+        let key = Key::from_slice(&key[..]);
+        let cipher = Aes256GcmSiv::new(key);
 
-        let cipher_1 = Aes128::new(GenericArray::from_slice(&key[..16]));
-        let cipher_2 = Aes128::new(GenericArray::from_slice(&key[16..]));
-
-        let xts = Xts128::<Aes128>::new(cipher_1, cipher_2);
-
-        EncryptionContext {
-            xts,
-            key,
-            block_size,
-        }
-    }
-
-    pub fn key(&self) -> &Vec<u8> {
-        &self.key
+        EncryptionContext { cipher, block_size }
     }
 
     pub fn block_size(&self) -> usize {
         self.block_size
     }
 
-    pub fn encrypt_in_place(&self, data: &mut [u8], sector_index: u128) {
-        self.xts.encrypt_area(
-            data,
-            self.block_size,
-            sector_index,
-            get_tweak_default,
-        );
+    pub fn get_random_nonce(&self) -> Nonce {
+        let mut rng = ChaCha20Rng::from_entropy();
+
+        let mut random_iv = Vec::<u8>::with_capacity(12);
+        random_iv.resize(12, 1);
+        rng.fill_bytes(&mut random_iv);
+
+        Nonce::clone_from_slice(&random_iv)
     }
 
-    pub fn decrypt_in_place(&self, data: &mut [u8], sector_index: u128) {
-        self.xts.decrypt_area(
-            data,
-            self.block_size,
-            sector_index,
-            get_tweak_default,
-        );
+    pub fn encrypt_in_place(&self, data: &mut [u8]) -> Result<(Nonce, Tag)> {
+        let nonce = self.get_random_nonce();
+
+        let tag = self.cipher.encrypt_in_place_detached(&nonce, b"", data);
+
+        if tag.is_err() {
+            bail!("Could not encrypt! {:?}", tag.err());
+        }
+
+        Ok((nonce, tag.unwrap()))
+    }
+
+    pub fn decrypt_in_place(
+        &self,
+        data: &mut [u8],
+        nonce: &Nonce,
+        tag: &Tag,
+    ) -> Result<()> {
+        let result =
+            self.cipher.decrypt_in_place_detached(nonce, b"", data, tag);
+
+        if result.is_err() {
+            bail!("Could not decrypt! {:?}", result.err().unwrap());
+        }
+
+        Ok(())
     }
 }
 
@@ -2153,8 +2224,7 @@ impl Upstairs {
         let mut sub = HashMap::new();
         sub.insert(next_id, 0);
 
-        let new_gtos =
-            GtoS::new(sub, Vec::new(), None, HashMap::new(), sender, None);
+        let new_gtos = GtoS::new(sub, Vec::new(), None, HashMap::new(), sender);
         gw.active.insert(gw_id, new_gtos);
         cdt::gw_flush_start!(|| (gw_id));
 
@@ -2231,23 +2301,26 @@ impl Upstairs {
             let byte_len: usize =
                 num_blocks.value as usize * ddef.block_size() as usize;
 
-            let sub_data = if let Some(context) = &self.encryption_context {
+            let (sub_data, nonce, tag) = if let Some(context) =
+                &self.encryption_context
+            {
                 // Encrypt here
                 let mut mut_data =
                     data.slice(cur_offset..(cur_offset + byte_len)).to_vec();
-                context.encrypt_in_place(&mut mut_data[..], bo.value as u128);
-                Bytes::copy_from_slice(&mut_data)
+                let (nonce, tag) =
+                    context.encrypt_in_place(&mut mut_data[..])?;
+                (Bytes::copy_from_slice(&mut_data), Some(nonce), Some(tag))
             } else {
                 // Unencrypted
-                data.slice(cur_offset..(cur_offset + byte_len))
+                (data.slice(cur_offset..(cur_offset + byte_len)), None, None)
             };
 
             writes.push(crucible_protocol::Write {
                 eid,
                 offset: bo,
                 data: sub_data,
-                nonce: None,
-                tag: None,
+                nonce: nonce.map(|v| Vec::from(v.as_slice())),
+                tag: tag.map(|v| Vec::from(v.as_slice())),
             });
 
             cur_offset += byte_len;
@@ -2261,14 +2334,8 @@ impl Upstairs {
         /*
          * New work created, add to the guest_work HM
          */
-        let new_gtos = GtoS::new(
-            sub,
-            Vec::new(),
-            None,
-            HashMap::new(),
-            Some(sender),
-            None,
-        );
+        let new_gtos =
+            GtoS::new(sub, Vec::new(), None, HashMap::new(), Some(sender));
         {
             gw.active.insert(gw_id, new_gtos);
         }
@@ -2368,7 +2435,6 @@ impl Upstairs {
             Some(data),
             HashMap::new(),
             Some(sender),
-            self.encryption_context.clone(),
         );
         {
             gw.active.insert(gw_id, new_gtos);
@@ -2722,10 +2788,15 @@ impl Upstairs {
         }
 
         // Mark this ds_id for the client_id as completed.
-        let notify_guest = work.complete(ds_id, client_id, &read_data)?;
+        let notify_guest = work.complete(
+            ds_id,
+            client_id,
+            read_data,
+            &self.encryption_context,
+        )?;
 
         // Mark this downstairs as bad if this was a write or flush
-        if let Some(err) = read_data.err() {
+        if let Err(err) = work.client_error(ds_id, client_id) {
             if err == CrucibleError::UpstairsInactive {
                 drop(work);
 
@@ -2735,6 +2806,16 @@ impl Upstairs {
                 );
                 self.ds_transition(client_id, DsState::Deactivated);
                 self.set_inactive();
+            } else if err == CrucibleError::DecryptionError {
+                println!(
+                    "Authenticated decryption failed from client id {}!",
+                    client_id
+                );
+
+                // XXX reconciliation needs to occur, but do we trust that
+                // Downstairs anymore? once could imagine:
+                //
+                // self.ds_transition(client_id, DsState::Untrusted);
             }
             /*
              * After work.complete, it's possible that the job is gone
@@ -2887,7 +2968,7 @@ struct DownstairsIO {
     /*
      * If the operation is a Read, this holds the resulting buffer
      */
-    data: Option<Vec<ReadResponse>>,
+    data: Option<Vec<Bytes>>,
 }
 
 impl DownstairsIO {
@@ -3250,7 +3331,7 @@ struct GtoS {
      * Data moving in/out of this buffer will be encrypted or decrypted
      * depending on the operation.
      */
-    downstairs_buffer: HashMap<u64, Vec<ReadResponse>>,
+    downstairs_buffer: HashMap<u64, Vec<Bytes>>,
 
     /*
      * Notify the caller waiting on the job to finish.
@@ -3262,12 +3343,6 @@ struct GtoS {
      * we don't have to ACK it to anyone.
      */
     sender: Option<std_mpsc::Sender<Result<(), CrucibleError>>>,
-
-    /*
-     * Optional encryption context - Some if the corresponding Upstairs is
-     * Some.
-     */
-    encryption_context: Option<Arc<EncryptionContext>>,
 }
 
 impl GtoS {
@@ -3275,9 +3350,8 @@ impl GtoS {
         submitted: HashMap<u64, u64>,
         completed: Vec<u64>,
         guest_buffer: Option<Buffer>,
-        downstairs_buffer: HashMap<u64, Vec<ReadResponse>>,
+        downstairs_buffer: HashMap<u64, Vec<Bytes>>,
         sender: Option<std_mpsc::Sender<Result<(), CrucibleError>>>,
-        encryption_context: Option<Arc<EncryptionContext>>,
     ) -> GtoS {
         GtoS {
             submitted,
@@ -3285,7 +3359,6 @@ impl GtoS {
             guest_buffer,
             downstairs_buffer,
             sender,
-            encryption_context,
         }
     }
 
@@ -3302,27 +3375,16 @@ impl GtoS {
 
             let mut offset = 0;
             for ds_id in self.completed.iter() {
-                let responses = self.downstairs_buffer.remove(ds_id).unwrap();
+                let data_vec = self.downstairs_buffer.remove(ds_id).unwrap();
 
-                for response in responses {
-                    let mut ds_vec = response.data.to_vec();
-
-                    // if there's an encryption context, decrypt the
-                    // downstairs buffer.
-                    if let Some(context) = &self.encryption_context {
-                        context.decrypt_in_place(
-                            &mut ds_vec[..],
-                            response.offset.value as u128,
-                        );
-                    }
-
+                for data in data_vec {
                     // Copy over into guest memory.
                     {
                         let _ignored =
                             span!(Level::TRACE, "copy to guest buffer")
                                 .entered();
                         let mut vec = guest_buffer.as_vec();
-                        for i in &ds_vec {
+                        for i in &data {
                             vec[offset] = *i;
                             offset += 1;
                         }
@@ -3421,7 +3483,7 @@ impl GuestWork {
         &mut self,
         gw_id: u64,
         ds_id: u64,
-        data: Option<Vec<ReadResponse>>,
+        data: Option<Vec<Bytes>>,
         result: Result<(), CrucibleError>,
     ) {
         /*


### PR DESCRIPTION
Replace the current AES-XTS-128 with AES-256-GCM-SIV. This builds off
the previous work to add nonces and tags to the protocol.

With authenticated encryption, decryption operations can fail now.
Decrypt in Downstairs::complete and set the job status to a new
DecryptionError if it fails. In the future, maybe we can mark that
Downstairs as untrustworthy? GtoS no longer needs an encryption context.

This means that Downstairs::complete only has to copy Bytes into the
job, not ReadResponses anymore.