### PR TITLE
Allow 20Mib regions, require one option to dump

### DIFF
--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -222,13 +222,13 @@ impl RegionOptions {
         }
 
         let bs = self.extent_size.value.saturating_mul(self.block_size);
-        if bs > 10 * 1024 * 1024 {
+        if bs > 20 * 1024 * 1024 {
             /*
              * For now, make sure we don't accidentally try to use a gigantic
              * extent.
              */
             bail!(
-                "extent size {:?} x {} bytes = {}MB, bigger than 10MB",
+                "extent size {:?} x {} bytes = {}MB, bigger than 20MB",
                 self.extent_size,
                 self.block_size,
                 bs / 1024 / 1024

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -1557,6 +1557,9 @@ async fn main() -> Result<()> {
             extent,
             only_show_differences,
         } => {
+            if data.is_empty() {
+                bail!("Need at least one data directory to dump");
+            }
             dump_region(data, extent, only_show_differences)?;
             Ok(())
         }


### PR DESCRIPTION
Open the door to larger region sizes (20Mib)
Check for and return error if the dump command has no regions
to dump.