### PR TITLE
Store multiple encryption contexts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +611,7 @@ dependencies = [
  "ringbuffer",
  "rusqlite",
  "serde",
+ "sha2 0.10.1",
  "structopt",
  "tempfile",
  "tokio",
@@ -719,6 +729,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +845,17 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
+dependencies = [
+ "block-buffer 0.10.0",
+ "crypto-common",
  "generic-array 0.14.4",
 ]
 
@@ -2118,7 +2148,7 @@ dependencies = [
  "md-5",
  "memchr",
  "rand",
- "sha2",
+ "sha2 0.9.8",
  "stringprep",
 ]
 
@@ -2823,6 +2853,17 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.1",
 ]
 
 [[package]]

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -34,6 +34,7 @@ tracing-opentelemetry = "0.14.0"
 uuid = { version = "0.8", features = [ "serde", "v4" ] }
 rusqlite = { version = "0.25" }
 hex = "0.4"
+sha2 = "0.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 Oxide Computer Company
 use super::*;
 use crate::region::ExtentMeta;
-use sha2::{Sha256, Digest};
+use sha2::{Digest, Sha256};
 
 #[derive(Debug, Default)]
 struct ExtInfo {
@@ -499,7 +499,8 @@ fn show_extent_block(
         for dir_index in 0..dir_count {
             let mut hasher = Sha256::new();
             hasher.update(&dvec[dir_index].data[..]);
-            println!("{:>6}  {:64}  {:^3}",
+            println!(
+                "{:>6}  {:64}  {:^3}",
                 dir_index,
                 hex::encode(hasher.finalize()),
                 status_letters[dir_index],
@@ -535,7 +536,7 @@ fn show_extent_block(
 
             max_nonce_depth = std::cmp::max(
                 max_nonce_depth,
-                dvec[dir_index].encryption_contexts.len()
+                dvec[dir_index].encryption_contexts.len(),
             );
         }
         if !only_show_differences {
@@ -550,7 +551,8 @@ fn show_extent_block(
             let mut nonces = Vec::with_capacity(dir_count);
             for dir_index in 0..dir_count {
                 let ctxs = &dvec[dir_index].encryption_contexts;
-                print!("{:^24} ",
+                print!(
+                    "{:^24} ",
                     if depth < ctxs.len() {
                         nonces.push(&ctxs[depth].nonce);
                         hex::encode(&ctxs[depth].nonce)
@@ -579,7 +581,7 @@ fn show_extent_block(
 
             max_tag_depth = std::cmp::max(
                 max_tag_depth,
-                dvec[dir_index].encryption_contexts.len()
+                dvec[dir_index].encryption_contexts.len(),
             );
         }
         if !only_show_differences {
@@ -594,7 +596,8 @@ fn show_extent_block(
             let mut tags = Vec::with_capacity(dir_count);
             for dir_index in 0..dir_count {
                 let ctxs = &dvec[dir_index].encryption_contexts;
-                print!("{:^32} ",
+                print!(
+                    "{:^32} ",
                     if depth < ctxs.len() {
                         tags.push(&ctxs[depth].tag);
                         hex::encode(&ctxs[depth].tag)

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -1,6 +1,7 @@
 // Copyright 2021 Oxide Computer Company
 use super::*;
 use crate::region::ExtentMeta;
+use sha2::{Sha256, Digest};
 
 #[derive(Debug, Default)]
 struct ExtInfo {
@@ -10,11 +11,13 @@ struct ExtInfo {
 /*
  * Dump the metadata for one or more region directories.
  *
- * If a specific extent is requested, only dump info on that extent.
+ * If a specific extent is requested, only dump info on that extent. If a
+ * specific block offset is supplied, show details for only that block.
  */
 pub fn dump_region(
     region_dir: Vec<PathBuf>,
     cmp_extent: Option<u32>,
+    block: Option<u64>,
     only_show_differences: bool,
 ) -> Result<()> {
     /*
@@ -91,10 +94,33 @@ pub fn dump_region(
                 total_extents,
             );
         }
+
         if dir_count < 2 {
             bail!("Need more than one region directory to compare data");
         }
+
         let en = all_extents.get(&ce).unwrap();
+
+        /*
+         * If we only want details about one block, show that
+         */
+        if let Some(block) = block {
+            if block >= blocks_per_extent {
+                bail!(
+                    "Requested block {} is higher than {}!",
+                    block,
+                    blocks_per_extent
+                );
+            }
+
+            return show_extent_block(
+                region_dir,
+                ce,
+                block,
+                only_show_differences,
+            );
+        }
+
         show_extent(
             region_dir,
             &en.ei_hm,
@@ -388,6 +414,202 @@ fn show_extent(
 
     if difference_found {
         bail!("Difference found!");
+    }
+
+    Ok(())
+}
+
+fn is_all_same<T: PartialEq>(slice: &[T]) -> bool {
+    slice.windows(2).all(|x| x[0] == x[1])
+}
+
+/*
+ * Show detailed comparison of different region's blocks
+ */
+fn show_extent_block(
+    region_dir: Vec<PathBuf>,
+    cmp_extent: u32,
+    block: u64,
+    only_show_differences: bool,
+) -> Result<()> {
+    println!("Extent {} Block {}", cmp_extent, block);
+    println!();
+
+    let dir_count = region_dir.len();
+
+    /*
+     * Build a Vector to hold our responses, one for each
+     * region we are comparing.
+     */
+    let mut dvec: Vec<ReadResponse> = Vec::with_capacity(dir_count);
+
+    /*
+     * Read the requested block in from the extent.  Store it
+     * in the Vec based on index.
+     */
+    for (index, dir) in region_dir.iter().enumerate() {
+        let region = Region::open(&dir, Default::default(), false)?;
+
+        dvec.insert(
+            index,
+            region.single_block_region_read(ReadRequest {
+                eid: cmp_extent as u64,
+                offset: Block::new_with_ddef(block, &region.def()),
+                num_blocks: 1,
+            })?,
+        );
+    }
+
+    /*
+     * Compare data
+     */
+    let mut different = false;
+    let mut status_letters = vec![String::new(); 3];
+
+    if dvec[0].data == dvec[1].data {
+        status_letters[0] += "A";
+        status_letters[1] += "A";
+
+        if dir_count > 2 {
+            if dvec[0].data == dvec[2].data {
+                status_letters[2] += "A";
+            } else {
+                status_letters[2] += "C";
+                different = true;
+            }
+        }
+    } else {
+        different = true;
+        status_letters[0] += "A";
+        status_letters[1] += "B";
+
+        if dir_count > 2 {
+            if dvec[0].data == dvec[2].data {
+                status_letters[2] += "A";
+            } else if dvec[1].data == dvec[2].data {
+                status_letters[2] += "B";
+            } else {
+                status_letters[2] += "C";
+            }
+        }
+    }
+
+    if !only_show_differences || different {
+        println!("{:>6}  {:<64}  {:3}", "DATA", "SHA256", "VER");
+        for dir_index in 0..dir_count {
+            let mut hasher = Sha256::new();
+            hasher.update(&dvec[dir_index].data[..]);
+            println!("{:>6}  {:64}  {:^3}",
+                dir_index,
+                hex::encode(hasher.finalize()),
+                status_letters[dir_index],
+            );
+        }
+        println!();
+    }
+
+    /*
+     * Compare encryption contexts
+     */
+    let mut different = false;
+    if dvec[0].encryption_contexts == dvec[1].encryption_contexts {
+        if dir_count > 2 {
+            if dvec[0].encryption_contexts != dvec[2].encryption_contexts {
+                different = true;
+            }
+        }
+    } else {
+        different = true;
+    }
+
+    if !only_show_differences || different {
+        /*
+         * Compare nonces (formatting assumes 12 byte nonces)
+         */
+        print!("{:>6}  ", "NONCES");
+
+        let mut max_nonce_depth = 0;
+
+        for dir_index in 0..dir_count {
+            print!("{:^24} ", dir_index);
+
+            max_nonce_depth = std::cmp::max(
+                max_nonce_depth,
+                dvec[dir_index].encryption_contexts.len()
+            );
+        }
+        if !only_show_differences {
+            print!(" {:<5}", "DIFF");
+        }
+        println!();
+
+        for depth in 0..max_nonce_depth {
+            print!("{:>6}  ", depth);
+
+            let mut all_same_len = true;
+            let mut nonces = Vec::with_capacity(dir_count);
+            for dir_index in 0..dir_count {
+                let ctxs = &dvec[dir_index].encryption_contexts;
+                print!("{:^24} ",
+                    if depth < ctxs.len() {
+                        nonces.push(&ctxs[depth].nonce);
+                        hex::encode(&ctxs[depth].nonce)
+                    } else {
+                        all_same_len = false;
+                        "".to_string()
+                    }
+                );
+            }
+            if !all_same_len || !is_all_same(&nonces) {
+                print!(" {:<5}", "<---");
+            }
+            println!();
+        }
+        println!();
+
+        /*
+         * Compare tags (formatting assumes 16 byte tags)
+         */
+        print!("{:>6}  ", "TAGS");
+
+        let mut max_tag_depth = 0;
+
+        for dir_index in 0..dir_count {
+            print!("{:^32} ", dir_index);
+
+            max_tag_depth = std::cmp::max(
+                max_tag_depth,
+                dvec[dir_index].encryption_contexts.len()
+            );
+        }
+        if !only_show_differences {
+            print!(" {:<5}", "DIFF");
+        }
+        println!();
+
+        for depth in 0..max_tag_depth {
+            print!("{:>6}  ", depth);
+
+            let mut all_same_len = true;
+            let mut tags = Vec::with_capacity(dir_count);
+            for dir_index in 0..dir_count {
+                let ctxs = &dvec[dir_index].encryption_contexts;
+                print!("{:^32} ",
+                    if depth < ctxs.len() {
+                        tags.push(&ctxs[depth].tag);
+                        hex::encode(&ctxs[depth].tag)
+                    } else {
+                        all_same_len = false;
+                        "".to_string()
+                    }
+                );
+            }
+            if !all_same_len || !is_all_same(&tags) {
+                print!(" {:<5}", "<---");
+            }
+            println!();
+        }
+        println!();
     }
 
     Ok(())

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -236,11 +236,7 @@ fn show_extent(
     }
     print!(" ");
     for (index, _) in region_dir.iter().enumerate() {
-        print!(" {0:^6}", format!("NONCE{}", index));
-    }
-    print!(" ");
-    for (index, _) in region_dir.iter().enumerate() {
-        print!(" {0:^4}", format!("TAG{}", index));
+        print!(" {0:^6}", format!("ECTX{}", index));
     }
     if !only_show_differences {
         print!(" {0:^5}", "DIFF");
@@ -255,9 +251,7 @@ fn show_extent(
     for block in 0..blocks_per_extent {
         let mut data_columns: [String; 3] =
             ["".to_string(), "".to_string(), "".to_string()];
-        let mut nonce_columns: [String; 3] =
-            ["".to_string(), "".to_string(), "".to_string()];
-        let mut tag_columns: [String; 3] =
+        let mut encryption_context_columns: [String; 3] =
             ["".to_string(), "".to_string(), "".to_string()];
 
         /*
@@ -332,15 +326,15 @@ fn show_extent(
                 format!("{0:^5} ", status_letters[dir_index]);
         }
 
-        // then, compare nonces
+        // then, compare encryption_context_columns
         let mut status_letters = vec![String::new(); 3];
 
-        if dvec[0].nonce == dvec[1].nonce {
+        if dvec[0].encryption_contexts == dvec[1].encryption_contexts {
             status_letters[0] += "A";
             status_letters[1] += "A";
 
             if dir_count > 2 {
-                if dvec[0].nonce == dvec[2].nonce {
+                if dvec[0].encryption_contexts == dvec[2].encryption_contexts {
                     status_letters[2] += "A";
                 } else {
                     status_letters[2] += "C";
@@ -353,9 +347,11 @@ fn show_extent(
             status_letters[1] += "B";
 
             if dir_count > 2 {
-                if dvec[0].nonce == dvec[2].nonce {
+                if dvec[0].encryption_contexts == dvec[2].encryption_contexts {
                     status_letters[2] += "A";
-                } else if dvec[1].nonce == dvec[2].nonce {
+                } else if dvec[1].encryption_contexts
+                    == dvec[2].encryption_contexts
+                {
                     status_letters[2] += "B";
                 } else {
                     status_letters[2] += "C";
@@ -365,44 +361,8 @@ fn show_extent(
 
         // Print nonce status letters
         for dir_index in 0..dir_count {
-            nonce_columns[dir_index] =
+            encryption_context_columns[dir_index] =
                 format!("{0:^6} ", status_letters[dir_index]);
-        }
-
-        // then, compare tags
-        let mut status_letters = vec![String::new(); 3];
-
-        if dvec[0].tag == dvec[1].tag {
-            status_letters[0] += "A";
-            status_letters[1] += "A";
-
-            if dir_count > 2 {
-                if dvec[0].tag == dvec[2].tag {
-                    status_letters[2] += "A";
-                } else {
-                    status_letters[2] += "C";
-                    different = true;
-                }
-            }
-        } else {
-            different = true;
-            status_letters[0] += "A";
-            status_letters[1] += "B";
-
-            if dir_count > 2 {
-                if dvec[0].tag == dvec[2].tag {
-                    status_letters[2] += "A";
-                } else if dvec[1].tag == dvec[2].tag {
-                    status_letters[2] += "B";
-                } else {
-                    status_letters[2] += "C";
-                }
-            }
-        }
-
-        for dir_index in 0..dir_count {
-            tag_columns[dir_index] =
-                format!("{0:^4} ", status_letters[dir_index]);
         }
 
         if !only_show_differences || different {
@@ -412,11 +372,7 @@ fn show_extent(
                 print!("{}", column);
             }
             print!(" ");
-            for column in nonce_columns.iter().take(dir_count) {
-                print!("{}", column);
-            }
-            print!(" ");
-            for column in tag_columns.iter().take(dir_count) {
+            for column in encryption_context_columns.iter().take(dir_count) {
                 print!("{}", column);
             }
 

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -514,10 +514,10 @@ fn show_extent_block(
      */
     let mut different = false;
     if dvec[0].encryption_contexts == dvec[1].encryption_contexts {
-        if dir_count > 2 {
-            if dvec[0].encryption_contexts != dvec[2].encryption_contexts {
-                different = true;
-            }
+        if (dir_count > 2)
+            && (dvec[0].encryption_contexts != dvec[2].encryption_contexts)
+        {
+            different = true;
         }
     } else {
         different = true;
@@ -531,12 +531,12 @@ fn show_extent_block(
 
         let mut max_nonce_depth = 0;
 
-        for dir_index in 0..dir_count {
+        for (dir_index, response) in dvec.iter().enumerate() {
             print!("{:^24} ", dir_index);
 
             max_nonce_depth = std::cmp::max(
                 max_nonce_depth,
-                dvec[dir_index].encryption_contexts.len(),
+                response.encryption_contexts.len(),
             );
         }
         if !only_show_differences {
@@ -549,8 +549,8 @@ fn show_extent_block(
 
             let mut all_same_len = true;
             let mut nonces = Vec::with_capacity(dir_count);
-            for dir_index in 0..dir_count {
-                let ctxs = &dvec[dir_index].encryption_contexts;
+            for response in dvec.iter() {
+                let ctxs = &response.encryption_contexts;
                 print!(
                     "{:^24} ",
                     if depth < ctxs.len() {
@@ -576,12 +576,12 @@ fn show_extent_block(
 
         let mut max_tag_depth = 0;
 
-        for dir_index in 0..dir_count {
+        for (dir_index, response) in dvec.iter().enumerate() {
             print!("{:^32} ", dir_index);
 
             max_tag_depth = std::cmp::max(
                 max_tag_depth,
-                dvec[dir_index].encryption_contexts.len(),
+                response.encryption_contexts.len(),
             );
         }
         if !only_show_differences {
@@ -594,8 +594,8 @@ fn show_extent_block(
 
             let mut all_same_len = true;
             let mut tags = Vec::with_capacity(dir_count);
-            for dir_index in 0..dir_count {
-                let ctxs = &dvec[dir_index].encryption_contexts;
+            for response in dvec.iter() {
+                let ctxs = &response.encryption_contexts;
                 print!(
                     "{:^32} ",
                     if depth < ctxs.len() {

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -26,7 +26,8 @@ pub use region::Region;
 pub fn lib_dump_region(
     region_dir: Vec<PathBuf>,
     cmp_extent: Option<u32>,
+    block: Option<u64>,
     only_show_differences: bool,
 ) -> Result<()> {
-    dump::dump_region(region_dir, cmp_extent, only_show_differences)
+    dump::dump_region(region_dir, cmp_extent, block, only_show_differences)
 }

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -66,6 +66,7 @@ enum Args {
      * Multiple directories can be passed (up to 3)
      * With -e, you can dump just a single extent which will include
      * a block by block comparison.
+     * With -b, you can dump a single block to see a detailed comparison.
      */
     Dump {
         /*
@@ -79,6 +80,12 @@ enum Args {
          */
         #[structopt(short, long)]
         extent: Option<u32>,
+
+        /*
+         * Detailed view for a block
+         */
+        #[structopt(short, long)]
+        block: Option<u64>,
 
         /*
          * Only show differences
@@ -1555,12 +1562,13 @@ async fn main() -> Result<()> {
         Args::Dump {
             data,
             extent,
+            block,
             only_show_differences,
         } => {
             if data.is_empty() {
                 bail!("Need at least one data directory to dump");
             }
-            dump_region(data, extent, only_show_differences)?;
+            dump_region(data, extent, block, only_show_differences)?;
             Ok(())
         }
         Args::Export {

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -8,6 +8,7 @@ use std::sync::{Mutex, MutexGuard};
 
 use anyhow::{bail, Result};
 use crucible_common::*;
+use crucible_protocol::EncryptionContext;
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
@@ -109,61 +110,99 @@ impl Inner {
         Ok(())
     }
 
-    fn get_encryption_context(
+    /*
+     * For a given block, return all encryption contexts since last fsync.
+     * Order so latest is last.
+     */
+    fn get_encryption_contexts(
         &self,
         block: u64,
-    ) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
-        let mut stmt = self.metadb.prepare(
-            &[
-                "SELECT nonce, tag FROM encryption_context",
-                "where block=?1",
-            ]
-            .join(" "),
-        )?;
+    ) -> Result<Vec<EncryptionContext>> {
+        // NOTE: "ORDER BY RANDOM()" would be a good --lossy addition here
+        let stmt = vec![
+            "SELECT nonce, tag FROM encryption_context where block=?1",
+            "ORDER BY counter ASC",
+        ]
+        .join(" ");
 
-        let stmt_iter = stmt.query_map(params![block], |row| {
-            Ok(Some((row.get(0)?, row.get(1)?)))
-        })?;
+        let mut stmt = self.metadb.prepare(&stmt)?;
+
+        let stmt_iter = stmt
+            .query_map(params![block], |row| Ok((row.get(0)?, row.get(1)?)))?;
 
         let mut results = Vec::new();
 
         for row in stmt_iter {
-            results.push(row);
+            let (nonce, tag) = row?;
+            results.push(EncryptionContext { nonce, tag });
         }
 
-        if results.is_empty() {
-            Ok(None)
-        } else {
-            assert_eq!(results.len(), 1);
-            let result = results.pop().unwrap();
-            drop(results);
-            result.map_err(anyhow::Error::new)
-        }
+        Ok(results)
     }
 
+    /*
+     * Given a list of (block, nonce, tag), append encryption context rows.
+     *
+     * For the params, keep a list of references so that copying is
+     * minimized.
+     */
     fn set_encryption_context(
         &mut self,
-        encryption_context_params: &[(u64, &[u8], &[u8])],
+        encryption_context_params: &[(u64, &EncryptionContext)],
     ) -> Result<()> {
-        let stmt: Vec<String> = vec![
-            "INSERT OR REPLACE INTO encryption_context".to_string(),
-            "(block, nonce, tag) values".to_string(),
-            encryption_context_params
-                .iter()
-                .map(|tuple| {
-                    let (block, nonce, tag) = tuple;
-                    format!(
-                        "({}, X'{}', X'{}')",
-                        block,
-                        hex::encode(nonce),
-                        hex::encode(tag),
-                    )
-                })
-                .collect::<Vec<String>>()
-                .join(","),
-        ];
+        let mut stmts: Vec<String> =
+            Vec::with_capacity(encryption_context_params.len());
 
-        let _rows_affected = self.metadb.execute(&stmt.join(" "), [])?;
+        for params in encryption_context_params {
+            let (block, encryption_context) = params;
+            let stmt: String = vec![format!(
+                "({}, {}, X'{}', X'{}')",
+                /*
+                 * Auto-increment counter based on what's in the db
+                 */
+                vec![
+                    "(SELECT IFNULL(MAX(counter),0) + 1".to_string(),
+                    format!("from encryption_context WHERE block={})", block,),
+                ]
+                .join(" "),
+                block,
+                hex::encode(&encryption_context.nonce),
+                hex::encode(&encryption_context.tag),
+            )]
+            .join(" ");
+
+            stmts.push(stmt);
+        }
+
+        let mut stmt: String = vec![
+            "INSERT INTO encryption_context".to_string(),
+            "(counter, block, nonce, tag) values".to_string(),
+        ]
+        .join(" ");
+        stmt.push_str(&stmts.join(","));
+
+        let rows_affected = self.metadb.execute(&stmt, [])?;
+
+        assert_eq!(rows_affected, encryption_context_params.len());
+
+        Ok(())
+    }
+
+    /*
+     * Get rid of all but largest encryption contexts
+     */
+    fn truncate_encryption_contexts(&mut self) -> Result<()> {
+        let stmt: String = vec![
+            "DELETE FROM encryption_context WHERE ROWID not in",
+            "(select ROWID from",
+            "(select ROWID,block,MAX(counter)",
+            "from encryption_context group by block)",
+            ");",
+            "UPDATE encryption_context SET counter = 0 WHERE block = ?1",
+        ]
+        .join(" ");
+
+        let _rows_affected = self.metadb.execute(&stmt, [])?;
 
         Ok(())
     }
@@ -270,6 +309,7 @@ impl Extent {
         let metadb = Connection::open(&path)?;
         assert!(metadb.is_autocommit());
         metadb.pragma_update(None, "journal_mode", &"WAL")?;
+        metadb.pragma_update(None, "synchronous", &"FULL")?;
 
         // XXX: schema updates?
 
@@ -324,6 +364,7 @@ impl Extent {
         let metadb = Connection::open(&path)?;
         assert!(metadb.is_autocommit());
         metadb.pragma_update(None, "journal_mode", &"WAL")?;
+        metadb.pragma_update(None, "synchronous", &"FULL")?;
 
         /*
          * Create tables and insert base data
@@ -359,9 +400,11 @@ impl Extent {
 
         metadb.execute(
             "CREATE TABLE encryption_context (
-                block INTEGER PRIMARY KEY,
+                counter INTEGER,
+                block INTEGER,
                 nonce BLOB NOT NULL,
-                tag BLOB NOT NULL
+                tag BLOB NOT NULL,
+                PRIMARY KEY (block, counter)
             )",
             [],
         )?;
@@ -413,11 +456,8 @@ impl Extent {
              */
             inner.file.read_exact(&mut response.data)?;
 
-            let ctx = inner.get_encryption_context(request.offset.value)?;
-            if let Some((nonce, tag)) = ctx {
-                response.nonce = Some(nonce);
-                response.tag = Some(tag);
-            }
+            response.encryption_contexts =
+                inner.get_encryption_contexts(request.offset.value)?;
 
             responses.push(response);
         }
@@ -472,7 +512,7 @@ impl Extent {
 
         inner.set_dirty()?;
 
-        let mut encryption_context_params: Vec<(u64, &[u8], &[u8])> =
+        let mut encryption_context_params: Vec<(u64, &EncryptionContext)> =
             Vec::with_capacity(writes.len());
 
         for write in writes {
@@ -481,12 +521,9 @@ impl Extent {
             inner.file.seek(SeekFrom::Start(byte_offset))?;
             inner.file.write_all(&write.data)?;
 
-            if write.nonce.is_some() && write.tag.is_some() {
-                encryption_context_params.push((
-                    write.offset.value,
-                    write.nonce.as_ref().unwrap(),
-                    write.tag.as_ref().unwrap(),
-                ));
+            if let Some(encryption_context) = &write.encryption_context {
+                encryption_context_params
+                    .push((write.offset.value, encryption_context));
             }
         }
 
@@ -529,6 +566,12 @@ impl Extent {
                 e
             );
         }
+
+        /*
+         * Clear old encryption contexts. In order to be crash consistent,
+         * only perform this after the extent fsync is done.
+         */
+        inner.truncate_encryption_contexts()?;
 
         inner.file.seek(SeekFrom::Start(0))?;
 
@@ -727,12 +770,20 @@ impl Region {
         nonce: Option<Vec<u8>>,
         tag: Option<Vec<u8>>,
     ) -> Result<(), CrucibleError> {
+        let encryption_context = if nonce.is_some() && tag.is_some() {
+            Some(EncryptionContext {
+                nonce: nonce.as_ref().unwrap().to_vec(),
+                tag: tag.as_ref().unwrap().to_vec(),
+            })
+        } else {
+            None
+        };
+
         self.region_write(&[crucible_protocol::Write {
             eid,
             offset,
             data,
-            nonce,
-            tag,
+            encryption_context,
         }])
     }
 
@@ -1135,33 +1186,112 @@ mod test {
 
         // Encryption context for blocks 0 and 1 should start blank
 
-        assert!(inner.get_encryption_context(0)?.is_none());
-        assert!(inner.get_encryption_context(1)?.is_none());
+        assert!(inner.get_encryption_contexts(0)?.is_empty());
+        assert!(inner.get_encryption_contexts(1)?.is_empty());
 
         // Set and verify block 0's context
 
-        inner.set_encryption_context(&[(0, &[1, 2, 3], &[4, 5, 6, 7])])?;
+        inner.set_encryption_context(&[(
+            0,
+            &EncryptionContext {
+                nonce: [1, 2, 3].to_vec(),
+                tag: [4, 5, 6, 7].to_vec(),
+            },
+        )])?;
 
-        let ctx = inner.get_encryption_context(0)?.unwrap();
+        let ctxs = inner.get_encryption_contexts(0)?;
 
-        assert_eq!(ctx.0, vec![1, 2, 3]);
-        assert_eq!(ctx.1, vec![4, 5, 6, 7]);
+        assert_eq!(ctxs.len(), 1);
+
+        assert_eq!(ctxs[0].nonce, vec![1, 2, 3]);
+        assert_eq!(ctxs[0].tag, vec![4, 5, 6, 7]);
 
         // Block 1 should still be blank
 
-        assert!(inner.get_encryption_context(1)?.is_none());
+        assert!(inner.get_encryption_contexts(1)?.is_empty());
 
         // Set and verify a new context for block 0
 
         let blob1 = rand::thread_rng().gen::<[u8; 32]>();
         let blob2 = rand::thread_rng().gen::<[u8; 32]>();
 
-        inner.set_encryption_context(&[(0, &blob1, &blob2)])?;
+        inner.set_encryption_context(&[(
+            0,
+            &EncryptionContext {
+                nonce: blob1.to_vec(),
+                tag: blob2.to_vec(),
+            },
+        )])?;
 
-        let ctx = inner.get_encryption_context(0)?.unwrap();
+        let ctxs = inner.get_encryption_contexts(0)?;
 
-        assert_eq!(ctx.0, blob1);
-        assert_eq!(ctx.1, blob2);
+        assert_eq!(ctxs.len(), 2);
+
+        assert_eq!(ctxs[0].nonce, vec![1, 2, 3]);
+        assert_eq!(ctxs[0].tag, vec![4, 5, 6, 7]);
+
+        assert_eq!(ctxs[1].nonce, blob1);
+        assert_eq!(ctxs[1].tag, blob2);
+
+        // "Flush", so only the latest should remain.
+        inner.truncate_encryption_contexts()?;
+
+        let ctxs = inner.get_encryption_contexts(0)?;
+
+        assert_eq!(ctxs.len(), 1);
+
+        assert_eq!(ctxs[0].nonce, blob1);
+        assert_eq!(ctxs[0].tag, blob2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn multiple_encryption_context() -> Result<()> {
+        let dir = tempdir()?;
+        let mut region = Region::create(&dir, new_region_options())?;
+        region.extend(1)?;
+
+        let ext = &region.extents[0];
+        let mut inner = ext.inner();
+
+        // Encryption context for blocks 0 and 1 should start blank
+
+        assert!(inner.get_encryption_contexts(0)?.is_empty());
+        assert!(inner.get_encryption_contexts(1)?.is_empty());
+
+        // Set and verify block 0's and 1's context
+
+        inner.set_encryption_context(&[
+            (
+                0,
+                &EncryptionContext {
+                    nonce: [1, 2, 3].to_vec(),
+                    tag: [4, 5, 6, 7].to_vec(),
+                },
+            ),
+            (
+                1,
+                &EncryptionContext {
+                    nonce: [4, 5, 6].to_vec(),
+                    tag: [8, 9, 0, 1].to_vec(),
+                },
+            ),
+        ])?;
+
+        let ctxs = inner.get_encryption_contexts(0)?;
+
+        assert_eq!(ctxs.len(), 1);
+
+        assert_eq!(ctxs[0].nonce, vec![1, 2, 3]);
+        assert_eq!(ctxs[0].tag, vec![4, 5, 6, 7]);
+
+        let ctxs = inner.get_encryption_contexts(1)?;
+
+        assert_eq!(ctxs.len(), 1);
+
+        assert_eq!(ctxs[0].nonce, vec![4, 5, 6]);
+        assert_eq!(ctxs[0].tag, vec![8, 9, 0, 1]);
 
         Ok(())
     }
@@ -1198,8 +1328,7 @@ mod test {
                 eid,
                 offset,
                 data: data.freeze(),
-                nonce: None,
-                tag: None,
+                encryption_context: None,
             });
         }
 

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -153,8 +153,7 @@ impl Inner {
         let mut stmts: Vec<String> =
             Vec::with_capacity(encryption_context_params.len());
 
-        for params in encryption_context_params {
-            let (block, encryption_context) = params;
+        for (block, encryption_context) in encryption_context_params {
             let stmt: String = vec![format!(
                 "({}, {}, X'{}', X'{}')",
                 /*

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -204,10 +204,8 @@ impl Inner {
 
         let _rows_affected = tx.execute(&stmt, [])?;
 
-        let _rows_affected = tx.execute(
-            &"UPDATE encryption_context SET counter = 0",
-            [],
-        )?;
+        let _rows_affected =
+            tx.execute(&"UPDATE encryption_context SET counter = 0", [])?;
 
         tx.commit()?;
 
@@ -220,12 +218,12 @@ impl Inner {
      */
     #[cfg(test)]
     fn get_blocks_and_counters(&mut self) -> Result<Vec<(u64, u64)>> {
-        let mut stmt = self.metadb.prepare(
-            &"SELECT block, counter FROM encryption_context"
-        )?;
+        let mut stmt = self
+            .metadb
+            .prepare(&"SELECT block, counter FROM encryption_context")?;
 
-        let stmt_iter = stmt
-            .query_map(params![], |row| Ok((row.get(0)?, row.get(1)?)))?;
+        let stmt_iter =
+            stmt.query_map(params![], |row| Ok((row.get(0)?, row.get(1)?)))?;
 
         let mut results = Vec::new();
 
@@ -1195,7 +1193,7 @@ mod test {
         /*
          * Dump the region
          */
-        dump_region(dvec, None,  None,false)?;
+        dump_region(dvec, None, None, false)?;
 
         Ok(())
     }

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1163,7 +1163,7 @@ mod test {
         /*
          * Dump the region
          */
-        dump_region(dvec, None, false)?;
+        dump_region(dvec, None, None, false)?;
 
         Ok(())
     }
@@ -1195,7 +1195,7 @@ mod test {
         /*
          * Dump the region
          */
-        dump_region(dvec, None, false)?;
+        dump_region(dvec, None,  None,false)?;
 
         Ok(())
     }
@@ -1228,7 +1228,7 @@ mod test {
         /*
          * Dump the region
          */
-        dump_region(dvec, Some(2), false)?;
+        dump_region(dvec, Some(2), None, false)?;
 
         Ok(())
     }

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -188,7 +188,7 @@ impl Inner {
     }
 
     /*
-     * Get rid of all but largest encryption contexts
+     * Get rid of all but most recent encryption context for each block.
      */
     fn truncate_encryption_contexts(&mut self) -> Result<()> {
         let stmt: String = vec![

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -205,7 +205,7 @@ impl Inner {
         let _rows_affected = tx.execute(&stmt, [])?;
 
         let _rows_affected =
-            tx.execute(&"UPDATE encryption_context SET counter = 0", [])?;
+            tx.execute("UPDATE encryption_context SET counter = 0", [])?;
 
         tx.commit()?;
 

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -163,6 +163,9 @@ fn main() -> Result<()> {
 
     for idx in 0..rounds {
         let cpf = if idx / handoff_amount != cpf_idx {
+            // One last flush
+            cpfs[cpf_idx].flush()?;
+
             cpf_idx = idx / handoff_amount;
             assert!(cpf_idx != 0);
 
@@ -256,6 +259,9 @@ fn main() -> Result<()> {
             cpf.write_all(&vec![0; bsz])?;
         }
     }
+
+    // One last flush
+    cpfs[cpf_idx].flush()?;
 
     println!("Done ok, waiting on show_work");
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -16,8 +16,7 @@ pub struct Write {
     pub eid: u64,
     pub offset: Block,
     pub data: bytes::Bytes,
-    pub nonce: Option<Vec<u8>>,
-    pub tag: Option<Vec<u8>>,
+    pub encryption_context: Option<EncryptionContext>,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -34,8 +33,13 @@ pub struct ReadResponse {
     pub num_blocks: u64,
 
     pub data: bytes::BytesMut,
-    pub nonce: Option<Vec<u8>>,
-    pub tag: Option<Vec<u8>>,
+    pub encryption_contexts: Vec<EncryptionContext>,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct EncryptionContext {
+    pub nonce: Vec<u8>,
+    pub tag: Vec<u8>,
 }
 
 impl ReadResponse {
@@ -55,8 +59,7 @@ impl ReadResponse {
             offset: request.offset,
             num_blocks: request.num_blocks,
             data,
-            nonce: None,
-            tag: None,
+            encryption_contexts: vec![],
         }
     }
 
@@ -69,8 +72,7 @@ impl ReadResponse {
             offset: request.offset,
             num_blocks: request.num_blocks,
             data: BytesMut::from(data),
-            nonce: None,
-            tag: None,
+            encryption_contexts: vec![],
         }
     }
 }
@@ -162,8 +164,10 @@ impl CrucibleEncoder {
                 data.resize(sz, 1);
                 bytes::Bytes::from(data)
             },
-            nonce: Some(vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-            tag: Some(vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            encryption_context: Some(EncryptionContext {
+                nonce: vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                tag: vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            }),
         }
     }
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1551,7 +1551,7 @@ impl Downstairs {
                             let encryption_context_iter =
                                 response.encryption_contexts.iter().rev();
                             for ctx in encryption_context_iter {
-                                // Note: decrypt_in_place does not overwrites
+                                // Note: decrypt_in_place does not overwrite
                                 // the buffer if it fails, otherwise we would
                                 // need to copy here.
                                 let decryption_result = context

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1532,26 +1532,50 @@ impl Downstairs {
                     let mut decryption_error = None;
 
                     for response in &mut responses {
-                        // XXX if we haven't encrypted it yet, is this an
-                        // attack?  block generation number would tell us
-                        if response.nonce.is_some() && response.tag.is_some() {
-                            let _nonce = response.nonce.as_ref().unwrap();
-                            let nonce = Nonce::from_slice(_nonce);
+                        // XXX because we don't have block generation numbers,
+                        // an attacker downstairs could:
+                        //
+                        // 1) remove encryption context and cause a denial of
+                        //    service, or
+                        // 2) roll back a block by writing an old data and
+                        //    encryption context
+                        //
+                        // check for response encryption contexts here
+                        if !response.encryption_contexts.is_empty() {
+                            let mut successful_decryption = false;
 
-                            let _tag = response.tag.as_ref().unwrap();
-                            let tag = Tag::from_slice(_tag);
+                            // Attempt decryption with each encryption context,
+                            // and fail if all do not work. The most recent
+                            // encryption context will most likely be the
+                            // correct one so start there.
+                            let encryption_context_iter =
+                                response.encryption_contexts.iter().rev();
+                            for ctx in encryption_context_iter {
+                                // Note: decrypt_in_place does not overwrites
+                                // the buffer if it fails, otherwise we would
+                                // need to copy here.
+                                let decryption_result = context
+                                    .decrypt_in_place(
+                                        &mut response.data[..],
+                                        Nonce::from_slice(&ctx.nonce[..]),
+                                        Tag::from_slice(&ctx.tag[..]),
+                                    );
 
-                            let decryption_result = context.decrypt_in_place(
-                                &mut response.data[..],
-                                nonce,
-                                tag,
-                            );
+                                if decryption_result.is_ok() {
+                                    successful_decryption = true;
+                                    break;
+                                }
+                            }
 
-                            if decryption_result.is_err() {
+                            if !successful_decryption {
                                 decryption_error =
                                     Some(Err(CrucibleError::DecryptionError));
                                 break;
                             }
+                        } else {
+                            // No encryption context! Either this is a read of
+                            // an unwritten block, or an attacker removed the
+                            // encryption contexts from the db
                         }
                     }
 
@@ -1565,7 +1589,7 @@ impl Downstairs {
                     responses
                 }
             } else {
-                // no encryption context
+                // no upstairs encryption context
                 responses
             };
 
@@ -2260,7 +2284,7 @@ impl Upstairs {
             let byte_len: usize =
                 num_blocks.value as usize * ddef.block_size() as usize;
 
-            let (sub_data, nonce, tag) = if let Some(context) =
+            let (sub_data, encryption_context) = if let Some(context) =
                 &self.encryption_context
             {
                 // Encrypt here
@@ -2268,18 +2292,23 @@ impl Upstairs {
                     data.slice(cur_offset..(cur_offset + byte_len)).to_vec();
                 let (nonce, tag) =
                     context.encrypt_in_place(&mut mut_data[..])?;
-                (Bytes::copy_from_slice(&mut_data), Some(nonce), Some(tag))
+                (
+                    Bytes::copy_from_slice(&mut_data),
+                    Some(crucible_protocol::EncryptionContext {
+                        nonce: Vec::from(nonce.as_slice()),
+                        tag: Vec::from(tag.as_slice()),
+                    }),
+                )
             } else {
                 // Unencrypted
-                (data.slice(cur_offset..(cur_offset + byte_len)), None, None)
+                (data.slice(cur_offset..(cur_offset + byte_len)), None)
             };
 
             writes.push(crucible_protocol::Write {
                 eid,
                 offset: bo,
                 data: sub_data,
-                nonce: nonce.map(|v| Vec::from(v.as_slice())),
-                tag: tag.map(|v| Vec::from(v.as_slice())),
+                encryption_context,
             });
 
             cur_offset += byte_len;


### PR DESCRIPTION
In order to be crash consistent, we have to store every encryption
context that corresponds to a data block until there's an extent fsync.
This is because sqlite will fsync after every operation but our extents
are only fsynced when the guest submits a flush. This commit sets the
synchronous pragma to FULL to be sure of this.

Add the "counter" column to the encryption context table and increment
it after every new encryption context insertion. Use counter to throw
away everything except the last row when a flush occurs.

Change ReadResponse to contain a list of encryption contexts, an the
upstairs will try each one of them in order to find the one that
decrypts the data successfully.