### PR TITLE
Register stats with downstairs requested local address, not localhost 

### DIFF
--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -1616,7 +1616,7 @@ async fn main() -> Result<()> {
 
                 tokio::spawn(async move {
                     let address =
-                        SocketAddr::new(std::net::IpAddr::V4(address), port);
+                        SocketAddr::new(std::net::IpAddr::V4(address), 0);
                     if let Err(e) =
                         stats::ox_stats(dss, oximeter, address).await
                     {

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -1615,7 +1615,11 @@ async fn main() -> Result<()> {
                 let dss = dssw.dss.clone();
 
                 tokio::spawn(async move {
-                    if let Err(e) = stats::ox_stats(dss, oximeter).await {
+                    let address =
+                        SocketAddr::new(std::net::IpAddr::V4(address), port);
+                    if let Err(e) =
+                        stats::ox_stats(dss, oximeter, address).await
+                    {
                         println!("ERROR: oximeter failed: {:?}", e);
                     } else {
                         println!("OK: oximeter all done");

--- a/downstairs/src/stats.rs
+++ b/downstairs/src/stats.rs
@@ -133,10 +133,10 @@ impl Producer for DsStatOuter {
 pub async fn ox_stats(
     dss: DsStatOuter,
     registration_address: SocketAddr,
+    my_address: SocketAddr,
 ) -> Result<()> {
-    let address = "[::1]:0".parse().unwrap();
     let dropshot_config = ConfigDropshot {
-        bind_address: address,
+        bind_address: my_address,
         request_body_max_bytes: 2048,
     };
     let logging_config = ConfigLogging::StderrTerminal {
@@ -145,14 +145,13 @@ pub async fn ox_stats(
 
     let server_info = ProducerEndpoint {
         id: Uuid::new_v4(),
-        address,
+        address: my_address,
         base_route: "/collect".to_string(),
         interval: Duration::from_secs(10),
     };
 
     let config = Config {
         server_info,
-        // registration_address: "127.0.0.1:12221".parse().unwrap(),
         registration_address,
         dropshot_config,
         logging_config,


### PR DESCRIPTION
Use the I.P. address requested on the command line for the dropshot server, don't
assume localhost.  Without this, the stats for a downstairs are never read.