### PR TITLE
Update crucible to take ipv4 or ipv6 addresses

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,5 +1,5 @@
 // Copyright 2021 Oxide Computer Company
-use std::net::SocketAddrV4;
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -17,7 +17,7 @@ use crucible::*;
  * The various tests this program supports.
  */
 arg_enum! {
-    #[derive(Debug, PartialEq,  StructOpt)]
+    #[derive(Debug, PartialEq, StructOpt)]
     enum Workload {
         Balloon,
         Big,
@@ -38,7 +38,7 @@ arg_enum! {
 #[structopt(about = "crucible upstairs test client")]
 pub struct Opt {
     #[structopt(short, long, default_value = "127.0.0.1:9000")]
-    target: Vec<SocketAddrV4>,
+    target: Vec<SocketAddr>,
 
     #[structopt(
         short,

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::fs::File;
 use std::io::{Read, Write};
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -97,7 +97,7 @@ enum Args {
     },
     Run {
         #[structopt(short, long, default_value = "0.0.0.0")]
-        address: Ipv4Addr,
+        address: IpAddr,
 
         #[structopt(short, long, parse(from_os_str), name = "DIRECTORY")]
         data: PathBuf,
@@ -1615,10 +1615,17 @@ async fn main() -> Result<()> {
                 let dss = dssw.dss.clone();
 
                 tokio::spawn(async move {
-                    let address =
-                        SocketAddr::new(std::net::IpAddr::V4(address), 0);
+                    let new_address = match address {
+                        IpAddr::V4(ipv4) => {
+                            SocketAddr::new(std::net::IpAddr::V4(ipv4), 0)
+                        }
+                        IpAddr::V6(ipv6) => {
+                            SocketAddr::new(std::net::IpAddr::V6(ipv6), 0)
+                        }
+                    };
+
                     if let Err(e) =
-                        stats::ox_stats(dss, oximeter, address).await
+                        stats::ox_stats(dss, oximeter, new_address).await
                     {
                         println!("ERROR: oximeter failed: {:?}", e);
                     } else {
@@ -1627,10 +1634,20 @@ async fn main() -> Result<()> {
                 });
             }
 
+            let listen_on = match address {
+                IpAddr::V4(ipv4) => {
+                    SocketAddr::new(std::net::IpAddr::V4(ipv4), port)
+                }
+                IpAddr::V6(ipv6) => {
+                    SocketAddr::new(std::net::IpAddr::V6(ipv6), port)
+                }
+            };
+
             /*
              * Establish a listen server on the port.
              */
-            let listen_on = SocketAddrV4::new(address, port);
+            // let listen_on = SocketAddrV4::new(address, port);
+            println!("Using address: {:?}", listen_on);
             let listener = TcpListener::bind(&listen_on).await?;
 
             /*

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 Oxide Computer Company
 
-use std::net::SocketAddrV4;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::{bail, Result};
@@ -24,7 +24,7 @@ fn do_vecs_match<T: PartialEq>(a: &[T], b: &[T]) -> bool {
 #[structopt(about = "volume-side storage component")]
 pub struct Opt {
     #[structopt(short, long, default_value = "127.0.0.1:9000")]
-    target: Vec<SocketAddrV4>,
+    target: Vec<SocketAddr>,
 
     /*
      * Verify that writes don't extend before or after the actual location.

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -1,5 +1,5 @@
 // Copyright 2021 Oxide Computer Company
-use std::net::SocketAddrV4;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::{bail, Result};
@@ -34,7 +34,7 @@ fn handle_nbd_client(
 #[structopt(about = "volume-side storage component")]
 pub struct Opt {
     #[structopt(short, long, default_value = "127.0.0.1:9000")]
-    target: Vec<SocketAddrV4>,
+    target: Vec<SocketAddr>,
 
     #[structopt(short, long)]
     key: Option<String>,

--- a/upstairs/src/main.rs
+++ b/upstairs/src/main.rs
@@ -1,5 +1,5 @@
 // Copyright 2021 Oxide Computer Company
-use std::net::SocketAddrV4;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::{bail, Result};
@@ -16,7 +16,7 @@ use crucible::*;
 #[structopt(about = "volume-side storage component")]
 pub struct Opt {
     #[structopt(short, long, default_value = "127.0.0.1:9000")]
-    target: Vec<SocketAddrV4>,
+    target: Vec<SocketAddr>,
 
     #[structopt(short, long)]
     key: Option<String>,
@@ -58,7 +58,7 @@ impl Opt {
 #[cfg(test)]
 mod tests {
     use crate::Opt;
-    use std::net::{Ipv4Addr, SocketAddrV4};
+    use std::net::{Ipv4Addr, SocketAddr};
 
     #[test]
     fn test_opt_from_string() {
@@ -71,11 +71,17 @@ mod tests {
 
         assert_eq!(
             opt.target[0],
-            SocketAddrV4::new(Ipv4Addr::new(192, 168, 1, 1), 3801)
+            SocketAddr::new(
+                std::net::IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
+                3801
+            )
         );
         assert_eq!(
             opt.target[1],
-            SocketAddrV4::new(Ipv4Addr::new(192, 168, 1, 2), 3801)
+            SocketAddr::new(
+                std::net::IpAddr::V4(Ipv4Addr::new(192, 168, 1, 2)),
+                3801
+            )
         );
     }
 


### PR DESCRIPTION
Crucible downstairs can now take either ipv4 or ipv6 address to listen
for a connection from the upstairs.

Crucible upstairs can now take either ipv4 or ipv6 address:port to use
to connect to the downstairs

Here is some example output from a ipv6 downstairs:
```
alan@buskin:crucible$ cargo run -p crucible-downstairs -- run -a fe80::1ac0:4dff:fe0d:9fb2 -p 3802 -d var/3802
    Finished dev [unoptimized + debuginfo] target(s) in 0.17s
     Running `target/debug/crucible-downstairs run -a 'fe80::1ac0:4dff:fe0d:9fb2' -p 3802 -d var/3802`
Opened existing region file "var/3802/region.json"
UUID: 12345678-3802-3802-3802-000000003802
Blocks per extent:100 Total Extents: 20
Using address: [fe80::1ac0:4dff:fe0d:9fb2]:3802
listening on [fe80::1ac0:4dff:fe0d:9fb2]:3802
connection from [fe80::1ac0:4dff:fe0d:a02a%2]:55007
upstairs 25e21fc2-24b0-4778-99ad-20be73687db6 connected
25e21fc2-24b0-4778-99ad-20be73687db6 is now active
Current flush_numbers [0..12]: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
Downstairs has completed Negotiation
upstairs 25e21fc2-24b0-4778-99ad-20be73687db6 disconnected, 0 jobs left
upstairs 25e21fc2-24b0-4778-99ad-20be73687db6 was previously active, clearing
OK: connection([fe80::1ac0:4dff:fe0d:a02a%2]:55007): all done
```