### PR TITLE
Add test_up.sh and test_ds.sh to the github buildomat job

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -19,3 +19,6 @@ ptime -m cargo build --verbose
 
 banner test
 ptime -m cargo test --lib --verbose
+
+banner Josh is the best
+ptime -m ./tools/test_up.sh

--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -20,5 +20,8 @@ ptime -m cargo build --verbose
 banner test
 ptime -m cargo test --lib --verbose
 
-banner Josh is the best
+banner test_up.sh
 ptime -m ./tools/test_up.sh
+
+banner test_ds.sh
+ptime -m ./tools/test_ds.sh

--- a/tools/test_ds.sh
+++ b/tools/test_ds.sh
@@ -25,7 +25,7 @@ fi
 
 cds="./target/debug/crucible-downstairs"
 if [[ ! -f ${cds} ]]; then
-    echo "Can't find crucible binary at $cds or $cc"
+    echo "Can't find crucible binary at $cds"
     exit 1
 fi
 

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 #
 # Simple script to start three downstairs, then run through all the tests
-# that exist on the crucible client program.  This should eventually either
-# move to some common test framework, or be thrown away.
+# that exist on the crucible client program, as well as a few other tests.
+# This should eventually either move to some common test framework, or be
+# thrown away.
 
 set -o pipefail
 SECONDS=0
@@ -126,7 +127,7 @@ else
     echo "dump test 2 passed"
 fi
 
-echo "Tests have completed, stopping all downstairs"
+echo "Upstairs tests have completed, stopping all downstairs"
 for pid in ${downstairs[*]}; do
     kill $pid >/dev/null 2>&1
     wait $pid


### PR DESCRIPTION
Now whenever the buildomat jobs run, it will include test_up.sh and test_ds.sh
Those two should add less than 6 minutes to the operation.

This is really the start of some sort of automated testing.  We can add and delete things from the build-and-test.sh script as we see fit.