### PR TITLE
add option to only show differences when dumping

### DIFF
--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -240,7 +240,9 @@ fn show_extent(
     for (index, _) in region_dir.iter().enumerate() {
         print!(" {0:^11}", format!("Tag {}", index));
     }
-    print!(" {0:^7}", "DIFF");
+    if !only_show_differences {
+        print!(" {0:^7}", "DIFF");
+    }
     println!();
 
     /*
@@ -412,7 +414,9 @@ fn show_extent(
                 print!("{}", column);
             }
 
-            print!("{0:^7}", if different { "<-------" } else { "" });
+            if !only_show_differences {
+                print!("{0:^7}", if different { "<-------" } else { "" });
+            }
 
             println!();
         }

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -95,7 +95,13 @@ pub fn dump_region(
             bail!("Need more than one region directory to compare data");
         }
         let en = all_extents.get(&ce).unwrap();
-        show_extent(region_dir, &en.ei_hm, ce, blocks_per_extent, only_show_differences)?;
+        show_extent(
+            region_dir,
+            &en.ei_hm,
+            ce,
+            blocks_per_extent,
+            only_show_differences,
+        )?;
 
         return Ok(());
     };
@@ -115,21 +121,24 @@ pub fn dump_region(
     let mut difference_found = false;
     for en in ext_num.iter() {
         if let Some(ei) = all_extents.get(en) {
-            let mut columns: [String; 3] = ["".to_string(), "".to_string(), "".to_string()];
+            let mut columns: [String; 3] =
+                ["".to_string(), "".to_string(), "".to_string()];
 
-            for dir_index in 0..dir_count {
+            for (dir_index, column) in
+                columns.iter_mut().enumerate().take(dir_count)
+            {
                 if let Some(em) = ei.ei_hm.get(&(dir_index as u32)) {
                     let dirty = if em.dirty {
                         "D".to_string()
                     } else {
                         " ".to_string()
                     };
-                    columns[dir_index] = format!(
+                    *column = format!(
                         "{:8} {:8} {} ",
                         em.gen_number, em.flush_number, dirty
                     );
                 } else {
-                    columns[dir_index] = format!("-");
+                    *column = "-".to_string();
                 }
             }
 
@@ -142,12 +151,12 @@ pub fn dump_region(
                 }
             }
 
-            if !only_show_differences || (only_show_differences && different) {
+            if !only_show_differences || different {
                 print!("{:3} ", en);
-                for dir_index in 0..dir_count {
-                    print!("{}", columns[dir_index]);
+                for column in columns.iter().take(dir_count) {
+                    print!("{}", column);
                 }
-                println!("");
+                println!();
             }
 
             difference_found |= different;
@@ -390,17 +399,17 @@ fn show_extent(
                 format!("{0:^11} ", status_letters[dir_index]);
         }
 
-        if !only_show_differences || (only_show_differences && different) {
+        if !only_show_differences || different {
             print!("Block {:4}", block);
 
-            for dir_index in 0..dir_count {
-                print!("{}", data_columns[dir_index]);
+            for column in data_columns.iter().take(dir_count) {
+                print!("{}", column);
             }
-            for dir_index in 0..dir_count {
-                print!("{}", nonce_columns[dir_index]);
+            for column in nonce_columns.iter().take(dir_count) {
+                print!("{}", column);
             }
-            for dir_index in 0..dir_count {
-                print!("{}", tag_columns[dir_index]);
+            for column in tag_columns.iter().take(dir_count) {
+                print!("{}", column);
             }
 
             print!("{0:^7}", if different { "<-------" } else { "" });

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -1551,7 +1551,11 @@ async fn main() -> Result<()> {
             );
             Ok(())
         }
-        Args::Dump { data, extent, only_show_differences } => {
+        Args::Dump {
+            data,
+            extent,
+            only_show_differences,
+        } => {
             dump_region(data, extent, only_show_differences)?;
             Ok(())
         }

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -78,6 +78,12 @@ enum Args {
          */
         #[structopt(short, long)]
         extent: Option<u32>,
+
+        /*
+         * Only show differences
+         */
+        #[structopt(short, long)]
+        only_show_differences: bool,
     },
     Export {
         /*
@@ -1545,8 +1551,8 @@ async fn main() -> Result<()> {
             );
             Ok(())
         }
-        Args::Dump { data, extent } => {
-            dump_region(data, extent)?;
+        Args::Dump { data, extent, only_show_differences } => {
+            dump_region(data, extent, only_show_differences)?;
             Ok(())
         }
         Args::Export {

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -980,7 +980,7 @@ mod test {
         /*
          * Dump the region
          */
-        dump_region(dvec, None)?;
+        dump_region(dvec, None, false)?;
 
         Ok(())
     }
@@ -1012,7 +1012,7 @@ mod test {
         /*
          * Dump the region
          */
-        dump_region(dvec, None)?;
+        dump_region(dvec, None, false)?;
 
         Ok(())
     }
@@ -1045,7 +1045,7 @@ mod test {
         /*
          * Dump the region
          */
-        dump_region(dvec, Some(2))?;
+        dump_region(dvec, Some(2), false)?;
 
         Ok(())
     }


### PR DESCRIPTION
when dumping (and comparing) downstairs, add an option to only show the
differences.

also bail with an error if differences are found.

Closes #140 