### PR TITLE
Batch downstairs read and write ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +258,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "cast"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
+dependencies = [
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -327,6 +348,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "criterion"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+dependencies = [
+ "cast",
+ "itertools",
 ]
 
 [[package]]
@@ -527,6 +584,7 @@ dependencies = [
  "bincode",
  "bytes",
  "chrono",
+ "criterion",
  "crucible 0.0.1",
  "crucible-common 0.0.0",
  "crucible-protocol 0.0.0",
@@ -667,6 +725,28 @@ checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array 0.14.4",
  "subtle",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1101,6 +1181,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,6 +1407,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,7 +1599,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac8cd24d9f185bb7223958d8c1ff7a961b74b1953fd05dba7cc568a63b3861ec"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.1.7",
 ]
 
 [[package]]
@@ -1643,6 +1738,12 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
@@ -1955,6 +2056,34 @@ name = "pkg-config"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
+
+[[package]]
+name = "plotters"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "polyval"
@@ -2377,6 +2506,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.4",
+]
+
+[[package]]
 name = "rustfmt-wrapper"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2521,6 +2659,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+
+[[package]]
 name = "semver-parser"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,6 +2688,16 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38636132857f68ec3d5f3eb121166d2af33cb55174c4d5ff645db6165cbef0fd"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
  "serde",
 ]
 
