### PR TITLE
update for nightly-2021-11-24

### DIFF
--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -1,5 +1,4 @@
 // Copyright 2021 Oxide Computer Company
-#![feature(with_options)]
 
 use std::net::SocketAddrV4;
 use std::sync::Arc;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-09-22"
+channel = "nightly-2021-11-24"
 profile = "default"

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1,5 +1,6 @@
 // Copyright 2021 Oxide Computer Company
 #![feature(asm)]
+#![cfg_attr(target_os = "macos", feature(asm_sym))]
 #![allow(clippy::mutex_atomic)]
 
 use std::clone::Clone;


### PR DESCRIPTION
We're moving omicron and all dependents past the asm_sym flag day. See https://github.com/oxidecomputer/omicron/pull/448