### PR TITLE
Implement integrity hashes

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -21,7 +21,8 @@ banner test
 ptime -m cargo test --lib --verbose
 
 banner test_up.sh
-ptime -m ./tools/test_up.sh
+ptime -m ./tools/test_up.sh unencrypted
+ptime -m ./tools/test_up.sh encrypted
 
 banner test_ds.sh
 ptime -m ./tools/test_ds.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,28 +692,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa 0.4.8",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ctr"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,11 +506,13 @@ name = "crucible-common"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
  "toml",
+ "twox-hash",
  "uuid",
 ]
 
@@ -2874,6 +2876,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "steno"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/steno?branch=main#c6ea85cfd268668a5974741b308d89acfae76063"
@@ -3381,6 +3389,17 @@ dependencies = [
  "thiserror",
  "url",
  "utf-8",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
+dependencies = [
+ "cfg-if",
+ "rand",
+ "static_assertions",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -13,3 +13,5 @@ toml = "0.5"
 tempfile = "3"
 thiserror = "1.0"
 uuid = { version = "0.8", features = [ "serde", "v4" ] }
+twox-hash = "1.6.2"
+rusqlite = { version = "0.26" }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,5 +1,6 @@
 // Copyright 2021 Oxide Computer Company
 use std::fs::File;
+use std::hash::Hasher;
 use std::io::{ErrorKind, Read, Write};
 use std::path::Path;
 
@@ -57,6 +58,9 @@ pub enum CrucibleError {
 
     #[error("Decryption failed!")]
     DecryptionError,
+
+    #[error("Integrity hash mismatch!")]
+    HashMismatch,
 }
 
 impl From<std::io::Error> for CrucibleError {
@@ -75,6 +79,12 @@ impl Into<std::io::Error> for CrucibleError {
 
 impl From<anyhow::Error> for CrucibleError {
     fn from(e: anyhow::Error) -> Self {
+        CrucibleError::GenericError(format!("{:?}", e))
+    }
+}
+
+impl From<rusqlite::Error> for CrucibleError {
+    fn from(e: rusqlite::Error) -> Self {
         CrucibleError::GenericError(format!("{:?}", e))
     }
 }
@@ -140,4 +150,12 @@ where
 
 pub fn mkdir_for_file(file: &Path) -> Result<()> {
     Ok(std::fs::create_dir_all(file.parent().expect("file path"))?)
+}
+
+pub fn integrity_hash(args: &[&[u8]]) -> u64 {
+    let mut hasher: twox_hash::XxHash64 = Default::default();
+    for arg in args {
+        hasher.write(arg);
+    }
+    hasher.finish()
 }

--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -122,11 +122,9 @@ pub struct RegionDefinition {
     uuid: Uuid,
 
     /**
-     * 0 if no upstairs has ever connected
-     * 1 if an upstairs previously connected without encryption
-     * 2 if an upstairs previously connected with encryption
+     * region expects upstairs to be encrypted
      */
-    upstairs_previous_connection: u32,
+    expect_upstairs_encrypted: bool,
 }
 
 impl RegionDefinition {
@@ -137,7 +135,7 @@ impl RegionDefinition {
             extent_size: opts.extent_size,
             extent_count: 0,
             uuid: opts.uuid,
-            upstairs_previous_connection: 0,
+            expect_upstairs_encrypted: opts.expect_upstairs_encrypted,
         })
     }
 
@@ -177,16 +175,8 @@ impl RegionDefinition {
         self.uuid = uuid;
     }
 
-    pub fn get_upstairs_previous_connection(&self) -> u32 {
-        self.upstairs_previous_connection
-    }
-
-    pub fn set_upstairs_previous_connection(&mut self, is_encrypted: bool) {
-        if is_encrypted {
-            self.upstairs_previous_connection = 2;
-        } else {
-            self.upstairs_previous_connection = 1;
-        }
+    pub fn get_expect_upstairs_encrypted(&self) -> bool {
+        self.expect_upstairs_encrypted
     }
 }
 
@@ -201,7 +191,7 @@ impl Default for RegionDefinition {
             extent_size: Block::new(0, 9),
             extent_count: 0,
             uuid: Uuid::nil(),
-            upstairs_previous_connection: 0,
+            expect_upstairs_encrypted: false,
         }
     }
 }
@@ -222,6 +212,11 @@ pub struct RegionOptions {
      * UUID for this region
      */
     uuid: Uuid,
+
+    /**
+     * region expects upstairs to be encrypted
+     */
+    expect_upstairs_encrypted: bool,
 }
 
 impl RegionOptions {
@@ -270,6 +265,13 @@ impl RegionOptions {
     pub fn set_uuid(&mut self, uuid: Uuid) {
         self.uuid = uuid;
     }
+
+    pub fn set_expect_upstairs_encrypted(
+        &mut self,
+        expect_upstairs_encrypted: bool,
+    ) {
+        self.expect_upstairs_encrypted = expect_upstairs_encrypted;
+    }
 }
 
 impl Default for RegionOptions {
@@ -280,6 +282,7 @@ impl Default for RegionOptions {
             block_size: MIN_BLOCK_SIZE as u64,
             extent_size: Block::new(100, 9),
             uuid: Uuid::nil(),
+            expect_upstairs_encrypted: false,
         }
     }
 }

--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -120,6 +120,13 @@ pub struct RegionDefinition {
      * UUID for this region
      */
     uuid: Uuid,
+
+    /**
+     * 0 if no upstairs has ever connected
+     * 1 if an upstairs previously connected without encryption
+     * 2 if an upstairs previously connected with encryption
+     */
+    upstairs_previous_connection: u32,
 }
 
 impl RegionDefinition {
@@ -130,6 +137,7 @@ impl RegionDefinition {
             extent_size: opts.extent_size,
             extent_count: 0,
             uuid: opts.uuid,
+            upstairs_previous_connection: 0,
         })
     }
 
