### PR TITLE
Fix compiler warnings from downstairs lib stub

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -16,3 +16,17 @@ use crucible_protocol::*;
 mod dump;
 mod region;
 pub use region::Region;
+
+/*
+ * This function exists only to prevent the compiler warnings that are
+ * otherwise produced when we include the dump.rs file.  It's a big
+ * cascade of dependencies that require it and having this exposed here
+ * will satisfy the compiler.
+ */
+pub fn lib_dump_region(
+    region_dir: Vec<PathBuf>,
+    cmp_extent: Option<u32>,
+    only_show_differences: bool,
+) -> Result<()> {
+    dump::dump_region(region_dir, cmp_extent, only_show_differences)
+}


### PR DESCRIPTION
This is a fix for issue #150 where the downstairs library stub needed
for cargo bench was creating compiler warnings.