### PR TITLE
merge agent/smf from demo_m2 and add agent-client crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,22 +40,13 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom",
  "once_cell",
  "version_check",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -69,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 
 [[package]]
 name = "api_identity"
@@ -192,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "byte-tools"
@@ -254,11 +245,11 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term",
  "atty",
  "bitflags",
  "strsim",
@@ -1129,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
@@ -1174,9 +1165,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.102"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
+checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1276,9 +1267,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mio"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
  "libc",
  "log",
@@ -1638,9 +1629,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "polyval"
@@ -1687,9 +1678,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "pq-sys"
@@ -1803,9 +1794,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -2052,9 +2043,9 @@ checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
 
 [[package]]
 name = "same-file"
@@ -2227,9 +2218,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
@@ -2273,9 +2264,9 @@ checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
 
 [[package]]
 name = "slab"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
+checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "slog"
@@ -2334,9 +2325,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "smf"
@@ -2401,9 +2392,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.23"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
+checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2412,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -2452,9 +2443,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2515,18 +2506,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2680,9 +2671,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2709,9 +2700,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -2721,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2732,9 +2723,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46125608c26121c81b0c6d693eab5a420e416da7e43c426d2e8f7df8da8a3acf"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
 ]
@@ -2775,11 +2766,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd0568dbfe3baf7048b7908d2b32bca0d81cd56bec6d2a8f894b01d74f86be3"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "chrono",
  "lazy_static",
  "matchers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,6 +433,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crucible-agent"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "crucible-common 0.0.0",
+ "crucible-smf",
+ "dropshot",
+ "futures",
+ "http",
+ "hyper",
+ "omicron-common",
+ "schemars",
+ "serde",
+ "serde_json",
+ "slog",
+ "structopt",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "crucible-client"
 version = "0.1.0"
 dependencies = [
@@ -610,6 +632,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+]
+
+[[package]]
+name = "crucible-smf"
+version = "0.0.0"
+dependencies = [
+ "libc",
+ "num-derive",
+ "num-traits",
+ "thiserror",
 ]
 
 [[package]]