@@ -168,6 +176,18 @@ impl RegionDefinition {
     pub fn set_uuid(&mut self, uuid: Uuid) {
         self.uuid = uuid;
     }
+
+    pub fn get_upstairs_previous_connection(&self) -> u32 {
+        self.upstairs_previous_connection
+    }
+
+    pub fn set_upstairs_previous_connection(&mut self, is_encrypted: bool) {
+        if is_encrypted {
+            self.upstairs_previous_connection = 2;
+        } else {
+            self.upstairs_previous_connection = 1;
+        }
+    }
 }
 
 /**
@@ -181,6 +201,7 @@ impl Default for RegionDefinition {
             extent_size: Block::new(0, 9),
             extent_count: 0,
             uuid: Uuid::nil(),
+            upstairs_previous_connection: 0,
         }
     }
 }

--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -122,9 +122,9 @@ pub struct RegionDefinition {
     uuid: Uuid,
 
     /**
-     * region expects upstairs to be encrypted
+     * region data will be encrypted
      */
-    expect_upstairs_encrypted: bool,
+    encrypted: bool,
 }
 
 impl RegionDefinition {
@@ -135,7 +135,7 @@ impl RegionDefinition {
             extent_size: opts.extent_size,
             extent_count: 0,
             uuid: opts.uuid,
-            expect_upstairs_encrypted: opts.expect_upstairs_encrypted,
+            encrypted: opts.encrypted,
         })
     }
 
@@ -175,8 +175,8 @@ impl RegionDefinition {
         self.uuid = uuid;
     }
 
-    pub fn get_expect_upstairs_encrypted(&self) -> bool {
-        self.expect_upstairs_encrypted
+    pub fn get_encrypted(&self) -> bool {
+        self.encrypted
     }
 }
 
@@ -191,7 +191,7 @@ impl Default for RegionDefinition {
             extent_size: Block::new(0, 9),
             extent_count: 0,
             uuid: Uuid::nil(),
-            expect_upstairs_encrypted: false,
+            encrypted: false,
         }
     }
 }
