### PR TITLE
derive Default for CrucibleOpts

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -60,7 +60,7 @@ mod cdt {
     fn ds__flush__io__done(_: u64, _: u64) {}
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct CrucibleOpts {
     pub target: Vec<SocketAddr>,
     pub lossy: bool,


### PR DESCRIPTION
Pulled this change out of https://github.com/oxidecomputer/crucible/pull/182 so that the merge of https://github.com/oxidecomputer/propolis/pull/86 will not have to be synchronized.