@@ -1462,6 +1494,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,24 +434,39 @@ dependencies = [
 
 [[package]]
 name = "crucible-agent"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "chrono",
  "crucible-common 0.0.0",
  "crucible-smf",
  "dropshot",
+ "expectorate",
  "futures",
  "http",
  "hyper",
  "omicron-common",
+ "openapiv3",
  "schemars",
  "serde",
  "serde_json",
  "slog",
  "structopt",
+ "subprocess",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "crucible-agent-client"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "percent-encoding",
+ "progenitor",
+ "reqwest",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -710,6 +725,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,7 +791,7 @@ dependencies = [
 [[package]]
 name = "dropshot"
 version = "0.6.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#a2928e5f144db66c8a156015a501455d9b9063e2"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#e145e9bf23231edca18eb7005fff936998517fda"
 dependencies = [
  "async-trait",
  "base64",
@@ -805,7 +826,7 @@ dependencies = [
 [[package]]
 name = "dropshot_endpoint"
 version = "0.6.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#a2928e5f144db66c8a156015a501455d9b9063e2"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#e145e9bf23231edca18eb7005fff936998517fda"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -853,6 +874,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3de9ad4541d99dc22b59134e7ff8dc3d6c988c89ecd7324bf10a8362b07a2afa"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "expectorate"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804d601ea8a13ddbecf5ab4b6cf75b5d6d0539479c6fb2aea1596e352a5ee27e"
+dependencies = [
+ "difference",
+ "newline-converter",
 ]
 
 [[package]]
@@ -1460,6 +1491,12 @@ checksum = "ae36b0aee27117ae0bc775511be136ac58692704b8650da1e6afee816394a11a"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "newline-converter"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f81c2b19eebbc4249b3ca6aff70ae05bf18d6a99b7cc63cf0248774e640565"
 
 [[package]]
 name = "newtype_derive"
@@ -2830,6 +2867,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "subprocess"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "055cf3ebc2981ad8f0a5a17ef6652f652d87831f79fddcba2ac57bcb9a0aa407"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
+name = "api_identity"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "array-init"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,10 +117,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "backoff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
+dependencies = [
+ "futures-core",
+ "getrandom",
+ "instant",
+ "pin-project",
+ "rand",
+ "tokio",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bhyve_api"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/propolis?branch=demo_m2#4b8c6b82fa5f588b3fb7b28b92ba654ecb4d28bc"
+dependencies = [
+ "libc",
+ "num_enum",
+]
 
 [[package]]
 name = "bincode"
@@ -138,6 +170,15 @@ dependencies = [
  "byte-tools",
  "byteorder",
  "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -177,6 +218,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +238,8 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "serde",
+ "time",
  "winapi",
 ]
 
@@ -238,6 +287,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,9 +329,9 @@ dependencies = [
  "anyhow",
  "base64",
  "bytes",
- "crucible-common",
- "crucible-protocol",
- "crucible-scope",
+ "crucible-common 0.0.0",
+ "crucible-protocol 0.0.0",
+ "crucible-scope 0.0.0",
  "futures",
  "futures-core",
  "rand",
@@ -271,9 +344,61 @@ dependencies = [
  "tokio-util",
  "toml",
  "tracing",
- "usdt",
+ "usdt 0.2.1",
  "uuid",
  "xts-mode",
+]
+
+[[package]]
+name = "crucible"
+version = "0.0.1"
+source = "git+https://github.com/oxidecomputer/crucible?branch=main#4c8cf92a542be24e2d0e81108f33718e69e1f878"
+dependencies = [
+ "aes",
+ "aes-gcm-siv",
+ "anyhow",
+ "base64",
+ "bytes",
+ "crucible-common 0.0.0 (git+https://github.com/oxidecomputer/crucible?branch=main)",
+ "crucible-protocol 0.0.0 (git+https://github.com/oxidecomputer/crucible?branch=main)",
+ "crucible-scope 0.0.0 (git+https://github.com/oxidecomputer/crucible?branch=main)",
+ "futures",
+ "futures-core",
+ "rand",
+ "rand_chacha",
+ "ringbuffer",
+ "serde",
+ "serde_json",
+ "structopt",
+ "tokio",
+ "tokio-util",
+ "toml",
+ "tracing",
+ "usdt 0.2.1",
+ "uuid",
+ "xts-mode",
+]
+
+[[package]]
+name = "crucible-agent"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "crucible-common 0.0.0",
+ "crucible-smf",
+ "dropshot",
+ "futures",
+ "http",
+ "hyper",
+ "omicron-common",
+ "schemars",
+ "serde",
+ "serde_json",
+ "slog",
+ "structopt",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -282,10 +407,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "crucible",
- "crucible-common",
- "crucible-protocol",
- "crucible-scope",
+ "crucible 0.0.1",
+ "crucible-common 0.0.0",
+ "crucible-protocol 0.0.0",
+ "crucible-scope 0.0.0",
  "futures",
  "futures-core",
  "rand",
@@ -313,15 +438,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "crucible-common"
+version = "0.0.0"
+source = "git+https://github.com/oxidecomputer/crucible?branch=main#4c8cf92a542be24e2d0e81108f33718e69e1f878"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "toml",
+ "uuid",
+]
+
+[[package]]
 name = "crucible-downstairs"
 version = "0.0.1"
 dependencies = [
  "anyhow",
  "bincode",
  "bytes",
- "crucible",
- "crucible-common",
- "crucible-protocol",
+ "crucible 0.0.1",
+ "crucible-common 0.0.0",
+ "crucible-protocol 0.0.0",
  "futures",
  "futures-core",
  "opentelemetry",
@@ -348,8 +487,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "crucible",
- "crucible-common",
+ "crucible 0.0.1",
+ "crucible-common 0.0.0",
  "opentelemetry",
  "opentelemetry-jaeger",
  "rand",
@@ -365,10 +504,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "crucible",
- "crucible-common",
- "crucible-protocol",
- "crucible-scope",
+ "crucible 0.0.1",
+ "crucible-common 0.0.0",
+ "crucible-protocol 0.0.0",
+ "crucible-scope 0.0.0",
  "futures",
  "futures-core",
  "nbd",
@@ -388,7 +527,21 @@ dependencies = [
  "anyhow",
  "bincode",
  "bytes",
- "crucible-common",
+ "crucible-common 0.0.0",
+ "serde",
+ "tokio-util",
+ "uuid",
+]
+
+[[package]]
+name = "crucible-protocol"
+version = "0.0.0"
+source = "git+https://github.com/oxidecomputer/crucible?branch=main#4c8cf92a542be24e2d0e81108f33718e69e1f878"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bytes",
+ "crucible-common 0.0.0 (git+https://github.com/oxidecomputer/crucible?branch=main)",
  "serde",
  "tokio-util",
  "uuid",
@@ -409,6 +562,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "crucible-scope"
+version = "0.0.0"
+source = "git+https://github.com/oxidecomputer/crucible?branch=main#4c8cf92a542be24e2d0e81108f33718e69e1f878"
+dependencies = [
+ "anyhow",
+ "futures",
+ "futures-core",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "toml",
+]
+
+[[package]]
+name = "crucible-smf"
+version = "0.0.0"
+dependencies = [
+ "libc",
+ "num-derive",
+ "num-traits",
+ "thiserror",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle",
+]
+
+[[package]]
 name = "ctr"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,12 +606,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "diesel"
+version = "2.0.0"
+source = "git+https://github.com/diesel-rs/diesel?rev=a39dd2e#a39dd2ebc5acccb8cde73d40b0d81dde3e073170"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "diesel_derives",
+ "itoa",
+ "pq-sys",
+ "r2d2",
+ "uuid",
+]
+
+[[package]]
+name = "diesel_derives"
+version = "2.0.0"
+source = "git+https://github.com/diesel-rs/diesel?rev=a39dd2e#a39dd2ebc5acccb8cde73d40b0d81dde3e073170"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "dladm"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/propolis?branch=demo_m2#4b8c6b82fa5f588b3fb7b28b92ba654ecb4d28bc"
+dependencies = [
+ "libc",
+ "num_enum",
 ]
 
 [[package]]
@@ -437,6 +700,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "dropshot"
+version = "0.6.1-dev"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#ff33033ad3d7fcf32caa352d76fc243bd20db176"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "dropshot_endpoint",
+ "futures",
+ "hostname",
+ "http",
+ "hyper",
+ "indexmap",
+ "openapiv3",
+ "paste",
+ "percent-encoding",
+ "proc-macro2",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "slog",
+ "slog-async",
+ "slog-bunyan",
+ "slog-json",
+ "slog-term",
+ "syn",
+ "tokio",
+ "toml",
+ "usdt 0.2.1",
+ "uuid",
+]
+
+[[package]]
+name = "dropshot_endpoint"
+version = "0.6.1-dev"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#ff33033ad3d7fcf32caa352d76fc243bd20db176"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_tokenstream",
+ "syn",
+]
+
+[[package]]
 name = "dtrace-parser"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +755,27 @@ dependencies = [
  "pest",
  "pest_derive",
  "thiserror",
+]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -466,10 +797,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
-name = "futures"
-version = "0.3.17"
+name = "filetime"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd0210d8c325c245ff06fd95a3b13689a1a276ac8cfa8e8720cb840bfb84b9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -482,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -492,15 +857,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "7b808bf53348a36cab739d7e04755909b9fcaaa69b7d7e588b37b6ec62704c97"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -509,18 +874,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -528,23 +891,22 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -554,8 +916,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -587,6 +947,25 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -626,6 +1005,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
+
+[[package]]
+name = "http"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "hyper"
+version = "0.14.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+ "serde",
+]
+
+[[package]]
+name = "input_buffer"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
+dependencies = [
+ "bytes",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +1141,15 @@ name = "integer-encoding"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
+
+[[package]]
+name = "ipnet"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "itoa"
@@ -696,10 +1207,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "macaddr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -711,10 +1237,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "md-5"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mio"
@@ -748,12 +1306,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "newtype_derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac8cd24d9f185bb7223958d8c1ff7a961b74b1953fd05dba7cc568a63b3861ec"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -786,6 +1364,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9bd055fb730c4f8f4f57d45d35cd6b3f0980535b056dc7ff119cee6a66ed6f"
+dependencies = [
+ "derivative",
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "486ea01961c4a818096de679a8b740b26d9033146ac5291b1c98557658f8cdd9"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "omicron-common"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "api_identity",
+ "async-trait",
+ "backoff",
+ "chrono",
+ "diesel",
+ "dropshot",
+ "futures",
+ "http",
+ "hyper",
+ "ipnet",
+ "libc",
+ "macaddr",
+ "postgres-protocol",
+ "propolis-server",
+ "rayon",
+ "reqwest",
+ "ring",
+ "schemars",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "signal-hook",
+ "signal-hook-tokio",
+ "slog",
+ "smf",
+ "steno",
+ "structopt",
+ "subprocess",
+ "tar",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tokio-postgres",
+ "toml",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,6 +1445,17 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openapiv3"
+version = "1.0.0-beta.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45518fa48878a21efa793483d3c5a3dd5f8f98026fc3dade65104d8b78bb535"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -868,6 +1522,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,7 +1573,35 @@ checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
 dependencies = [
  "maplit",
  "pest",
- "sha-1",
+ "sha-1 0.8.2",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fc3db1018c4b59d7d582a739436478b6035138b6aecbce989fc91c3e98409f"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -967,10 +1655,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres-protocol"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b145e6a4ed52cb316a27787fc20fe8a25221cb476479f61e4e0327c15b98d91a"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04619f94ba0cc80999f4fc7073607cb825bc739a883cb6d20900fc5e009d6b0d"
+dependencies = [
+ "bytes",
+ "chrono",
+ "fallible-iterator",
+ "postgres-protocol",
+ "uuid",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "pq-sys"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac25eee5a0582f45a67e837e350d784e7003bd29a5f460796772061ca49ffda"
+dependencies = [
+ "vcpkg",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+dependencies = [
+ "thiserror",
+ "toml",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -997,24 +1735,70 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "propolis"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/propolis?branch=demo_m2#4b8c6b82fa5f588b3fb7b28b92ba654ecb4d28bc"
+dependencies = [
+ "bhyve_api",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crucible 0.0.1 (git+https://github.com/oxidecomputer/crucible?branch=main)",
+ "dladm",
+ "lazy_static",
+ "libc",
+ "num_enum",
+ "thiserror",
+ "tokio",
+ "usdt 0.1.19",
+ "viona_api",
+]
+
+[[package]]
+name = "propolis-client"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/propolis?branch=demo_m2#4b8c6b82fa5f588b3fb7b28b92ba654ecb4d28bc"
+dependencies = [
+ "reqwest",
+ "ring",
+ "schemars",
+ "serde",
+ "serde_json",
+ "slog",
+ "structopt",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
+name = "propolis-server"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/propolis?branch=demo_m2#4b8c6b82fa5f588b3fb7b28b92ba654ecb4d28bc"
+dependencies = [
+ "anyhow",
+ "dropshot",
+ "futures",
+ "hyper",
+ "propolis",
+ "propolis-client",
+ "serde",
+ "serde_derive",
+ "slog",
+ "structopt",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite",
+ "toml",
+ "uuid",
 ]
 
 [[package]]
@@ -1024,6 +1808,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r2d2"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
 ]
 
 [[package]]
@@ -1067,12 +1862,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1109,6 +1939,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bea77bc708afa10e59905c3d4af7c8fd43c9214251673095ff8b14345fcbc5"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "ringbuffer"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,16 +2015,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
+name = "schemars"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6b5a3c80cea1ab61f4260238409510e814e38b4b563c06044edf91e7dc070e3"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ae4dce13e8614c46ac3c38ef1c0d668b101df6ac39817aebdaa26642ddae9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "semver"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 
 [[package]]
 name = "serde"
@@ -1165,10 +2143,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.68"
+name = "serde_derive_internals"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
 dependencies = [
  "itoa",
  "ryu",
@@ -1187,15 +2176,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
  "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -1208,6 +2235,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,16 +2254,144 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-tokio"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c5d32165ff8b94e68e7b3bdecb1b082e958c22434b363482cfb89dcd6f3ff8"
+dependencies = [
+ "futures-core",
+ "libc",
+ "signal-hook",
+ "tokio",
+]
+
+[[package]]
+name = "siphasher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+
+[[package]]
 name = "slab"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
+name = "slog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+
+[[package]]
+name = "slog-async"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "766c59b252e62a34651412870ff55d8c4e6d04df19b43eecb2703e417b097ffe"
+dependencies = [
+ "crossbeam-channel",
+ "slog",
+ "take_mut",
+ "thread_local",
+]
+
+[[package]]
+name = "slog-bunyan"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924f5e8b5a1069e484f6ad80024322990e21ee8399f12ba289e48cd30bc0dda0"
+dependencies = [
+ "chrono",
+ "hostname",
+ "slog",
+ "slog-json",
+]
+
+[[package]]
+name = "slog-json"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e9b96fb6b5e80e371423b4aca6656eb537661ce8f82c2697e619f8ca85d043"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "slog",
+]
+
+[[package]]
+name = "slog-term"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c1e7e5aab61ced6006149ea772770b84a0d16ce0f7885def313e4829946d76"
+dependencies = [
+ "atty",
+ "chrono",
+ "slog",
+ "term",
+ "thread_local",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "smf"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f19d427ae89311c2770c49fdcfa14627577c499311fe8f4cc8fcfde2dd3c4e2e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "steno"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/steno?branch=main#c6ea85cfd268668a5974741b308d89acfae76063"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "newtype_derive",
+ "petgraph",
+ "schemars",
+ "serde",
+ "serde_json",
+ "slog",
+ "thiserror",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "strsim"
@@ -1259,6 +2424,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "subprocess"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "055cf3ebc2981ad8f0a5a17ef6652f652d87831f79fddcba2ac57bcb9a0aa407"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,9 +2441,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.77"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5239bc68e0fef57495900cfea4e8dc75596d9a319d7e16b1e0a440d24e6fe0a0"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1288,6 +2463,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tar"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +2490,17 @@ dependencies = [
  "rand",
  "redox_syscall",
  "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
  "winapi",
 ]
 
@@ -1373,10 +2576,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.12.0"
+name = "time"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tokio"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1394,13 +2622,60 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.3.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6c8b33df661b548dcd8f9bf87debb8c56c05657ed291122e1188698c2ece95"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "socket2",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4baa378e417d780beff82bf54ceb0d195193ea6a00c14e22359e7f39456b5689"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e96bb520beab540ab664bd5a9cfeaa1fcd846fa68c830b42e2c8963071251d2"
+dependencies = [
+ "futures-util",
+ "log",
+ "pin-project",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -1425,6 +2700,12 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
@@ -1515,6 +2796,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "tungstenite"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fe8dada8c1a3aeca77d6b51a4f1314e0f4b8e438b7b1b71e3ddaca8080e4093"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "input_buffer",
+ "log",
+ "rand",
+ "sha-1 0.9.8",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +2832,21 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1555,6 +2877,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "usdt"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aba50f80946d1ef9b21f40e46b74dd211b9ff5e603ad028c0d58871835ada4f"
+dependencies = [
+ "dof",
+ "dtrace-parser",
+ "serde",
+ "usdt-attr-macro 0.1.5",
+ "usdt-impl 0.1.14",
+ "usdt-macro 0.1.15",
+]
+
+[[package]]
 name = "usdt"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,9 +2917,23 @@ dependencies = [
  "dof",
  "dtrace-parser",
  "serde",
- "usdt-attr-macro",
- "usdt-impl",
- "usdt-macro",
+ "usdt-attr-macro 0.2.1",
+ "usdt-impl 0.2.1",
+ "usdt-macro 0.2.1",
+]
+
+[[package]]
+name = "usdt-attr-macro"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd55281622053408612f20f3d92df0db533d4b15ec4842883e94c23b1e9351f2"
+dependencies = [
+ "dtrace-parser",
+ "proc-macro2",
+ "quote",
+ "serde_tokenstream",
+ "syn",
+ "usdt-impl 0.1.14",
 ]
 
 [[package]]
@@ -1579,7 +2947,26 @@ dependencies = [
  "quote",
  "serde_tokenstream",
  "syn",
- "usdt-impl",
+ "usdt-impl 0.2.1",
+]
+
+[[package]]
+name = "usdt-impl"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e71989deee492038dec04ea3e5ad68bd876947b5ba35562d0bee04e784557f6a"
+dependencies = [
+ "byteorder",
+ "dof",
+ "dtrace-parser",
+ "libc",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "thiserror",
+ "thread-id",
 ]
 
 [[package]]
@@ -1603,6 +2990,20 @@ dependencies = [
 
 [[package]]
 name = "usdt-macro"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e4feae7fabf18bc31413acb5bdeb52581c093e2578e80ab7c2a8402ad4e039"
+dependencies = [
+ "dtrace-parser",
+ "proc-macro2",
+ "quote",
+ "serde_tokenstream",
+ "syn",
+ "usdt-impl 0.1.14",
+]
+
+[[package]]
+name = "usdt-macro"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8dae3bb94dfc25189d8566b8da97ad05003fe24346b118c697c6671b4b7d10"
@@ -1612,8 +3013,14 @@ dependencies = [
  "quote",
  "serde_tokenstream",
  "syn",
- "usdt-impl",
+ "usdt-impl 0.2.1",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
@@ -1642,6 +3049,32 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "viona_api"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/propolis?branch=demo_m2#4b8c6b82fa5f588b3fb7b28b92ba654ecb4d28bc"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1675,6 +3108,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,6 +3149,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
+name = "web-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki 0.21.4",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,10 +3204,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "xts-mode"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,6 @@ members = [
 	"nbd_server",
 	"protocol",
 	"scope",
+	"smf",
 	"upstairs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
 	"agent",
+	"agent-client",
 	"client",
 	"common",
 	"downstairs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+	"agent",
 	"client",
 	"common",
 	"downstairs",

--- a/agent-client/Cargo.toml
+++ b/agent-client/Cargo.toml
@@ -7,22 +7,10 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11", default-features = false, features = ["json"] }
 percent-encoding = "2.1.0"
 serde_json = "1.0"
-
-# [dependencies.chrono]
-# version = "0.4"
-# features = [ "serde" ]
 
 [dependencies.serde]
 version = "1.0"
 features = [ "derive" ]
-
-# [dependencies.slog]
-# version = "2.5"
-# features = [ "max_level_trace", "release_max_level_debug" ]
-
-# [dependencies.uuid]
-# version = "0.8"
-# features = [ "serde", "v4" ]

--- a/agent-client/Cargo.toml
+++ b/agent-client/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "crucible-agent-client"
+version = "0.0.1"
+license = "MPL-2.0"
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+percent-encoding = "2.1.0"
+serde_json = "1.0"
+
+# [dependencies.chrono]
+# version = "0.4"
+# features = [ "serde" ]
+
+[dependencies.serde]
+version = "1.0"
+features = [ "derive" ]
+
+# [dependencies.slog]
+# version = "2.5"
+# features = [ "max_level_trace", "release_max_level_debug" ]
+
+# [dependencies.uuid]
+# version = "0.8"
+# features = [ "serde", "v4" ]

--- a/agent-client/src/lib.rs
+++ b/agent-client/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Oxide Computer Company
+
 use progenitor::generate_api;
 
 generate_api!("../openapi/crucible-agent.json");

--- a/agent-client/src/lib.rs
+++ b/agent-client/src/lib.rs
@@ -1,0 +1,3 @@
+use progenitor::generate_api;
+
+generate_api!("../openapi/crucible-agent.json");

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1.0"
 slog = { version = "2.5", features = [ "max_level_trace", "release_max_level_debug" ] }
 crucible-common = { path = "../common" }
 crucible-smf = { path = "../smf" }
-omicron-common = { path = "../../omicron/omicron-common" }
+omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 structopt = "0.3"
 tokio = { version = "1.10", features = [ "full" ] }
 uuid = { version = "0.8", features = [ "serde", "v4" ] }

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "crucible-agent"
-version = "0.0.0"
+version = "0.0.1"
+license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]
@@ -20,3 +21,8 @@ omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "m
 structopt = "0.3"
 tokio = { version = "1.10", features = [ "full" ] }
 uuid = { version = "0.8", features = [ "serde", "v4" ] }
+
+[dev-dependencies]
+expectorate = "1.0.4"
+openapiv3 = "1.0.0-beta.5"
+subprocess = "0.2.8"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "crucible-agent"
+version = "0.0.0"
+edition = "2018"
+
+[dependencies]
+anyhow = "1"
+chrono = { version = "0.4", features = [ "serde" ] }
+dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
+futures = "0.3.15"
+http = "0.2.0"
+hyper = "0.14"
+schemars = { version = "0.8", features = [ "chrono", "uuid" ] }
+serde = { version = "1.0", features = [ "derive" ] }
+serde_json = "1.0"
+slog = { version = "2.5", features = [ "max_level_trace", "release_max_level_debug" ] }
+crucible-common = { path = "../common" }
+crucible-smf = { path = "../smf" }
+omicron-common = { path = "../../omicron/omicron-common" }
+structopt = "0.3"
+tokio = { version = "1.10", features = [ "full" ] }
+uuid = { version = "0.8", features = [ "serde", "v4" ] }

--- a/agent/agent.xml
+++ b/agent/agent.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+
+<service_bundle type='manifest' name='oxide-crucible-agent'>
+
+<service name='oxide/crucible/agent' type='service' version='1'>
+  <create_default_instance enabled='false' />
+
+  <!-- Run once we hit multi-user, so that the network and file systems have
+    been set up. -->
+  <dependency name='multi-user' grouping='require_all' restart_on='none'
+    type='service'>
+    <service_fmri value='svc:/milestone/multi-user' />
+  </dependency>
+
+  <exec_method type='method' name='start'
+    exec='/opt/oxide/crucible/bin/agent run
+      -D /opt/oxide/crucible/bin/downstairs
+      -d %{config/datadir}
+      -l %{config/listen}
+      -i %{config/uuid}
+      -n %{config/nexus}
+      -P %{config/portbase}
+      -p %{config/prefix}'
+    timeout_seconds='30'
+    />
+
+  <exec_method type='method' name='stop' exec=':kill' timeout_seconds='30' />
+
+  <property_group name='startd' type='framework'>
+    <propval name='duration' type='astring' value='child' />
+  </property_group>
+
+  <property_group name='config' type='application'>
+    <propval name='datadir' type='astring' value='/data/crucible' />
+    <propval name='listen' type='astring' value='127.0.0.1:17000' />
+    <propval name='uuid' type='astring' value='' />
+    <propval name='nexus' type='astring' value='127.0.0.1:12221' />
+    <propval name='portbase' type='astring' value='19000' />
+    <propval name='prefix' type='astring' value='downstairs' />
+  </property_group>
+
+  <stability value='Unstable' />
+
+  <template>
+    <common_name>
+      <loctext xml:lang='C'>Oxide Crucible Downstairs</loctext>
+    </common_name>
+    <description>
+      <loctext xml:lang='C'>Disk-side storage component</loctext>
+    </description>
+  </template>
+</service>
+
+</service_bundle>
+<!-- vim: set ts=2 sts=2 sw=2 et: -->

--- a/agent/downstairs.xml
+++ b/agent/downstairs.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+
+<service_bundle type='manifest' name='oxide-crucible-downstairs'>
+
+<service name='oxide/crucible/downstairs' type='service' version='1'>
+  <create_default_instance enabled='false' />
+
+  <!-- Run once we hit multi-user, so that the network and file systems have
+    been set up. -->
+  <dependency name='multi-user' grouping='require_all' restart_on='none'
+    type='service'>
+    <service_fmri value='svc:/milestone/multi-user' />
+  </dependency>
+
+  <exec_method type='method' name='start'
+    exec='/opt/oxide/crucible/bin/downstairs
+      --data %{config/directory}
+      --port %{config/port}'
+    timeout_seconds='30'
+    />
+
+  <exec_method type='method' name='stop' exec=':kill' timeout_seconds='30' />
+
+  <property_group name='startd' type='framework'>
+    <propval name='duration' type='astring' value='child' />
+  </property_group>
+
+  <property_group name='config' type='application'>
+    <propval name='directory' type='astring' value='/dev/null' />
+    <propval name='port' type='count' value='0' />
+  </property_group>
+
+  <stability value='Unstable' />
+
+  <template>
+    <common_name>
+      <loctext xml:lang='C'>Oxide Crucible Downstairs</loctext>
+    </common_name>
+    <description>
+      <loctext xml:lang='C'>Disk-side storage component</loctext>
+    </description>
+  </template>
+</service>
+
+</service_bundle>
+<!-- vim: set ts=2 sts=2 sw=2 et: -->

--- a/agent/rustfmt.toml
+++ b/agent/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 80
+edition = "2018"

--- a/agent/rustfmt.toml
+++ b/agent/rustfmt.toml
@@ -1,2 +1,0 @@
-max_width = 80
-edition = "2018"

--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Oxide Computer Company
+
 use super::model::{CreateRegion, Region, RegionId, State};
 use anyhow::{anyhow, bail, Result};
 use crucible_common::write_json;

--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -1,0 +1,318 @@
+use super::model::{CreateRegion, Region, RegionId, State};
+use anyhow::{anyhow, bail, Result};
+use crucible_common::write_json;
+use slog::{crit, info, Logger};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Condvar, Mutex, MutexGuard};
+
+pub struct DataFile {
+    log: Logger,
+    path: PathBuf,
+    port_min: u16,
+    port_max: u16,
+    bell: Condvar,
+    inner: Mutex<Inner>,
+}
+
+struct Inner {
+    regions: BTreeMap<RegionId, Region>,
+}
+
+impl DataFile {
+    pub fn new(
+        log: Logger,
+        path: &Path,
+        port_min: u16,
+        port_max: u16,
+    ) -> Result<DataFile> {
+        /*
+         * Open data file, load contents.
+         */
+        let regions = match crucible_common::read_json_maybe(path) {
+            Ok(Some(regions)) => regions,
+            Ok(None) => BTreeMap::new(),
+            Err(e) => bail!("failed to load data file {:?}: {:?}", path, e),
+        };
+
+        Ok(DataFile {
+            log,
+            path: path.to_path_buf(),
+            port_min,
+            port_max,
+            bell: Condvar::new(),
+            inner: Mutex::new(Inner { regions }),
+        })
+    }
+
+    pub fn all(&self) -> Vec<Region> {
+        self.inner
+            .lock()
+            .unwrap()
+            .regions
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    pub fn get(&self, id: &RegionId) -> Option<Region> {
+        self.inner.lock().unwrap().regions.get(id).cloned()
+    }
+
+    /**
+     * Store the database into the JSON file.
+     */
+    fn store(&self, inner: MutexGuard<Inner>) {
+        loop {
+            match write_json(&self.path, &inner.regions, true) {
+                Ok(()) => return,
+                Err(e) => {
+                    /*
+                     * XXX What else could we do here?
+                     */
+                    crit!(
+                        self.log,
+                        "could not write data file {:?} (will retry): {:?}",
+                        &self.path,
+                        e
+                    );
+                    std::thread::sleep(std::time::Duration::from_secs(1));
+                }
+            }
+        }
+    }
+
+    /**
+     * Nexus will request that we create a new region by telling us the ID it
+     * should have.  To make this idempotent, we will either create the region
+     * or return the current state of the region if it was already created in
+     * the past.
+     *
+     * The actual heavy lifting is performed in a worker thread.
+     */
+    pub fn request(&self, create: CreateRegion) -> Result<Region> {
+        let mut inner = self.inner.lock().unwrap();
+
+        /*
+         * Look for a region with this ID.
+         */
+        if let Some(r) = inner.regions.get(&create.id) {
+            if let Some(mis) = create.mismatch(r) {
+                bail!(
+                    "requested region {} already exists, with {}",
+                    create.id.0,
+                    mis
+                );
+            }
+
+            /*
+             * Return the region we already have, with its current status and
+             * allocated port number.
+             */
+            return Ok(r.clone());
+        }
+
+        /*
+         * Allocate a port number that is not yet in use.
+         */
+        let port_number = (self.port_min..=self.port_max)
+            .find(|n| {
+                !inner
+                    .regions
+                    .values()
+                    .filter(|r| {
+                        /*
+                         * We can ignore any completely destroyed region.  We
+                         * choose not to ignore regions in the failed state for
+                         * now, as they may still prevent use of their assigned
+                         * port number.
+                         */
+                        r.state != State::Destroyed
+                    })
+                    .any(|r| r.port_number == *n)
+            })
+            .ok_or_else(|| anyhow!("no free port numbers"))?;
+
+        let r = Region {
+            id: create.id.clone(),
+            volume_id: create.volume_id,
+            block_size: create.block_size,
+            extent_size: create.extent_size,
+            extent_count: create.extent_count,
+            port_number,
+            state: State::Requested,
+        };
+
+        info!(self.log, "region {} state: {:?}", r.id.0, r.state);
+        let old = inner.regions.insert(create.id, r.clone());
+        assert!(old.is_none());
+
+        /*
+         * Wake the worker thread to look at the region we've created.
+         */
+        self.bell.notify_all();
+
+        self.store(inner);
+
+        return Ok(r);
+    }
+
+    /**
+     * Mark a particular region as failed to provision.
+     */
+    pub fn fail(&self, id: &RegionId) {
+        let mut inner = self.inner.lock().unwrap();
+
+        let mut r = inner.regions.get_mut(id).unwrap();
+        let nstate = State::Failed;
+        if r.state == nstate {
+            return;
+        }
+
+        info!(
+            self.log,
+            "region {} state: {:?} -> {:?}", r.id.0, r.state, nstate,
+        );
+        r.state = nstate;
+
+        self.store(inner);
+    }
+
+    /**
+     * Mark a particular region as provisioned.
+     */
+    pub fn created(&self, id: &RegionId) -> Result<()> {
+        let mut inner = self.inner.lock().unwrap();
+
+        let mut r = inner.regions.get_mut(id).unwrap();
+        let nstate = State::Created;
+        match &r.state {
+            State::Requested => (),
+            State::Tombstoned => {
+                /*
+                 * Nexus requested that we destroy this region before we
+                 * finished provisioning it.
+                 */
+                return Ok(());
+            }
+            x => bail!("created region in weird state {:?}", x),
+        }
+
+        info!(
+            self.log,
+            "region {} state: {:?} -> {:?}", r.id.0, r.state, nstate,
+        );
+        r.state = nstate;
+
+        self.store(inner);
+        Ok(())
+    }
+
+    /**
+     * Mark a particular region as destroyed.
+     */
+    pub fn destroyed(&self, id: &RegionId) -> Result<()> {
+        let mut inner = self.inner.lock().unwrap();
+
+        let mut r = inner.regions.get_mut(id).unwrap();
+        let nstate = State::Destroyed;
+        match &r.state {
+            State::Tombstoned => (),
+            x => bail!("region to destroy in weird state {:?}", x),
+        }
+
+        info!(
+            self.log,
+            "region {} state: {:?} -> {:?}", r.id.0, r.state, nstate,
+        );
+        r.state = nstate;
+
+        self.store(inner);
+        Ok(())
+    }
+
+    /**
+     * Nexus has requested that we destroy this particular region.
+     */
+    pub fn destroy(&self, id: &RegionId) -> Result<bool> {
+        let mut inner = self.inner.lock().unwrap();
+
+        let mut r = inner
+            .regions
+            .get_mut(id)
+            .ok_or_else(|| anyhow!("region {} does not exist", id.0))?;
+
+        Ok(match r.state {
+            State::Tombstoned => {
+                /*
+                 * Destroy already scheduled.
+                 */
+                false
+            }
+            State::Requested | State::Created => {
+                /*
+                 * Schedule the destruction of this region.
+                 */
+                info!(
+                    self.log,
+                    "region {} state: {:?} -> {:?}",
+                    r.id.0,
+                    r.state,
+                    State::Tombstoned
+                );
+                r.state = State::Tombstoned;
+                self.bell.notify_all();
+                self.store(inner);
+                false
+            }
+            State::Destroyed => {
+                /*
+                 * Already destroyed; no more work to do.
+                 */
+                true
+            }
+            State::Failed => {
+                /*
+                 * For now, this terminal state will preserve evidence for
+                 * investigation.
+                 */
+                bail!(
+                    "region {} failed to provision and cannot be \
+                    destroyed",
+                    r.id.0
+                );
+            }
+        })
+    }
+
+    /**
+     * The worker thread will request the first region that is in a particular
+     * state.  If there are no tasks in the provided state, we sleep waiting for
+     * work to do.
+     */
+    pub fn first_in_states(&self, states: &[State]) -> Region {
+        let mut inner = self.inner.lock().unwrap();
+
+        loop {
+            /*
+             * States are provided in priority order.  We check for regions in
+             * the first requested state before we check for regions in the
+             * second provided state, etc.  This allows us to focus on
+             * destroying tombstoned regions ahead of creating new regions.
+             */
+            for s in states {
+                for r in inner.regions.values() {
+                    if &r.state == s {
+                        return r.clone();
+                    }
+                }
+            }
+
+            /*
+             * If we did not find any regions in the specified state, sleep on
+             * the condvar.
+             */
+            inner = self.bell.wait(inner).unwrap();
+        }
+    }
+}

--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -85,10 +85,10 @@ impl DataFile {
     }
 
     /**
-     * Nexus will request that we create a new region by telling us the ID it
-     * should have.  To make this idempotent, we will either create the region
-     * or return the current state of the region if it was already created in
-     * the past.
+     * Nexus will request that we create a new region by telling us the ID
+     * it should have.  To make this idempotent, we will either create
+     * the region or return the current state of the region if it was
+     * already created in the past.
      *
      * The actual heavy lifting is performed in a worker thread.
      */
@@ -125,8 +125,9 @@ impl DataFile {
                     .filter(|r| {
                         /*
                          * We can ignore any completely destroyed region.  We
-                         * choose not to ignore regions in the failed state for
-                         * now, as they may still prevent use of their assigned
+                         * choose not to ignore regions in the failed state
+                         * for now, as they may still
+                         * prevent use of their assigned
                          * port number.
                          */
                         r.state != State::Destroyed
@@ -288,19 +289,20 @@ impl DataFile {
     }
 
     /**
-     * The worker thread will request the first region that is in a particular
-     * state.  If there are no tasks in the provided state, we sleep waiting for
-     * work to do.
+     * The worker thread will request the first region that is in a
+     * particular state.  If there are no tasks in the provided state,
+     * we sleep waiting for work to do.
      */
     pub fn first_in_states(&self, states: &[State]) -> Region {
         let mut inner = self.inner.lock().unwrap();
 
         loop {
             /*
-             * States are provided in priority order.  We check for regions in
-             * the first requested state before we check for regions in the
-             * second provided state, etc.  This allows us to focus on
-             * destroying tombstoned regions ahead of creating new regions.
+             * States are provided in priority order.  We check for regions
+             * in the first requested state before we check for
+             * regions in the second provided state, etc.  This
+             * allows us to focus on destroying tombstoned
+             * regions ahead of creating new regions.
              */
             for s in states {
                 for r in inner.regions.values() {
@@ -311,8 +313,8 @@ impl DataFile {
             }
 
             /*
-             * If we did not find any regions in the specified state, sleep on
-             * the condvar.
+             * If we did not find any regions in the specified state, sleep
+             * on the condvar.
              */
             inner = self.bell.wait(inner).unwrap();
         }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -100,8 +100,9 @@ async fn main() -> Result<()> {
             std::fs::create_dir_all(&datapath)?;
 
             /*
-             * Ensure that the SMF service we will use exists already.  If not,
-             * something is seriously wrong with this machine.
+             * Ensure that the SMF service we will use exists already.  If
+             * not, something is seriously wrong with this
+             * machine.
              */
             {
                 let scf = crucible_smf::Scf::new()?;
@@ -141,10 +142,10 @@ fn write_openapi<W: Write>(f: &mut W) -> Result<()> {
  * downstairs data files, but SMF services are a bit different.
  *
  * If the zone is upgraded, we will likely start from a blank SMF repository
- * database and will need to set up all of our instances again.  As such, the
- * process of aligning SMF with the intent datastore is a separate idempotent
- * routine that we can call both at startup and after any changes to the intent
- * store.
+ * database and will need to set up all of our instances again.  As such,
+ * the process of aligning SMF with the intent datastore is a separate
+ * idempotent routine that we can call both at startup and after any changes
+ * to the intent store.
  */
 fn apply_smf(
     log: &Logger,
@@ -161,8 +162,8 @@ fn apply_smf(
         .ok_or(anyhow!("service missing"))?;
 
     /*
-     * First, check to see if there are any instances that we do not expect, and
-     * remove them.
+     * First, check to see if there are any instances that we do not expect,
+     * and remove them.
      */
     let expected_instances = all
         .iter()
@@ -252,8 +253,8 @@ fn apply_smf(
         } else {
             /*
              * No running snapshot means the service has never started.  Prod
-             * the restarter by disabling it, then we'll create everything from
-             * scratch.
+             * the restarter by disabling it, then we'll create everything
+             * from scratch.
              */
             inst.disable(false)?;
             true
@@ -382,8 +383,9 @@ fn worker_region_create(
     let log = log.new(o!("region" => region.id.0.to_string()));
 
     /*
-     * We may have crashed half way through a previous provision.  To make this
-     * idempotent, clean out the target data directory and try again.
+     * We may have crashed half way through a previous provision.  To make
+     * this idempotent, clean out the target data directory and try
+     * again.
      *
      * XXX This could obviously be improved.
      */

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Oxide Computer Company
+
 use anyhow::{anyhow, bail, Result};
 use dropshot::{ConfigLogging, ConfigLoggingLevel};
 use slog::{error, info, o, warn, Logger};

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1,0 +1,476 @@
+use anyhow::{anyhow, bail, Result};
+use dropshot::{ConfigLogging, ConfigLoggingLevel};
+use slog::{error, warn, info, o, Logger};
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use structopt::StructOpt;
+
+const PROG: &str = "crucible-agent";
+const SERVICE: &str = "oxide/crucible/downstairs";
+
+mod datafile;
+mod model;
+mod server;
+
+use model::State;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = PROG, about = "Crucible zone management agent")]
+enum Args {
+    OpenApi {
+        #[structopt(short = "o", parse(try_from_str))]
+        output: PathBuf,
+    },
+    Run {
+        #[structopt(short = "d", parse(try_from_str))]
+        data_dir: PathBuf,
+
+        #[structopt(short = "l", parse(try_from_str))]
+        listen: SocketAddr,
+
+        #[structopt(short = "i", parse(try_from_str))]
+        uuid: uuid::Uuid,
+
+        #[structopt(short = "D", parse(try_from_str))]
+        downstairs_program: PathBuf,
+
+        #[structopt(short = "P", parse(try_from_str))]
+        lowport: u16,
+
+        #[structopt(short = "p", parse(try_from_str))]
+        prefix: String,
+
+        #[structopt(short = "n", parse(try_from_str))]
+        nexus: Option<SocketAddr>,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::from_args_safe()?;
+
+    match args {
+        Args::OpenApi { output } => {
+            let mut f = std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(output)?;
+            let api = server::make_api()?;
+            api.openapi("Crucible Agent", "0.0.0").write(&mut f)?;
+            Ok(())
+        }
+        Args::Run {
+            data_dir,
+            listen,
+            uuid,
+            nexus,
+            downstairs_program,
+            lowport,
+            prefix,
+        } => {
+            let log = ConfigLogging::StderrTerminal {
+                level: ConfigLoggingLevel::Info,
+            }
+            .to_logger(PROG)?;
+
+            info!(log, "data directory: {:?}", data_dir);
+            info!(log, "listen IP: {:?}", listen);
+            info!(log, "SMF instance name prefix: {:?}", prefix);
+
+            let mut dfpath = data_dir.clone();
+            std::fs::create_dir_all(&dfpath)?;
+            dfpath.push("crucible.json");
+
+            let df = Arc::new(datafile::DataFile::new(
+                log.new(o!("component" => "datafile")),
+                &dfpath,
+                lowport,
+                lowport + 999,
+            )?);
+
+            let mut datapath = data_dir.clone();
+            datapath.push("regions");
+            std::fs::create_dir_all(&datapath)?;
+
+            /*
+             * Ensure that the SMF service we will use exists already.  If not,
+             * something is seriously wrong with this machine.
+             */
+            {
+                let scf = crucible_smf::Scf::new()?;
+                let scope = scf.scope_local()?;
+
+                let svc = scope.get_service(SERVICE)?;
+                if svc.is_none() {
+                    bail!("SMF service {} does not exist", SERVICE);
+                }
+            }
+
+            apply_smf(&log, &df, datapath.clone(), &prefix)?;
+
+            /*
+             * Create the worker thread that will perform provisioning and
+             * deprovisioning tasks.
+             */
+            let log0 = log.new(o!("component" => "worker"));
+            let df0 = Arc::clone(&df);
+            std::thread::spawn(|| {
+                worker(log0, df0, datapath, downstairs_program, prefix)
+            });
+
+            if let Some(nexus) = nexus {
+                use omicron_common::api::internal::nexus;
+
+                let log0 = log.new(o!("component" => "nexus"));
+                let listen0 = listen.clone();
+                tokio::spawn(async move {
+                    let log = log0.clone();
+                    let c = omicron_common::NexusClient::new(nexus, log0);
+
+                    loop {
+                        let casi = nexus::CrucibleAgentStartupInfo {
+                            address: listen0.clone(),
+                        };
+                        let r =
+                            c.notify_crucible_agent_online(uuid, casi).await;
+
+                        let dur = if let Err(e) = r {
+                            error!(log, "notify nexus failed: {:?}", e);
+                            std::time::Duration::from_secs(5)
+                        } else {
+                            info!(log, "notify nexus ok");
+                            std::time::Duration::from_secs(30)
+                        };
+
+                        tokio::time::sleep(dur).await;
+                    }
+                });
+            }
+
+            server::run_server(&log, listen, df).await
+        }
+    }
+}
+
+/**
+ * Provisioning requests will update the local intent store, and provision
+ * downstairs data files, but SMF services are a bit different.
+ *
+ * If the zone is upgraded, we will likely start from a blank SMF repository
+ * database and will need to set up all of our instances again.  As such, the
+ * process of aligning SMF with the intent datastore is a separate idempotent
+ * routine that we can call both at startup and after any changes to the intent
+ * store.
+ */
+fn apply_smf(
+    log: &Logger,
+    df: &Arc<datafile::DataFile>,
+    datapath: PathBuf,
+    prefix: &str,
+) -> Result<()> {
+    let all = df.all();
+
+    let scf = crucible_smf::Scf::new()?;
+    let scope = scf.scope_local()?;
+    let svc = scope
+        .get_service(SERVICE)?
+        .ok_or(anyhow!("service missing"))?;
+
+    /*
+     * First, check to see if there are any instances that we do not expect, and
+     * remove them.
+     */
+    let expected_instances = all
+        .iter()
+        .filter(|r| r.state == State::Created)
+        .map(|r| format!("{}-{}", prefix, r.id.0))
+        .collect::<HashSet<_>>();
+    let mut insts = svc.instances()?;
+    while let Some(inst) = insts.next().transpose()? {
+        let n = inst.name()?;
+
+        if &n == "default" {
+            continue;
+        }
+
+        if !n.starts_with(&format!("{}-", prefix)) {
+            warn!(log, "ignoring instance with other prefix: {:?}", n);
+            continue;
+        }
+
+        if !expected_instances.contains(&n) {
+            error!(log, "remove instance: {}", n);
+            info!(log, "instance states: {:?}", inst.states()?);
+            /*
+             * XXX just disable for now.
+             */
+            inst.disable(false)?;
+            continue;
+        }
+
+        info!(log, "found expected instance: {}", n);
+    }
+
+    /*
+     * Second, create any instances that are missing.
+     */
+    for r in all.iter() {
+        if r.state != State::Created {
+            continue;
+        }
+
+        let name = format!("{}-{}", prefix, r.id.0);
+        let mut dir = datapath.clone();
+        dir.push(&r.id.0);
+        let datadir = dir.to_str().unwrap().to_string();
+
+        let inst = if let Some(inst) = svc.get_instance(&name)? {
+            inst
+        } else {
+            info!(log, "creating missing instance {}", name);
+            let inst = svc.add_instance(&name)?;
+            info!(log, "ok, have {}", inst.fmri()?);
+            inst
+        };
+
+        /*
+         * Determine the contents of the running snapshot.
+         */
+        let reconfig = if let Some(snap) = inst.get_snapshot("running")? {
+            /*
+             * Just check the values.
+             */
+            if let Some(pg) = snap.get_pg("config")? {
+                let mut found_directory = false;
+                let dir = pg.get_property("directory")?;
+                if let Some(dir) = dir {
+                    if let Some(val) = dir.value()? {
+                        if val.as_string()? == datadir {
+                            found_directory = true;
+                        }
+                    }
+                }
+
+                let mut found_port = false;
+                let dir = pg.get_property("port")?;
+                if let Some(dir) = dir {
+                    if let Some(val) = dir.value()? {
+                        if val.as_string()? == r.port_number.to_string() {
+                            found_port = true;
+                        }
+                    }
+                }
+
+                !found_port || !found_directory
+            } else {
+                true
+            }
+        } else {
+            /*
+             * No running snapshot means the service has never started.  Prod
+             * the restarter by disabling it, then we'll create everything from
+             * scratch.
+             */
+            inst.disable(false)?;
+            true
+        };
+
+        if reconfig {
+            use crucible_smf::scf_type_t::*;
+
+            /*
+             * Ensure that there is a "config" property group:
+             */
+            let pg = if let Some(pg) = inst.get_pg("config")? {
+                pg
+            } else {
+                inst.add_pg("config", "application")?
+            };
+
+            info!(log, "reconfiguring {}", inst.fmri()?);
+
+            let tx = pg.transaction()?;
+            tx.start()?;
+            let mut entries = Vec::new();
+
+            /*
+             * An expression of our values:
+             */
+            let mut e = if pg.get_property("directory")?.is_some() {
+                info!(log, "change directory");
+                tx.property_change("directory", SCF_TYPE_ASTRING)?
+            } else {
+                info!(log, "add directory");
+                tx.property_new("directory", SCF_TYPE_ASTRING)?
+            };
+            e.add_from_string(SCF_TYPE_ASTRING, &datadir)?;
+            entries.push(e);
+
+            let mut e = if pg.get_property("port")?.is_some() {
+                info!(log, "change port");
+                tx.property_change("port", SCF_TYPE_COUNT)?
+            } else {
+                info!(log, "add port");
+                tx.property_new("port", SCF_TYPE_COUNT)?
+            };
+            e.add_from_string(SCF_TYPE_COUNT, &r.port_number.to_string())?;
+            entries.push(e);
+
+            info!(log, "commit");
+            match tx.commit()? {
+                crucible_smf::CommitResult::Success => {
+                    info!(log, "ok!");
+                }
+                crucible_smf::CommitResult::OutOfDate => {
+                    error!(log, "concurrent modification?!");
+                }
+            }
+        } else {
+            info!(log, "do not need to reconfigure {}", inst.fmri()?);
+        }
+
+        /*
+         * Finally, make sure the instance is enabled.
+         */
+        inst.enable(false)?;
+    }
+
+    Ok(())
+}
+
+fn worker(
+    log: Logger,
+    df: Arc<datafile::DataFile>,
+    datapath: PathBuf,
+    downstairs_program: PathBuf,
+    prefix: String,
+) {
+    loop {
+        let r = df.first_in_states(&[State::Tombstoned, State::Requested]);
+
+        match &r.state {
+            State::Tombstoned => {
+                let mut dir = datapath.clone();
+                dir.push(&r.id.0);
+
+                let res = worker_region_destroy(&log, &r, &dir)
+                    .and_then(|_| df.destroyed(&r.id));
+
+                if let Err(e) = res {
+                    error!(log, "region {:?} destroy failed: {:?}", r.id.0, e);
+                    df.fail(&r.id);
+                }
+            }
+            State::Requested => {
+                let mut dir = datapath.clone();
+                dir.push(&r.id.0);
+
+                let res =
+                    worker_region_create(&log, &downstairs_program, &r, &dir)
+                        .and_then(|_| df.created(&r.id));
+
+                if let Err(e) = res {
+                    error!(log, "region {:?} create failed: {:?}", r.id.0, e);
+                    df.fail(&r.id);
+                }
+            }
+            _ => {
+                eprintln!("worker got unexpected region state: {:?}", r);
+                std::process::exit(1);
+            }
+        }
+
+        info!(log, "applying SMF actions...");
+        if let Err(e) = apply_smf(&log, &df, datapath.clone(), &prefix) {
+            error!(log, "SMF application failure: {:?}", e);
+        } else {
+            info!(log, "SMF ok!");
+        }
+    }
+}
+
+fn worker_region_create(
+    log: &Logger,
+    prog: &Path,
+    region: &model::Region,
+    dir: &Path,
+) -> Result<()> {
+    let log = log.new(o!("region" => region.id.0.to_string()));
+
+    /*
+     * We may have crashed half way through a previous provision.  To make this
+     * idempotent, clean out the target data directory and try again.
+     *
+     * XXX This could obviously be improved.
+     */
+    if dir.exists() {
+        info!(log, "removing directory {:?}", dir);
+        std::fs::remove_dir_all(&dir)?;
+    }
+
+    /*
+     * Run the downstairs program in the mode where it will create the data
+     * files.
+     */
+    //let image = "/dev/null"; /* XXX */
+    let image = "/var/tmp/alpine.iso";
+    info!(log, "creating region files from image {:?}", image);
+    let cmd = Command::new(prog)
+        .env_clear()
+        .arg("--create")
+        .arg("--data")
+        .arg(dir)
+        .arg("--import-path")
+        .arg(image)
+        .arg("--block-size")
+        .arg(region.block_size.to_string())
+        .arg("--extent-size")
+        .arg(region.extent_size.to_string())
+        .arg("--extent-count")
+        .arg(region.extent_count.to_string())
+        .output()?;
+
+    if cmd.status.success() {
+        info!(log, "region files created ok");
+    } else {
+        let err = String::from_utf8_lossy(&cmd.stderr);
+        let out = String::from_utf8_lossy(&cmd.stdout);
+        error!(log, "downstairs create failed: out {:?} err {:?}", out, err);
+        bail!("region files create failure");
+    }
+
+    /*
+     * - create/enable SMF instance
+     */
+    let scf = crucible_smf::Scf::new()?;
+    let scope = scf.scope_local()?;
+
+    /*
+     * First, ensure that the service exists.
+     */
+
+    Ok(())
+}
+
+fn worker_region_destroy(
+    log: &Logger,
+    region: &model::Region,
+    dir: &Path,
+) -> Result<()> {
+    let log = log.new(o!("region" => region.id.0.to_string()));
+
+    /*
+     * - stop/destroy SMF instance
+     */
+
+    if dir.exists() {
+        info!(log, "removing directory {:?}", dir);
+        std::fs::remove_dir_all(&dir)?;
+    }
+
+    Ok(())
+}

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -31,6 +31,7 @@ enum Args {
         #[structopt(short = "l", parse(try_from_str))]
         listen: SocketAddr,
 
+        #[allow(dead_code)]
         #[structopt(short = "i", parse(try_from_str))]
         uuid: uuid::Uuid,
 
@@ -43,6 +44,7 @@ enum Args {
         #[structopt(short = "p", parse(try_from_str))]
         prefix: String,
 
+        #[allow(dead_code)]
         #[structopt(short = "n", parse(try_from_str))]
         nexus: Option<SocketAddr>,
     },
@@ -66,8 +68,8 @@ async fn main() -> Result<()> {
         Args::Run {
             data_dir,
             listen,
-            uuid,
-            nexus,
+            uuid: _,
+            nexus: _,
             downstairs_program,
             lowport,
             prefix,
@@ -418,11 +420,13 @@ fn worker_region_create(
      * - create/enable SMF instance
      */
     let scf = crucible_smf::Scf::new()?;
-    let scope = scf.scope_local()?;
+    let _scope = scf.scope_local()?;
 
     /*
      * First, ensure that the service exists.
      */
+
+    // TODO this is where Josh stopped...
 
     Ok(())
 }

--- a/agent/src/model.rs
+++ b/agent/src/model.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Oxide Computer Company
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/agent/src/model.rs
+++ b/agent/src/model.rs
@@ -63,15 +63,17 @@ impl CreateRegion {
 }
 
 #[derive(
-    Serialize, Deserialize, JsonSchema, Debug, PartialEq, Eq, Clone, Ord,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    PartialOrd,
+    Ord,
 )]
 pub struct RegionId(pub String);
-
-impl PartialOrd for RegionId {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.0.partial_cmp(&other.0)
-    }
-}
 
 #[cfg(test)]
 mod test {
@@ -84,6 +86,9 @@ mod test {
             volume_id: "def".to_string(),
             port_number: 1701,
             state: State::Requested,
+            block_size: 4096,
+            extent_size: 4096,
+            extent_count: 100,
         };
 
         let s = serde_json::to_string(&r).expect("serialise");

--- a/agent/src/model.rs
+++ b/agent/src/model.rs
@@ -1,0 +1,96 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, PartialEq, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum State {
+    Requested,
+    Created,
+    Tombstoned,
+    Destroyed,
+    Failed,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, PartialEq, Clone)]
+pub struct Region {
+    pub id: RegionId,
+    pub volume_id: String,
+
+    pub block_size: u64,
+    pub extent_size: u64,
+    pub extent_count: u64,
+
+    pub port_number: u16,
+    pub state: State,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, PartialEq, Clone)]
+pub struct CreateRegion {
+    pub id: RegionId,
+    pub volume_id: String,
+
+    pub block_size: u64,
+    pub extent_size: u64,
+    pub extent_count: u64,
+}
+
+impl CreateRegion {
+    pub fn mismatch(&self, r: &Region) -> Option<String> {
+        if self.volume_id != r.volume_id {
+            Some(format!(
+                "volume ID {} instead of requested {}",
+                self.volume_id, r.volume_id
+            ))
+        } else if self.block_size != r.block_size {
+            Some(format!(
+                "block size {} instead of requested {}",
+                self.block_size, r.block_size
+            ))
+        } else if self.extent_size != r.extent_size {
+            Some(format!(
+                "extent size {} instead of requested {}",
+                self.extent_size, r.extent_size
+            ))
+        } else if self.extent_count != r.extent_count {
+            Some(format!(
+                "extent count {} instead of requested {}",
+                self.extent_count, r.extent_count
+            ))
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(
+    Serialize, Deserialize, JsonSchema, Debug, PartialEq, Eq, Clone, Ord,
+)]
+pub struct RegionId(pub String);
+
+impl PartialOrd for RegionId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn basic() {
+        let r = Region {
+            id: RegionId("abc".to_string()),
+            volume_id: "def".to_string(),
+            port_number: 1701,
+            state: State::Requested,
+        };
+
+        let s = serde_json::to_string(&r).expect("serialise");
+        println!("{}", s);
+
+        let recons: Region = serde_json::from_str(&s).expect("deserialise");
+
+        assert_eq!(r, recons);
+    }
+}

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -1,0 +1,127 @@
+use super::datafile::DataFile;
+use super::model;
+use anyhow::{anyhow, bail, Result};
+use dropshot::{
+    endpoint, HttpError, HttpResponseOk, Path as TypedPath, RequestContext,
+    TypedBody,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use slog::{o, Logger};
+use std::net::SocketAddr;
+use std::result::Result as SResult;
+use std::sync::Arc;
+
+trait AnyhowFromString<T> {
+    fn or_bail(self, msg: &str) -> Result<T>;
+}
+
+impl<T> AnyhowFromString<T> for SResult<T, String> {
+    fn or_bail(self, msg: &str) -> Result<T> {
+        self.map_err(|e| anyhow!("{}: {:?}", msg, e))
+    }
+}
+
+#[endpoint {
+    method = GET,
+    path = "/crucible/0/regions",
+}]
+async fn region_list(
+    rc: Arc<RequestContext<Arc<DataFile>>>,
+) -> SResult<HttpResponseOk<Vec<model::Region>>, HttpError> {
+    Ok(HttpResponseOk(rc.context().all()))
+}
+
+#[endpoint {
+    method = POST,
+    path = "/crucible/0/regions",
+}]
+async fn region_create(
+    rc: Arc<RequestContext<Arc<DataFile>>>,
+    body: TypedBody<model::CreateRegion>,
+) -> SResult<HttpResponseOk<model::Region>, HttpError> {
+    let create = body.into_inner();
+
+    match rc.context().request(create) {
+        Ok(r) => Ok(HttpResponseOk(r)),
+        Err(e) => Err(HttpError::for_internal_error(format!(
+            "region create failure: {:?}",
+            e
+        ))),
+    }
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct RegionPath {
+    id: model::RegionId,
+}
+
+#[endpoint {
+    method = GET,
+    path = "/crucible/0/regions/{id}",
+}]
+async fn region_get(
+    rc: Arc<RequestContext<Arc<DataFile>>>,
+    path: TypedPath<RegionPath>,
+) -> SResult<HttpResponseOk<model::Region>, HttpError> {
+    let p = path.into_inner();
+
+    match rc.context().get(&p.id) {
+        Some(r) => Ok(HttpResponseOk(r)),
+        None => Err(HttpError::for_not_found(
+            None,
+            format!("region {:?} not found", p.id),
+        )),
+    }
+}
+
+#[endpoint {
+    method = DELETE,
+    path = "/crucible/0/regions/{id}",
+}]
+async fn region_delete(
+    rc: Arc<RequestContext<Arc<DataFile>>>,
+    path: TypedPath<RegionPath>,
+) -> SResult<HttpResponseOk<()>, HttpError> {
+    let p = path.into_inner();
+
+    match rc.context().destroy(&p.id) {
+        Ok(_) => Ok(HttpResponseOk(())),
+        Err(e) => Err(HttpError::for_bad_request(None, e.to_string())),
+    }
+}
+
+pub fn make_api() -> Result<dropshot::ApiDescription<Arc<DataFile>>> {
+    let mut api = dropshot::ApiDescription::new();
+    api.register(region_list).or_bail("registration failure")?;
+    api.register(region_create)
+        .or_bail("registration failure")?;
+    api.register(region_get).or_bail("registration failure")?;
+    api.register(region_delete)
+        .or_bail("registration failure")?;
+    Ok(api)
+}
+
+pub async fn run_server(
+    log: &Logger,
+    bind_address: SocketAddr,
+    df: Arc<DataFile>,
+) -> Result<()> {
+    let api = make_api()?;
+
+    let server = dropshot::HttpServerStarter::new(
+        &dropshot::ConfigDropshot {
+            bind_address,
+            ..Default::default()
+        },
+        api,
+        df,
+        &log.new(o!("component" => "dropshot")),
+    )
+    .map_err(|e| anyhow!("creating server: {:?}", e))?
+    .start();
+
+    server
+        .await
+        .map_err(|e| anyhow!("starting server: {:?}", e))
+}

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -2,8 +2,8 @@ use super::datafile::DataFile;
 use super::model;
 use anyhow::{anyhow, Result};
 use dropshot::{
-    endpoint, HttpError, HttpResponseOk, Path as TypedPath, RequestContext,
-    TypedBody,
+    endpoint, HttpError, HttpResponseDeleted, HttpResponseOk,
+    Path as TypedPath, RequestContext, TypedBody,
 };
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -82,11 +82,11 @@ async fn region_get(
 async fn region_delete(
     rc: Arc<RequestContext<Arc<DataFile>>>,
     path: TypedPath<RegionPath>,
-) -> SResult<HttpResponseOk<()>, HttpError> {
+) -> SResult<HttpResponseDeleted, HttpError> {
     let p = path.into_inner();
 
     match rc.context().destroy(&p.id) {
-        Ok(_) => Ok(HttpResponseOk(())),
+        Ok(_) => Ok(HttpResponseDeleted()),
         Err(e) => Err(HttpError::for_bad_request(None, e.to_string())),
     }
 }

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Oxide Computer Company
+
 use super::datafile::DataFile;
 use super::model;
 use anyhow::{anyhow, Result};

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -1,12 +1,12 @@
 use super::datafile::DataFile;
 use super::model;
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
 use dropshot::{
     endpoint, HttpError, HttpResponseOk, Path as TypedPath, RequestContext,
     TypedBody,
 };
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use slog::{o, Logger};
 use std::net::SocketAddr;
 use std::result::Result as SResult;

--- a/openapi/crucible-agent.json
+++ b/openapi/crucible-agent.json
@@ -1,0 +1,206 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Crucible Agent",
+    "version": "0.0.0"
+  },
+  "paths": {
+    "/crucible/0/regions": {
+      "get": {
+        "operationId": "region_list",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_Region",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Region"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "region_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRegion"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Region"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/crucible/0/regions/{id}": {
+      "get": {
+        "operationId": "region_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RegionId"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Region"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "region_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RegionId"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Null",
+                  "type": "string",
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CreateRegion": {
+        "type": "object",
+        "properties": {
+          "block_size": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "extent_count": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "extent_size": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "id": {
+            "$ref": "#/components/schemas/RegionId"
+          },
+          "volume_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "block_size",
+          "extent_count",
+          "extent_size",
+          "id",
+          "volume_id"
+        ]
+      },
+      "Region": {
+        "type": "object",
+        "properties": {
+          "block_size": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "extent_count": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "extent_size": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "id": {
+            "$ref": "#/components/schemas/RegionId"
+          },
+          "port_number": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "state": {
+            "$ref": "#/components/schemas/State"
+          },
+          "volume_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "block_size",
+          "extent_count",
+          "extent_size",
+          "id",
+          "port_number",
+          "state",
+          "volume_id"
+        ]
+      },
+      "RegionId": {
+        "type": "string"
+      },
+      "State": {
+        "type": "string",
+        "enum": [
+          "requested",
+          "created",
+          "tombstoned",
+          "destroyed",
+          "failed"
+        ]
+      }
+    }
+  }
+}

--- a/openapi/crucible-agent.json
+++ b/openapi/crucible-agent.json
@@ -92,19 +92,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Null",
-                  "type": "string",
-                  "enum": [
-                    null
-                  ]
-                }
-              }
-            }
+          "204": {
+            "description": "successful deletion"
           }
         }
       }

--- a/smf/Cargo.toml
+++ b/smf/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "crucible-smf"
+version = "0.0.0"
+edition = "2018"
+
+[dependencies]
+libc = "0.2.99"
+thiserror = "1"
+num-traits = "0.2"
+num-derive = "0.3"

--- a/smf/examples/info.rs
+++ b/smf/examples/info.rs
@@ -1,0 +1,94 @@
+use crucible_smf::{PropertyGroups, Result};
+
+fn fil(n: usize, c: char) -> String {
+    let mut s = String::new();
+    while s.len() < n {
+        s.push(c);
+    }
+    s
+}
+
+fn ind(n: usize) -> String {
+    fil(n * 4, ' ')
+}
+
+fn dump_pgs(indent: usize, name: &str, mut pgs: PropertyGroups) -> Result<()> {
+    while let Some(pg) = pgs.next().transpose()? {
+        let mut infostr = format!("type {:?}", pg.type_()?);
+        if pg.is_persistent()? {
+            infostr += ", persistent";
+        } else {
+            infostr += ", non-persistent";
+        }
+
+        println!("{}{}: {} ({})", ind(indent), name, pg.name()?, infostr);
+        let mut properties = pg.properties()?;
+        while let Some(prop) = properties.next().transpose()? {
+            println!(
+                "{}prop: {} ({:?})",
+                ind(indent + 1),
+                prop.name()?,
+                prop.type_()?
+            );
+
+            let mut values = prop.values()?;
+            while let Some(v) = values.next().transpose()? {
+                println!(
+                    "{}value: {:?} ({:?}, base {:?})",
+                    ind(indent + 2),
+                    v.as_string()?,
+                    v.type_()?,
+                    v.base_type()?
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+
+    let scf = crucible_smf::Scf::new()?;
+    let scope = scf.scope_local()?;
+
+    let mut services = scope.services()?;
+    while let Some(service) = services.next().transpose()? {
+        let n = service.name()?;
+
+        if !args.is_empty() {
+            if !args.iter().any(|a| n.contains(a)) {
+                continue;
+            }
+        }
+
+        println!("{}", fil(78, '='));
+        println!("{}service: {}", ind(0), n);
+
+        dump_pgs(1, "pg(s)", service.pgs()?)?;
+        println!();
+
+        let mut instances = service.instances()?;
+        while let Some(instance) = instances.next().transpose()? {
+            println!("{}", fil(78, '-'));
+            println!("{}instance: {}", ind(1), instance.name()?);
+
+            dump_pgs(2, "pg(i)", instance.pgs()?)?;
+            println!();
+
+            let mut snapshots = instance.snapshots()?;
+            while let Some(snapshot) = snapshots.next().transpose()? {
+                println!("{}snapshot: {}", ind(2), snapshot.name()?);
+
+                dump_pgs(3, "pg(c)", snapshot.pgs()?)?;
+                println!();
+            }
+
+            println!();
+        }
+
+        println!();
+    }
+
+    Ok(())
+}

--- a/smf/examples/info.rs
+++ b/smf/examples/info.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Oxide Computer Company
+
 use crucible_smf::{PropertyGroups, Result};
 
 fn fil(n: usize, c: char) -> String {

--- a/smf/src/instance.rs
+++ b/smf/src/instance.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Oxide Computer Company
+
 use std::ffi::CString;
 use std::ptr::NonNull;
 

--- a/smf/src/instance.rs
+++ b/smf/src/instance.rs
@@ -107,8 +107,8 @@ impl<'a> Instance<'a> {
     }
 
     /**
-     * Get the current state and the next state (if any) of the instance from
-     * the restarter.
+     * Get the current state and the next state (if any) of the instance
+     * from the restarter.
      */
     pub fn states(&self) -> Result<(Option<State>, Option<State>)> {
         let restarter = self.get_pg("restarter")?.ok_or(ScfError::NotFound)?;

--- a/smf/src/instance.rs
+++ b/smf/src/instance.rs
@@ -1,0 +1,270 @@
+use std::ffi::CString;
+use std::ptr::NonNull;
+
+use super::scf_sys::*;
+use super::{
+    buf_for, str_from, Iter, PropertyGroup, PropertyGroups, Result, Scf,
+    ScfError, Service, Snapshot, Snapshots,
+};
+
+#[derive(Debug)]
+pub struct Instance<'a> {
+    pub(crate) scf: &'a Scf,
+    pub(crate) instance: NonNull<scf_instance_t>,
+}
+
+#[derive(Debug)]
+pub enum State {
+    Uninitialized,
+    Maintenance,
+    Offline,
+    Disabled,
+    Online,
+    Degraded,
+    LegacyRun,
+    Unknown(String),
+}
+
+impl State {
+    fn parse(v: &str) -> Option<State> {
+        use State::*;
+
+        match v {
+            "none" => None,
+            "uninitialized" => Some(Uninitialized),
+            "maintenance" => Some(Maintenance),
+            "offline" => Some(Offline),
+            "disabled" => Some(Disabled),
+            "online" => Some(Online),
+            "degraded" => Some(Degraded),
+            "legacy_run" => Some(LegacyRun),
+            other => Some(Unknown(other.to_string())),
+        }
+    }
+}
+
+impl<'a> Instance<'a> {
+    pub(crate) fn new(scf: &'a Scf) -> Result<Instance> {
+        if let Some(instance) =
+            NonNull::new(unsafe { scf_instance_create(scf.handle.as_ptr()) })
+        {
+            Ok(Instance { scf, instance })
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    pub fn name(&self) -> Result<String> {
+        let mut buf = buf_for(SCF_LIMIT_MAX_NAME_LENGTH)?;
+
+        let ret = unsafe {
+            scf_instance_get_name(
+                self.instance.as_ptr(),
+                buf.as_mut_ptr() as *mut libc::c_char,
+                buf.len(),
+            )
+        };
+
+        str_from(&mut buf, ret)
+    }
+
+    pub fn fmri(&self) -> Result<String> {
+        let mut buf = buf_for(SCF_LIMIT_MAX_FMRI_LENGTH)?;
+
+        let ret = unsafe {
+            scf_instance_to_fmri(
+                self.instance.as_ptr(),
+                buf.as_mut_ptr() as *mut libc::c_char,
+                buf.len(),
+            )
+        };
+
+        str_from(&mut buf, ret)
+    }
+
+    pub fn enable(&self, temporary: bool) -> Result<()> {
+        let fmri = CString::new(self.fmri()?).unwrap();
+        let flags = if temporary { SMF_TEMPORARY } else { 0 };
+
+        if unsafe { smf_enable_instance(fmri.as_ptr(), flags) } == 0 {
+            Ok(())
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    pub fn disable(&self, temporary: bool) -> Result<()> {
+        let fmri = CString::new(self.fmri()?).unwrap();
+        let flags = if temporary { SMF_TEMPORARY } else { 0 };
+
+        if unsafe { smf_disable_instance(fmri.as_ptr(), flags) } == 0 {
+            Ok(())
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    /**
+     * Get the current state and the next state (if any) of the instance from
+     * the restarter.
+     */
+    pub fn states(&self) -> Result<(Option<State>, Option<State>)> {
+        let restarter = self.get_pg("restarter")?.ok_or(ScfError::NotFound)?;
+
+        fn get_val(pg: &PropertyGroup, n: &str) -> Result<Option<String>> {
+            let prop = pg.get_property(n)?;
+            if let Some(prop) = prop {
+                let val = prop.value()?;
+                if let Some(val) = val {
+                    Ok(Some(val.as_string()?))
+                } else {
+                    Ok(None)
+                }
+            } else {
+                Ok(None)
+            }
+        }
+
+        let state = get_val(&restarter, "state")?
+            .map(|v| State::parse(&v))
+            .flatten();
+        let next_state = get_val(&restarter, "next_state")?
+            .map(|v| State::parse(&v))
+            .flatten();
+
+        Ok((state, next_state))
+    }
+
+    pub fn snapshots(&self) -> Result<Snapshots> {
+        Snapshots::new(self)
+    }
+
+    pub fn get_snapshot(&self, name: &str) -> Result<Option<Snapshot>> {
+        let name = CString::new(name).unwrap();
+        let snap = Snapshot::new(self)?;
+
+        let ret = unsafe {
+            scf_instance_get_snapshot(
+                self.instance.as_ptr(),
+                name.as_ptr(),
+                snap.snapshot.as_ptr(),
+            )
+        };
+
+        if ret == 0 {
+            Ok(Some(snap))
+        } else {
+            match ScfError::last() {
+                ScfError::NotFound => Ok(None),
+                other => Err(other),
+            }
+        }
+    }
+
+    pub fn pgs(&self) -> Result<PropertyGroups> {
+        PropertyGroups::new_instance(self)
+    }
+
+    pub fn get_pg(&self, name: &str) -> Result<Option<PropertyGroup>> {
+        let name = CString::new(name).unwrap();
+        let pg = PropertyGroup::new(self.scf)?;
+
+        let ret = unsafe {
+            scf_instance_get_pg(
+                self.instance.as_ptr(),
+                name.as_ptr(),
+                pg.propertygroup.as_ptr(),
+            )
+        };
+
+        if ret == 0 {
+            Ok(Some(pg))
+        } else {
+            match ScfError::last() {
+                ScfError::NotFound => Ok(None),
+                other => Err(other),
+            }
+        }
+    }
+
+    pub fn add_pg(&self, name: &str, pgtype: &str) -> Result<PropertyGroup> {
+        let name = CString::new(name).unwrap();
+        let pgtype = CString::new(pgtype).unwrap();
+        let pg = PropertyGroup::new(self.scf)?;
+
+        let ret = unsafe {
+            scf_instance_add_pg(
+                self.instance.as_ptr(),
+                name.as_ptr(),
+                pgtype.as_ptr(),
+                0,
+                pg.propertygroup.as_ptr(),
+            )
+        };
+
+        if ret == 0 {
+            Ok(pg)
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    /*
+     * XXX fn delete(&self) -> Result<()> {
+     * scf_instance_delete(3SCF)
+     */
+}
+
+impl Drop for Instance<'_> {
+    fn drop(&mut self) {
+        unsafe { scf_instance_destroy(self.instance.as_ptr()) };
+    }
+}
+
+pub struct Instances<'a> {
+    pub(crate) service: &'a Service<'a>,
+    pub(crate) iter: Iter<'a>,
+}
+
+impl<'a> Instances<'a> {
+    pub(crate) fn new(service: &'a Service) -> Result<Instances<'a>> {
+        let iter = Iter::new(service.scf)?;
+
+        if unsafe {
+            scf_iter_service_instances(
+                iter.iter.as_ptr(),
+                service.service.as_ptr(),
+            )
+        } != 0
+        {
+            Err(ScfError::last())
+        } else {
+            Ok(Instances { service, iter })
+        }
+    }
+
+    fn get(&self) -> Result<Option<Instance<'a>>> {
+        let instance = Instance::new(self.service.scf)?;
+
+        let res = unsafe {
+            scf_iter_next_instance(
+                self.iter.iter.as_ptr(),
+                instance.instance.as_ptr(),
+            )
+        };
+
+        match res {
+            0 => Ok(None),
+            1 => Ok(Some(instance)),
+            _ => Err(ScfError::last()),
+        }
+    }
+}
+
+impl<'a> Iterator for Instances<'a> {
+    type Item = Result<Instance<'a>>;
+
+    fn next(&mut self) -> Option<Result<Instance<'a>>> {
+        self.get().transpose()
+    }
+}

--- a/smf/src/lib.rs
+++ b/smf/src/lib.rs
@@ -205,7 +205,7 @@ fn str_from(buf: &mut Vec<u8>, ret: libc::ssize_t) -> Result<String> {
 
 #[derive(Debug)]
 pub struct Iter<'a> {
-    scf: &'a Scf,
+    _scf: &'a Scf, // Prevent from being dropped
     iter: NonNull<scf_iter_t>,
 }
 
@@ -214,7 +214,7 @@ impl<'a> Iter<'a> {
         if let Some(iter) =
             NonNull::new(unsafe { scf_iter_create(scf.handle.as_ptr()) })
         {
-            Ok(Iter { scf, iter })
+            Ok(Iter { _scf: scf, iter })
         } else {
             Err(ScfError::last())
         }
@@ -232,7 +232,7 @@ impl Drop for Iter<'_> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(target_os = "illumos", test))]
 mod tests {
     use super::{Iter, Scf, ScfError, Scope};
 

--- a/smf/src/lib.rs
+++ b/smf/src/lib.rs
@@ -1,0 +1,335 @@
+use num_traits::FromPrimitive;
+use std::ffi::CStr;
+use std::ptr::NonNull;
+use thiserror::Error;
+
+#[macro_use]
+extern crate num_derive;
+
+mod scf_sys;
+pub use scf_sys::scf_type_t;
+use scf_sys::*;
+
+mod scope;
+pub use scope::{Scope, Scopes};
+
+mod service;
+pub use service::{Service, Services};
+
+mod instance;
+pub use instance::{Instance, Instances};
+
+mod snapshot;
+pub use snapshot::{Snapshot, Snapshots};
+
+mod propertygroup;
+pub use propertygroup::{PropertyGroup, PropertyGroups};
+
+mod property;
+pub use property::{Properties, Property};
+
+mod value;
+pub use value::{Value, Values};
+
+mod transaction;
+pub use transaction::{CommitResult, Transaction, TransactionEntry};
+
+pub type Result<T> = std::result::Result<T, ScfError>;
+
+#[derive(Error, Debug)]
+pub enum ScfError {
+    #[error("no error")]
+    None,
+    #[error("handle not bound")]
+    NotBound,
+    #[error("cannot use unset argument")]
+    NotSet,
+    #[error("nothing of that name found")]
+    NotFound,
+    #[error("type does not match value")]
+    TypeMismatch,
+    #[error("cannot modify while in-use")]
+    InUse,
+    #[error("repository connection gone")]
+    ConnectionBroken,
+    #[error("bad argument")]
+    InvalidArgument,
+    #[error("no memory available")]
+    NoMemory,
+    #[error("required constraint not met")]
+    ConstraintViolated,
+    #[error("object already exists")]
+    Exists,
+    #[error("repository server unavailable")]
+    NoServer,
+    #[error("server has insufficient resources")]
+    NoResources,
+    #[error("insufficient privileges for action")]
+    PermissionDenied,
+    #[error("backend refused access")]
+    BackendAccess,
+    #[error("mismatched SCF handles")]
+    HandleMismatch,
+    #[error("object bound to destroyed handle")]
+    HandleDestroyed,
+    #[error("incompatible SCF version")]
+    VersionMismatch,
+    #[error("backend is read-only")]
+    BackendReadonly,
+    #[error("object has been deleted")]
+    Deleted,
+    #[error("template data is invalid")]
+    TemplateInvalid,
+    #[error("user callback function failed")]
+    CallbackFailed,
+    #[error("internal error")]
+    Internal,
+    #[error("unknown error ({0})")]
+    Unknown(u32),
+}
+
+impl From<u32> for ScfError {
+    fn from(error: u32) -> Self {
+        use scf_error_t::*;
+        use ScfError::*;
+
+        match scf_error_t::from_u32(error) {
+            Some(SCF_ERROR_NONE) => None,
+            Some(SCF_ERROR_NOT_BOUND) => NotBound,
+            Some(SCF_ERROR_NOT_SET) => NotSet,
+            Some(SCF_ERROR_NOT_FOUND) => NotFound,
+            Some(SCF_ERROR_TYPE_MISMATCH) => TypeMismatch,
+            Some(SCF_ERROR_IN_USE) => InUse,
+            Some(SCF_ERROR_CONNECTION_BROKEN) => ConnectionBroken,
+            Some(SCF_ERROR_INVALID_ARGUMENT) => InvalidArgument,
+            Some(SCF_ERROR_NO_MEMORY) => NoMemory,
+            Some(SCF_ERROR_CONSTRAINT_VIOLATED) => ConstraintViolated,
+            Some(SCF_ERROR_EXISTS) => Exists,
+            Some(SCF_ERROR_NO_SERVER) => NoServer,
+            Some(SCF_ERROR_NO_RESOURCES) => NoResources,
+            Some(SCF_ERROR_PERMISSION_DENIED) => PermissionDenied,
+            Some(SCF_ERROR_BACKEND_ACCESS) => BackendAccess,
+            Some(SCF_ERROR_HANDLE_MISMATCH) => HandleMismatch,
+            Some(SCF_ERROR_HANDLE_DESTROYED) => HandleDestroyed,
+            Some(SCF_ERROR_VERSION_MISMATCH) => VersionMismatch,
+            Some(SCF_ERROR_BACKEND_READONLY) => BackendReadonly,
+            Some(SCF_ERROR_DELETED) => Deleted,
+            Some(SCF_ERROR_TEMPLATE_INVALID) => TemplateInvalid,
+            Some(SCF_ERROR_CALLBACK_FAILED) => CallbackFailed,
+            Some(SCF_ERROR_INTERNAL) => Internal,
+            Option::None => Unknown(error),
+        }
+    }
+}
+
+impl ScfError {
+    fn last() -> Self {
+        ScfError::from(unsafe { scf_error() })
+    }
+}
+
+#[derive(Debug)]
+pub struct Scf {
+    handle: NonNull<scf_handle_t>,
+}
+
+impl Scf {
+    pub fn new() -> Result<Scf> {
+        if let Some(handle) =
+            NonNull::new(unsafe { scf_handle_create(SCF_VERSION) })
+        {
+            if unsafe { scf_handle_bind(handle.as_ptr()) } != 0 {
+                let e = ScfError::last();
+                unsafe { scf_handle_destroy(handle.as_ptr()) };
+                Err(e)
+            } else {
+                Ok(Scf { handle })
+            }
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    pub fn scope_local(&self) -> Result<Scope> {
+        let scope = Scope::new(self)?;
+
+        if unsafe {
+            scf_handle_get_scope(
+                self.handle.as_ptr(),
+                SCF_SCOPE_LOCAL.as_ptr() as *mut libc::c_char,
+                scope.scope.as_ptr(),
+            )
+        } != 0
+        {
+            return Err(ScfError::last());
+        }
+
+        Ok(scope)
+    }
+
+    pub fn scopes(&self) -> Result<Scopes> {
+        Scopes::new(self)
+    }
+}
+
+impl Drop for Scf {
+    fn drop(&mut self) {
+        unsafe { scf_handle_unbind(self.handle.as_ptr()) };
+        unsafe { scf_handle_destroy(self.handle.as_ptr()) };
+    }
+}
+
+fn buf_for(name: u32) -> Result<Vec<u8>> {
+    let len = unsafe { scf_limit(name) };
+    if len < 0 {
+        return Err(ScfError::last());
+    }
+    let len = len as usize;
+
+    Ok(vec![0; len + 1])
+}
+
+fn str_from(buf: &mut Vec<u8>, ret: libc::ssize_t) -> Result<String> {
+    if ret < 0 {
+        return Err(ScfError::last());
+    }
+    let sz = ret as usize;
+    unsafe { buf.set_len(sz + 1) };
+
+    Ok(CStr::from_bytes_with_nul(buf)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string())
+}
+
+#[derive(Debug)]
+pub struct Iter<'a> {
+    scf: &'a Scf,
+    iter: NonNull<scf_iter_t>,
+}
+
+impl<'a> Iter<'a> {
+    fn new(scf: &'a Scf) -> Result<Iter> {
+        if let Some(iter) =
+            NonNull::new(unsafe { scf_iter_create(scf.handle.as_ptr()) })
+        {
+            Ok(Iter { scf, iter })
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    #[allow(dead_code)]
+    fn reset(&self) {
+        unsafe { scf_iter_reset(self.iter.as_ptr()) };
+    }
+}
+
+impl Drop for Iter<'_> {
+    fn drop(&mut self) {
+        unsafe { scf_iter_destroy(self.iter.as_ptr()) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Iter, Scf, ScfError, Scope};
+
+    #[test]
+    fn basic() {
+        let _scf = Scf::new().expect("scf");
+    }
+
+    #[test]
+    fn scope_not_set() {
+        let scf = Scf::new().expect("scf");
+        let scope = Scope::new(&scf).expect("scope");
+        let name = scope.name();
+        assert!(matches!(name, Err(ScfError::NotSet)));
+    }
+
+    #[test]
+    fn scope_local() {
+        let scf = Scf::new().expect("scf");
+        let local = scf.scope_local().expect("scope local");
+        let name = local.name();
+        println!("name = {:?}", name);
+        assert_eq!(name.unwrap().as_str(), "localhost");
+    }
+
+    #[test]
+    fn iter() {
+        let scf = Scf::new().expect("scf");
+        let _iter = Iter::new(&scf).expect("iter");
+    }
+
+    #[test]
+    fn scope_iter() {
+        let scf = Scf::new().expect("scf");
+        let scopes = scf.scopes().expect("scopes");
+        let names = scopes.map(|s| s.map(|s| s.name())).collect::<Vec<_>>();
+        assert_eq!(names.len(), 1);
+        assert_eq!(
+            names[0].as_ref().unwrap().as_ref().unwrap().as_str(),
+            "localhost"
+        );
+    }
+
+    #[test]
+    fn service_iter() {
+        let scf = Scf::new().expect("scf");
+        let local = scf.scope_local().expect("local scope");
+        let services = local.services().expect("service iterator");
+        for s in services {
+            println!("{:?}", s);
+            let s = s.expect("service");
+            println!("{}", s.name().expect("service name"));
+        }
+    }
+
+    #[test]
+    fn instance_iter() {
+        let scf = Scf::new().expect("scf");
+        let local = scf.scope_local().expect("local scope");
+        let services = local.services().expect("service iterator");
+        for s in services {
+            println!("{:?}", s);
+            let s = s.expect("service");
+            println!("{}", s.name().expect("service name"));
+
+            let instances = s.instances().expect("instance iterator");
+            for i in instances {
+                println!("    {:?}", i);
+                let i = i.expect("instance");
+                println!("    {}", i.name().expect("instance name"));
+            }
+        }
+    }
+
+    #[test]
+    fn snapshot_iter() {
+        let scf = Scf::new().expect("scf");
+        let local = scf.scope_local().expect("local scope");
+        let services = local.services().expect("service iterator");
+        for s in services {
+            println!("{:?}", s);
+            let s = s.expect("service");
+            println!("{}", s.name().expect("service name"));
+
+            let instances = s.instances().expect("instance iterator");
+            for i in instances {
+                println!("    {:?}", i);
+                let i = i.expect("instance");
+                println!("    {}", i.name().expect("instance name"));
+
+                let snapshots = i.snapshots().expect("snapshot iterator");
+                for sn in snapshots {
+                    println!("    {:?}", i);
+                    let sn = sn.expect("snapshot");
+                    println!("        {}", sn.name().expect("snapshot name"));
+                }
+            }
+        }
+    }
+}

--- a/smf/src/lib.rs
+++ b/smf/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Oxide Computer Company
+
 use num_traits::FromPrimitive;
 use std::ffi::CStr;
 use std::ptr::NonNull;

--- a/smf/src/property.rs
+++ b/smf/src/property.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Oxide Computer Company
+
 use std::ptr::NonNull;
 
 use super::scf_sys::*;

--- a/smf/src/property.rs
+++ b/smf/src/property.rs
@@ -1,0 +1,122 @@
+use std::ptr::NonNull;
+
+use super::scf_sys::*;
+use super::{
+    buf_for, str_from, Iter, PropertyGroup, Result, Scf, ScfError, Value,
+    Values,
+};
+
+#[derive(Debug)]
+pub struct Property<'a> {
+    pub(crate) scf: &'a Scf,
+    pub(crate) property: NonNull<scf_property_t>,
+}
+
+impl<'a> Property<'a> {
+    pub(crate) fn new(scf: &'a Scf) -> Result<Property> {
+        if let Some(property) =
+            NonNull::new(unsafe { scf_property_create(scf.handle.as_ptr()) })
+        {
+            Ok(Property { scf, property })
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    pub fn name(&self) -> Result<String> {
+        let mut buf = buf_for(SCF_LIMIT_MAX_NAME_LENGTH)?;
+
+        let ret = unsafe {
+            scf_property_get_name(
+                self.property.as_ptr(),
+                buf.as_mut_ptr() as *mut libc::c_char,
+                buf.len(),
+            )
+        };
+
+        str_from(&mut buf, ret)
+    }
+
+    pub fn type_(&self) -> Result<scf_type_t> {
+        let mut typ: scf_type_t = scf_type_t::SCF_TYPE_INVALID;
+
+        if unsafe { scf_property_type(self.property.as_ptr(), &mut typ) } == 0 {
+            Ok(typ)
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    /*
+     * XXX fn value(&self) -> Result<Value> {
+     * scf_property_get_value(3SCF)
+     */
+
+    pub fn values(&self) -> Result<Values> {
+        Values::new(self)
+    }
+
+    pub fn value(&self) -> Result<Option<Value>> {
+        let mut values = Values::new(self)?.collect::<Result<Vec<_>>>()?;
+        match values.len() {
+            0 => Ok(None),
+            1 => Ok(values.pop()),
+            n => Err(ScfError::Internal),
+        }
+    }
+}
+
+impl Drop for Property<'_> {
+    fn drop(&mut self) {
+        unsafe { scf_property_destroy(self.property.as_ptr()) };
+    }
+}
+
+pub struct Properties<'a> {
+    pub(crate) scf: &'a Scf,
+    pub(crate) iter: Iter<'a>,
+}
+
+impl<'a> Properties<'a> {
+    pub(crate) fn new(pg: &'a PropertyGroup) -> Result<Properties<'a>> {
+        let scf = pg.scf;
+        let iter = Iter::new(scf)?;
+
+        if unsafe {
+            scf_iter_pg_properties(
+                iter.iter.as_ptr(),
+                pg.propertygroup.as_ptr(),
+            )
+        } != 0
+        {
+            Err(ScfError::last())
+        } else {
+            Ok(Properties { scf, iter })
+        }
+    }
+
+    fn get(&self) -> Result<Option<Property<'a>>> {
+        let property = Property::new(self.scf)?;
+
+        let res = unsafe {
+            scf_iter_next_property(
+                self.iter.iter.as_ptr(),
+                property.property.as_ptr(),
+            )
+        };
+
+        match res {
+            0 => Ok(None),
+            1 => Ok(Some(property)),
+            _ => Err(ScfError::last()),
+        }
+    }
+}
+
+impl<'a> Iterator for Properties<'a> {
+    type Item = Result<Property<'a>>;
+
+    fn next(&mut self) -> Option<Result<Property<'a>>> {
+        self.get().transpose()
+    }
+}

--- a/smf/src/property.rs
+++ b/smf/src/property.rs
@@ -61,7 +61,7 @@ impl<'a> Property<'a> {
         match values.len() {
             0 => Ok(None),
             1 => Ok(values.pop()),
-            n => Err(ScfError::Internal),
+            _ => Err(ScfError::Internal),
         }
     }
 }

--- a/smf/src/propertygroup.rs
+++ b/smf/src/propertygroup.rs
@@ -1,0 +1,219 @@
+use std::ffi::CString;
+use std::ptr::NonNull;
+
+use super::scf_sys::*;
+use super::{
+    buf_for, str_from, Instance, Iter, Properties, Property, Result, Scf,
+    ScfError, Service, Snapshot, Transaction,
+};
+
+#[derive(Debug)]
+pub struct PropertyGroup<'a> {
+    pub(crate) scf: &'a Scf,
+    pub(crate) propertygroup: NonNull<scf_propertygroup_t>,
+}
+
+impl<'a> PropertyGroup<'a> {
+    pub(crate) fn new(scf: &'a Scf) -> Result<PropertyGroup> {
+        if let Some(propertygroup) =
+            NonNull::new(unsafe { scf_pg_create(scf.handle.as_ptr()) })
+        {
+            Ok(PropertyGroup { scf, propertygroup })
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    pub fn name(&self) -> Result<String> {
+        let mut buf = buf_for(SCF_LIMIT_MAX_NAME_LENGTH)?;
+
+        let ret = unsafe {
+            scf_pg_get_name(
+                self.propertygroup.as_ptr(),
+                buf.as_mut_ptr() as *mut libc::c_char,
+                buf.len(),
+            )
+        };
+
+        str_from(&mut buf, ret)
+    }
+
+    pub fn type_(&self) -> Result<String> {
+        let mut buf = buf_for(SCF_LIMIT_MAX_PG_TYPE_LENGTH)?;
+
+        let ret = unsafe {
+            scf_pg_get_type(
+                self.propertygroup.as_ptr(),
+                buf.as_mut_ptr() as *mut libc::c_char,
+                buf.len(),
+            )
+        };
+
+        str_from(&mut buf, ret)
+    }
+
+    pub fn properties(&self) -> Result<Properties> {
+        Properties::new(self)
+    }
+
+    pub fn get_property(&self, name: &str) -> Result<Option<Property>> {
+        let name = CString::new(name).unwrap();
+        let prop = Property::new(self.scf)?;
+
+        let ret = unsafe {
+            scf_pg_get_property(
+                self.propertygroup.as_ptr(),
+                name.as_ptr(),
+                prop.property.as_ptr(),
+            )
+        };
+
+        if ret == 0 {
+            Ok(Some(prop))
+        } else {
+            match ScfError::last() {
+                ScfError::NotFound => Ok(None),
+                other => Err(other),
+            }
+        }
+    }
+
+    pub fn is_persistent(&self) -> Result<bool> {
+        let mut flags = 0;
+
+        if unsafe { scf_pg_get_flags(self.propertygroup.as_ptr(), &mut flags) }
+            == 0
+        {
+            Ok((flags & SCF_PG_FLAG_NONPERSISTENT) == 0)
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    pub fn update(&self) -> Result<()> {
+        if unsafe { scf_pg_update(self.propertygroup.as_ptr()) } == 0 {
+            Ok(())
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    pub fn transaction(&self) -> Result<Transaction> {
+        let tx = Transaction::new(self)?;
+        Ok(tx)
+    }
+
+    /*
+     * XXX fn type_(&self) -> Result<String> {
+     * scf_pg_get_type(3SCF)
+     */
+
+    /*
+     * XXX fn flags(&self) -> Result<u32> {
+     * scf_pg_get_flags(3SCF)
+     */
+
+    /*
+     * XXX fn delete(&self) -> Result<()> {
+     * scf_pg_delete(3SCF)
+     */
+
+    /*
+     * XXX fn update(&self) -> Result<()> {
+     * scf_pg_update(3SCF)
+     */
+}
+
+impl Drop for PropertyGroup<'_> {
+    fn drop(&mut self) {
+        unsafe { scf_pg_destroy(self.propertygroup.as_ptr()) };
+    }
+}
+
+pub struct PropertyGroups<'a> {
+    pub(crate) scf: &'a Scf,
+    pub(crate) iter: Iter<'a>,
+}
+
+impl<'a> PropertyGroups<'a> {
+    pub(crate) fn new_instance(
+        instance: &'a Instance,
+    ) -> Result<PropertyGroups<'a>> {
+        let scf = instance.scf;
+        let iter = Iter::new(scf)?;
+
+        if unsafe {
+            scf_iter_instance_pgs(
+                iter.iter.as_ptr(),
+                instance.instance.as_ptr(),
+            )
+        } != 0
+        {
+            Err(ScfError::last())
+        } else {
+            Ok(PropertyGroups { scf, iter })
+        }
+    }
+
+    pub(crate) fn new_composed(
+        instance: &'a Instance,
+        snapshot: &'a Snapshot,
+    ) -> Result<PropertyGroups<'a>> {
+        let scf = instance.scf;
+        let iter = Iter::new(scf)?;
+
+        if unsafe {
+            scf_iter_instance_pgs_composed(
+                iter.iter.as_ptr(),
+                instance.instance.as_ptr(),
+                snapshot.snapshot.as_ptr(),
+            )
+        } != 0
+        {
+            Err(ScfError::last())
+        } else {
+            Ok(PropertyGroups { scf, iter })
+        }
+    }
+
+    pub(crate) fn new_service(
+        service: &'a Service,
+    ) -> Result<PropertyGroups<'a>> {
+        let scf = service.scf;
+        let iter = Iter::new(scf)?;
+
+        if unsafe {
+            scf_iter_service_pgs(iter.iter.as_ptr(), service.service.as_ptr())
+        } != 0
+        {
+            Err(ScfError::last())
+        } else {
+            Ok(PropertyGroups { scf, iter })
+        }
+    }
+
+    fn get(&self) -> Result<Option<PropertyGroup<'a>>> {
+        let propertygroup = PropertyGroup::new(self.scf)?;
+
+        let res = unsafe {
+            scf_iter_next_pg(
+                self.iter.iter.as_ptr(),
+                propertygroup.propertygroup.as_ptr(),
+            )
+        };
+
+        match res {
+            0 => Ok(None),
+            1 => Ok(Some(propertygroup)),
+            _ => Err(ScfError::last()),
+        }
+    }
+}
+
+impl<'a> Iterator for PropertyGroups<'a> {
+    type Item = Result<PropertyGroup<'a>>;
+
+    fn next(&mut self) -> Option<Result<PropertyGroup<'a>>> {
+        self.get().transpose()
+    }
+}

--- a/smf/src/propertygroup.rs
+++ b/smf/src/propertygroup.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Oxide Computer Company
+
 use std::ffi::CString;
 use std::ptr::NonNull;
 

--- a/smf/src/scf_sys.rs
+++ b/smf/src/scf_sys.rs
@@ -1,0 +1,435 @@
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+
+use libc::{size_t, ssize_t};
+use std::os::raw::{c_char, c_int, c_ulong};
+
+type scf_version_t = c_ulong;
+
+pub const SCF_VERSION: scf_version_t = 1;
+
+pub const SCF_PG_FLAG_NONPERSISTENT: u32 = 0x1;
+
+/*
+ * Flags for the smf_enable_instance(3SCF) family of functions:
+ */
+pub const SMF_IMMEDIATE: c_int = 0x1;
+pub const SMF_TEMPORARY: c_int = 0x2;
+pub const SMF_AT_NEXT_BOOT: c_int = 0x4;
+
+macro_rules! opaque_handle {
+    ($type_name:ident) => {
+        pub enum $type_name {}
+        impl Copy for $type_name {}
+        impl Clone for $type_name {
+            fn clone(&self) -> $type_name {
+                *self
+            }
+        }
+    };
+}
+
+opaque_handle!(scf_handle_t);
+opaque_handle!(scf_iter_t);
+opaque_handle!(scf_scope_t);
+opaque_handle!(scf_service_t);
+opaque_handle!(scf_instance_t);
+opaque_handle!(scf_snapshot_t);
+opaque_handle!(scf_propertygroup_t);
+opaque_handle!(scf_property_t);
+opaque_handle!(scf_value_t);
+opaque_handle!(scf_snaplevel_t);
+opaque_handle!(scf_transaction_t);
+opaque_handle!(scf_transaction_entry_t);
+
+#[derive(Debug, FromPrimitive, ToPrimitive)]
+#[repr(C)]
+pub enum scf_error_t {
+    SCF_ERROR_NONE = 1000,            /* no error */
+    SCF_ERROR_NOT_BOUND,              /* handle not bound */
+    SCF_ERROR_NOT_SET,                /* cannot use unset argument */
+    SCF_ERROR_NOT_FOUND,              /* nothing of that name found */
+    SCF_ERROR_TYPE_MISMATCH,          /* type does not match value */
+    SCF_ERROR_IN_USE,                 /* cannot modify while in-use */
+    SCF_ERROR_CONNECTION_BROKEN,      /* repository connection gone */
+    SCF_ERROR_INVALID_ARGUMENT,       /* bad argument */
+    SCF_ERROR_NO_MEMORY,              /* no memory available */
+    SCF_ERROR_CONSTRAINT_VIOLATED,    /* required constraint not met */
+    SCF_ERROR_EXISTS,                 /* object already exists */
+    SCF_ERROR_NO_SERVER,              /* repository server unavailable */
+    SCF_ERROR_NO_RESOURCES,           /* server has insufficient resources */
+    SCF_ERROR_PERMISSION_DENIED,      /* insufficient privileges for action */
+    SCF_ERROR_BACKEND_ACCESS,         /* backend refused access */
+    SCF_ERROR_HANDLE_MISMATCH,        /* mismatched SCF handles */
+    SCF_ERROR_HANDLE_DESTROYED,       /* object bound to destroyed handle */
+    SCF_ERROR_VERSION_MISMATCH,       /* incompatible SCF version */
+    SCF_ERROR_BACKEND_READONLY,       /* backend is read-only */
+    SCF_ERROR_DELETED,                /* object has been deleted */
+    SCF_ERROR_TEMPLATE_INVALID,       /* template data is invalid */
+    SCF_ERROR_CALLBACK_FAILED = 1080, /* user callback function failed */
+    SCF_ERROR_INTERNAL = 1101,        /* internal error */
+}
+
+#[derive(Debug, FromPrimitive, ToPrimitive)]
+#[repr(C)]
+pub enum scf_type_t {
+    SCF_TYPE_INVALID = 0,
+
+    SCF_TYPE_BOOLEAN,
+    SCF_TYPE_COUNT,
+    SCF_TYPE_INTEGER,
+    SCF_TYPE_TIME,
+    SCF_TYPE_ASTRING,
+    SCF_TYPE_OPAQUE,
+
+    SCF_TYPE_USTRING = 100,
+
+    SCF_TYPE_URI = 200,
+    SCF_TYPE_FMRI,
+
+    SCF_TYPE_HOST = 300,
+    SCF_TYPE_HOSTNAME,
+    SCF_TYPE_NET_ADDR_V4,
+    SCF_TYPE_NET_ADDR_V6,
+    SCF_TYPE_NET_ADDR,
+}
+
+pub const SCF_LIMIT_MAX_NAME_LENGTH: u32 = 0xfffff830;
+pub const SCF_LIMIT_MAX_VALUE_LENGTH: u32 = 0xfffff82f;
+pub const SCF_LIMIT_MAX_PG_TYPE_LENGTH: u32 = 0xfffff82e;
+pub const SCF_LIMIT_MAX_FMRI_LENGTH: u32 = 0xfffff82d;
+
+pub const SCF_SCOPE_LOCAL: &[u8] = b"localhost\0";
+
+#[link(name = "scf")]
+extern "C" {
+    pub fn scf_handle_create(version: scf_version_t) -> *mut scf_handle_t;
+    pub fn scf_handle_destroy(handle: *mut scf_handle_t);
+    pub fn scf_handle_bind(handle: *mut scf_handle_t) -> c_int;
+    pub fn scf_handle_unbind(handle: *mut scf_handle_t) -> c_int;
+
+    pub fn scf_myname(
+        handle: *mut scf_handle_t,
+        out: *mut c_char,
+        sz: size_t,
+    ) -> ssize_t;
+
+    pub fn scf_error() -> u32;
+    pub fn scf_strerror(error: scf_error_t) -> *const c_char;
+
+    pub fn scf_limit(name: u32) -> ssize_t;
+
+    pub fn scf_iter_create(handle: *mut scf_handle_t) -> *mut scf_iter_t;
+    pub fn scf_iter_destroy(iter: *mut scf_iter_t);
+    pub fn scf_iter_reset(iter: *mut scf_iter_t);
+
+    pub fn scf_scope_create(handle: *mut scf_handle_t) -> *mut scf_scope_t;
+    pub fn scf_scope_destroy(scope: *mut scf_scope_t);
+    pub fn scf_scope_get_name(
+        scope: *mut scf_scope_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t;
+    pub fn scf_handle_get_scope(
+        handle: *mut scf_handle_t,
+        name: *const c_char,
+        out: *mut scf_scope_t,
+    ) -> c_int;
+
+    pub fn scf_scope_get_service(
+        scope: *mut scf_scope_t,
+        name: *const c_char,
+        out: *mut scf_service_t,
+    ) -> c_int;
+    pub fn scf_scope_add_service(
+        scope: *mut scf_scope_t,
+        name: *const c_char,
+        out: *mut scf_service_t,
+    ) -> c_int;
+
+    pub fn scf_iter_handle_scopes(
+        iter: *mut scf_iter_t,
+        handle: *const scf_handle_t,
+    ) -> c_int;
+    pub fn scf_iter_next_scope(
+        iter: *mut scf_iter_t,
+        out: *mut scf_scope_t,
+    ) -> c_int;
+
+    pub fn scf_service_create(handle: *mut scf_handle_t) -> *mut scf_service_t;
+    pub fn scf_service_destroy(service: *mut scf_service_t);
+
+    pub fn scf_service_get_name(
+        service: *mut scf_service_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t;
+    pub fn scf_service_get_instance(
+        service: *mut scf_service_t,
+        name: *const c_char,
+        out: *mut scf_instance_t,
+    ) -> c_int;
+    pub fn scf_service_add_instance(
+        service: *mut scf_service_t,
+        name: *const c_char,
+        out: *mut scf_instance_t,
+    ) -> c_int;
+
+    pub fn scf_iter_scope_services(
+        iter: *mut scf_iter_t,
+        scope: *const scf_scope_t,
+    ) -> c_int;
+    pub fn scf_iter_next_service(
+        iter: *mut scf_iter_t,
+        out: *mut scf_service_t,
+    ) -> c_int;
+
+    pub fn scf_instance_create(
+        handle: *mut scf_handle_t,
+    ) -> *mut scf_instance_t;
+    pub fn scf_instance_destroy(instance: *mut scf_instance_t);
+
+    pub fn scf_instance_get_name(
+        instance: *mut scf_instance_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t;
+    pub fn scf_instance_get_pg(
+        instance: *mut scf_instance_t,
+        name: *const c_char,
+        out: *mut scf_propertygroup_t,
+    ) -> c_int;
+    pub fn scf_instance_add_pg(
+        instance: *mut scf_instance_t,
+        name: *const c_char,
+        pgtype: *const c_char,
+        flags: u32,
+        out: *mut scf_propertygroup_t,
+    ) -> c_int;
+    pub fn scf_instance_get_pg_composed(
+        instance: *mut scf_instance_t,
+        snapshot: *mut scf_snapshot_t,
+        name: *const c_char,
+        out: *mut scf_propertygroup_t,
+    ) -> c_int;
+    pub fn scf_instance_get_snapshot(
+        instance: *mut scf_instance_t,
+        name: *const c_char,
+        out: *mut scf_snapshot_t,
+    ) -> c_int;
+    pub fn scf_instance_to_fmri(
+        instance: *const scf_instance_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t;
+
+    pub fn scf_iter_service_instances(
+        iter: *mut scf_iter_t,
+        service: *const scf_service_t,
+    ) -> c_int;
+    pub fn scf_iter_next_instance(
+        iter: *mut scf_iter_t,
+        out: *mut scf_instance_t,
+    ) -> c_int;
+
+    pub fn scf_snapshot_create(
+        handle: *mut scf_handle_t,
+    ) -> *mut scf_snapshot_t;
+    pub fn scf_snapshot_destroy(snapshot: *mut scf_snapshot_t);
+
+    pub fn scf_snapshot_get_name(
+        snapshot: *mut scf_snapshot_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t;
+    pub fn scf_snapshot_get_parent(
+        snapshot: *const scf_snapshot_t,
+        inst: *mut scf_instance_t,
+    ) -> c_int;
+
+    pub fn scf_iter_instance_snapshots(
+        iter: *mut scf_iter_t,
+        instance: *const scf_instance_t,
+    ) -> c_int;
+    pub fn scf_iter_next_snapshot(
+        iter: *mut scf_iter_t,
+        out: *mut scf_snapshot_t,
+    ) -> c_int;
+
+    pub fn scf_iter_instance_pgs(
+        iter: *mut scf_iter_t,
+        instance: *const scf_instance_t,
+    ) -> c_int;
+    pub fn scf_iter_instance_pgs_composed(
+        iter: *mut scf_iter_t,
+        instance: *const scf_instance_t,
+        snapshot: *const scf_snapshot_t,
+    ) -> c_int;
+    pub fn scf_iter_service_pgs(
+        iter: *mut scf_iter_t,
+        service: *const scf_service_t,
+    ) -> c_int;
+    pub fn scf_iter_next_pg(
+        iter: *mut scf_iter_t,
+        out: *mut scf_propertygroup_t,
+    ) -> c_int;
+
+    pub fn scf_pg_create(handle: *mut scf_handle_t)
+        -> *mut scf_propertygroup_t;
+    pub fn scf_pg_destroy(pg: *mut scf_propertygroup_t);
+
+    pub fn scf_pg_get_name(
+        pg: *mut scf_propertygroup_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t;
+    pub fn scf_pg_get_type(
+        pg: *mut scf_propertygroup_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t;
+    pub fn scf_pg_get_flags(
+        pg: *mut scf_propertygroup_t,
+        out: *mut u32,
+    ) -> c_int;
+    pub fn scf_pg_update(pg: *mut scf_propertygroup_t) -> c_int;
+    pub fn scf_pg_get_property(
+        pg: *mut scf_propertygroup_t,
+        name: *const c_char,
+        out: *mut scf_property_t,
+    ) -> c_int;
+
+    pub fn scf_iter_pg_properties(
+        iter: *mut scf_iter_t,
+        pg: *const scf_propertygroup_t,
+    ) -> c_int;
+    pub fn scf_iter_next_property(
+        iter: *mut scf_iter_t,
+        out: *mut scf_property_t,
+    ) -> c_int;
+
+    pub fn scf_property_create(
+        handle: *mut scf_handle_t,
+    ) -> *mut scf_property_t;
+    pub fn scf_property_destroy(prop: *mut scf_property_t);
+
+    pub fn scf_property_get_name(
+        prop: *mut scf_property_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t;
+    pub fn scf_property_type(
+        prop: *mut scf_property_t,
+        typ: *mut scf_type_t,
+    ) -> ssize_t;
+
+    pub fn scf_iter_property_values(
+        iter: *mut scf_iter_t,
+        prop: *const scf_property_t,
+    ) -> c_int;
+    pub fn scf_iter_next_value(
+        iter: *mut scf_iter_t,
+        out: *mut scf_value_t,
+    ) -> c_int;
+
+    pub fn scf_value_create(handle: *mut scf_handle_t) -> *mut scf_value_t;
+    pub fn scf_value_destroy(val: *mut scf_value_t);
+    pub fn scf_value_reset(val: *mut scf_value_t);
+
+    pub fn scf_value_type(val: *mut scf_value_t) -> c_int;
+    pub fn scf_value_base_type(val: *mut scf_value_t) -> c_int;
+
+    pub fn scf_value_get_as_string(
+        val: *mut scf_value_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t;
+    pub fn scf_value_set_from_string(
+        val: *mut scf_value_t,
+        valtype: scf_type_t,
+        valstr: *const c_char,
+    ) -> c_int;
+
+    pub fn scf_type_base_type(typ: scf_type_t, out: *mut scf_type_t) -> c_int;
+
+    pub fn scf_transaction_create(
+        handle: *mut scf_handle_t,
+    ) -> *mut scf_transaction_t;
+    pub fn scf_transaction_destroy(tran: *mut scf_transaction_t);
+    pub fn scf_transaction_reset(tran: *mut scf_transaction_t);
+    pub fn scf_transaction_reset_all(tran: *mut scf_transaction_t);
+
+    pub fn scf_transaction_start(
+        tran: *mut scf_transaction_t,
+        pg: *mut scf_propertygroup_t,
+    ) -> c_int;
+    pub fn scf_transaction_commit(tran: *mut scf_transaction_t) -> c_int;
+
+    pub fn scf_transaction_property_delete(
+        tran: *mut scf_transaction_t,
+        entry: *mut scf_transaction_entry_t,
+        name: *const c_char,
+    ) -> c_int;
+    pub fn scf_transaction_property_new(
+        tran: *mut scf_transaction_t,
+        entry: *mut scf_transaction_entry_t,
+        name: *const c_char,
+        proptype: scf_type_t,
+    ) -> c_int;
+    pub fn scf_transaction_property_change(
+        tran: *mut scf_transaction_t,
+        entry: *mut scf_transaction_entry_t,
+        name: *const c_char,
+        proptype: scf_type_t,
+    ) -> c_int;
+    pub fn scf_transaction_property_change_type(
+        tran: *mut scf_transaction_t,
+        entry: *mut scf_transaction_entry_t,
+        name: *const c_char,
+        proptype: scf_type_t,
+    ) -> c_int;
+
+    pub fn scf_entry_create(
+        handle: *mut scf_handle_t,
+    ) -> *mut scf_transaction_entry_t;
+    pub fn scf_entry_destroy(tran: *mut scf_transaction_entry_t);
+    pub fn scf_entry_destroy_children(tran: *mut scf_transaction_entry_t);
+    pub fn scf_entry_reset(tran: *mut scf_transaction_entry_t);
+
+    pub fn scf_entry_add_value(
+        tran: *mut scf_transaction_entry_t,
+        value: *mut scf_value_t,
+    ) -> c_int;
+
+    pub fn smf_disable_instance(instance: *const c_char, flags: c_int)
+        -> c_int;
+    pub fn smf_enable_instance(instance: *const c_char, flags: c_int) -> c_int;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! limit_test {
+        ($limit:ident) => {
+            let val = unsafe { scf_limit($limit) };
+            println!("{} = {}", stringify!($limit), val);
+            assert!(val > 0);
+        };
+    }
+
+    #[test]
+    fn limits() {
+        limit_test!(SCF_LIMIT_MAX_NAME_LENGTH);
+        limit_test!(SCF_LIMIT_MAX_VALUE_LENGTH);
+        limit_test!(SCF_LIMIT_MAX_PG_TYPE_LENGTH);
+        limit_test!(SCF_LIMIT_MAX_FMRI_LENGTH);
+    }
+
+    #[test]
+    fn handle() {
+        let handle = unsafe { scf_handle_create(SCF_VERSION) };
+        assert!(!handle.is_null());
+        unsafe { scf_handle_destroy(handle) };
+    }
+}

--- a/smf/src/scf_sys.rs
+++ b/smf/src/scf_sys.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Oxide Computer Company
+
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 

--- a/smf/src/scf_sys.rs
+++ b/smf/src/scf_sys.rs
@@ -913,6 +913,7 @@ mod dummy {
     }
 }
 
+#[cfg(not(target_os = "illumos"))]
 pub use dummy::*;
 
 #[cfg(all(target_os = "illumos", test))]

--- a/smf/src/scf_sys.rs
+++ b/smf/src/scf_sys.rs
@@ -101,6 +101,7 @@ pub const SCF_LIMIT_MAX_FMRI_LENGTH: u32 = 0xfffff82d;
 
 pub const SCF_SCOPE_LOCAL: &[u8] = b"localhost\0";
 
+#[cfg(target_os = "illumos")]
 #[link(name = "scf")]
 extern "C" {
     pub fn scf_handle_create(version: scf_version_t) -> *mut scf_handle_t;
@@ -406,7 +407,513 @@ extern "C" {
     pub fn smf_enable_instance(instance: *const c_char, flags: c_int) -> c_int;
 }
 
-#[cfg(test)]
+#[cfg(not(target_os = "illumos"))]
+mod dummy {
+    #![allow(unused_variables)]
+
+    use super::*;
+
+    pub unsafe fn scf_handle_create(
+        version: scf_version_t,
+    ) -> *mut scf_handle_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_handle_destroy(handle: *mut scf_handle_t) {
+        unimplemented!()
+    }
+    pub unsafe fn scf_handle_bind(handle: *mut scf_handle_t) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_handle_unbind(handle: *mut scf_handle_t) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_myname(
+        handle: *mut scf_handle_t,
+        out: *mut c_char,
+        sz: size_t,
+    ) -> ssize_t {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_error() -> u32 {
+        unimplemented!()
+    }
+    pub unsafe fn scf_strerror(error: scf_error_t) -> *const c_char {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_limit(name: u32) -> ssize_t {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_iter_create(
+        handle: *mut scf_handle_t,
+    ) -> *mut scf_iter_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_iter_destroy(iter: *mut scf_iter_t) {
+        unimplemented!()
+    }
+    pub unsafe fn scf_iter_reset(iter: *mut scf_iter_t) {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_scope_create(
+        handle: *mut scf_handle_t,
+    ) -> *mut scf_scope_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_scope_destroy(scope: *mut scf_scope_t) {
+        unimplemented!()
+    }
+    pub unsafe fn scf_scope_get_name(
+        scope: *mut scf_scope_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_handle_get_scope(
+        handle: *mut scf_handle_t,
+        name: *const c_char,
+        out: *mut scf_scope_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_scope_get_service(
+        scope: *mut scf_scope_t,
+        name: *const c_char,
+        out: *mut scf_service_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_scope_add_service(
+        scope: *mut scf_scope_t,
+        name: *const c_char,
+        out: *mut scf_service_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_iter_handle_scopes(
+        iter: *mut scf_iter_t,
+        handle: *const scf_handle_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_iter_next_scope(
+        iter: *mut scf_iter_t,
+        out: *mut scf_scope_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_service_create(
+        handle: *mut scf_handle_t,
+    ) -> *mut scf_service_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_service_destroy(service: *mut scf_service_t) {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_service_get_name(
+        service: *mut scf_service_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_service_get_instance(
+        service: *mut scf_service_t,
+        name: *const c_char,
+        out: *mut scf_instance_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_service_add_instance(
+        service: *mut scf_service_t,
+        name: *const c_char,
+        out: *mut scf_instance_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_iter_scope_services(
+        iter: *mut scf_iter_t,
+        scope: *const scf_scope_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_iter_next_service(
+        iter: *mut scf_iter_t,
+        out: *mut scf_service_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_instance_create(
+        handle: *mut scf_handle_t,
+    ) -> *mut scf_instance_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_instance_destroy(instance: *mut scf_instance_t) {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_instance_get_name(
+        instance: *mut scf_instance_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_instance_get_pg(
+        instance: *mut scf_instance_t,
+        name: *const c_char,
+        out: *mut scf_propertygroup_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_instance_add_pg(
+        instance: *mut scf_instance_t,
+        name: *const c_char,
+        pgtype: *const c_char,
+        flags: u32,
+        out: *mut scf_propertygroup_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_instance_get_pg_composed(
+        instance: *mut scf_instance_t,
+        snapshot: *mut scf_snapshot_t,
+        name: *const c_char,
+        out: *mut scf_propertygroup_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_instance_get_snapshot(
+        instance: *mut scf_instance_t,
+        name: *const c_char,
+        out: *mut scf_snapshot_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_instance_to_fmri(
+        instance: *const scf_instance_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_iter_service_instances(
+        iter: *mut scf_iter_t,
+        service: *const scf_service_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_iter_next_instance(
+        iter: *mut scf_iter_t,
+        out: *mut scf_instance_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_snapshot_create(
+        handle: *mut scf_handle_t,
+    ) -> *mut scf_snapshot_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_snapshot_destroy(snapshot: *mut scf_snapshot_t) {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_snapshot_get_name(
+        snapshot: *mut scf_snapshot_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_snapshot_get_parent(
+        snapshot: *const scf_snapshot_t,
+        inst: *mut scf_instance_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_iter_instance_snapshots(
+        iter: *mut scf_iter_t,
+        instance: *const scf_instance_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_iter_next_snapshot(
+        iter: *mut scf_iter_t,
+        out: *mut scf_snapshot_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_iter_instance_pgs(
+        iter: *mut scf_iter_t,
+        instance: *const scf_instance_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_iter_instance_pgs_composed(
+        iter: *mut scf_iter_t,
+        instance: *const scf_instance_t,
+        snapshot: *const scf_snapshot_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_iter_service_pgs(
+        iter: *mut scf_iter_t,
+        service: *const scf_service_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_iter_next_pg(
+        iter: *mut scf_iter_t,
+        out: *mut scf_propertygroup_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_pg_create(
+        handle: *mut scf_handle_t,
+    ) -> *mut scf_propertygroup_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_pg_destroy(pg: *mut scf_propertygroup_t) {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_pg_get_name(
+        pg: *mut scf_propertygroup_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_pg_get_type(
+        pg: *mut scf_propertygroup_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_pg_get_flags(
+        pg: *mut scf_propertygroup_t,
+        out: *mut u32,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_pg_update(pg: *mut scf_propertygroup_t) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_pg_get_property(
+        pg: *mut scf_propertygroup_t,
+        name: *const c_char,
+        out: *mut scf_property_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_iter_pg_properties(
+        iter: *mut scf_iter_t,
+        pg: *const scf_propertygroup_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_iter_next_property(
+        iter: *mut scf_iter_t,
+        out: *mut scf_property_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_property_create(
+        handle: *mut scf_handle_t,
+    ) -> *mut scf_property_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_property_destroy(prop: *mut scf_property_t) {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_property_get_name(
+        prop: *mut scf_property_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_property_type(
+        prop: *mut scf_property_t,
+        typ: *mut scf_type_t,
+    ) -> ssize_t {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_iter_property_values(
+        iter: *mut scf_iter_t,
+        prop: *const scf_property_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_iter_next_value(
+        iter: *mut scf_iter_t,
+        out: *mut scf_value_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_value_create(
+        handle: *mut scf_handle_t,
+    ) -> *mut scf_value_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_value_destroy(val: *mut scf_value_t) {
+        unimplemented!()
+    }
+    pub unsafe fn scf_value_reset(val: *mut scf_value_t) {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_value_type(val: *mut scf_value_t) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_value_base_type(val: *mut scf_value_t) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_value_get_as_string(
+        val: *mut scf_value_t,
+        buf: *mut c_char,
+        size: size_t,
+    ) -> ssize_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_value_set_from_string(
+        val: *mut scf_value_t,
+        valtype: scf_type_t,
+        valstr: *const c_char,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_type_base_type(
+        typ: scf_type_t,
+        out: *mut scf_type_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_transaction_create(
+        handle: *mut scf_handle_t,
+    ) -> *mut scf_transaction_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_transaction_destroy(tran: *mut scf_transaction_t) {
+        unimplemented!()
+    }
+    pub unsafe fn scf_transaction_reset(tran: *mut scf_transaction_t) {
+        unimplemented!()
+    }
+    pub unsafe fn scf_transaction_reset_all(tran: *mut scf_transaction_t) {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_transaction_start(
+        tran: *mut scf_transaction_t,
+        pg: *mut scf_propertygroup_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_transaction_commit(
+        tran: *mut scf_transaction_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_transaction_property_delete(
+        tran: *mut scf_transaction_t,
+        entry: *mut scf_transaction_entry_t,
+        name: *const c_char,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_transaction_property_new(
+        tran: *mut scf_transaction_t,
+        entry: *mut scf_transaction_entry_t,
+        name: *const c_char,
+        proptype: scf_type_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_transaction_property_change(
+        tran: *mut scf_transaction_t,
+        entry: *mut scf_transaction_entry_t,
+        name: *const c_char,
+        proptype: scf_type_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn scf_transaction_property_change_type(
+        tran: *mut scf_transaction_t,
+        entry: *mut scf_transaction_entry_t,
+        name: *const c_char,
+        proptype: scf_type_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_entry_create(
+        handle: *mut scf_handle_t,
+    ) -> *mut scf_transaction_entry_t {
+        unimplemented!()
+    }
+    pub unsafe fn scf_entry_destroy(tran: *mut scf_transaction_entry_t) {
+        unimplemented!()
+    }
+    pub unsafe fn scf_entry_destroy_children(
+        tran: *mut scf_transaction_entry_t,
+    ) {
+        unimplemented!()
+    }
+    pub unsafe fn scf_entry_reset(tran: *mut scf_transaction_entry_t) {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_entry_add_value(
+        tran: *mut scf_transaction_entry_t,
+        value: *mut scf_value_t,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn smf_disable_instance(
+        instance: *const c_char,
+        flags: c_int,
+    ) -> c_int {
+        unimplemented!()
+    }
+    pub unsafe fn smf_enable_instance(
+        instance: *const c_char,
+        flags: c_int,
+    ) -> c_int {
+        unimplemented!()
+    }
+}
+
+pub use dummy::*;
+
+#[cfg(all(target_os = "illumos", test))]
 mod tests {
     use super::*;
 

--- a/smf/src/scope.rs
+++ b/smf/src/scope.rs
@@ -1,0 +1,137 @@
+use std::ffi::CString;
+use std::ptr::NonNull;
+
+use super::scf_sys::*;
+use super::{
+    buf_for, str_from, Iter, Result, Scf, ScfError, Service, Services,
+};
+
+#[derive(Debug)]
+pub struct Scope<'a> {
+    pub(crate) scf: &'a Scf,
+    pub(crate) scope: NonNull<scf_scope_t>,
+}
+
+impl<'a> Scope<'a> {
+    pub(crate) fn new(scf: &'a Scf) -> Result<Scope> {
+        if let Some(scope) =
+            NonNull::new(unsafe { scf_scope_create(scf.handle.as_ptr()) })
+        {
+            Ok(Scope { scf, scope })
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    pub fn name(&self) -> Result<String> {
+        let mut buf = buf_for(SCF_LIMIT_MAX_NAME_LENGTH)?;
+
+        let ret = unsafe {
+            scf_scope_get_name(
+                self.scope.as_ptr(),
+                buf.as_mut_ptr() as *mut libc::c_char,
+                buf.len(),
+            )
+        };
+
+        str_from(&mut buf, ret)
+    }
+
+    pub fn services(&self) -> Result<Services> {
+        Services::new(self)
+    }
+
+    pub fn get_service(&self, name: &str) -> Result<Option<Service>> {
+        let name = CString::new(name).unwrap();
+        let service = Service::new(self.scf)?;
+
+        let ret = unsafe {
+            scf_scope_get_service(
+                self.scope.as_ptr(),
+                name.as_ptr(),
+                service.service.as_ptr(),
+            )
+        };
+
+        if ret == 0 {
+            Ok(Some(service))
+        } else {
+            match ScfError::last() {
+                ScfError::NotFound => Ok(None),
+                other => Err(other),
+            }
+        }
+    }
+
+    pub fn add_service(&self, name: &str) -> Result<Service> {
+        let name = CString::new(name).unwrap();
+        let service = Service::new(self.scf)?;
+
+        let ret = unsafe {
+            scf_scope_add_service(
+                self.scope.as_ptr(),
+                name.as_ptr(),
+                service.service.as_ptr(),
+            )
+        };
+
+        if ret == 0 {
+            Ok(service)
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    /*
+     * XXX fn add(&self, name: &str) -> Result<Service> {
+     * scf_scope_add_service(3SCF)
+     */
+}
+
+impl Drop for Scope<'_> {
+    fn drop(&mut self) {
+        unsafe { scf_scope_destroy(self.scope.as_ptr()) };
+    }
+}
+
+pub struct Scopes<'a> {
+    scf: &'a Scf,
+    iter: Iter<'a>,
+}
+
+impl<'a> Scopes<'a> {
+    pub(crate) fn new(scf: &'a Scf) -> Result<Scopes> {
+        let iter = Iter::new(scf)?;
+
+        if unsafe {
+            scf_iter_handle_scopes(iter.iter.as_ptr(), scf.handle.as_ptr())
+        } != 0
+        {
+            Err(ScfError::last())
+        } else {
+            Ok(Scopes { scf, iter })
+        }
+    }
+
+    fn get(&self) -> Result<Option<Scope<'a>>> {
+        let scope = Scope::new(self.scf)?;
+
+        let res = unsafe {
+            scf_iter_next_scope(self.iter.iter.as_ptr(), scope.scope.as_ptr())
+        };
+
+        match res {
+            0 => Ok(None),
+            1 => Ok(Some(scope)),
+            _ => Err(ScfError::last()),
+        }
+    }
+}
+
+impl<'a> Iterator for Scopes<'a> {
+    type Item = Result<Scope<'a>>;
+
+    fn next(&mut self) -> Option<Result<Scope<'a>>> {
+        self.get().transpose()
+    }
+}

--- a/smf/src/scope.rs
+++ b/smf/src/scope.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Oxide Computer Company
+
 use std::ffi::CString;
 use std::ptr::NonNull;
 

--- a/smf/src/service.rs
+++ b/smf/src/service.rs
@@ -1,0 +1,149 @@
+use std::ffi::CString;
+use std::ptr::NonNull;
+
+use super::scf_sys::*;
+use super::{
+    buf_for, str_from, Instance, Instances, Iter, PropertyGroups, Result, Scf,
+    ScfError, Scope,
+};
+
+#[derive(Debug)]
+pub struct Service<'a> {
+    pub(crate) scf: &'a Scf,
+    pub(crate) service: NonNull<scf_service_t>,
+}
+
+impl<'a> Service<'a> {
+    pub(crate) fn new(scf: &'a Scf) -> Result<Service> {
+        if let Some(service) =
+            NonNull::new(unsafe { scf_service_create(scf.handle.as_ptr()) })
+        {
+            Ok(Service { scf, service })
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    pub fn name(&self) -> Result<String> {
+        let mut buf = buf_for(SCF_LIMIT_MAX_NAME_LENGTH)?;
+        let ret = unsafe {
+            scf_service_get_name(
+                self.service.as_ptr(),
+                buf.as_mut_ptr() as *mut libc::c_char,
+                buf.len(),
+            )
+        };
+
+        str_from(&mut buf, ret)
+    }
+
+    pub fn instances(&self) -> Result<Instances> {
+        Instances::new(self)
+    }
+
+    pub fn pgs(&self) -> Result<PropertyGroups> {
+        PropertyGroups::new_service(self)
+    }
+
+    /*
+     * XXX fn delete(&self) -> Result<()> {
+     * scf_service_delete(3SCF)
+     */
+
+    pub fn get_instance(&self, name: &str) -> Result<Option<Instance>> {
+        let name = CString::new(name).unwrap();
+        let instance = Instance::new(self.scf)?;
+
+        let ret = unsafe {
+            scf_service_get_instance(
+                self.service.as_ptr(),
+                name.as_ptr(),
+                instance.instance.as_ptr(),
+            )
+        };
+
+        if ret == 0 {
+            Ok(Some(instance))
+        } else {
+            match ScfError::last() {
+                ScfError::NotFound => Ok(None),
+                other => Err(other),
+            }
+        }
+    }
+
+    pub fn add_instance(&self, name: &str) -> Result<Instance> {
+        let name = CString::new(name).unwrap();
+        let instance = Instance::new(self.scf)?;
+
+        let ret = unsafe {
+            scf_service_add_instance(
+                self.service.as_ptr(),
+                name.as_ptr(),
+                instance.instance.as_ptr(),
+            )
+        };
+
+        if ret == 0 {
+            Ok(instance)
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    /*
+     * XXX fn add(&self, name: &str) -> Result<()> {
+     * scf_service_add_instance(3SCF)
+     */
+}
+
+impl Drop for Service<'_> {
+    fn drop(&mut self) {
+        unsafe { scf_service_destroy(self.service.as_ptr()) };
+    }
+}
+
+pub struct Services<'a> {
+    scope: &'a Scope<'a>,
+    iter: Iter<'a>,
+}
+
+impl<'a> Services<'a> {
+    pub(crate) fn new(scope: &'a Scope) -> Result<Services<'a>> {
+        let iter = Iter::new(scope.scf)?;
+
+        if unsafe {
+            scf_iter_scope_services(iter.iter.as_ptr(), scope.scope.as_ptr())
+        } != 0
+        {
+            Err(ScfError::last())
+        } else {
+            Ok(Services { scope, iter })
+        }
+    }
+
+    fn get(&self) -> Result<Option<Service<'a>>> {
+        let service = Service::new(self.scope.scf)?;
+
+        let res = unsafe {
+            scf_iter_next_service(
+                self.iter.iter.as_ptr(),
+                service.service.as_ptr(),
+            )
+        };
+
+        match res {
+            0 => Ok(None),
+            1 => Ok(Some(service)),
+            _ => Err(ScfError::last()),
+        }
+    }
+}
+
+impl<'a> Iterator for Services<'a> {
+    type Item = Result<Service<'a>>;
+
+    fn next(&mut self) -> Option<Result<Service<'a>>> {
+        self.get().transpose()
+    }
+}

--- a/smf/src/service.rs
+++ b/smf/src/service.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Oxide Computer Company
+
 use std::ffi::CString;
 use std::ptr::NonNull;
 

--- a/smf/src/snapshot.rs
+++ b/smf/src/snapshot.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Oxide Computer Company
+
 use std::ffi::CString;
 use std::ptr::NonNull;
 

--- a/smf/src/snapshot.rs
+++ b/smf/src/snapshot.rs
@@ -1,0 +1,126 @@
+use std::ffi::CString;
+use std::ptr::NonNull;
+
+use super::scf_sys::*;
+use super::{
+    buf_for, str_from, Instance, Iter, PropertyGroup, PropertyGroups, Result,
+    ScfError,
+};
+
+#[derive(Debug)]
+pub struct Snapshot<'a> {
+    pub(crate) instance: &'a Instance<'a>,
+    pub(crate) snapshot: NonNull<scf_snapshot_t>,
+}
+
+impl<'a> Snapshot<'a> {
+    pub(crate) fn new(instance: &'a Instance) -> Result<Snapshot<'a>> {
+        if let Some(snapshot) = NonNull::new(unsafe {
+            scf_snapshot_create(instance.scf.handle.as_ptr())
+        }) {
+            Ok(Snapshot { instance, snapshot })
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    pub fn name(&self) -> Result<String> {
+        let mut buf = buf_for(SCF_LIMIT_MAX_NAME_LENGTH)?;
+
+        let ret = unsafe {
+            scf_snapshot_get_name(
+                self.snapshot.as_ptr(),
+                buf.as_mut_ptr() as *mut libc::c_char,
+                buf.len(),
+            )
+        };
+
+        str_from(&mut buf, ret)
+    }
+
+    pub fn pgs(&self) -> Result<PropertyGroups> {
+        PropertyGroups::new_composed(self.instance, self)
+    }
+
+    pub fn get_pg(&self, name: &str) -> Result<Option<PropertyGroup>> {
+        let name = CString::new(name).unwrap();
+        let pg = PropertyGroup::new(self.instance.scf)?;
+
+        let ret = unsafe {
+            scf_instance_get_pg_composed(
+                self.instance.instance.as_ptr(),
+                self.snapshot.as_ptr(),
+                name.as_ptr(),
+                pg.propertygroup.as_ptr(),
+            )
+        };
+
+        if ret == 0 {
+            Ok(Some(pg))
+        } else {
+            match ScfError::last() {
+                ScfError::NotFound => Ok(None),
+                other => Err(other),
+            }
+        }
+    }
+
+    /*
+     * XXX fn delete(&self) -> Result<()> {
+     * scf_snapshot_delete(3SCF)
+     */
+}
+
+impl Drop for Snapshot<'_> {
+    fn drop(&mut self) {
+        unsafe { scf_snapshot_destroy(self.snapshot.as_ptr()) };
+    }
+}
+
+pub struct Snapshots<'a> {
+    pub(crate) instance: &'a Instance<'a>,
+    pub(crate) iter: Iter<'a>,
+}
+
+impl<'a> Snapshots<'a> {
+    pub(crate) fn new(instance: &'a Instance) -> Result<Snapshots<'a>> {
+        let iter = Iter::new(instance.scf)?;
+
+        if unsafe {
+            scf_iter_instance_snapshots(
+                iter.iter.as_ptr(),
+                instance.instance.as_ptr(),
+            )
+        } != 0
+        {
+            Err(ScfError::last())
+        } else {
+            Ok(Snapshots { instance, iter })
+        }
+    }
+
+    fn get(&self) -> Result<Option<Snapshot<'a>>> {
+        let snapshot = Snapshot::new(self.instance)?;
+
+        let res = unsafe {
+            scf_iter_next_snapshot(
+                self.iter.iter.as_ptr(),
+                snapshot.snapshot.as_ptr(),
+            )
+        };
+
+        match res {
+            0 => Ok(None),
+            1 => Ok(Some(snapshot)),
+            _ => Err(ScfError::last()),
+        }
+    }
+}
+
+impl<'a> Iterator for Snapshots<'a> {
+    type Item = Result<Snapshot<'a>>;
+
+    fn next(&mut self) -> Option<Result<Snapshot<'a>>> {
+        self.get().transpose()
+    }
+}

--- a/smf/src/transaction.rs
+++ b/smf/src/transaction.rs
@@ -1,0 +1,200 @@
+use std::ffi::CString;
+use std::ptr::NonNull;
+
+use num_traits::cast::FromPrimitive;
+
+use super::scf_sys::*;
+use super::{
+    buf_for, str_from, Iter, Property, PropertyGroup, Result, Scf, ScfError,
+    Value,
+};
+
+#[derive(Debug)]
+pub struct Transaction<'a> {
+    pub(crate) pg: &'a PropertyGroup<'a>,
+    pub(crate) transaction: NonNull<scf_transaction_t>,
+}
+
+pub enum CommitResult {
+    Success,
+    OutOfDate,
+}
+
+impl<'a> Transaction<'a> {
+    pub(crate) fn new(pg: &'a PropertyGroup<'a>) -> Result<Transaction> {
+        let scf = pg.scf;
+
+        if let Some(transaction) =
+            NonNull::new(unsafe { scf_transaction_create(scf.handle.as_ptr()) })
+        {
+            Ok(Transaction { pg, transaction })
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    pub fn start(&self) -> Result<()> {
+        if unsafe {
+            scf_transaction_start(
+                self.transaction.as_ptr(),
+                self.pg.propertygroup.as_ptr(),
+            )
+        } == 0
+        {
+            Ok(())
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    pub fn commit(&self) -> Result<CommitResult> {
+        match unsafe { scf_transaction_commit(self.transaction.as_ptr()) } {
+            0 => Ok(CommitResult::OutOfDate),
+            1 => Ok(CommitResult::Success),
+            _ => Err(ScfError::last()),
+        }
+    }
+
+    pub fn reset(&self) {
+        unsafe { scf_transaction_reset(self.transaction.as_ptr()) };
+    }
+
+    pub fn reset_all(&self) {
+        unsafe { scf_transaction_reset_all(self.transaction.as_ptr()) };
+    }
+
+    pub fn property_delete(&self, name: &str) -> Result<TransactionEntry> {
+        let name = CString::new(name).unwrap();
+        let ent = TransactionEntry::new(self)?;
+
+        let ret = unsafe {
+            scf_transaction_property_delete(
+                self.transaction.as_ptr(),
+                ent.entry.as_ptr(),
+                name.as_ptr(),
+            )
+        };
+
+        if ret == 0 {
+            Ok(ent)
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    pub fn property_new(
+        &self,
+        name: &str,
+        typ: scf_type_t,
+    ) -> Result<TransactionEntry> {
+        let name = CString::new(name).unwrap();
+        let ent = TransactionEntry::new(self)?;
+
+        let ret = unsafe {
+            scf_transaction_property_new(
+                self.transaction.as_ptr(),
+                ent.entry.as_ptr(),
+                name.as_ptr(),
+                typ,
+            )
+        };
+
+        if ret == 0 {
+            Ok(ent)
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    pub fn property_change(
+        &self,
+        name: &str,
+        typ: scf_type_t,
+    ) -> Result<TransactionEntry> {
+        let name = CString::new(name).unwrap();
+        let ent = TransactionEntry::new(self)?;
+
+        let ret = unsafe {
+            scf_transaction_property_change(
+                self.transaction.as_ptr(),
+                ent.entry.as_ptr(),
+                name.as_ptr(),
+                typ,
+            )
+        };
+
+        if ret == 0 {
+            Ok(ent)
+        } else {
+            Err(ScfError::last())
+        }
+    }
+}
+
+impl Drop for Transaction<'_> {
+    fn drop(&mut self) {
+        /*
+         * Call scf_transaction_reset_all(3SCF) to reset any entries that are
+         * associated with this transaction before we destroy it.
+         */
+        self.reset_all();
+        unsafe { scf_transaction_destroy(self.transaction.as_ptr()) };
+    }
+}
+
+#[derive(Debug)]
+pub struct TransactionEntry<'a> {
+    pub(crate) transaction: &'a Transaction<'a>,
+    pub(crate) entry: NonNull<scf_transaction_entry_t>,
+    values: Vec<Value<'a>>,
+}
+
+impl<'a> TransactionEntry<'a> {
+    pub(crate) fn new(tx: &'a Transaction<'a>) -> Result<TransactionEntry> {
+        let scf = tx.pg.scf;
+
+        if let Some(entry) =
+            NonNull::new(unsafe { scf_entry_create(scf.handle.as_ptr()) })
+        {
+            Ok(TransactionEntry {
+                transaction: tx,
+                entry,
+                values: Vec::new(),
+            })
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    pub fn add_from_string(
+        &mut self,
+        typ: scf_type_t,
+        val: &str,
+    ) -> Result<()> {
+        let v = Value::new(self.transaction.pg.scf)?;
+        v.set_from_string(typ, val)?;
+        if unsafe { scf_entry_add_value(self.entry.as_ptr(), v.value.as_ptr()) }
+            == 0
+        {
+            /*
+             * Keep the Value around so that we can free it later when we
+             * drop this entry.
+             */
+            self.values.push(v);
+            Ok(())
+        } else {
+            Err(ScfError::last())
+        }
+    }
+}
+
+impl Drop for TransactionEntry<'_> {
+    fn drop(&mut self) {
+        /*
+         * First, reset any Values that might have been associated.  They'll get
+         * freed separately in their own drop actions.
+         */
+        unsafe { scf_entry_reset(self.entry.as_ptr()) };
+        unsafe { scf_entry_destroy(self.entry.as_ptr()) };
+    }
+}

--- a/smf/src/transaction.rs
+++ b/smf/src/transaction.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Oxide Computer Company
+
 use std::ffi::CString;
 use std::ptr::NonNull;
 

--- a/smf/src/transaction.rs
+++ b/smf/src/transaction.rs
@@ -1,13 +1,8 @@
 use std::ffi::CString;
 use std::ptr::NonNull;
 
-use num_traits::cast::FromPrimitive;
-
 use super::scf_sys::*;
-use super::{
-    buf_for, str_from, Iter, Property, PropertyGroup, Result, Scf, ScfError,
-    Value,
-};
+use super::{PropertyGroup, Result, ScfError, Value};
 
 #[derive(Debug)]
 pub struct Transaction<'a> {
@@ -191,8 +186,8 @@ impl<'a> TransactionEntry<'a> {
 impl Drop for TransactionEntry<'_> {
     fn drop(&mut self) {
         /*
-         * First, reset any Values that might have been associated.  They'll get
-         * freed separately in their own drop actions.
+         * First, reset any Values that might have been associated.  They'll
+         * get freed separately in their own drop actions.
          */
         unsafe { scf_entry_reset(self.entry.as_ptr()) };
         unsafe { scf_entry_destroy(self.entry.as_ptr()) };

--- a/smf/src/value.rs
+++ b/smf/src/value.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 Oxide Computer Company
+
 use std::ffi::CString;
 use std::ptr::NonNull;
 

--- a/smf/src/value.rs
+++ b/smf/src/value.rs
@@ -1,0 +1,130 @@
+use std::ffi::CString;
+use std::ptr::NonNull;
+
+use num_traits::cast::FromPrimitive;
+
+use super::scf_sys::*;
+use super::{buf_for, str_from, Iter, Property, Result, Scf, ScfError};
+
+#[derive(Debug)]
+pub struct Value<'a> {
+    pub(crate) scf: &'a Scf,
+    pub(crate) value: NonNull<scf_value_t>,
+}
+
+impl<'a> Value<'a> {
+    pub(crate) fn new(scf: &'a Scf) -> Result<Value> {
+        if let Some(value) =
+            NonNull::new(unsafe { scf_value_create(scf.handle.as_ptr()) })
+        {
+            Ok(Value { scf, value })
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    pub fn as_string(&self) -> Result<String> {
+        let mut buf = buf_for(SCF_LIMIT_MAX_VALUE_LENGTH)?;
+
+        let ret = unsafe {
+            scf_value_get_as_string(
+                self.value.as_ptr(),
+                buf.as_mut_ptr() as *mut libc::c_char,
+                buf.len(),
+            )
+        };
+
+        str_from(&mut buf, ret)
+    }
+
+    pub fn set_from_string(&self, typ: scf_type_t, val: &str) -> Result<()> {
+        let val = CString::new(val).unwrap();
+
+        let ret = unsafe {
+            scf_value_set_from_string(self.value.as_ptr(), typ, val.as_ptr())
+        };
+
+        if ret == 0 {
+            Ok(())
+        } else {
+            Err(ScfError::last())
+        }
+    }
+
+    pub fn type_(&self) -> Result<scf_type_t> {
+        let ret = unsafe { scf_value_type(self.value.as_ptr()) };
+        match scf_type_t::from_i32(ret) {
+            Some(scf_type_t::SCF_TYPE_INVALID) => Err(ScfError::last()),
+            Some(typ) => Ok(typ),
+            None => Err(ScfError::Internal),
+        }
+    }
+
+    pub fn base_type(&self) -> Result<scf_type_t> {
+        let ret = unsafe { scf_value_base_type(self.value.as_ptr()) };
+        match scf_type_t::from_i32(ret) {
+            Some(scf_type_t::SCF_TYPE_INVALID) => Err(ScfError::last()),
+            Some(typ) => Ok(typ),
+            None => Err(ScfError::Internal),
+        }
+    }
+
+    /*
+     * XXX fn value(&self) -> Result<Value> {
+     * scf_value_get_value(3SCF)
+     */
+
+    /*
+     * XXX fn values(&self) -> Result<Values> {
+     * scf_iter_value_values(3SCF)
+     */
+}
+
+impl Drop for Value<'_> {
+    fn drop(&mut self) {
+        unsafe { scf_value_destroy(self.value.as_ptr()) };
+    }
+}
+
+pub struct Values<'a> {
+    pub(crate) scf: &'a Scf,
+    pub(crate) iter: Iter<'a>,
+}
+
+impl<'a> Values<'a> {
+    pub(crate) fn new(prop: &'a Property) -> Result<Values<'a>> {
+        let scf = prop.scf;
+        let iter = Iter::new(scf)?;
+
+        if unsafe {
+            scf_iter_property_values(iter.iter.as_ptr(), prop.property.as_ptr())
+        } != 0
+        {
+            Err(ScfError::last())
+        } else {
+            Ok(Values { scf, iter })
+        }
+    }
+
+    fn get(&self) -> Result<Option<Value<'a>>> {
+        let value = Value::new(self.scf)?;
+
+        let res = unsafe {
+            scf_iter_next_value(self.iter.iter.as_ptr(), value.value.as_ptr())
+        };
+
+        match res {
+            0 => Ok(None),
+            1 => Ok(Some(value)),
+            _ => Err(ScfError::last()),
+        }
+    }
+}
+
+impl<'a> Iterator for Values<'a> {
+    type Item = Result<Value<'a>>;
+
+    fn next(&mut self) -> Option<Result<Value<'a>>> {
+        self.get().transpose()
+    }
+}

--- a/smf/src/value.rs
+++ b/smf/src/value.rs
@@ -8,7 +8,7 @@ use super::{buf_for, str_from, Iter, Property, Result, Scf, ScfError};
 
 #[derive(Debug)]
 pub struct Value<'a> {
-    pub(crate) scf: &'a Scf,
+    _scf: &'a Scf, // Prevent from being dropped
     pub(crate) value: NonNull<scf_value_t>,
 }
 
@@ -17,7 +17,7 @@ impl<'a> Value<'a> {
         if let Some(value) =
             NonNull::new(unsafe { scf_value_create(scf.handle.as_ptr()) })
         {
-            Ok(Value { scf, value })
+            Ok(Value { _scf: scf, value })
         } else {
             Err(ScfError::last())
         }


### PR DESCRIPTION
The merges agent and the smf crate that @jclulow did in demo_m2; it also adds the generation of an OpenAPI description of the crucible agent API and a progenitor-generated client crate. This work is not yet done in that the agent requires more work; however, I'm proposing that we merge this so that @smklein can start wiring up the agent-client and so that others can potentially help nudge this forward. I don't think the less-than-completed state would be detrimental to other work in this repo.

The next steps to getting this completed:

- fix some of the downstairs command flags as they're invoked from agent/downstairs.xml
- test agent with SMF

... and of course, the door is open to evolve the agent and its API as we see what we need it to do.