### PR TITLE
[Closes #108] Create a simple AWS performance test framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ core
 /fio/*.log
 /fio/*.log.hist
 /fio/*.report
+/aws_benchmark/.terraform*
+/aws_benchmark/inventory
+/aws_benchmark/results.txt
+/aws_benchmark/terraform.tfstate*

--- a/aws_benchmark/README.md
+++ b/aws_benchmark/README.md
@@ -1,0 +1,24 @@
+`driver.sh` will benchmark Crucible by doing the following:
+
+- use terraform to create three downstairs and one upstairs
+- use ansible to (among other things):
+    - ship this repo to each instance,
+    - compile crucible,
+    - create a 2G region on the downstairs,
+    - start the downstairs as a service
+- run `bench.sh` on the upstairs, saving the timing output to results.txt
+- clean up the resources
+
+Both helios and ubuntu are supported as host operating systems, and AWS region
+is a parameter:
+
+    ./driver.sh helios us-east-1
+
+    ./driver.sh ubuntu ca-central-1
+
+Results are output into results.txt, which is `cat`ed at the end of driver.sh.
+
+Any error results in cleanup being performed. Add an `echo` to the terraform
+apply -destroy command in cleanup() if you want to debug further, but make sure
+to clean up your AWS resources!
+

--- a/aws_benchmark/ansible.cfg
+++ b/aws_benchmark/ansible.cfg
@@ -1,0 +1,8 @@
+[defaults]
+retry_files_enabled = False
+forks = 10
+nocows = 1
+host_key_checking = False
+
+[ssh_connection]
+pipelining = True

--- a/aws_benchmark/bench.sh
+++ b/aws_benchmark/bench.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+D0=$(dig +short downstairs0.private.lan | tail -1)
+D1=$(dig +short downstairs1.private.lan | tail -1)
+D2=$(dig +short downstairs2.private.lan | tail -1)
+
+set -e
+
+./target/release/crucible-hammer \
+  -t $D0:3801 -t $D1:3801 -t $D2:3801 \
+  --key "ukJBfV956H22EH5Qv4L0iKPWdtTYhdsdw1+eV5/6xdU=" --num-upstairs 1 >/dev/null
+

--- a/aws_benchmark/cleanup.yml
+++ b/aws_benchmark/cleanup.yml
@@ -1,0 +1,19 @@
+---
+
+- hosts: downstairs
+  user: "{{ user }}"
+  tasks:
+    # don't hold on to ebs volumes, this prevents shutdown
+    - name: stop downstairs smf instances
+      become: yes
+      shell: |
+        svcadm disable -s 'svc:/oxide/crucible/downstairs*'
+        svccfg delete svc:/oxide/crucible/downstairs
+      when: os == "helios"
+
+    - name: export zpools (why doesn't shut down do this?)
+      become: yes
+      shell: |
+        zpool export data
+      when: os == "helios"
+

--- a/aws_benchmark/crucible_simple_test_vpc/ec2.tf
+++ b/aws_benchmark/crucible_simple_test_vpc/ec2.tf
@@ -1,0 +1,103 @@
+resource "aws_key_pair" "temp" {
+  key_name_prefix = "crucible-benchmarking-"
+  public_key      = file(pathexpand("~/.ssh/id_ed25519.pub"))
+}
+
+module "upstairs" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 3.0"
+
+  name = "upstairs"
+
+  ami                         = var.ami_id
+  instance_type               = var.instance_type
+  key_name                    = aws_key_pair.temp.id
+  monitoring                  = true
+  vpc_security_group_ids      = [module.upstairs_sg.security_group_id]
+  associate_public_ip_address = true
+  subnet_id                   = module.vpc.public_subnets[0]
+  user_data                   = var.user_data_path != null ? file("${path.module}/${var.user_data_path}") : null
+
+  root_block_device = [
+    {
+      name        = "/dev/sda1"
+      volume_type = "gp3"
+      iops        = 5000,
+      volume_size = 50
+    },
+  ]
+
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+  }
+}
+
+resource "aws_route53_record" "upstairs" {
+  zone_id = aws_route53_zone.private.zone_id
+  name    = "upstairs.${aws_route53_zone.private.name}"
+  type    = "CNAME"
+  ttl     = "60"
+  records = [module.upstairs.private_dns]
+}
+
+resource "aws_ebs_volume" "downstairs" {
+  for_each = toset(["0", "1", "2"])
+
+  availability_zone = module.vpc.azs[each.key]
+
+  # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html
+  type = "io1"
+  size = 100
+  iops = 5000
+}
+
+resource "aws_volume_attachment" "downstairs" {
+  device_name = "/dev/sdh"
+  volume_id   = aws_ebs_volume.downstairs["${each.key}"].id
+  instance_id = module.downstairs["${each.key}"].id
+
+  for_each = toset(["0", "1", "2"])
+}
+
+module "downstairs" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 3.0"
+
+  for_each = toset(["0", "1", "2"])
+
+  name = "downstairs-${each.key}"
+
+  ami                         = var.ami_id
+  instance_type               = var.instance_type
+  key_name                    = aws_key_pair.temp.id
+  monitoring                  = true
+  vpc_security_group_ids      = [module.downstairs_sg.security_group_id]
+  associate_public_ip_address = true
+  subnet_id                   = module.vpc.public_subnets["${each.key}"]
+  user_data                   = var.user_data_path != null ? file("${path.module}/${var.user_data_path}") : null
+
+  root_block_device = [
+    {
+      name        = "/dev/sda1"
+      volume_type = "gp3"
+      iops        = 5000,
+      volume_size = 50
+    },
+  ]
+
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+  }
+}
+
+resource "aws_route53_record" "private" {
+  for_each = toset(["0", "1", "2"])
+
+  zone_id = aws_route53_zone.private.zone_id
+  name    = "downstairs${each.key}.${aws_route53_zone.private.name}"
+  type    = "CNAME"
+  ttl     = "60"
+  records = [module.downstairs["${each.key}"].private_dns]
+}

--- a/aws_benchmark/crucible_simple_test_vpc/helios_user_data.sh
+++ b/aws_benchmark/crucible_simple_test_vpc/helios_user_data.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+export PATH="/usr/bin/:/sbin/:/usr/sbin/:$PATH"
+
+zfs create -o mountpoint=/home/helios 'rpool/helios'
+# XGECOS=$(getent passwd helios | cut -d: -f5) == helios,,,
+useradd -u '1000' -g staff -c 'helios,,,' -d '/home/helios' -P 'Primary Administrator' -s /bin/bash 'helios'
+passwd -N 'helios'
+mkdir '/home/helios/.ssh'
+cp /root/.ssh/authorized_keys /home/helios/.ssh/authorized_keys
+chown -R 'helios:staff' '/home/helios'
+chmod 0700 '/home/helios'
+sed -i -e '/^PATH=/s#\$#:/opt/ooce/bin:/opt/ooce/sbin#' /etc/default/login
+ntpdig -S 0.pool.ntp.org || true
+
+# passwordless sudo for ansible
+echo 'helios ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/helios
+
+cd /home/helios
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
+chmod u+x rustup.sh
+sed -i -e 's_/bin/sh_/bin/bash_g' rustup.sh
+sed -i -e '/shellcheck shell=dash/d' rustup.sh
+chown helios rustup.sh
+sudo -u helios ./rustup.sh -y
+
+pkg install htop
+pkg install rsync
+
+touch /var/booted_ok
+

--- a/aws_benchmark/crucible_simple_test_vpc/outputs.tf
+++ b/aws_benchmark/crucible_simple_test_vpc/outputs.tf
@@ -1,0 +1,21 @@
+output "upstairs_ip" {
+  value = module.upstairs.public_ip
+}
+output "upstairs_id" {
+  value = module.upstairs.id
+}
+
+output "downstairs_ips" {
+  value = [
+    module.downstairs["0"].public_ip,
+    module.downstairs["1"].public_ip,
+    module.downstairs["2"].public_ip,
+   ]
+}
+output "downstairs_ids" {
+  value = [
+    module.downstairs["0"].id,
+    module.downstairs["1"].id,
+    module.downstairs["2"].id,
+   ]
+}

--- a/aws_benchmark/crucible_simple_test_vpc/sg.tf
+++ b/aws_benchmark/crucible_simple_test_vpc/sg.tf
@@ -1,0 +1,49 @@
+module "upstairs_sg" {
+  source = "terraform-aws-modules/security-group/aws"
+
+  name   = "crucible-upstairs"
+  vpc_id = module.vpc.vpc_id
+
+  ingress_with_cidr_blocks = [
+    {
+      rule        = "ssh-tcp",
+      cidr_blocks = "0.0.0.0/0"
+    },
+  ]
+
+  egress_with_cidr_blocks = [
+    {
+      rule        = "all-all",
+      cidr_blocks = "0.0.0.0/0",
+    }
+  ]
+}
+
+module "downstairs_sg" {
+  source = "terraform-aws-modules/security-group/aws"
+
+  name   = "crucible-downstairs"
+  vpc_id = module.vpc.vpc_id
+
+  ingress_with_cidr_blocks = [
+    {
+      rule        = "ssh-tcp",
+      cidr_blocks = "0.0.0.0/0"
+    },
+    {
+      from_port                = 3801,
+      to_port                  = 3801,
+      protocol                 = "tcp",
+      description              = "crucible traffic",
+      source_security_group_id = module.upstairs_sg.security_group_id,
+      cidr_blocks              = module.vpc.vpc_cidr_block
+    },
+  ]
+
+  egress_with_cidr_blocks = [
+    {
+      rule        = "all-all",
+      cidr_blocks = "0.0.0.0/0",
+    }
+  ]
+}

--- a/aws_benchmark/crucible_simple_test_vpc/ubuntu_user_data.sh
+++ b/aws_benchmark/crucible_simple_test_vpc/ubuntu_user_data.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -ex
+
+# format data volume
+apt update
+apt install -y gdisk
+
+if [[ -e /dev/nvme1n1 ]];
+then
+    sgdisk --zap /dev/nvme1n1
+    sgdisk -n1 /dev/nvme1n1
+    mkfs.ext4 /dev/nvme1n1p1
+    mkdir /data
+    mount /dev/nvme1n1p1 /data
+    chown -R ubuntu /data
+fi
+
+# done
+touch /var/booted_ok
+

--- a/aws_benchmark/crucible_simple_test_vpc/variables.tf
+++ b/aws_benchmark/crucible_simple_test_vpc/variables.tf
@@ -1,0 +1,12 @@
+variable "ami_id" {
+  type = string
+}
+
+variable "instance_type" {
+  type = string
+}
+
+variable "user_data_path" {
+  type    = string
+  default = null
+}

--- a/aws_benchmark/crucible_simple_test_vpc/vpc.tf
+++ b/aws_benchmark/crucible_simple_test_vpc/vpc.tf
@@ -1,0 +1,49 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "random_string" "random" {
+  length  = 32
+  special = false
+  lower   = true
+  upper   = true
+  number  = true
+}
+
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = "crucible-benchmark-vpc-${random_string.random.id}"
+  cidr = "10.0.0.0/16"
+
+  azs             = slice(data.aws_availability_zones.available.names, 0, 3)
+  private_subnets = ["10.0.103.0/24", "10.0.104.0/24", "10.0.105.0/24"]
+  public_subnets  = ["10.0.100.0/24", "10.0.101.0/24", "10.0.102.0/24"]
+
+  enable_nat_gateway   = true
+  enable_vpn_gateway   = false
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  # TODO: IPv6 testing
+  #enable_ipv6                                    = true
+  #assign_ipv6_address_on_creation                = true
+  #private_subnet_assign_ipv6_address_on_creation = false
+  #public_subnet_ipv6_prefixes                    = [0, 1]
+  #private_subnet_ipv6_prefixes                   = [2, 3]
+  #database_subnet_ipv6_prefixes                  = [4, 5]
+
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+  }
+}
+
+resource "aws_route53_zone" "private" {
+  name = "private.lan"
+
+  vpc {
+    vpc_id = module.vpc.vpc_id
+  }
+}
+

--- a/aws_benchmark/downstairs.service.j2
+++ b/aws_benchmark/downstairs.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description="Crucible Downstairs"
+Requires=network.target
+After=syslog.target network.target
+
+[Service]
+Type=simple
+ExecStart=/opt/crucible/target/release/crucible-downstairs run -p "3801" -d /data/disk
+User=ubuntu
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/aws_benchmark/downstairs.xml
+++ b/aws_benchmark/downstairs.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+
+<service_bundle type='manifest' name='oxide-crucible-downstairs'>
+
+<service name='oxide/crucible/downstairs' type='service' version='1'>
+  <create_default_instance enabled='false' />
+
+  <!-- Run once we hit multi-user, so that the network and file systems have
+    been set up. -->
+  <dependency name='multi-user' grouping='require_all' restart_on='none'
+    type='service'>
+    <service_fmri value='svc:/milestone/multi-user' />
+  </dependency>
+
+  <exec_method type='method' name='start'
+    exec='/opt/oxide/crucible/bin/downstairs
+      run
+      --data %{config/directory}
+      --port %{config/port}'
+    timeout_seconds='30'
+    />
+
+  <exec_method type='method' name='stop' exec=':kill' timeout_seconds='30' />
+
+  <property_group name='startd' type='framework'>
+    <propval name='duration' type='astring' value='child' />
+  </property_group>
+
+  <property_group name='config' type='application'>
+    <propval name='directory' type='astring' value='/dev/null' />
+    <propval name='port' type='count' value='0' />
+  </property_group>
+
+  <stability value='Unstable' />
+
+  <template>
+    <common_name>
+      <loctext xml:lang='C'>Oxide Crucible Downstairs</loctext>
+    </common_name>
+    <description>
+      <loctext xml:lang='C'>Disk-side storage component</loctext>
+    </description>
+  </template>
+</service>
+
+</service_bundle>
+<!-- vim: set ts=2 sts=2 sw=2 et: -->

--- a/aws_benchmark/driver.sh
+++ b/aws_benchmark/driver.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+
+if [[ ${#} -lt 2 ]];
+then
+    echo "usage: <OS> <REGION>"
+    exit 1
+fi
+
+case "${1}" in
+    "ubuntu")
+        # ok
+        ;;
+    "helios")
+        # ok
+        ;;
+    *)
+        echo "for OS, choose ubuntu or helios!"
+        exit 1
+        ;;
+esac
+
+if [[ ! -e "${HOME}/.ssh/id_ed25519.pub" ]];
+then
+    echo "terraform code expects ${HOME}/.ssh/id_ed25519.pub to exist, please create: ssh-keygen -t ed25519 ..."
+    exit 1
+fi
+
+OS="${1}"
+REGION="${2}"
+
+cleanup() {
+    ansible-playbook -i inventory cleanup.yml -e user="${user}" -e os="${OS}" || true
+
+    terraform apply -destroy -auto-approve \
+        -var "ami_id=${ami_id}" -var "region=${REGION}" \
+        -var "instance_type=${instance_type}" \
+        -var "user_data_path=${user_data_path}" >/dev/null
+}
+
+# with errexit, cleanup
+trap 'cleanup' ERR
+
+function program_required() {
+    if ! type "${1}";
+    then
+        echo "please install ${1}";
+        exit 1
+    fi
+}
+
+program_required terraform
+program_required virtualenv
+program_required python3
+program_required pip
+
+# set AMI, instance type, user data path
+case "${OS}" in
+    "ubuntu")
+        # get the latest ami that matches the filter
+        ami_id=$(aws ec2 describe-images --region "${REGION}" --owner 099720109477 \
+                 --filter "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-*-21.04-amd64-server-*" \
+                 --query 'Images[*].[ImageId,CreationDate]' --output text \
+                 | sort -k2 \
+                 | tail -n1 | awk '{ print $1 }')
+        echo "ubuntu ami: ${ami_id} $(aws ec2 describe-images --region "${REGION}" --image-id "${ami_id}" --query 'Images[*].[Name]' --output text)"
+
+        instance_type="m5d.2xlarge"
+        user_data_path="ubuntu_user_data.sh"
+        user="ubuntu"
+        ;;
+
+    "helios")
+        # get the latest ami that matches the filter
+        ami_id=$(aws ec2 describe-images --region "${REGION}" --owner 128433874814 \
+                 --filter "Name=name,Values=helios-full-*-*" \
+                 --query 'Images[*].[ImageId,CreationDate]' --output text \
+                 | sort -k2 \
+                 | tail -n1 | awk '{ print $1 }')
+        echo "helios ami: ${ami_id} $(aws ec2 describe-images --region "${REGION}" --image-id "${ami_id}" --query 'Images[*].[Name]' --output text)"
+
+        # TODO: rpz's ena patch for m5d? need an updated helios-full-* image.
+        # need: 6f443ebc1fb4fec01d6e8fa8ca4648182ed215bb, so helios version at least 20793
+        instance_type="m4.2xlarge"
+        user_data_path="helios_user_data.sh"
+        user="helios"
+        ;;
+
+    *)
+        echo "for OS, choose ubuntu or helios!"
+        exit 1
+        ;;
+esac
+
+# make sure the chosen instance type is available in at least 3 azs,
+# otherwise terraform will fail
+azs=$(aws ec2 describe-instance-type-offerings \
+    --location-type availability-zone \
+    --filters "Name=instance-type,Values=${instance_type}" \
+    --region "${REGION}" \
+    --output text | wc -l)
+
+if [[ ${azs} -lt 3 ]];
+then
+    echo "instance ${instance_type} only available in ${azs} azs!"
+    exit 1
+fi
+
+set -o xtrace
+
+# bring up aws resources
+terraform init
+terraform apply -auto-approve \
+    -var "ami_id=${ami_id}" -var "region=${REGION}" \
+    -var "instance_type=${instance_type}" \
+    -var "user_data_path=${user_data_path}" >/dev/null
+
+# create ansible inventory from terraform outputs
+./inv.sh
+
+# install ansible into python virtualenv
+if [[ ! -e .venv/bin/activate ]];
+then
+    virtualenv -p python3 .venv
+fi
+
+source .venv/bin/activate
+
+if ! pip show ansible;
+then
+    pip install "ansible==5.0.1"
+fi
+
+# wait for instance status ok (status checks ok, user data has run)
+INSTANCE_ID_0=$(terraform output -raw upstairs_id)
+INSTANCE_ID_1=$(terraform output -json downstairs_ids 2>&1 | jq -r .[0])
+INSTANCE_ID_2=$(terraform output -json downstairs_ids 2>&1 | jq -r .[1])
+INSTANCE_ID_3=$(terraform output -json downstairs_ids 2>&1 | jq -r .[2])
+
+aws ec2 wait instance-status-ok --region "${REGION}" --instance-ids \
+    "$INSTANCE_ID_0" "$INSTANCE_ID_1" "$INSTANCE_ID_2" "$INSTANCE_ID_3"
+
+# prepare instances - install crucible, run downstairs, etc
+ansible-playbook -i inventory install_crucible.yml -e user="${user}" -e os="${OS}"
+
+# run upstairs benchmark, collect results
+## warm up 3 times
+for i in $(seq 1 3);
+do
+    ssh -o "StrictHostKeyChecking no" "${user}@$(terraform output -raw upstairs_ip)" \
+        "cd /opt/crucible/ && /usr/bin/time -p ./bench.sh"
+done
+
+## 25 (or user configurable) real runs
+rm results.txt
+
+for i in $(seq 1 "${RUNS:-25}");
+do
+    ssh -o "StrictHostKeyChecking no" "${user}@$(terraform output -raw upstairs_ip)" \
+        "cd /opt/crucible/ && /usr/bin/time -p ./bench.sh 2>&1" | tee -a results.txt
+done
+
+# done! clean up
+cleanup
+
+cat results.txt
+

--- a/aws_benchmark/install_crucible.yml
+++ b/aws_benchmark/install_crucible.yml
@@ -1,0 +1,141 @@
+---
+
+- hosts: all
+  user: "{{ user }}"
+  tasks:
+    - name: check that user data script ran ok | part 1
+      stat:
+        path: /var/booted_ok
+      register: user_data_file
+    - name: check that user data script ran ok | part 2
+      fail:
+        msg: "/var/booted_ok not found!"
+      when: not user_data_file.stat.exists
+
+    - name: prepare opt
+      become: yes
+      file:
+        path: /opt
+        owner: "{{ user }}"
+
+    - name: copy code
+      synchronize:
+        src: "{{ playbook_dir }}/../"
+        dest: "/opt/crucible/"
+        rsync_opts:
+          - '--exclude=".git"'
+          - '--exclude="target"'
+
+    - name: build ubuntu pre-reqs
+      become: yes
+      apt:
+        name:
+          - build-essential
+          - libssl-dev
+          - pkg-config
+          - libsqlite3-dev
+        state: present
+      when: os == "ubuntu"
+
+    - name: install rust
+      shell: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
+        chmod u+x rustup.sh
+        ./rustup.sh -y
+      when: os == "ubuntu"
+
+    - name: build crucible
+      shell:
+        cmd: "/home/{{ user }}/.cargo/bin/cargo build --release"
+        chdir: /opt/crucible/
+        executable: /bin/bash
+      args:
+        creates: /opt/crucible/target/release/crucible-downstairs
+
+- hosts: upstairs
+  user: "{{ user }}"
+  tasks:
+    - template:
+        src: bench.sh
+        dest: /opt/crucible/bench.sh
+        mode: u+rwx
+
+- hosts: downstairs
+  user: "{{ user }}"
+  tasks:
+    - name: increase nofile
+      become: yes
+      pam_limits:
+        domain: "{{ user }}"
+        limit_type: soft
+        limit_item: nofile
+        value: 131072
+      when: os == "ubuntu"
+
+    - name: create downstairs zpool
+      become: yes
+      shell: |
+        zpool create data /dev/dsk/c1t7d0
+        chown -R '{{ user }}:staff' '/data'
+      when: os == "helios"
+
+    - file:
+        path: /data/disk
+        state: absent
+    - name: create 2G region (512b sectors)
+      shell:
+        cmd: |
+          /opt/crucible/target/release/crucible-downstairs \
+            create \
+              -u $(uuidgen) \
+              -d /data/disk/ \
+              --extent-count 204 \
+              --extent-size 20480 \
+              --block-size 512
+
+    - name: create downstairs systemd service
+      become: yes
+      template:
+        src: downstairs.service.j2
+        dest: /etc/systemd/system/downstairs.service
+      when: os == "ubuntu"
+    - name: start downstairs systemd service
+      become: yes
+      systemd:
+        daemon_reload: yes
+        name: downstairs
+        state: started
+        enabled: yes
+      when: os == "ubuntu"
+
+    - name: copy downstairs.xml and import it
+      become: yes
+      shell: |
+        svcadm disable -s 'svc:/oxide/crucible/downstairs*'
+        svccfg delete svc:/oxide/crucible/downstairs
+        cp /opt/crucible/aws_benchmark/downstairs.xml /var/svc/manifest/site/
+        svccfg import /var/svc/manifest/site/downstairs.xml
+      when: os == "helios"
+
+    - name: copy binary to /opt/oxide/crucible/bin/downstairs to match downstairs.xml
+      become: yes
+      shell: |
+        mkdir -p /opt/oxide/crucible/bin/
+        cp /opt/crucible/target/release/crucible-downstairs /opt/oxide/crucible/bin/downstairs
+        chmod a+x /opt/oxide/crucible/bin/downstairs
+      when: os == "helios"
+
+    - name: create downstairs smf instance
+      become: yes
+      shell: |
+        INSTANCE_ID=$(curl -sq http://169.254.169.254/latest/meta-data/instance-id)
+        svccfg -s oxide/crucible/downstairs add $INSTANCE_ID
+        svccfg -s oxide/crucible/downstairs:$INSTANCE_ID addpg config application
+        svccfg -s oxide/crucible/downstairs:$INSTANCE_ID setprop config/directory = "/data/disk/"
+        svccfg -s oxide/crucible/downstairs:$INSTANCE_ID setprop config/port = "3801"
+        svcadm refresh oxide/crucible/downstairs:$INSTANCE_ID
+        svcadm enable oxide/crucible/downstairs:$INSTANCE_ID
+        sleep 2
+        svcs "oxide/crucible/downstairs:$INSTANCE_ID"
+      when: os == "helios"
+

--- a/aws_benchmark/inv.sh
+++ b/aws_benchmark/inv.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+rm inventory
+
+echo '[upstairs]' >> inventory
+terraform output -raw upstairs_ip >> inventory
+echo '' >> inventory
+echo '' >> inventory
+
+echo '[downstairs]' >> inventory
+terraform output -json downstairs_ips 2>&1 | jq -r .[0] >> inventory
+terraform output -json downstairs_ips 2>&1 | jq -r .[1] >> inventory
+terraform output -json downstairs_ips 2>&1 | jq -r .[2] >> inventory
+
+echo '' >> inventory
+

--- a/aws_benchmark/main.tf
+++ b/aws_benchmark/main.tf
@@ -1,0 +1,33 @@
+variable "ami_id" {
+  type = string
+}
+
+variable "instance_type" {
+  type = string
+}
+
+variable "user_data_path" {
+  type = string
+}
+
+module "crucible_simple_test" {
+  source         = "./crucible_simple_test_vpc/"
+  ami_id         = var.ami_id
+  instance_type  = var.instance_type
+  user_data_path = var.user_data_path
+}
+
+output "upstairs_ip" {
+  value = module.crucible_simple_test.upstairs_ip
+}
+output "upstairs_id" {
+  value = module.crucible_simple_test.upstairs_id
+}
+
+output "downstairs_ips" {
+  value = module.crucible_simple_test.downstairs_ips
+}
+output "downstairs_ids" {
+  value = module.crucible_simple_test.downstairs_ids
+}
+

--- a/aws_benchmark/providers.tf
+++ b/aws_benchmark/providers.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+variable "region" {
+  type = string
+}
+
+provider "aws" {
+  region = var.region
+}
+


### PR DESCRIPTION
Bring up an Upstairs plus three Downstairs in an AWS VPC, and run
performance tests against the setup. The basic test so far is simply
running hammer with `--num-upstairs 1` and using encryption.

Both Ubuntu and Helios are supported as the host OS.

The main programs doing the work here are terraform and ansible. Export
your AWS credentials and see README.md for how to run.