### PR TITLE
Implement TLS between Upstairs and Downstairs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ core
 /aws_benchmark/inventory
 /aws_benchmark/results.txt
 /aws_benchmark/terraform.tfstate*
+/x509/*.pem
+/x509/*.json
+/x509/*.csr

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "toml",
  "tracing",
@@ -444,10 +445,12 @@ name = "crucible-common"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
+ "tokio-rustls",
  "toml",
  "uuid",
 ]
@@ -481,6 +484,7 @@ dependencies = [
  "structopt",
  "tempfile",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "toml",
  "tracing",

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -86,6 +86,14 @@ pub struct Opt {
      */
     #[structopt(long, parse(from_os_str), name = "FILE")]
     verify_out: Option<PathBuf>,
+
+    // TLS options
+    #[structopt(long)]
+    cert_pem: Option<String>,
+    #[structopt(long)]
+    key_pem: Option<String>,
+    #[structopt(long)]
+    root_cert_pem: Option<String>,
 }
 
 pub fn opts() -> Result<Opt> {
@@ -218,6 +226,9 @@ fn main() -> Result<()> {
         target: opt.target,
         lossy: opt.lossy,
         key: opt.key,
+        cert_pem: opt.cert_pem,
+        key_pem: opt.key_pem,
+        root_cert_pem: opt.root_cert_pem,
     };
 
     /*

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -13,3 +13,5 @@ toml = "0.5"
 tempfile = "3"
 thiserror = "1.0"
 uuid = { version = "0.8", features = [ "serde", "v4" ] }
+tokio-rustls = { version = "0.23.2" }
+rustls-pemfile = { version = "0.2.1" }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -14,6 +14,8 @@ pub use region::{
     Block, RegionDefinition, RegionOptions, MAX_BLOCK_SIZE, MIN_BLOCK_SIZE,
 };
 
+pub mod x509;
+
 #[derive(thiserror::Error, Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum CrucibleError {
     #[error("Error: {0}")]

--- a/common/src/x509.rs
+++ b/common/src/x509.rs
@@ -1,0 +1,82 @@
+// Copyright 2021 Oxide Computer Company
+use std::fs::File;
+use std::io::{self, BufReader};
+
+// Reference tokio-rustls repo examples/server/src/main.rs
+use rustls_pemfile::{certs, rsa_private_keys};
+use tokio_rustls::rustls::{Certificate, PrivateKey, ClientConfig, ServerConfig, RootCertStore};
+use tokio_rustls::rustls::server::AllowAnyAuthenticatedClient;
+
+pub fn load_certs(path: &str) -> io::Result<Vec<Certificate>> {
+    certs(&mut BufReader::new(File::open(path)?))
+        .map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "invalid cert")
+        })
+        .map(|mut certs| certs.drain(..).map(Certificate).collect())
+}
+
+pub fn load_rsa_keys(path: &str) -> io::Result<Vec<PrivateKey>> {
+    rsa_private_keys(&mut BufReader::new(File::open(path)?))
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid key"))
+        .map(|mut keys| keys.drain(..).map(PrivateKey).collect())
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum TLSContextError {
+    #[error("PKI error")]
+    PKIError(#[from] tokio_rustls::webpki::Error),
+
+    #[error("IO error")]
+    IOError(#[from] std::io::Error),
+
+    #[error("rustls error")]
+    RusTLSError(#[from] tokio_rustls::rustls::Error),
+}
+
+
+#[derive(Debug)]
+pub struct TLSContext {
+    certs: Vec<Certificate>,
+    keys: Vec<PrivateKey>,
+    root_cert_store: RootCertStore,
+}
+
+impl TLSContext {
+    pub fn from_paths(
+        cert_pem_path: &str,
+        key_pem_path: &str,
+        root_cert_pem_path: &str,
+    ) -> Result<Self, TLSContextError> {
+        let mut root_cert_store = RootCertStore::empty();
+        for root_cert in load_certs(&root_cert_pem_path)? {
+            root_cert_store.add(&root_cert)?;
+        }
+
+        Ok(Self {
+            certs: load_certs(cert_pem_path)?,
+            keys: load_rsa_keys(key_pem_path)?,
+            root_cert_store
+        })
+    }
+
+    pub fn get_client_config(&self) -> Result<ClientConfig, TLSContextError> {
+        Ok(ClientConfig::builder()
+            .with_safe_defaults()
+            .with_root_certificates(self.root_cert_store.clone())
+            .with_single_cert(self.certs.clone(), self.keys[0].clone())
+            ?)
+    }
+
+    pub fn get_server_config(&self) -> Result<ServerConfig, TLSContextError> {
+        let client_cert_verifier = AllowAnyAuthenticatedClient::new(
+            self.root_cert_store.clone(),
+        );
+
+        Ok(ServerConfig::builder()
+            .with_safe_defaults()
+            .with_client_cert_verifier(client_cert_verifier)
+            .with_single_cert(self.certs.clone(), self.keys[0].clone())
+            ?)
+    }
+}
+

--- a/common/src/x509.rs
+++ b/common/src/x509.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 use std::fs::File;
 use std::io::{self, BufReader};
 

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1", features = ["derive"] }
 structopt = "0.3"
 tokio = { version = "1.15.0", features = ["full"] }
 tokio-util = { version = "0.6", features = ["codec"]}
+tokio-rustls = { version = "0.23.2" }
 tracing = "0.1.29"
 toml = "0.5"
 opentelemetry = "0.16.0"

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -20,8 +20,7 @@ use bytes::BytesMut;
 use futures::{SinkExt, StreamExt};
 use rand::prelude::*;
 use structopt::StructOpt;
-use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::time::{sleep_until, Instant};
@@ -139,6 +138,14 @@ enum Args {
 
         #[structopt(short, long)]
         trace_endpoint: Option<String>,
+
+        // TLS options
+        #[structopt(long)]
+        cert_pem: Option<String>,
+        #[structopt(long)]
+        key_pem: Option<String>,
+        #[structopt(long)]
+        root_cert_pem: Option<String>,
     },
 }
 
@@ -413,13 +420,16 @@ async fn _show_work(ds: &Downstairs) {
  * If the message is a ping or negotiation message, send the correct
  * response. If the message is an IO, then put the new IO the work hashmap.
  */
-async fn proc_frame(
+async fn proc_frame<WT>(
     upstairs_uuid: Uuid,
     ad: &mut Arc<Mutex<Downstairs>>,
     m: &Message,
-    fw: &mut Arc<Mutex<FramedWrite<OwnedWriteHalf, CrucibleEncoder>>>,
+    fw: &mut Arc<Mutex<FramedWrite<WT, CrucibleEncoder>>>,
     job_channel_tx: &Arc<Mutex<Sender<u64>>>,
-) -> Result<()> {
+) -> Result<()>
+where
+    WT: tokio::io::AsyncWrite + std::marker::Unpin + std::marker::Send,
+{
     let new_ds_id = match m {
         Message::Write(uuid, ds_id, dependencies, writes) => {
             if upstairs_uuid != *uuid {
@@ -483,11 +493,14 @@ async fn proc_frame(
     Ok(())
 }
 
-async fn do_work_task(
+async fn do_work_task<T>(
     ads: &mut Arc<Mutex<Downstairs>>,
     mut job_channel_rx: Receiver<u64>,
-    fw: &mut Arc<Mutex<FramedWrite<OwnedWriteHalf, CrucibleEncoder>>>,
-) -> Result<()> {
+    fw: &mut Arc<Mutex<FramedWrite<T, CrucibleEncoder>>>,
+) -> Result<()>
+where
+    T: tokio::io::AsyncWrite + std::marker::Unpin,
+{
     /*
      * job_channel_rx is a notification that we should look for new work.
      */
@@ -560,18 +573,46 @@ async fn do_work_task(
     Ok(())
 }
 
+async fn proc_stream(
+    ads: &mut Arc<Mutex<Downstairs>>,
+    stream: WrappedStream,
+) -> Result<()> {
+    match stream {
+        WrappedStream::Http(sock) => {
+            let (read, write) = sock.into_split();
+
+            let fr = FramedRead::new(read, CrucibleDecoder::new());
+            let fw = Arc::new(Mutex::new(FramedWrite::new(write, CrucibleEncoder::new())));
+
+            proc(ads, fr, fw).await
+        },
+        WrappedStream::Https(stream) => {
+            let (read, write) = tokio::io::split(stream);
+
+            let fr = FramedRead::new(read, CrucibleDecoder::new());
+            let fw = Arc::new(Mutex::new(FramedWrite::new(write, CrucibleEncoder::new())));
+
+            proc(ads, fr, fw).await
+        },
+    }
+}
+
+
 /*
  * This function handles the initial negotiation steps between the
  * upstairs and the downstairs.  Either we return error, or we call
  * the next function if everything was successful and we can start
  * taking IOs from the upstairs.
  */
-async fn proc(ads: &mut Arc<Mutex<Downstairs>>, sock: TcpStream) -> Result<()> {
-    let (read, write) = sock.into_split();
-    let mut fr = FramedRead::new(read, CrucibleDecoder::new());
-    let fw =
-        Arc::new(Mutex::new(FramedWrite::new(write, CrucibleEncoder::new())));
-
+async fn proc<RT, WT>(
+    ads: &mut Arc<Mutex<Downstairs>>,
+    mut fr: FramedRead<RT, CrucibleDecoder>,
+    fw: Arc<Mutex<FramedWrite<WT, CrucibleEncoder>>>,
+) -> Result<()>
+where
+    RT: tokio::io::AsyncRead + std::marker::Unpin + std::marker::Send,
+    WT: tokio::io::AsyncWrite + std::marker::Unpin + std::marker::Send + 'static,
+{
     let mut negotiated = 0;
     let mut upstairs_uuid = None;
 
@@ -780,13 +821,17 @@ async fn proc(ads: &mut Arc<Mutex<Downstairs>>, sock: TcpStream) -> Result<()> {
  * We assume here that correct negotiation has taken place and this
  * downstairs is ready to receive IO.
  */
-async fn resp_loop(
+async fn resp_loop<RT, WT>(
     ads: &mut Arc<Mutex<Downstairs>>,
-    mut fr: FramedRead<OwnedReadHalf, CrucibleDecoder>,
-    fw: Arc<Mutex<FramedWrite<OwnedWriteHalf, CrucibleEncoder>>>,
+    mut fr: FramedRead<RT, CrucibleDecoder>,
+    fw: Arc<Mutex<FramedWrite<WT, CrucibleEncoder>>>,
     mut another_upstairs_active_rx: mpsc::Receiver<u64>,
     upstairs_uuid: Uuid,
-) -> Result<()> {
+) -> Result<()>
+where
+    RT: tokio::io::AsyncRead + std::marker::Unpin + std::marker::Send,
+    WT: tokio::io::AsyncWrite + std::marker::Unpin + std::marker::Send + 'static,
+{
     let mut lossy_interval = deadline_secs(5);
 
     // XXX flow control size to double what Upstairs has for upper limit?
@@ -893,7 +938,7 @@ async fn resp_loop(
                 return Ok(());
             }
             new_read = fr.next() => {
-                match new_read.transpose()? {
+                match new_read {
                     None => {
                         let mut ds = ads.lock().await;
 
@@ -910,7 +955,7 @@ async fn resp_loop(
 
                         return Ok(());
                     }
-                    Some(msg) => {
+                    Some(Ok(msg)) => {
                         if matches!(msg, Message::Ruok) {
                             // Respond instantly to pings, don't wait.
                             let mut fw = fw.lock().await;
@@ -918,6 +963,11 @@ async fn resp_loop(
                         } else {
                             message_channel_tx.send(msg).await?;
                         }
+                    }
+                    Some(Err(e)) => {
+                        // XXX "unexpected end of file" can occur if upstairs
+                        // terminates, we don't yet have a HangUp message
+                        return Err(e);
                     }
                 }
             }
@@ -1509,6 +1559,11 @@ impl fmt::Display for WorkState {
     }
 }
 
+enum WrappedStream {
+    Http(tokio::net::TcpStream),
+    Https(tokio_rustls::server::TlsStream<tokio::net::TcpStream>),
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::from_args_safe()?;
@@ -1590,6 +1645,9 @@ async fn main() -> Result<()> {
             port,
             return_errors,
             trace_endpoint,
+            cert_pem,
+            key_pem,
+            root_cert_pem,
         } => {
             region = Region::open(&data, Default::default(), true)?;
 
@@ -1672,6 +1730,27 @@ async fn main() -> Result<()> {
             println!("Using address: {:?}", listen_on);
             let listener = TcpListener::bind(&listen_on).await?;
 
+            let ssl_acceptor = if let Some(cert_pem_path) = cert_pem {
+                let key_pem_path = key_pem.unwrap();
+                let root_cert_pem_path = root_cert_pem.unwrap();
+
+                let context = crucible_common::x509::TLSContext::from_paths(
+                    &cert_pem_path,
+                    &key_pem_path,
+                    &root_cert_pem_path
+                )?;
+
+                let config = context.get_server_config()?;
+
+                println!("Configured SSL acceptor");
+
+                Some(tokio_rustls::TlsAcceptor::from(Arc::new(config)))
+            } else {
+                // unencrypted
+                println!("No SSL acceptor configured");
+                None
+            };
+
             /*
              * We now loop listening for a connection from the Upstairs.
              * When we get one, we then spawn the proc() function to handle
@@ -1682,7 +1761,26 @@ async fn main() -> Result<()> {
             loop {
                 let (sock, raddr) = listener.accept().await?;
 
-                println!("connection from {:?}", raddr);
+                let stream: WrappedStream =
+                    if let Some(ssl_acceptor) = &ssl_acceptor {
+                        let ssl_acceptor = ssl_acceptor.clone();
+                        WrappedStream::Https(
+                            match ssl_acceptor.accept(sock).await {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    println!(
+                                        "rejecting connection from {:?}: {:?}",
+                                        raddr, e,
+                                    );
+                                    continue;
+                                }
+                            },
+                        )
+                    } else {
+                        WrappedStream::Http(sock)
+                    };
+
+                println!("accepted connection from {:?}", raddr);
                 {
                     /*
                      * Add one to the counter every time we have a connection
@@ -1695,7 +1793,7 @@ async fn main() -> Result<()> {
                 let mut dd = d.clone();
 
                 tokio::spawn(async move {
-                    if let Err(e) = proc(&mut dd, sock).await {
+                    if let Err(e) = proc_stream(&mut dd, stream).await {
                         println!("ERROR: connection({}): {:?}", raddr, e);
                     } else {
                         println!("OK: connection({}): all done", raddr);

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -582,21 +582,26 @@ async fn proc_stream(
             let (read, write) = sock.into_split();
 
             let fr = FramedRead::new(read, CrucibleDecoder::new());
-            let fw = Arc::new(Mutex::new(FramedWrite::new(write, CrucibleEncoder::new())));
+            let fw = Arc::new(Mutex::new(FramedWrite::new(
+                write,
+                CrucibleEncoder::new(),
+            )));
 
             proc(ads, fr, fw).await
-        },
+        }
         WrappedStream::Https(stream) => {
             let (read, write) = tokio::io::split(stream);
 
             let fr = FramedRead::new(read, CrucibleDecoder::new());
-            let fw = Arc::new(Mutex::new(FramedWrite::new(write, CrucibleEncoder::new())));
+            let fw = Arc::new(Mutex::new(FramedWrite::new(
+                write,
+                CrucibleEncoder::new(),
+            )));
 
             proc(ads, fr, fw).await
-        },
+        }
     }
 }
-
 
 /*
  * This function handles the initial negotiation steps between the
@@ -611,7 +616,10 @@ async fn proc<RT, WT>(
 ) -> Result<()>
 where
     RT: tokio::io::AsyncRead + std::marker::Unpin + std::marker::Send,
-    WT: tokio::io::AsyncWrite + std::marker::Unpin + std::marker::Send + 'static,
+    WT: tokio::io::AsyncWrite
+        + std::marker::Unpin
+        + std::marker::Send
+        + 'static,
 {
     let mut negotiated = 0;
     let mut upstairs_uuid = None;
@@ -830,7 +838,10 @@ async fn resp_loop<RT, WT>(
 ) -> Result<()>
 where
     RT: tokio::io::AsyncRead + std::marker::Unpin + std::marker::Send,
-    WT: tokio::io::AsyncWrite + std::marker::Unpin + std::marker::Send + 'static,
+    WT: tokio::io::AsyncWrite
+        + std::marker::Unpin
+        + std::marker::Send
+        + 'static,
 {
     let mut lossy_interval = deadline_secs(5);
 
@@ -1737,7 +1748,7 @@ async fn main() -> Result<()> {
                 let context = crucible_common::x509::TLSContext::from_paths(
                     &cert_pem_path,
                     &key_pem_path,
-                    &root_cert_pem_path
+                    &root_cert_pem_path,
                 )?;
 
                 let config = context.get_server_config()?;

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -46,6 +46,14 @@ pub struct Opt {
      */
     #[structopt(short, long, default_value = "5")]
     num_upstairs: usize,
+
+    // TLS options
+    #[structopt(long)]
+    cert_pem: Option<String>,
+    #[structopt(long)]
+    key_pem: Option<String>,
+    #[structopt(long)]
+    root_cert_pem: Option<String>,
 }
 
 pub fn opts() -> Result<Opt> {
@@ -70,6 +78,9 @@ fn main() -> Result<()> {
         target: opt.target,
         lossy: false,
         key: opt.key,
+        cert_pem: opt.cert_pem,
+        key_pem: opt.key_pem,
+        root_cert_pem: opt.root_cert_pem,
     };
     let mut generation_number = opt.gen;
 

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -41,6 +41,14 @@ pub struct Opt {
 
     #[structopt(short, long, default_value = "0")]
     gen: u64,
+
+    // TLS options
+    #[structopt(long)]
+    cert_pem: Option<String>,
+    #[structopt(long)]
+    key_pem: Option<String>,
+    #[structopt(long)]
+    root_cert_pem: Option<String>,
 }
 
 pub fn opts() -> Result<Opt> {
@@ -60,6 +68,9 @@ fn main() -> Result<()> {
         target: opt.target,
         lossy: false,
         key: opt.key,
+        cert_pem: opt.cert_pem,
+        key_pem: opt.key_pem,
+        root_cert_pem: opt.root_cert_pem,
     };
 
     /*

--- a/upstairs/Cargo.toml
+++ b/upstairs/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1"
 structopt = "0.3"
 tokio = { version = "1.15.0", features = ["full"] }
 tokio-util = { version = "0.6", features = ["codec"]}
+tokio-rustls = { version = "0.23.2" }
 toml = "0.5"
 tracing = "0.1.29"
 usdt = "0.3.1"

--- a/upstairs/src/main.rs
+++ b/upstairs/src/main.rs
@@ -119,6 +119,7 @@ mod tests {
             target: opt.target,
             lossy: false,
             key: opt.key,
+            ..Default::default()
         };
 
         if let Some(key) = crucible_opts.key_bytes() {

--- a/upstairs/src/main.rs
+++ b/upstairs/src/main.rs
@@ -23,6 +23,14 @@ pub struct Opt {
 
     #[structopt(short, long, default_value = "0")]
     gen: u64,
+
+    // TLS options
+    #[structopt(long)]
+    cert_pem: Option<String>,
+    #[structopt(long)]
+    key_pem: Option<String>,
+    #[structopt(long)]
+    root_cert_pem: Option<String>,
 }
 
 pub fn opts() -> Result<Opt> {
@@ -127,6 +135,9 @@ fn main() -> Result<()> {
         target: opt.target,
         lossy: false,
         key: opt.key,
+        cert_pem: opt.cert_pem,
+        key_pem: opt.key_pem,
+        root_cert_pem: opt.root_cert_pem,
     };
 
     let runtime = Builder::new_multi_thread()

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -240,6 +240,7 @@ mod test {
             target: vec![],
             lossy: false,
             key: None,
+            ..Default::default()
         };
 
         Upstairs::new(&opts, def, Arc::new(Guest::new()))

--- a/x509/Makefile
+++ b/x509/Makefile
@@ -1,0 +1,11 @@
+
+
+.PHONY: certs
+
+all: certs
+
+certs:
+	./gen_certs.sh
+
+clean:
+	rm *.json *.pem *.csr || true

--- a/x509/README.md
+++ b/x509/README.md
@@ -1,0 +1,63 @@
+# How to enable TLS between the Upstairs and Downstairs #
+
+Generate the appropriate X509 keys and certificates by running `make` in this
+directory.
+
+Create a downstairs like normal, but run with new arguments:
+
+    cargo run --release -q -p crucible-downstairs -- \
+        run -p "44100" -d "disks/d0/" \
+        --cert-pem x509/downstairs0.pem \
+        --key-pem x509/downstairs0-key.pem \
+        --root-cert-pem x509/ca.pem
+        
+    cargo run --release -q -p crucible-downstairs -- \
+        run -p "44101" -d "disks/d0/" \
+        --cert-pem x509/downstairs1.pem \
+        --key-pem x509/downstairs1-key.pem \
+        --root-cert-pem x509/ca.pem
+        
+    cargo run --release -q -p crucible-downstairs -- \
+        run -p "44102" -d "disks/d0/" \
+        --cert-pem x509/downstairs2.pem \
+        --key-pem x509/downstairs2-key.pem \
+        --root-cert-pem x509/ca.pem
+
+Run the upstairs with similar arguments:
+
+    cargo run --bin=crucible-client -- \
+        -q \
+        -t 127.0.0.1:44100 \
+        -t 127.0.0.1:44101 \
+        -t 127.0.0.1:44102 \
+        --key "HLyo7ZhAf/E9IdX2DDHPHJO0dLgrRxZabWiTlnoKZXc=" \
+        --cert-pem x509/upstairs.pem \
+        --key-pem x509/upstairs-key.pem \
+        --root-cert-pem x509/ca.pem \
+        --workload one
+
+Note that the Downstairs at port 44100 is running with the key and certificate
+for downstairs0, the Downstairs at port 44101 is running for downstairs1, etc.
+This is important because the Upstairs will attempt connecting to the clients in
+its list with server name "downstairs${i}", where `i` is the number of the
+client in its list:
+
+        -t 127.0.0.1:44100 => downstairs0
+        -t 127.0.0.1:44101 => downstairs1
+        -t 127.0.0.1:44102 => downstairs2
+
+To test that certificates not signed by x509/ca.pem are rejected, try using
+x509/selfsigned.pem and x509/selfsigned-key.pem in the client connection. The
+client should fail with:
+
+    error: InvalidCertificateData("invalid peer certificate: UnknownIssuer")
+
+And the Downstairs should say:
+
+    rejecting connection from 127.0.0.1:49462: Custom { kind: InvalidData, error: AlertReceived(BadCertificate) }
+
+If you try to connect without certificates in the client, it should fail, and
+the Downstairs should say:
+
+    rejecting connection from 127.0.0.1:38116: Custom { kind: InvalidData, error: CorruptMessage }
+

--- a/x509/README.md
+++ b/x509/README.md
@@ -12,13 +12,13 @@ Create a downstairs like normal, but run with new arguments:
         --root-cert-pem x509/ca.pem
         
     cargo run --release -q -p crucible-downstairs -- \
-        run -p "44101" -d "disks/d0/" \
+        run -p "44101" -d "disks/d1/" \
         --cert-pem x509/downstairs1.pem \
         --key-pem x509/downstairs1-key.pem \
         --root-cert-pem x509/ca.pem
         
     cargo run --release -q -p crucible-downstairs -- \
-        run -p "44102" -d "disks/d0/" \
+        run -p "44102" -d "disks/d2/" \
         --cert-pem x509/downstairs2.pem \
         --key-pem x509/downstairs2-key.pem \
         --root-cert-pem x509/ca.pem

--- a/x509/gen_certs.sh
+++ b/x509/gen_certs.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+set -e
+
+#cfssl print-defaults config > ca-config.json
+#cfssl print-defaults csr > ca-csr.json
+cat > ca-config.json <<EOF
+{
+    "signing": {
+        "default": {
+            "expiry": "168h"
+        },
+        "profiles": {
+            "www": {
+                "expiry": "8760h",
+                "usages": [
+                    "signing",
+                    "key encipherment",
+                    "server auth"
+                ]
+            },
+            "client": {
+                "expiry": "8760h",
+                "usages": [
+                    "signing",
+                    "key encipherment",
+                    "client auth"
+                ]
+            }
+        }
+    }
+}
+EOF
+
+cat > ca-csr.json <<EOF
+{
+    "CN": "crucible trust root",
+    "hosts": [
+    ],
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    },
+    "names": [
+        {
+            "C": "CA",
+            "ST": "ON",
+            "L": "Fonthill"
+        }
+    ]
+}
+EOF
+
+cfssl gencert -initca ca-csr.json | cfssljson -bare ca -
+
+for i in {0..2};
+do
+    echo ${i}
+    cat > downstairs${i}-csr.json <<EOF
+{
+    "CN": "downstairs${i}",
+    "hosts": [
+        "downstairs${i}"
+    ],
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    }
+}
+EOF
+
+    cat downstairs${i}-csr.json
+
+    cfssl genkey downstairs${i}-csr.json | cfssljson -bare downstairs${i} -
+    cfssl sign -ca ca.pem -ca-key ca-key.pem downstairs${i}.csr | cfssljson -bare downstairs${i} -
+done
+
+cat > upstairs-csr.json <<EOF
+{
+    "CN": "upstairs",
+    "hosts": [
+        "upstairs"
+    ],
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    }
+}
+EOF
+
+cat upstairs-csr.json
+
+cfssl genkey upstairs-csr.json | cfssljson -bare upstairs -
+cfssl sign -ca ca.pem -ca-key ca-key.pem upstairs.csr | cfssljson -bare upstairs -
+
+# self signed should be rejected
+cat > selfsigned-csr.json <<EOF
+{
+    "CN": "self signed",
+    "hosts": [
+    ],
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    },
+    "names": [
+        {
+            "C": "CA",
+            "ST": "ON",
+            "L": "Fonthill"
+        }
+    ]
+}
+EOF
+
+cfssl gencert -initca selfsigned-csr.json | cfssljson -bare selfsigned -


### PR DESCRIPTION
Add the option to use authenticated TLS between the Upstairs and
Downstairs. This required generalizing the FramedRead and FramedWrite
types so that either TlsStream or TcpStream could be used, plus wrapping
those streams with an enum in order to pass them around without rustc
complaining :)

When I use the term "authenticated" TLS here, I mean that the server
will check that client certificates are signed by a mutual certificate
authority. Clients do **not** yet check that server certs are also
signed by that authority - aka, this is not mutual TLS. I couldn't find
the appropriate options in rustls to enable this.

Scripts that generate keys and certificates have been added to an x509
directory. You'll need the cfssl tool. First, run "make" there to
generate the appropriate files for Upstairs and Downstairs.

Then, create the Downstairs like normal, but run with new arguments:

    cargo run --release -q -p crucible-downstairs -- \
        run -p "44100" -d "disks/d0/" \
        --cert-pem x509/downstairs0.pem \
        --key-pem x509/downstairs0-key.pem \
        --root-cert-pem x509/ca.pem

Certificate number is important here. Part of the TLS connection is a
hostname specification. The Upstairs will try to connect to the first
client as "downstairs0", the second as "downstairs1", and so on.

The Downstairs will then spawn an listener that only accepts client
certificates from the "root" cert. Connect Upstairs with the same
arguments:

    cargo run --bin=crucible-client -- \
        -q \
        -t 127.0.0.1:44100 \
        -t 127.0.0.1:44101 \
        -t 127.0.0.1:44102 \
        --key "HLyo7ZhAf/E9IdX2DDHPHJO0dLgrRxZabWiTlnoKZXc=" \
        --cert-pem x509/upstairs.pem \
        --key-pem x509/upstairs-key.pem \
        --root-cert-pem x509/ca.pem \
        --workload one

To test that certificates not signed by x509/ca.pem are rejected, try
using x509/selfsigned.pem and x509/selfsigned-key.pem in the client
connection. The client should fail with:

        error: InvalidCertificateData("invalid peer certificate: UnknownIssuer")

And the Downstairs should say:

        rejecting connection from 127.0.0.1:49462: Custom { kind: InvalidData, error: AlertReceived(BadCertificate) }

If you try to connect without certificates in the client, it should
fail, and the Downstairs should say:

        rejecting connection from 127.0.0.1:38116: Custom { kind: InvalidData, error: CorruptMessage }