@@ -214,9 +214,9 @@ pub struct RegionOptions {
     uuid: Uuid,
 
     /**
-     * region expects upstairs to be encrypted
+     * region data will be encrypted
      */
-    expect_upstairs_encrypted: bool,
+    encrypted: bool,
 }
 
 impl RegionOptions {
@@ -266,11 +266,8 @@ impl RegionOptions {
         self.uuid = uuid;
     }
 
-    pub fn set_expect_upstairs_encrypted(
-        &mut self,
-        expect_upstairs_encrypted: bool,
-    ) {
-        self.expect_upstairs_encrypted = expect_upstairs_encrypted;
+    pub fn set_encrypted(&mut self, encrypted: bool) {
+        self.encrypted = encrypted;
     }
 }
 
@@ -282,7 +279,7 @@ impl Default for RegionOptions {
             block_size: MIN_BLOCK_SIZE as u64,
             extent_size: Block::new(100, 9),
             uuid: Uuid::nil(),
-            expect_upstairs_encrypted: false,
+            encrypted: false,
         }
     }
 }

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -264,6 +264,10 @@ fn show_extent(
     for (index, _) in region_dir.iter().enumerate() {
         print!(" {0:^6}", format!("ECTX{}", index));
     }
+    print!(" ");
+    for (index, _) in region_dir.iter().enumerate() {
+        print!(" {0:^6}", format!("HASH{}", index));
+    }
     if !only_show_differences {
         print!(" {0:^5}", "DIFF");
     }
@@ -279,6 +283,8 @@ fn show_extent(
             ["".to_string(), "".to_string(), "".to_string()];
         let mut encryption_context_columns: [String; 3] =
             ["".to_string(), "".to_string(), "".to_string()];
+        let mut hash_columns: [String; 3] =
+            ["".to_string(), "".to_string(), "".to_string()];
 
         /*
          * Build a Vector to hold our responses, one for each
@@ -293,14 +299,14 @@ fn show_extent(
         for (index, dir) in region_dir.iter().enumerate() {
             let region = Region::open(&dir, Default::default(), false)?;
 
-            dvec.insert(
-                index,
-                region.single_block_region_read(ReadRequest {
-                    eid: cmp_extent as u64,
-                    offset: Block::new_with_ddef(block, &region.def()),
-                    num_blocks: 1,
-                })?,
-            );
+            let mut responses = region.region_read(&[ReadRequest {
+                eid: cmp_extent as u64,
+                offset: Block::new_with_ddef(block, &region.def()),
+                num_blocks: 1,
+            }])?;
+            let response = responses.pop().unwrap();
+
+            dvec.insert(index, response);
         }
 
         /*
@@ -391,6 +397,43 @@ fn show_extent(
                 format!("{0:^6} ", status_letters[dir_index]);
         }
 
+        // then, compare hashes
+        let mut status_letters = vec![String::new(); 3];
+
+        if dvec[0].hashes == dvec[1].hashes {
+            status_letters[0] += "A";
+            status_letters[1] += "A";
+
+            if dir_count > 2 {
+                if dvec[0].hashes == dvec[2].hashes {
+                    status_letters[2] += "A";
+                } else {
+                    status_letters[2] += "C";
+                    different = true;
+                }
+            }
+        } else {
+            different = true;
+            status_letters[0] += "A";
+            status_letters[1] += "B";
+
+            if dir_count > 2 {
+                if dvec[0].hashes == dvec[2].hashes {
+                    status_letters[2] += "A";
+                } else if dvec[1].hashes == dvec[2].hashes {
+                    status_letters[2] += "B";
+                } else {
+                    status_letters[2] += "C";
+                }
+            }
+        }
+
+        // Print hash status letters
+        for dir_index in 0..dir_count {
+            hash_columns[dir_index] =
+                format!("{0:^6} ", status_letters[dir_index]);
+        }
+
         if !only_show_differences || different {
             print!("{:5}  ", block);
 
@@ -399,6 +442,10 @@ fn show_extent(
             }
             print!(" ");
             for column in encryption_context_columns.iter().take(dir_count) {
+                print!("{}", column);
+            }
+            print!(" ");
+            for column in hash_columns.iter().take(dir_count) {
                 print!("{}", column);
             }
 
@@ -450,14 +497,14 @@ fn show_extent_block(
     for (index, dir) in region_dir.iter().enumerate() {
         let region = Region::open(&dir, Default::default(), false)?;
 
-        dvec.insert(
-            index,
-            region.single_block_region_read(ReadRequest {
-                eid: cmp_extent as u64,
-                offset: Block::new_with_ddef(block, &region.def()),
-                num_blocks: 1,
-            })?,
-        );
+        let mut responses = region.region_read(&[ReadRequest {
+            eid: cmp_extent as u64,
+            offset: Block::new_with_ddef(block, &region.def()),
+            num_blocks: 1,
+        }])?;
+        let response = responses.pop().unwrap();
+
+        dvec.insert(index, response);
     }
 
     /*
@@ -496,6 +543,12 @@ fn show_extent_block(
 
     if !only_show_differences || different {
         println!("{:>6}  {:<64}  {:3}", "DATA", "SHA256", "VER");
+        println!(
+            "{}  {}  {}",
+            String::from_utf8(vec![b'-'; 6])?,
+            String::from_utf8(vec![b'-'; 64])?,
+            String::from_utf8(vec![b'-'; 3])?,
+        );
         for dir_index in 0..dir_count {
             let mut hasher = Sha256::new();
             hasher.update(&dvec[dir_index].data[..]);
@@ -544,6 +597,15 @@ fn show_extent_block(
         }
         println!();
 
+        print!("{}  ", String::from_utf8(vec![b'-'; 6])?);
+        for (_, _) in dvec.iter().enumerate() {
+            print!("{} ", String::from_utf8(vec![b'-'; 24])?);
+        }
+        if !only_show_differences {
+            print!("{} ", String::from_utf8(vec![b'-'; 5])?);
+        }
+        println!();
+
         for depth in 0..max_nonce_depth {
             print!("{:>6}  ", depth);
 
@@ -589,6 +651,15 @@ fn show_extent_block(
         }
         println!();
 
+        print!("{}  ", String::from_utf8(vec![b'-'; 6])?);
+        for (_, _) in dvec.iter().enumerate() {
+            print!("{} ", String::from_utf8(vec![b'-'; 32])?);
+        }
+        if !only_show_differences {
+            print!("{} ", String::from_utf8(vec![b'-'; 5])?);
+        }
+        println!();
+
         for depth in 0..max_tag_depth {
             print!("{:>6}  ", depth);
 
@@ -608,6 +679,71 @@ fn show_extent_block(
                 );
             }
             if !all_same_len || !is_all_same(&tags) {
+                print!(" {:<5}", "<---");
+            }
+            println!();
+        }
+        println!();
+    }
+
+    /*
+     * Compare integrity hashes
+     */
+    let mut different = false;
+    if dvec[0].hashes == dvec[1].hashes {
+        if (dir_count > 2) && (dvec[0].hashes != dvec[2].hashes) {
+            different = true;
+        }
+    } else {
+        different = true;
+    }
+
+    if !only_show_differences || different {
+        /*
+         * note formatting assumes 8 byte integrity hashes
+         */
+        print!("{:>6}  ", "HASHES");
+
+        let mut max_hash_depth = 0;
+
+        for (dir_index, response) in dvec.iter().enumerate() {
+            print!("{:^16} ", dir_index);
+
+            max_hash_depth =
+                std::cmp::max(max_hash_depth, response.hashes.len());
+        }
+        if !only_show_differences {
+            print!(" {:<5}", "DIFF");
+        }
+        println!();
+
+        print!("{}  ", String::from_utf8(vec![b'-'; 6])?);
+        for (_, _) in dvec.iter().enumerate() {
+            print!("{} ", String::from_utf8(vec![b'-'; 16])?);
+        }
+        if !only_show_differences {
+            print!("{} ", String::from_utf8(vec![b'-'; 5])?);
+        }
+        println!();
+
+        for depth in 0..max_hash_depth {
+            print!("{:>6}  ", depth);
+
+            let mut all_same_len = true;
+            let mut hashes = Vec::with_capacity(dir_count);
+            for response in dvec.iter() {
+                print!(
+                    "{:^16} ",
+                    if depth < response.hashes.len() {
+                        hashes.push(&response.hashes[depth]);
+                        hex::encode(&response.hashes[depth].to_le_bytes())
+                    } else {
+                        all_same_len = false;
+                        "".to_string()
+                    }
+                );
+            }
+            if !all_same_len || !is_all_same(&hashes) {
                 print!(" {:<5}", "<---");
             }
             println!();

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -60,6 +60,9 @@ enum Args {
 
         #[structopt(short, long, name = "UUID", parse(try_from_str))]
         uuid: Uuid,
+
+        #[structopt(long)]
+        expect_upstairs_encrypted: bool,
     },
     /*
      * Dump region information.
@@ -573,7 +576,6 @@ async fn proc(ads: &mut Arc<Mutex<Downstairs>>, sock: TcpStream) -> Result<()> {
 
     let mut negotiated = 0;
     let mut upstairs_uuid = None;
-    let mut upstairs_is_encrypted = None;
 
     let (_another_upstairs_active_tx, mut another_upstairs_active_rx) =
         channel(1);
@@ -673,25 +675,24 @@ async fn proc(ads: &mut Arc<Mutex<Downstairs>>, sock: TcpStream) -> Result<()> {
                          * what the downstairs expects for encryption.
                          */
                         let ds = ads.lock().await;
-                        if let Some(expect_encryption) = ds.expect_upstairs_encryption_context() {
-                            if expect_encryption != is_encrypted {
-                                println!(
-                                    "downstairs expects {} but upstairs {}!",
-                                    if expect_encryption {
-                                        "encryption"
-                                    } else {
-                                        "no encryption"
-                                    },
-                                    if is_encrypted {
-                                        "is encrypted"
-                                    } else {
-                                        "is not encrypted"
-                                    },
-                                );
-                                bail!("Encryption expectation mismatch!");
-                            }
+                        let expect_encryption
+                            = ds.expect_upstairs_encryption_context();
+                        if is_encrypted != expect_encryption {
+                            println!(
+                                "downstairs expects {} but upstairs {}!",
+                                if expect_encryption {
+                                    "encryption"
+                                } else {
+                                    "no encryption"
+                                },
+                                if is_encrypted {
+                                    "is encrypted"
+                                } else {
+                                    "is not encrypted"
+                                },
+                            );
+                            bail!("Encryption expectation mismatch!");
                         }
-                        upstairs_is_encrypted = Some(is_encrypted);
 
                         let mut fw = fw.lock().await;
                         fw.send(Message::YesItsMe(1)).await?;
@@ -797,17 +798,6 @@ async fn proc(ads: &mut Arc<Mutex<Downstairs>>, sock: TcpStream) -> Result<()> {
     println!("Downstairs has completed Negotiation");
     assert!(upstairs_uuid.is_some());
     let u_uuid = upstairs_uuid.unwrap();
-
-    /*
-     * If an upstairs completes negotation, set the encryption context
-     * expectation downstairs.
-     */
-    {
-        let mut ds = ads.lock().await;
-        ds.set_expect_upstairs_encryption_context(
-            upstairs_is_encrypted.unwrap(),
-        )?;
-    }
 
     resp_loop(ads, fr, fw, another_upstairs_active_rx, u_uuid).await
 }
@@ -1226,16 +1216,8 @@ impl Downstairs {
         work.last_flush = 0;
     }
 
-    fn expect_upstairs_encryption_context(&self) -> Option<bool> {
+    fn expect_upstairs_encryption_context(&self) -> bool {
         self.region.expect_upstairs_encryption_context()
-    }
-
-    fn set_expect_upstairs_encryption_context(
-        &mut self,
-        is_encrypted: bool,
-    ) -> Result<()> {
-        self.region
-            .set_expect_upstairs_encryption_context(is_encrypted)
     }
 }
 
@@ -1575,6 +1557,7 @@ async fn main() -> Result<()> {
             extent_count,
             import_path,
             uuid,
+            expect_upstairs_encrypted,
         } => {
             /*
              * Create the region options, then the region.
@@ -1587,6 +1570,8 @@ async fn main() -> Result<()> {
                 block_size.trailing_zeros(),
             ));
             region_options.set_uuid(uuid);
+            region_options
+                .set_expect_upstairs_encrypted(expect_upstairs_encrypted);
 
             region = Region::create(&data, region_options)?;
             region.extend(extent_count as u32)?;

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -62,7 +62,7 @@ enum Args {
         uuid: Uuid,
 
         #[structopt(long)]
-        expect_upstairs_encrypted: bool,
+        encrypted: bool,
     },
     /*
      * Dump region information.
@@ -1529,7 +1529,7 @@ async fn main() -> Result<()> {
             extent_count,
             import_path,
             uuid,
-            expect_upstairs_encrypted,
+            encrypted,
         } => {
             /*
              * Create the region options, then the region.
@@ -1542,8 +1542,7 @@ async fn main() -> Result<()> {
                 block_size.trailing_zeros(),
             ));
             region_options.set_uuid(uuid);
-            region_options
-                .set_expect_upstairs_encrypted(expect_upstairs_encrypted);
+            region_options.set_encrypted(encrypted);
 
             region = Region::create(&data, region_options)?;
             region.extend(extent_count as u32)?;

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -194,15 +194,12 @@ fn downstairs_export<P: AsRef<Path> + std::fmt::Debug>(
             if (extent_offset + block_offset) >= start_block {
                 blocks_copied += 1;
 
-                let response =
-                    region.single_block_region_read(ReadRequest {
-                        eid: eid as u64,
-                        offset: Block::new_with_ddef(
-                            block_offset,
-                            &region.def(),
-                        ),
-                        num_blocks: 1,
-                    })?;
+                let mut responses = region.region_read(&[ReadRequest {
+                    eid: eid as u64,
+                    offset: Block::new_with_ddef(block_offset, &region.def()),
+                    num_blocks: 1,
+                }])?;
+                let response = responses.pop().unwrap();
 
                 out_file.write_all(&response.data).unwrap();
 
@@ -316,23 +313,25 @@ fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
          */
         let nblocks = Block::from_bytes(total, &rm);
         let mut pos = Block::from_bytes(0, &rm);
-        for (eid, offset, len) in
-            extent_from_offset(rm, offset, nblocks, false)?
-        {
+        let mut writes = vec![];
+        for (eid, offset, len) in extent_from_offset(rm, offset, nblocks)? {
             let data = &buffer[pos.bytes()..(pos.bytes() + len.bytes())];
             let mut buffer = BytesMut::with_capacity(data.len());
             buffer.resize(data.len(), 0);
             buffer.copy_from_slice(data);
-            region.single_block_region_write(
+
+            writes.push(crucible_protocol::Write {
                 eid,
                 offset,
-                buffer.freeze(),
-                None,
-                None,
-            )?;
+                data: buffer.freeze(),
+                encryption_context: None,
+                hash: integrity_hash(&[data]),
+            });
 
             pos.advance(len);
         }
+
+        region.region_write(&writes)?;
 
         assert_eq!(nblocks, pos);
         assert_eq!(total, pos.bytes());
@@ -2461,6 +2460,84 @@ mod test {
         let mut padding = Vec::with_capacity(padding_in_extra_block);
         padding.resize(padding_in_extra_block, 0);
         assert_eq!(actual[total_bytes..], padding);
+
+        Ok(())
+    }
+
+    #[test]
+    fn import_test_basic_read_blocks() -> Result<()> {
+        /*
+         * import + export test where data matches region size, and read the
+         * blocks
+         */
+        let block_size: u64 = 512;
+        let extent_size = 10;
+
+        // create region
+
+        let mut region_options: crucible_common::RegionOptions =
+            Default::default();
+        region_options.set_block_size(block_size);
+        region_options.set_extent_size(Block::new(
+            extent_size,
+            block_size.trailing_zeros(),
+        ));
+        region_options.set_uuid(Uuid::new_v4());
+
+        let dir = tempdir()?;
+        mkdir_for_file(dir.path())?;
+
+        let mut region = Region::create(&dir, region_options)?;
+        region.extend(10)?;
+
+        // create random file
+
+        let total_bytes = region.def().total_size();
+        let mut random_data = Vec::with_capacity(total_bytes as usize);
+        random_data.resize(total_bytes as usize, 0);
+
+        let mut rng = ChaCha20Rng::from_entropy();
+        rng.fill_bytes(&mut random_data);
+
+        // write random_data to file
+
+        let tempdir = tempdir()?;
+        mkdir_for_file(tempdir.path())?;
+
+        let random_file_path = tempdir.path().join("random_data");
+        let mut random_file = File::create(&random_file_path)?;
+        random_file.write_all(&random_data[..])?;
+
+        // import random_data to the region
+
+        downstairs_import(&mut region, &random_file_path)?;
+        region.region_flush(1, 1)?;
+
+        // read block by block
+        let mut read_data = Vec::with_capacity(total_bytes as usize);
+        for eid in 0..region.def().extent_count() {
+            for offset in 0..region.def().extent_size().value {
+                let responses =
+                    region.region_read(&[crucible_protocol::ReadRequest {
+                        eid: eid.into(),
+                        offset: Block::new_512(offset),
+                        num_blocks: 1,
+                    }])?;
+
+                assert_eq!(responses.len(), 1);
+
+                let response = &responses[0];
+                assert_eq!(response.hashes.len(), 1);
+                assert_eq!(
+                    integrity_hash(&[&response.data[..]]),
+                    response.hashes[0],
+                );
+
+                read_data.extend_from_slice(&response.data[..]);
+            }
+        }
+
+        assert_eq!(random_data, read_data);
 
         Ok(())
     }

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -317,7 +317,8 @@ fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
         let nblocks = Block::from_bytes(total, &rm);
         let mut pos = Block::from_bytes(0, &rm);
         let mut writes = vec![];
-        for (eid, offset, len) in extent_from_offset(rm, offset, nblocks)? {
+        for (eid, offset) in extent_from_offset(rm, offset, nblocks)? {
+            let len = Block::new_with_ddef(1, &region.def());
             let data = &buffer[pos.bytes()..(pos.bytes() + len.bytes())];
             let mut buffer = BytesMut::with_capacity(data.len());
             buffer.resize(data.len(), 0);

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1083,36 +1083,11 @@ impl Region {
     }
 
     /*
-     * If an upstairs connects with an encryption context, we don't want to
-     * support another upstairs connecting without one. Likewise, if an
-     * upstairs is using this downstairs without an encryption context,
-     * don't support connecting upstairs with encryption contexts.
-     *
-     * This function returns Some(true) if an upstairs previously connected
-     * with an encryption context, Some(false) if an upstairs connected
-     * without an encryption context, and None if no upstairs has
-     * connected.
+     * Regions are created with the expectation that upstairs will attach
+     * unencrypted or encrypted.
      */
-    pub fn expect_upstairs_encryption_context(&self) -> Option<bool> {
-        match self.def.get_upstairs_previous_connection() {
-            2 => Some(true),
-            1 => Some(false),
-            0 => None,
-            _ => panic!("bad value for expect_upstairs_encryption_context!"),
-        }
-    }
-
-    pub fn set_expect_upstairs_encryption_context(
-        &mut self,
-        is_encrypted: bool,
-    ) -> Result<()> {
-        self.def.set_upstairs_previous_connection(is_encrypted);
-
-        // Write out json
-        let cp = config_path(&self.dir);
-        write_json(&cp, &self.def, true)?;
-
-        Ok(())
+    pub fn expect_upstairs_encryption_context(&self) -> bool {
+        self.def.get_expect_upstairs_encrypted()
     }
 }
 
@@ -1768,7 +1743,7 @@ mod test {
     }
 
     #[test]
-    fn test_expect_encryption_context_downstairs() -> Result<()> {
+    fn test_expect_encryption_context_downstairs_default() -> Result<()> {
         // create region
 
         let block_size: u64 = 512;
@@ -1786,27 +1761,16 @@ mod test {
         let dir = tempdir()?;
         mkdir_for_file(dir.path())?;
 
-        let mut region = Region::create(&dir, region_options.clone())?;
+        let region = Region::create(&dir, region_options.clone())?;
 
-        // it should start out with no expectation
-        assert_eq!(region.expect_upstairs_encryption_context(), None);
-
-        // upstairs connects encrypted
-        region.set_expect_upstairs_encryption_context(true)?;
-
-        // this should return true
-        assert_eq!(region.expect_upstairs_encryption_context(), Some(true));
-
-        // the option should persist
-        drop(region);
-        let region = Region::open(&dir, region_options, false)?;
-        assert_eq!(region.expect_upstairs_encryption_context(), Some(true));
+        // default is unencrypted
+        assert_eq!(region.expect_upstairs_encryption_context(), false);
 
         Ok(())
     }
 
     #[test]
-    fn test_expect_no_encryption_context_downstairs() -> Result<()> {
+    fn test_expect_encryption_context_downstairs_false() -> Result<()> {
         // create region
 
         let block_size: u64 = 512;
@@ -1820,25 +1784,41 @@ mod test {
             block_size.trailing_zeros(),
         ));
         region_options.set_uuid(Uuid::new_v4());
+        region_options.set_expect_upstairs_encrypted(false);
 
         let dir = tempdir()?;
         mkdir_for_file(dir.path())?;
 
-        let mut region = Region::create(&dir, region_options.clone())?;
+        let region = Region::create(&dir, region_options.clone())?;
 
-        // it should start out with no expectation
-        assert_eq!(region.expect_upstairs_encryption_context(), None);
+        assert_eq!(region.expect_upstairs_encryption_context(), false);
 
-        // upstairs connects unencrypted
-        region.set_expect_upstairs_encryption_context(false)?;
+        Ok(())
+    }
 
-        // this should return true
-        assert_eq!(region.expect_upstairs_encryption_context(), Some(false));
+    #[test]
+    fn test_expect_encryption_context_downstairs_true() -> Result<()> {
+        // create region
 
-        // the option should persist
-        drop(region);
-        let region = Region::open(&dir, region_options, false)?;
-        assert_eq!(region.expect_upstairs_encryption_context(), Some(false));
+        let block_size: u64 = 512;
+        let extent_size = 10;
+
+        let mut region_options: crucible_common::RegionOptions =
+            Default::default();
+        region_options.set_block_size(block_size);
+        region_options.set_extent_size(Block::new(
+            extent_size,
+            block_size.trailing_zeros(),
+        ));
+        region_options.set_uuid(Uuid::new_v4());
+        region_options.set_expect_upstairs_encrypted(true);
+
+        let dir = tempdir()?;
+        mkdir_for_file(dir.path())?;
+
+        let region = Region::create(&dir, region_options.clone())?;
+
+        assert_eq!(region.expect_upstairs_encryption_context(), true);
 
         Ok(())
     }

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1081,14 +1081,6 @@ impl Region {
         }
         Ok(())
     }
-
-    /*
-     * Regions are created with the expectation that upstairs will attach
-     * unencrypted or encrypted.
-     */
-    pub fn expect_upstairs_encryption_context(&self) -> bool {
-        self.def.get_expect_upstairs_encrypted()
-    }
 }
 
 #[cfg(test)]
@@ -1738,87 +1730,6 @@ mod test {
         assert_eq!(responses.len(), 1);
         assert_eq!(responses[0].hashes.len(), 0);
         assert_eq!(responses[0].data[..], [0u8; 512][..]);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_expect_encryption_context_downstairs_default() -> Result<()> {
-        // create region
-
-        let block_size: u64 = 512;
-        let extent_size = 10;
-
-        let mut region_options: crucible_common::RegionOptions =
-            Default::default();
-        region_options.set_block_size(block_size);
-        region_options.set_extent_size(Block::new(
-            extent_size,
-            block_size.trailing_zeros(),
-        ));
-        region_options.set_uuid(Uuid::new_v4());
-
-        let dir = tempdir()?;
-        mkdir_for_file(dir.path())?;
-
-        let region = Region::create(&dir, region_options.clone())?;
-
-        // default is unencrypted
-        assert_eq!(region.expect_upstairs_encryption_context(), false);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_expect_encryption_context_downstairs_false() -> Result<()> {
-        // create region
-
-        let block_size: u64 = 512;
-        let extent_size = 10;
-
-        let mut region_options: crucible_common::RegionOptions =
-            Default::default();
-        region_options.set_block_size(block_size);
-        region_options.set_extent_size(Block::new(
-            extent_size,
-            block_size.trailing_zeros(),
-        ));
-        region_options.set_uuid(Uuid::new_v4());
-        region_options.set_expect_upstairs_encrypted(false);
-
-        let dir = tempdir()?;
-        mkdir_for_file(dir.path())?;
-
-        let region = Region::create(&dir, region_options.clone())?;
-
-        assert_eq!(region.expect_upstairs_encryption_context(), false);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_expect_encryption_context_downstairs_true() -> Result<()> {
-        // create region
-
-        let block_size: u64 = 512;
-        let extent_size = 10;
-
-        let mut region_options: crucible_common::RegionOptions =
-            Default::default();
-        region_options.set_block_size(block_size);
-        region_options.set_extent_size(Block::new(
-            extent_size,
-            block_size.trailing_zeros(),
-        ));
-        region_options.set_uuid(Uuid::new_v4());
-        region_options.set_expect_upstairs_encrypted(true);
-
-        let dir = tempdir()?;
-        mkdir_for_file(dir.path())?;
-
-        let region = Region::create(&dir, region_options.clone())?;
-
-        assert_eq!(region.expect_upstairs_encryption_context(), true);
 
         Ok(())
     }

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -633,9 +633,6 @@ impl Extent {
     /**
      * Verify that the requested block offset and size of the buffer
      * will fit within the extent.
-     *
-     * Note that the checks here do take into account that the first block
-     * is the metadata block.
      */
     fn check_input(
         &self,

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -94,10 +94,9 @@ impl ReadResponse {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum Message {
     /*
-     * Initial negotiation: version, upstairs uuid, and a boolean for if
-     * the upstairs is connecting with an encryption context.
+     * Initial negotiation: version, upstairs uuid.
      */
-    HereIAm(u32, Uuid, bool),
+    HereIAm(u32, Uuid),
     YesItsMe(u32),
 
     /*
@@ -405,7 +404,7 @@ mod tests {
 
     #[test]
     fn rt_here_i_am() -> Result<()> {
-        let input = Message::HereIAm(2, Uuid::new_v4(), false);
+        let input = Message::HereIAm(2, Uuid::new_v4());
         assert_eq!(input, round_trip(&input)?);
         Ok(())
     }
@@ -461,7 +460,7 @@ mod tests {
         let mut encoder = CrucibleEncoder::new();
         let mut decoder = CrucibleDecoder::new();
 
-        let input = Message::HereIAm(0, Uuid::new_v4(), false);
+        let input = Message::HereIAm(0, Uuid::new_v4());
         let mut buffer = BytesMut::new();
 
         encoder.encode(input, &mut buffer)?;

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -94,9 +94,10 @@ impl ReadResponse {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum Message {
     /*
-     * Initial negotiation
+     * Initial negotiation: version, upstairs uuid, and a boolean for if
+     * the upstairs is connecting with an encryption context.
      */
-    HereIAm(u32, Uuid),
+    HereIAm(u32, Uuid, bool),
     YesItsMe(u32),
 
     /*
@@ -404,7 +405,7 @@ mod tests {
 
     #[test]
     fn rt_here_i_am() -> Result<()> {
-        let input = Message::HereIAm(2, Uuid::new_v4());
+        let input = Message::HereIAm(2, Uuid::new_v4(), false);
         assert_eq!(input, round_trip(&input)?);
         Ok(())
     }
@@ -460,7 +461,7 @@ mod tests {
         let mut encoder = CrucibleEncoder::new();
         let mut decoder = CrucibleDecoder::new();
 
-        let input = Message::HereIAm(0, Uuid::new_v4());
+        let input = Message::HereIAm(0, Uuid::new_v4(), false);
         let mut buffer = BytesMut::new();
 
         encoder.encode(input, &mut buffer)?;

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -19,15 +19,15 @@ pub struct Write {
     pub encryption_context: Option<EncryptionContext>,
 
     /*
-     * If this is a non-encrypted write, then the integrity hasher has the data
-     * as an input:
+     * If this is a non-encrypted write, then the integrity hasher has the
+     * data as an input:
      *
      *   let hasher = Hasher()
      *   hasher.write(&data)
      *   hash = hasher.digest()
      *
-     * If this is an encrypted write, then the integrity hasher has the nonce,
-     * then tag, then data written to it.
+     * If this is an encrypted write, then the integrity hasher has the
+     * nonce, then tag, then data written to it.
      *
      *   let hasher = Hasher()
      *   hasher.write(&nonce)

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -19,11 +19,21 @@ pub struct Write {
     pub encryption_context: Option<EncryptionContext>,
 
     /*
-     * xxHash of:
+     * If this is a non-encrypted write, then the integrity hasher has the data
+     * as an input:
      *
-     * [data] if non-encrypted
-     * [nonce + tag + data] if encrypted
+     *   let hasher = Hasher()
+     *   hasher.write(&data)
+     *   hash = hasher.digest()
      *
+     * If this is an encrypted write, then the integrity hasher has the nonce,
+     * then tag, then data written to it.
+     *
+     *   let hasher = Hasher()
+     *   hasher.write(&nonce)
+     *   hasher.write(&tag)
+     *   hasher.write(&data)
+     *   hash = hasher.digest()
      */
     pub hash: u64,
 }

--- a/tools/README.md
+++ b/tools/README.md
@@ -270,4 +270,7 @@ client/src/main.  It's an easy way to quickly run some simple tests without
 having to spin up a bunch of things.  These tests are limited in their scope and
 should not be considered substantial.
 
+Specify "unencrypted" or "encrypted" when running the script to test both code
+paths.
+
 That's all for now!

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -52,7 +52,14 @@ for (( i = 0; i < 3; i++ )); do
     args+=( -t "127.0.0.1:$port" )
     echo ${cds} create -u "$uuid" -p "$port" -d "$dir" --extent-count 5 --extent-size 10
     set -o errexit
-    ${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10
+    case ${1} in
+        "unencrypted")
+            ${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10
+            ;;
+        "encrypted")
+            ${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10 --expect-upstairs-encrypted
+            ;;
+    esac
     echo ${cds} run -p "$port" -d "$dir"
     ${cds} run -p "$port" -d "$dir" &
     downstairs[$i]=$!

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -57,7 +57,7 @@ for (( i = 0; i < 3; i++ )); do
             ${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10
             ;;
         "encrypted")
-            ${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10 --expect-upstairs-encrypted
+            ${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10 --encrypted
             ;;
     esac
     echo ${cds} run -p "$port" -d "$dir"

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -50,13 +50,14 @@ for (( i = 0; i < 3; i++ )); do
     dir="${testdir}/$port"
     uuid="${uuidprefix}${port}"
     args+=( -t "127.0.0.1:$port" )
-    echo ${cds} create -u "$uuid" -p "$port" -d "$dir" --extent-count 5 --extent-size 10
     set -o errexit
     case ${1} in
         "unencrypted")
+            echo ${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10
             ${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10
             ;;
         "encrypted")
+            echo ${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10 --encrypted
             ${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10 --encrypted
             ;;
     esac

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -5,6 +5,12 @@
 # This should eventually either move to some common test framework, or be
 # thrown away.
 
+if [[ ${#} -ne 1 ]];
+then
+    echo "specify either 'unencrypted' or 'encrypted' string"
+    exit 1
+fi
+
 set -o pipefail
 SECONDS=0
 
@@ -53,6 +59,16 @@ for (( i = 0; i < 3; i++ )); do
     set +o errexit
 done
 
+case ${1} in
+    "unencrypted")
+        ;;
+    "encrypted")
+        args+=( --key "$(openssl rand -base64 32)" )
+        ;;
+    *)
+        ;;
+esac
+
 res=0
 test_list="one big dep rand balloon"
 for tt in ${test_list}; do
@@ -71,8 +87,7 @@ done
 
 echo "Running hammer"
 if ! time cargo run -p crucible-hammer -- \
-    "${args[@]}" \
-    --key "$(openssl rand -base64 32)"; then
+    "${args[@]}"; then
 
 	echo "Failed hammer test"
     (( res += 1 ))

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1553,8 +1553,6 @@ impl Downstairs {
                             // Hashes and encryption contexts are written out at
                             // the same time, therefore there should be the same
                             // number of them.
-                            //
-                            // XXX shouldn't be an assert?
                             assert_eq!(
                                 response.encryption_contexts.len(),
                                 response.hashes.len(),

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2917,6 +2917,12 @@ impl Upstairs {
     ) -> Result<()> {
         println!("[{}] Got region def {:?}", client_id, client_ddef);
 
+        if client_ddef.get_expect_upstairs_encrypted()
+            != self.encryption_context.is_some()
+        {
+            bail!("Encryption expectation mismatch!");
+        }
+
         /*
          * XXX Eventually we will be provided UUIDs when the upstairs
          * starts, so we can compare those with what we get here.

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -390,10 +390,12 @@ async fn proc(
     }
 
     let mut self_promotion = false;
+
     /*
      * As the "client", we must begin the negotiation.
      */
-    fw.send(Message::HereIAm(1, up.uuid)).await?;
+    let m = Message::HereIAm(1, up.uuid, up.encryption_context.is_some());
+    fw.send(m).await?;
 
     /*
      * Used to track where we are in the current negotiation.

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2933,9 +2933,7 @@ impl Upstairs {
     ) -> Result<()> {
         println!("[{}] Got region def {:?}", client_id, client_ddef);
 
-        if client_ddef.get_expect_upstairs_encrypted()
-            != self.encryption_context.is_some()
-        {
+        if client_ddef.get_encrypted() != self.encryption_context.is_some() {
             bail!("Encryption expectation mismatch!");
         }
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -394,7 +394,7 @@ async fn proc(
     /*
      * As the "client", we must begin the negotiation.
      */
-    let m = Message::HereIAm(1, up.uuid, up.encryption_context.is_some());
+    let m = Message::HereIAm(1, up.uuid);
     fw.send(m).await?;
 
     /*

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -10,8 +10,8 @@ mod test {
     use ringbuffer::RingBuffer;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-    fn extent_tuple(eid: u64, offset: u64) -> (u64, Block, Block) {
-        (eid, Block::new_512(offset), Block::new_512(1))
+    fn extent_tuple(eid: u64, offset: u64) -> (u64, Block) {
+        (eid, Block::new_512(offset))
     }
 
     #[test]
@@ -221,7 +221,7 @@ mod test {
         up: &Arc<Upstairs>,
         offset: Block,
         num_blocks: u64,
-    ) -> Result<Vec<(u64, Block, Block)>> {
+    ) -> Result<Vec<(u64, Block)>> {
         let ddef = up.ddef.lock().unwrap();
         let num_blocks = Block::new_with_ddef(num_blocks, &ddef);
         extent_from_offset(*ddef, offset, num_blocks)
@@ -303,7 +303,7 @@ mod test {
          * Largest buffer at different offsets
          */
         for offset in 0..100 {
-            let expected: Vec<(u64, Block, Block)> = (0..100)
+            let expected: Vec<(u64, Block)> = (0..100)
                 .map(|i| extent_tuple((offset + i) / 100, (offset + i) % 100))
                 .collect();
             assert_eq!(


### PR DESCRIPTION
Use an [xxHash][1] crate to implement integrity hashes:

    xxHash is an Extremely fast Hash algorithm, running at RAM speed
    limits.

This required adding a hash field to Write, and a hashes field to
ReadResponse - a list of hashes must be returned to remain crash
consistent, just like with encryption context, and must be written
before extent data is.

Downstairs, a new table in sqlite was required, plus additional code for
unencrypted and encrypted branches. A new error was also created for
hash mismatches. Note that the downstairs can verify the hashes which
should aid in reconciliation.

Unfortunately adding integrity hashes caused import performance to drop
significantly. This is due to the fact that hashes have to be stored per
block, and the import code sends up to a 32M buffer at a time. New code
had to be added downstairs to split this up and hash each block during
the write operation. Rayon has been used downstairs to parallelize the
hash computation, but the big bottleneck was found to be the way I was
doing sqlite IMPORT WITH VALUES execution in set_hashes.

Performance was gained back by changing the large IMPORT WITH VALUES
from sending many values in a large statement to individual IMPORT
statements with one set of values each. This dramatically increased
performance, potentially pointing to some issue scaling query parsing or
planning in sqlite.

Importantly, extent_from_offset only supports single block address
output now. Guest reads and writes still can be any multiple of block
size but this is now always separated to single blocks when reading from
and writing to downstairs. Tests were updated to reflect this change.
This was done primarily to keep the downstairs simple, and to reflect
the decision that integrity hashes can be verified downstairs but should
not be generated downstairs. If a read of an arbitrary number of blocks
can be requested, the downstairs would have to compute the read response
hash instead of reading it from the database.

Integrity hashes were added to the dump output, along with dashes
separating table headers and rows:

    HASHES         0                1                2          DIFF
    ------  ---------------- ---------------- ---------------- -----
         0  16bdfe6adb2a4fe0 16bdfe6adb2a4fe1 16bdfe6adb2a4fe0  <---
         1  0011223344556677                                    <---

[1]: https://github.com/Cyan4973/xxHash