@@ -3030,6 +3184,16 @@ dependencies = [
  "libc",
  "wasi",
  "winapi",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,7 @@ dependencies = [
  "dropshot",
  "futures",
  "futures-core",
+ "hex",
  "omicron-common",
  "opentelemetry",
  "opentelemetry-jaeger",
@@ -1221,6 +1222,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"

--- a/README.md
+++ b/README.md
@@ -205,6 +205,20 @@ LAST_FLUSH=$(cargo run --bin oxdb -- query crucible_downstairs:flush downstairs_
 cargo run --bin oxdb -- query crucible_downstairs:flush downstairs_uuid==12345678-3801-3801-3801-000000003801 | jq ".[].measurements[] | select(.timestamp == $LAST_FLUSH) | .datum.CumulativeI64.value"
 ```
 
+# Benchmarking #
+
+To run the benchmarks, do:
+
+```
+cargo bench
+```
+
+You can include a benchmark name (read: what criterion's "bench_function" string is) to limit which bencharks are run. Example:
+
+```
+cargo bench region_write
+```
+
 ## License
 
 Unless otherwise noted, all components are licensed under the [Mozilla Public License Version 2.0](LICENSE).

--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -44,6 +44,10 @@ impl Block {
         Block::new(value, 9)
     }
 
+    pub fn new_4096(value: u64) -> Block {
+        Block::new(value, 12)
+    }
+
     pub fn new_with_ddef(value: u64, ddef: &RegionDefinition) -> Block {
         Block {
             value,

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -37,3 +37,8 @@ rusqlite = { version = "0.25" }
 [dev-dependencies]
 tempfile = "3"
 rand_chacha = "0.3.1"
+criterion = "0.3"
+
+[[bench]]
+name = "downstairs"
+harness = false

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -33,6 +33,7 @@ tracing-subscriber = "0.2.19"
 tracing-opentelemetry = "0.14.0"
 uuid = { version = "0.8", features = [ "serde", "v4" ] }
 rusqlite = { version = "0.25" }
+hex = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/downstairs/benches/downstairs.rs
+++ b/downstairs/benches/downstairs.rs
@@ -1,0 +1,143 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use bytes::BytesMut;
+use rand::{Rng, RngCore};
+use tempfile::tempdir;
+
+use crucible_common::Block;
+use crucible_downstairs::Region;
+
+fn new_region_options() -> crucible_common::RegionOptions {
+    let mut region_options: crucible_common::RegionOptions = Default::default();
+    let block_size = 512;
+    region_options.set_block_size(block_size);
+    region_options.set_extent_size(Block::new(10, block_size.trailing_zeros()));
+    region_options
+        .set_uuid("12345678-1111-2222-3333-123456789999".parse().unwrap());
+    region_options
+}
+
+pub fn downstairs_rw_speed_benchmark(c: &mut Criterion) {
+    let dir = tempdir().unwrap();
+    let mut region = Region::create(&dir, new_region_options()).unwrap();
+    region.extend(1024).unwrap();
+
+    let ddef = region.def();
+    let total_size: usize = ddef.total_size() as usize;
+    let num_blocks: usize =
+        ddef.extent_size().value as usize * ddef.extent_count() as usize;
+
+    c.bench_function("region_write", |b| {
+        let mut rng = rand::thread_rng();
+        let mut buffer: Vec<u8> = Vec::with_capacity(total_size);
+        buffer.resize(total_size, 0u8);
+        rng.fill_bytes(&mut buffer);
+
+        let mut writes: Vec<crucible_protocol::Write> =
+            Vec::with_capacity(num_blocks);
+
+        for i in 0..num_blocks {
+            let eid: u64 = i as u64 / ddef.extent_size().value;
+            let offset: Block =
+                Block::new_512((i as u64) % ddef.extent_size().value);
+
+            let data = BytesMut::from(&buffer[(i * 512)..((i + 1) * 512)]);
+
+            writes.push(crucible_protocol::Write {
+                eid,
+                offset,
+                data: data.freeze(),
+                nonce: None,
+                tag: None,
+            });
+        }
+
+        b.iter(|| {
+            region.region_write(&writes).unwrap();
+        })
+    });
+
+    c.bench_function("region_read", |b| {
+        let mut requests: Vec<crucible_protocol::ReadRequest> =
+            Vec::with_capacity(num_blocks);
+
+        for i in 0..num_blocks {
+            let eid: u64 = i as u64 / ddef.extent_size().value;
+            let offset: Block =
+                Block::new_512((i as u64) % ddef.extent_size().value);
+
+            requests.push(crucible_protocol::ReadRequest {
+                eid,
+                offset,
+                num_blocks: 1,
+            });
+        }
+
+        b.iter(|| {
+            let responses = region.region_read(&requests).unwrap();
+            for response in responses {
+                assert!(response.nonce.is_none());
+            }
+        })
+    });
+
+    c.bench_function("region_write with nonce and tag", |b| {
+        let mut rng = rand::thread_rng();
+        let mut buffer: Vec<u8> = Vec::with_capacity(total_size);
+        buffer.resize(total_size, 0u8);
+        rng.fill_bytes(&mut buffer);
+
+        let mut writes: Vec<crucible_protocol::Write> =
+            Vec::with_capacity(num_blocks);
+
+        for i in 0..num_blocks {
+            let eid: u64 = i as u64 / ddef.extent_size().value;
+            let offset: Block =
+                Block::new_512((i as u64) % ddef.extent_size().value);
+
+            let data = BytesMut::from(&buffer[(i * 512)..((i + 1) * 512)]);
+
+            writes.push(crucible_protocol::Write {
+                eid,
+                offset,
+                data: data.freeze(),
+                nonce: Some(Vec::from(rng.gen::<[u8; 12]>())),
+                tag: Some(Vec::from(rng.gen::<[u8; 16]>())),
+            });
+        }
+
+        b.iter(|| {
+            region.region_write(&writes).unwrap();
+        })
+    });
+
+    c.bench_function("region_read with nonce and tag", |b| {
+        let mut requests: Vec<crucible_protocol::ReadRequest> =
+            Vec::with_capacity(num_blocks);
+
+        for i in 0..num_blocks {
+            let eid: u64 = i as u64 / ddef.extent_size().value;
+            let offset: Block =
+                Block::new_512((i as u64) % ddef.extent_size().value);
+
+            requests.push(crucible_protocol::ReadRequest {
+                eid,
+                offset,
+                num_blocks: 1,
+            });
+        }
+
+        b.iter(|| {
+            let responses = region.region_read(&requests).unwrap();
+
+            for response in responses {
+                assert!(response.nonce.is_some());
+            }
+        })
+    });
+
+}
+
+criterion_group!(benches, downstairs_rw_speed_benchmark);
+
+criterion_main!(benches);

--- a/downstairs/benches/downstairs.rs
+++ b/downstairs/benches/downstairs.rs
@@ -7,9 +7,8 @@ use tempfile::tempdir;
 use crucible_common::Block;
 use crucible_downstairs::Region;
 
-fn new_region_options() -> crucible_common::RegionOptions {
+fn new_region_options(block_size: u64) -> crucible_common::RegionOptions {
     let mut region_options: crucible_common::RegionOptions = Default::default();
-    let block_size = 512;
     region_options.set_block_size(block_size);
     region_options.set_extent_size(Block::new(10, block_size.trailing_zeros()));
     region_options
@@ -17,9 +16,10 @@ fn new_region_options() -> crucible_common::RegionOptions {
     region_options
 }
 
-pub fn downstairs_rw_speed_benchmark(c: &mut Criterion) {
+pub fn downstairs_rw_speed_benchmark<const BS: usize>(c: &mut Criterion) {
     let dir = tempdir().unwrap();
-    let mut region = Region::create(&dir, new_region_options()).unwrap();
+    let mut region =
+        Region::create(&dir, new_region_options(BS as u64)).unwrap();
     region.extend(1024).unwrap();
 
     let ddef = region.def();
@@ -27,7 +27,7 @@ pub fn downstairs_rw_speed_benchmark(c: &mut Criterion) {
     let num_blocks: usize =
         ddef.extent_size().value as usize * ddef.extent_count() as usize;
 
-    c.bench_function("region_write", |b| {
+    c.bench_function(format!("[{} sectors] region_write", BS).as_str(), |b| {
         b.iter_batched(
             || {
                 let mut rng = rand::thread_rng();
@@ -40,10 +40,13 @@ pub fn downstairs_rw_speed_benchmark(c: &mut Criterion) {
 
                 for i in 0..num_blocks {
                     let eid: u64 = i as u64 / ddef.extent_size().value;
-                    let offset: Block =
-                        Block::new_512((i as u64) % ddef.extent_size().value);
+                    let offset: Block = Block::new(
+                        (i as u64) % ddef.extent_size().value,
+                        BS.trailing_zeros(),
+                    );
 
-                    let data = BytesMut::from(&buffer[(i * 512)..((i + 1) * 512)]);
+                    let data =
+                        BytesMut::from(&buffer[(i * BS)..((i + 1) * BS)]);
 
                     writes.push(crucible_protocol::Write {
                         eid,
@@ -63,7 +66,7 @@ pub fn downstairs_rw_speed_benchmark(c: &mut Criterion) {
         );
     });
 
-    c.bench_function("region_read", |b| {
+    c.bench_function(format!("[{} sectors] region_read", BS).as_str(), |b| {
         b.iter_batched(
             || {
                 let mut requests: Vec<crucible_protocol::ReadRequest> =
@@ -71,8 +74,10 @@ pub fn downstairs_rw_speed_benchmark(c: &mut Criterion) {
 
                 for i in 0..num_blocks {
                     let eid: u64 = i as u64 / ddef.extent_size().value;
-                    let offset: Block =
-                        Block::new_512((i as u64) % ddef.extent_size().value);
+                    let offset: Block = Block::new(
+                        (i as u64) % ddef.extent_size().value,
+                        BS.trailing_zeros(),
+                    );
 
                     requests.push(crucible_protocol::ReadRequest {
                         eid,
@@ -93,73 +98,88 @@ pub fn downstairs_rw_speed_benchmark(c: &mut Criterion) {
         );
     });
 
-    c.bench_function("region_write with nonce and tag", |b| {
-        b.iter_batched(
-            || {
-                let mut rng = rand::thread_rng();
-                let mut buffer: Vec<u8> = Vec::with_capacity(total_size);
-                buffer.resize(total_size, 0u8);
-                rng.fill_bytes(&mut buffer);
+    c.bench_function(
+        format!("[{} sectors] region_write with nonce and tag", BS).as_str(),
+        |b| {
+            b.iter_batched(
+                || {
+                    let mut rng = rand::thread_rng();
+                    let mut buffer: Vec<u8> = Vec::with_capacity(total_size);
+                    buffer.resize(total_size, 0u8);
+                    rng.fill_bytes(&mut buffer);
 
-                let mut writes: Vec<crucible_protocol::Write> =
-                    Vec::with_capacity(num_blocks);
+                    let mut writes: Vec<crucible_protocol::Write> =
+                        Vec::with_capacity(num_blocks);
 
-                for i in 0..num_blocks {
-                    let eid: u64 = i as u64 / ddef.extent_size().value;
-                    let offset: Block =
-                        Block::new_512((i as u64) % ddef.extent_size().value);
+                    for i in 0..num_blocks {
+                        let eid: u64 = i as u64 / ddef.extent_size().value;
+                        let offset: Block = Block::new(
+                            (i as u64) % ddef.extent_size().value,
+                            BS.trailing_zeros(),
+                        );
 
-                    let data = BytesMut::from(&buffer[(i * 512)..((i + 1) * 512)]);
+                        let data =
+                            BytesMut::from(&buffer[(i * BS)..((i + 1) * BS)]);
 
-                    writes.push(crucible_protocol::Write {
-                        eid,
-                        offset,
-                        data: data.freeze(),
-                        nonce: Some(Vec::from(rng.gen::<[u8; 12]>())),
-                        tag: Some(Vec::from(rng.gen::<[u8; 16]>())),
-                    });
-                }
+                        writes.push(crucible_protocol::Write {
+                            eid,
+                            offset,
+                            data: data.freeze(),
+                            nonce: Some(Vec::from(rng.gen::<[u8; 12]>())),
+                            tag: Some(Vec::from(rng.gen::<[u8; 16]>())),
+                        });
+                    }
 
-                writes
-            },
-            |writes| {
-                region.region_write(&writes).unwrap();
-            },
-            criterion::BatchSize::SmallInput,
-        );
-    });
+                    writes
+                },
+                |writes| {
+                    region.region_write(&writes).unwrap();
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        },
+    );
 
-    c.bench_function("region_read with nonce and tag", |b| {
-        b.iter_batched(
-            || {
-                let mut requests: Vec<crucible_protocol::ReadRequest> =
-                    Vec::with_capacity(num_blocks);
+    c.bench_function(
+        format!("[{} sectors] region_read with nonce and tag", BS).as_str(),
+        |b| {
+            b.iter_batched(
+                || {
+                    let mut requests: Vec<crucible_protocol::ReadRequest> =
+                        Vec::with_capacity(num_blocks);
 
-                for i in 0..num_blocks {
-                    let eid: u64 = i as u64 / ddef.extent_size().value;
-                    let offset: Block =
-                        Block::new_512((i as u64) % ddef.extent_size().value);
+                    for i in 0..num_blocks {
+                        let eid: u64 = i as u64 / ddef.extent_size().value;
+                        let offset: Block = Block::new(
+                            (i as u64) % ddef.extent_size().value,
+                            BS.trailing_zeros(),
+                        );
 
-                    requests.push(crucible_protocol::ReadRequest {
-                        eid,
-                        offset,
-                        num_blocks: 1,
-                    });
-                }
+                        requests.push(crucible_protocol::ReadRequest {
+                            eid,
+                            offset,
+                            num_blocks: 1,
+                        });
+                    }
 
-                requests
-            },
-            |requests| {
-                let responses = region.region_read(&requests).unwrap();
-                for response in responses {
-                    assert!(response.nonce.is_some());
-                }
-            },
-            criterion::BatchSize::SmallInput,
-        );
-    });
+                    requests
+                },
+                |requests| {
+                    let responses = region.region_read(&requests).unwrap();
+                    for response in responses {
+                        assert!(response.nonce.is_some());
+                    }
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        },
+    );
 }
 
-criterion_group!(benches, downstairs_rw_speed_benchmark);
+criterion_group!(
+    benches,
+    downstairs_rw_speed_benchmark<512>,
+    downstairs_rw_speed_benchmark<4096>,
+);
 
 criterion_main!(benches);

--- a/downstairs/benches/downstairs.rs
+++ b/downstairs/benches/downstairs.rs
@@ -135,7 +135,6 @@ pub fn downstairs_rw_speed_benchmark(c: &mut Criterion) {
             }
         })
     });
-
 }
 
 criterion_group!(benches, downstairs_rw_speed_benchmark);

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1,0 +1,11 @@
+// Copyright 2021 Oxide Computer Company
+use anyhow::{bail, Result};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use crucible_common::Block;
+use crucible_protocol::*;
+
+mod dump;
+mod region;
+pub use region::Region;

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1,4 +1,11 @@
 // Copyright 2021 Oxide Computer Company
+
+/*
+ * Note: This lib.rs was created to facilitate criterion benchmarks, which
+ * cannot benchmark binary crates. Including a minimal number of uses here
+ * allows us to write those microbenchmarks.
+ */
+
 use anyhow::{bail, Result};
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -33,6 +33,7 @@ use uuid::Uuid;
 mod dump;
 mod region;
 mod stats;
+
 use dump::dump_region;
 use region::Region;
 use stats::*;

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -145,23 +145,23 @@ impl Inner {
         &mut self,
         encryption_context_params: &[(u64, &[u8], &[u8])],
     ) -> Result<()> {
-        let stmt: Vec<String> =
-            vec![
-                "INSERT OR REPLACE INTO encryption_context".to_string(),
-                "(block, nonce, tag) values".to_string(),
-                encryption_context_params
-                    .iter()
-                    .map(|tuple| {
-                        let (block, nonce, tag) = tuple;
-                        format!("({}, X'{}', X'{}')",
-                            block,
-                            hex::encode(nonce),
-                            hex::encode(tag),
-                        )
-                    })
-                    .collect::<Vec<String>>()
-                    .join(",")
-            ];
+        let stmt: Vec<String> = vec![
+            "INSERT OR REPLACE INTO encryption_context".to_string(),
+            "(block, nonce, tag) values".to_string(),
+            encryption_context_params
+                .iter()
+                .map(|tuple| {
+                    let (block, nonce, tag) = tuple;
+                    format!(
+                        "({}, X'{}', X'{}')",
+                        block,
+                        hex::encode(nonce),
+                        hex::encode(tag),
+                    )
+                })
+                .collect::<Vec<String>>()
+                .join(","),
+        ];
 
         let _rows_affected = self.metadb.execute(&stmt.join(" "), [])?;
 
@@ -406,9 +406,10 @@ impl Extent {
             inner.file.seek(SeekFrom::Start(byte_offset))?;
 
             /*
-             * XXX This read_exact only works because we have filled our buffer
-             * with data ahead of time.  If we want to use an uninitialized
-             * buffer, then we need a different read or type for the destination
+             * XXX This read_exact only works because we have filled our
+             * buffer with data ahead of time.  If we want to use
+             * an uninitialized buffer, then we need a different
+             * read or type for the destination
              */
             inner.file.read_exact(&mut response.data)?;
 
@@ -471,8 +472,8 @@ impl Extent {
 
         inner.set_dirty()?;
 
-        let mut encryption_context_params: Vec<(u64, &[u8], &[u8])>
-            = Vec::with_capacity(writes.len());
+        let mut encryption_context_params: Vec<(u64, &[u8], &[u8])> =
+            Vec::with_capacity(writes.len());
 
         for write in writes {
             let byte_offset = write.offset.value * self.block_size;
@@ -481,13 +482,11 @@ impl Extent {
             inner.file.write_all(&write.data)?;
 
             if write.nonce.is_some() && write.tag.is_some() {
-                encryption_context_params.push(
-                    (
-                        write.offset.value,
-                        write.nonce.as_ref().unwrap(),
-                        write.tag.as_ref().unwrap(),
-                    )
-                );
+                encryption_context_params.push((
+                    write.offset.value,
+                    write.nonce.as_ref().unwrap(),
+                    write.tag.as_ref().unwrap(),
+                ));
             }
         }
 
@@ -746,7 +745,9 @@ impl Region {
             HashMap::new();
 
         for write in writes {
-            let extent_vec = batched_writes.entry(write.eid as usize).or_insert_with(Vec::new);
+            let extent_vec = batched_writes
+                .entry(write.eid as usize)
+                .or_insert_with(Vec::new);
             extent_vec.push(write);
         }
 
@@ -779,7 +780,8 @@ impl Region {
 
         // have to maintain order with reads! can't use hashmap
         let mut eid: Option<u64> = None;
-        let mut batched_reads: Vec<&crucible_protocol::ReadRequest> = Vec::with_capacity(requests.len());
+        let mut batched_reads: Vec<&crucible_protocol::ReadRequest> =
+            Vec::with_capacity(requests.len());
 
         for request in requests {
             if let Some(_eid) = eid {

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -787,8 +787,8 @@ impl Region {
          * together.
          *
          * Note: Have to maintain order with reads! The Upstairs expects read
-         * responses to be in the same order as read requests, so we can't use
-         * a hashmap in the same way that batching writes can.
+         * responses to be in the same order as read requests, so we can't
+         * use a hashmap in the same way that batching writes can.
          */
         let mut eid: Option<u64> = None;
         let mut batched_reads: Vec<&crucible_protocol::ReadRequest> =

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -741,6 +741,10 @@ impl Region {
         &self,
         writes: &[crucible_protocol::Write],
     ) -> Result<(), CrucibleError> {
+        /*
+         * Batch writes so they can all be sent to the appropriate extent
+         * together.
+         */
         let mut batched_writes: HashMap<usize, Vec<&crucible_protocol::Write>> =
             HashMap::new();
 
@@ -778,7 +782,14 @@ impl Region {
     ) -> Result<Vec<crucible_protocol::ReadResponse>, CrucibleError> {
         let mut responses = Vec::with_capacity(requests.len());
 
-        // have to maintain order with reads! can't use hashmap
+        /*
+         * Batch reads so they can all be sent to the appropriate extent
+         * together.
+         *
+         * Note: Have to maintain order with reads! The Upstairs expects read
+         * responses to be in the same order as read requests, so we can't use
+         * a hashmap in the same way that batching writes can.
+         */
         let mut eid: Option<u64> = None;
         let mut batched_reads: Vec<&crucible_protocol::ReadRequest> =
             Vec::with_capacity(requests.len());


### PR DESCRIPTION
Use criterion to benchmark the downstairs functions region_read and region_write. This required adding a downstairs/src/lib.rs to the project because Criterion cannot use a binary crate as a dependency.

Also added test_big_write was also added to fully validate region_write and region_read.

The main performance gain of this PR is from sending all values in a giant INSERT OR REPLACE call in set_encryption_context, followed by a secondary performance improvement of reducing the number of lock operations on `region_*` by batching calls to the extent read and write functions.

Criterion results show a large improvement to the region_write micro benchmarks:

Before:
```
Created new region file "/tmp/.tmpPeXi5o/region.json"
Benchmarking region_write: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.9s, or reduce sample count to 80.
region_write            time:   [49.274 ms 49.387 ms 49.505 ms]                         
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

region_read             time:   [39.671 ms 39.794 ms 39.943 ms]                        
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

Benchmarking region_write with nonce and tag: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 547.3s, or reduce sample count to 10.
region_write with nonce and tag                                                                            
	                time:   [5.0685 s 5.1573 s 5.2230 s]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low severe
  1 (1.00%) high mild

region_read with nonce and tag                                                                            
	                time:   [43.019 ms 43.183 ms 43.362 ms]
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe
```

After:
```
Created new region file "/tmp/.tmpwWNFcL/region.json"
region_write            time:   [11.659 ms 11.719 ms 11.784 ms]                         
	                change: [-76.404% -76.271% -76.131%] (p = 0.00 < 0.05)
	                Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

region_read             time:   [41.086 ms 41.237 ms 41.404 ms]                        
	                change: [+3.0621% +3.6272% +4.1825%] (p = 0.00 < 0.05)
	                Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

Benchmarking region_write with nonce and tag: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 57.1s, or reduce sample count to 10.
region_write with nonce and tag                                                                            
	                time:   [539.00 ms 542.17 ms 545.58 ms]
	                change: [-89.637% -89.487% -89.295%] (p = 0.00 < 0.05)
	                Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  8 (8.00%) high mild
  3 (3.00%) high severe

region_read with nonce and tag                                                                            
	                time:   [43.466 ms 43.515 ms 43.568 ms]
	                change: [+0.3467% +0.7711% +1.1765%] (p = 0.00 < 0.05)
	                Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
```