### PR TITLE
Simple CLI for crucible client.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 core
 *.swp
 /.*.sock
+.cli_history.txt
 /fio/*.png
 /fio/*.log
 /fio/*.log.hist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4d3d118de1bf9678546f65e12f749b46abb5a56129d435af21fc7e42768f974"
+dependencies = [
+ "error-code",
+ "str-buf",
+ "winapi",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +433,7 @@ name = "crucible-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode",
  "bytes",
  "crucible",
  "crucible-common",
@@ -432,12 +444,14 @@ dependencies = [
  "rand",
  "rand_chacha",
  "ringbuffer",
+ "rustyline",
  "serde",
  "serde_json",
  "structopt",
  "tokio",
  "tokio-util",
  "toml",
+ "uuid",
 ]
 
 [[package]]
@@ -778,6 +792,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
+]
+
+[[package]]
 name = "expectorate"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +855,17 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fd-lock"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcef756dea9cf3db5ce73759cf0467330427a786b47711b8d6c97620d718ceb9"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -1189,6 +1251,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
 
 [[package]]
+name = "io-lifetimes"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ef6787e7f0faedc040f95716bdd0e62bcfcf4ba93da053b62dea2691c13864"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1316,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95f5690fef754d905294c56f7ac815836f2513af966aa47f2e07ac79be07827f"
 
 [[package]]
 name = "lock_api"
@@ -1307,6 +1384,15 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1393,6 +1479,28 @@ dependencies = [
  "serde_json",
  "slog",
  "uuid",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1951,6 +2059,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,6 +2254,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cee647393af53c750e15dcbf7781cdd2e550b246bde76e46c326e7ea3c73773"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rustls"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,6 +2293,30 @@ name = "rustversion"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+
+[[package]]
+name = "rustyline"
+version = "9.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7826789c0e25614b03e5a54a0717a86f9ff6e6e5247f92b369472869320039"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "clipboard-win",
+ "dirs-next",
+ "fd-lock",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "scopeguard",
+ "smallvec",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
+]
 
 [[package]]
 name = "ryu"
@@ -2555,6 +2711,12 @@ dependencies = [
  "tokio",
  "uuid",
 ]
+
+[[package]]
+name = "str-buf"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44a3643b4ff9caf57abcee9c2c621d6c03d9135e0d8b589bd9afb5992cb176a"
 
 [[package]]
 name = "stringprep"
@@ -3232,6 +3394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3411,6 +3579,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030b7ff91626e57a05ca64a07c481973cbb2db774e4852c9c7ca342408c6a99a"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29277a4435d642f775f63c7d1faeb927adba532886ce0287bd985bffb16b6bca"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145e1989da93956c68d1864f32fb97c8f561a8f89a5125f6a2b7ea75524e4b8"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a09e3a0d4753b73019db171c1339cd4362c8c44baf1bcea336235e955954a6"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca64fcb0220d58db4c119e050e7af03c69e6f4f415ef69ec1773d9aab422d5a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08cabc9f0066848fef4bc6a1c1668e6efce38b661d2aeec75d18d8617eebb5f1"
 
 [[package]]
 name = "winreg"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
+bincode = "1.3.3"
 bytes = "1"
 crucible = { path = "../upstairs" }
 crucible-common = { path = "../common" }
@@ -17,9 +18,11 @@ futures-core = "0.3"
 ringbuffer = "0.8"
 rand = "0.8.4"
 rand_chacha = "0.3.1"
+rustyline = "9.1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 structopt = "0.3"
 tokio = { version = "1.15.0", features = ["full"] }
 tokio-util = { version = "0.6", features = ["codec"]}
 toml = "0.5"
+uuid = { version = "0.8", features = [ "serde", "v4" ] }

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -1,0 +1,566 @@
+// Copyright 2022 Oxide Computer Company
+use std::net::SocketAddr;
+
+use futures::{SinkExt, StreamExt};
+use rustyline::error::ReadlineError;
+use rustyline::Editor;
+use structopt::clap::AppSettings;
+use tokio::net::tcp::WriteHalf;
+use tokio::net::{TcpListener, TcpSocket, TcpStream};
+use tokio_util::codec::{FramedRead, FramedWrite};
+
+use super::*;
+use protocol::*;
+
+/*
+ * Commands supported by the crucible CLI.  Most of these translate into
+ * an actual BlockOpt, but some are processed locally, and some happen
+ * on the cli_server side.
+ *
+ * I'm not totally happy with how structopt is working here, as it
+ * thinks of everything as a subcommand.  Perhaps there is a better
+ * library for this. XXX
+ */
+#[derive(Debug, StructOpt)]
+#[structopt(name = "", setting(AppSettings::NoBinaryName))]
+/// Commands supported by the Crucible CLI
+enum CliCommand {
+    /// Activate the upstairs
+    Activate {
+        #[structopt(long, short, default_value = "1")]
+        gen: u64,
+    },
+    /// Deactivate the upstairs
+    Deactivate,
+    /// Flush
+    Flush,
+    /// Request region information
+    Info,
+    /// Report if the Upstairs is ready for guest IO
+    IsActive,
+    /// Read from a given block offset
+    Read {
+        #[structopt(long, short)]
+        offset: usize,
+        #[structopt(long, short, default_value = "1")]
+        len: usize,
+    },
+    /// Issue a random read
+    Rr,
+    /// Issue a random write
+    Rw,
+    /// Show the work queues
+    Show,
+    /// Change the wait state between true and false
+    Wait,
+    /// Read and verify the whole volume.
+    Verify,
+    /// Write to a given block offset
+    Write {
+        #[structopt(short)]
+        offset: usize,
+        #[structopt(long, short, default_value = "1")]
+        len: usize,
+    },
+    /// Get the upstairs UUID
+    Uuid,
+}
+
+/*
+ * A wrapper around read that just picks a random offset.
+ */
+fn rand_read(
+    guest: &Arc<Guest>,
+    ri: &mut RegionInfo,
+) -> Result<Vec<u8>, CrucibleError> {
+    let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
+    let size = 1;
+    let block_max = ri.total_blocks - size + 1;
+    let block_index = rng.gen_range(0..block_max);
+
+    cli_read(guest, ri, block_index, size)
+}
+
+/*
+ * Generate a read for the guest with the given offset/length.
+ * Wait for the IO to return.
+ * Verify the data is as we expect using the client based validation.
+ * Note that if you have not written to a block yet and you are not
+ * importing a verify file, this will default to passing.  Only when
+ * there is non zero data in the ri.write_count will we have something
+ * to verify against.
+ *
+ * After verify, we truncate the data to 10 fields and return that so
+ * the cli server can send it back to the client for display.
+ */
+fn cli_read(
+    guest: &Arc<Guest>,
+    ri: &mut RegionInfo,
+    block_index: usize,
+    size: usize,
+) -> Result<Vec<u8>, CrucibleError> {
+    /*
+     * Convert offset to its byte value.
+     */
+    let offset = Block::new(block_index as u64, ri.block_size.trailing_zeros());
+    let length: usize = size * ri.block_size as usize;
+
+    let vec: Vec<u8> = vec![255; length];
+    let data = crucible::Buffer::from_vec(vec);
+
+    println!("Read  at block {:5}, len:{:7}", offset.value, data.len());
+    let mut waiter = guest.read(offset, data.clone())?;
+    waiter.block_wait()?;
+
+    let mut dl = data.as_vec().to_vec();
+    if !validate_vec(dl.clone(), block_index, &ri.write_count, ri.block_size) {
+        println!("Data mismatch error at {}", block_index);
+        Err(CrucibleError::GenericError("Data mismatch".to_string()))
+    } else {
+        dl.truncate(10);
+        Ok(dl)
+    }
+}
+
+/*
+ * A wrapper around write that just picks a random offset.
+ */
+fn rand_write(
+    guest: &Arc<Guest>,
+    ri: &mut RegionInfo,
+) -> Result<(), CrucibleError> {
+    /*
+     * TODO: Allow the user to specify a seed here.
+     */
+    let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
+
+    /*
+     * Once we have our IO size, decide where the starting offset should
+     * be, which is the total possible size minus the randomly chosen
+     * IO size.
+     */
+    let size = 1;
+    let block_max = ri.total_blocks - size + 1;
+    let block_index = rng.gen_range(0..block_max) as usize;
+
+    cli_write(guest, ri, block_index, size)
+}
+
+/*
+ * Issue a write to the guest at the given offset/len.
+ * Data is generated based on the value in the internal write counter.
+ * Update the internal write counter so we have something to compare to.
+ */
+fn cli_write(
+    guest: &Arc<Guest>,
+    ri: &mut RegionInfo,
+    block_index: usize,
+    size: usize,
+) -> Result<(), CrucibleError> {
+    /*
+     * Convert offset and length to their byte values.
+     */
+    let offset = Block::new(block_index as u64, ri.block_size.trailing_zeros());
+
+    /*
+     * Update the write count for the block we plan to write to.
+     */
+    ri.write_count[block_index] += 1;
+
+    let vec = fill_vec(block_index, size, &ri.write_count, ri.block_size);
+    let data = Bytes::from(vec);
+
+    println!("Write at block {:5}, len:{:7}", offset.value, data.len());
+
+    let mut waiter = guest.write(offset, data)?;
+    waiter.block_wait()?;
+
+    Ok(())
+}
+
+/*
+ * Take a CLI cmd coming from our client program and translate it into
+ * an actual CliMessage to send to the cli server.
+ *
+ * At the moment, we ping pong here, where we send a command to the
+ * cli_server, then we wait for the response.
+ * Eventually we could make this async, but, yeah, I got things to do.
+ */
+async fn cmd_to_msg(
+    cmd: CliCommand,
+    fr: &mut FramedRead<tokio::net::tcp::ReadHalf<'_>, CliDecoder>,
+    fw: &mut FramedWrite<WriteHalf<'_>, CliEncoder>,
+) -> Result<()> {
+    match cmd {
+        CliCommand::Uuid => {
+            fw.send(CliMessage::Uuid).await?;
+        }
+        CliCommand::Info => {
+            fw.send(CliMessage::InfoPlease).await?;
+        }
+        CliCommand::Activate { gen } => {
+            fw.send(CliMessage::Activate(gen)).await?;
+        }
+        CliCommand::Deactivate => {
+            fw.send(CliMessage::Deactivate).await?;
+        }
+        CliCommand::Read { offset, len } => {
+            fw.send(CliMessage::Read(offset, len)).await?;
+        }
+        CliCommand::Rr => {
+            fw.send(CliMessage::RandRead).await?;
+        }
+        CliCommand::Write { offset, len } => {
+            fw.send(CliMessage::Write(offset, len)).await?;
+        }
+        CliCommand::Rw => {
+            fw.send(CliMessage::RandWrite).await?;
+        }
+        CliCommand::Flush => {
+            fw.send(CliMessage::Flush).await?;
+        }
+        CliCommand::IsActive => {
+            fw.send(CliMessage::IsActive).await?;
+        }
+        CliCommand::Show => {
+            println!("No support for {:?}", cmd);
+            return Ok(());
+        }
+        CliCommand::Wait => {
+            println!("No support for {:?}", cmd);
+            return Ok(());
+        }
+        CliCommand::Verify => {
+            println!("No support for {:?}", cmd);
+            return Ok(());
+        }
+    }
+    /*
+     * Now, wait for our response
+     */
+    let new_read = fr.next().await;
+    match new_read.transpose()? {
+        Some(CliMessage::MyUuid(uuid)) => {
+            println!("uuid: {}", uuid);
+        }
+        Some(CliMessage::Info(es, bs, bl)) => {
+            println!("Got info: {} {} {}", es, bs, bl);
+        }
+        Some(CliMessage::DoneOk) => {
+            println!("Ok");
+        }
+        Some(CliMessage::ReadResponse(resp)) => match resp {
+            Ok(data) => {
+                println!("Data: {:?}", data);
+            }
+            Err(e) => {
+                println!("ERROR: {:?}", e);
+            }
+        },
+        Some(CliMessage::Error(e)) => {
+            println!("ERROR: {:?}", e);
+        }
+        Some(CliMessage::ActiveIs(active)) => {
+            println!("Active is: {}", active);
+        }
+        m => {
+            println!("No code for this response {:?}", m);
+        }
+    }
+    Ok(())
+}
+
+/*
+ * The CLI just sends commands to the cli_server where all the logic
+ * lives, including any state about what blocks were written.
+ */
+pub async fn start_cli_client(attach: SocketAddr) -> Result<()> {
+    'outer: loop {
+        let sock = if attach.is_ipv4() {
+            TcpSocket::new_v4().unwrap()
+        } else {
+            TcpSocket::new_v6().unwrap()
+        };
+
+        println!("cli connecting to {0}", attach);
+
+        let deadline = tokio::time::sleep_until(deadline_secs(100));
+        tokio::pin!(deadline);
+        let tcp = sock.connect(attach);
+        tokio::pin!(tcp);
+
+        let mut tcp: TcpStream = loop {
+            tokio::select! {
+                _ = &mut deadline => {
+                    println!("connect timeout");
+                    continue 'outer;
+                }
+                tcp = &mut tcp => {
+                    match tcp {
+                        Ok(tcp) => {
+                            println!("connected to {}", attach);
+                            break tcp;
+                        }
+                        Err(e) => {
+                            println!("connect to {0} failure: {1:?}",
+                                attach, e);
+                            tokio::time::sleep_until(deadline_secs(10)).await;
+                            continue 'outer;
+                        }
+                    }
+                }
+            }
+        };
+
+        /*
+         * Create the read/write endpoints so this client can send and
+         * receive messages from the cli_server.
+         */
+        let (r, w) = tcp.split();
+        let mut fr = FramedRead::new(r, CliDecoder::new());
+        let mut fw = FramedWrite::new(w, CliEncoder::new());
+
+        let mut rl = Editor::<()>::new();
+
+        if rl.load_history(".cli_history.txt").is_err() {
+            println!("No previous history.");
+        }
+        loop {
+            let readline = rl.readline(">> ");
+            match readline {
+                Ok(line) => {
+                    rl.add_history_entry(line.as_str());
+                    let cmds: Vec<&str> = line.trim().split(' ').collect();
+
+                    // Empty command, just ignore it and loop.
+                    if cmds[0].is_empty() {
+                        continue;
+                    }
+                    // TODO: add a quit command
+                    match CliCommand::from_iter_safe(cmds) {
+                        Ok(vc) => {
+                            cmd_to_msg(vc, &mut fr, &mut fw).await?;
+                            // TODO: Handle this error
+                        }
+                        Err(e) => {
+                            println!("{}", e);
+                        }
+                    }
+                }
+                Err(ReadlineError::Interrupted) => {
+                    println!("CTRL-C");
+                    break;
+                }
+                Err(ReadlineError::Eof) => {
+                    println!("CTRL-D");
+                    break;
+                }
+                Err(err) => {
+                    println!("CLI Error: {:?}", err);
+                    break;
+                }
+            }
+        }
+        // TODO: Figure out how to handle a disconnect from the crucible
+        // side and let things continue.
+
+        rl.save_history(".cli_history.txt").unwrap();
+        break;
+    }
+    Ok(())
+}
+
+/*
+ * Server for a crucible client CLI.
+ * This opens a network port and listens for commands from the cli_client.
+ * When it receives one, it translates it into the crucible Guest command
+ * and passes it on to the Upstairs.
+ * State is kept here.
+ * No checking is done.
+ * Wait here if you want.
+ */
+pub async fn start_cli_server(
+    guest: &Arc<Guest>,
+    address: IpAddr,
+    port: u16,
+) -> Result<()> {
+    let listen_on = match address {
+        IpAddr::V4(ipv4) => SocketAddr::new(std::net::IpAddr::V4(ipv4), port),
+        IpAddr::V6(ipv6) => SocketAddr::new(std::net::IpAddr::V6(ipv6), port),
+    };
+
+    /*
+     * Establish a listen server on the port.
+     */
+    println!("Listening for a CLI connection on: {:?}", listen_on);
+    let listener = TcpListener::bind(&listen_on).await?;
+
+    loop {
+        let (sock, raddr) = listener.accept().await?;
+        println!("connection from {:?}", raddr);
+
+        let (read, write) = sock.into_split();
+        let mut fr = FramedRead::new(read, CliDecoder::new());
+        let mut fw = FramedWrite::new(write, CliEncoder::new());
+
+        /*
+         * If write_count len is zero, then the RegionInfo has
+         * not been filled.
+         */
+        let mut ri: RegionInfo = RegionInfo {
+            block_size: 0,
+            extent_size: Block::new_512(0),
+            total_size: 0,
+            total_blocks: 0,
+            write_count: Vec::new(),
+            max_block_io: 0,
+        };
+
+        loop {
+            tokio::select! {
+                new_read = fr.next() => {
+                    match new_read.transpose()? {
+                        None => {
+                            println!("Got nothing from socket");
+                            break;
+                        },
+                        Some(CliMessage::Uuid) => {
+                            let uuid = guest.query_upstairs_uuid()?;
+                            fw.send(CliMessage::MyUuid(uuid)).await?;
+                        },
+                        Some(CliMessage::InfoPlease) => {
+                            let new_ri = get_region_info(guest);
+                            match new_ri {
+                                Ok(new_ri) => {
+                                    let bs = new_ri.block_size;
+                                    let es = new_ri.extent_size.value;
+                                    let ts = new_ri.total_size;
+                                    ri = new_ri;
+                                    fw.send(CliMessage::Info(
+                                        bs, es, ts
+                                    )).await?;
+                                }
+                                Err(e) => {
+                                    fw.send(CliMessage::Error(e)).await?;
+                                }
+                            }
+                        },
+                        Some(CliMessage::Read(offset, len)) => {
+                            if ri.write_count.is_empty() {
+                                fw.send(CliMessage::Error(
+                                    CrucibleError::GenericError(
+                                        "Info not initialized".to_string()
+                                    )
+                                )).await?;
+                            } else {
+                                let res = cli_read(guest, &mut ri, offset, len);
+                                fw.send(CliMessage::ReadResponse(res)).await?;
+                            }
+                        },
+                        Some(CliMessage::RandRead) => {
+                            if ri.write_count.is_empty() {
+                                fw.send(CliMessage::Error(
+                                    CrucibleError::GenericError(
+                                        "Info not initialized".to_string()
+                                    )
+                                )).await?;
+                            } else {
+                                let res = rand_read(guest, &mut ri);
+                                fw.send(CliMessage::ReadResponse(res)).await?;
+                            }
+                        },
+                        Some(CliMessage::Write(offset, len)) => {
+                            if ri.write_count.is_empty() {
+                                fw.send(CliMessage::Error(
+                                    CrucibleError::GenericError(
+                                        "Info not initialized".to_string()
+                                    )
+                                )).await?;
+                            } else {
+                                match cli_write(guest, &mut ri, offset, len) {
+                                    Ok(_) => {
+                                        fw.send(CliMessage::DoneOk).await?;
+                                    }
+                                    Err(e) => {
+                                        fw.send(CliMessage::Error(e)).await?;
+                                    }
+                                }
+                            }
+                        },
+                        Some(CliMessage::RandWrite) => {
+                            if ri.write_count.is_empty() {
+                                fw.send(CliMessage::Error(
+                                    CrucibleError::GenericError(
+                                        "Info not initialized".to_string()
+                                    )
+                                )).await?;
+                            } else {
+                                match rand_write(guest, &mut ri) {
+                                    Ok(_) => {
+                                        fw.send(CliMessage::DoneOk).await?;
+                                    }
+                                    Err(e) => {
+                                        fw.send(CliMessage::Error(e)).await?;
+                                    }
+                                }
+                            }
+                        },
+                        Some(CliMessage::Activate(gen)) => {
+                            match guest.activate(gen) {
+                                Ok(_) => {
+                                    fw.send(CliMessage::DoneOk).await?;
+                                }
+                                Err(e) => {
+                                    fw.send(CliMessage::Error(e)).await?;
+                                }
+                            }
+                        },
+                        Some(CliMessage::IsActive) => {
+                            match guest.query_is_active() {
+                                Ok(a) => {
+                                    fw.send(CliMessage::ActiveIs(a)).await?;
+                                }
+                                Err(e) => {
+                                    fw.send(CliMessage::Error(e)).await?;
+                                }
+                            }
+                        },
+                        Some(CliMessage::Flush) => {
+                            match guest.flush() {
+                                Ok(_) => {
+                                    fw.send(CliMessage::DoneOk).await?;
+                                }
+                                Err(e) => {
+                                    fw.send(CliMessage::Error(e)).await?;
+                                }
+                            }
+                        },
+                        Some(CliMessage::Deactivate) => {
+                            match guest.deactivate() {
+                                Ok(mut waiter) => {
+                                    match waiter.block_wait() {
+                                        Ok(_) => {
+                                            fw.send(CliMessage::DoneOk).await?;
+                                        }
+                                        Err(e) => {
+                                            fw.send(CliMessage::Error(
+                                                e
+                                            )).await?;
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    fw.send(CliMessage::Error(e)).await?;
+                                }
+                            }
+                        },
+                        Some(msg) => {
+                            println!("No code written for {:?}", msg);
+                        }
+                    }
+                }
+            }
+        }
+        println!("Exiting, wait for another connection");
+    }
+}

--- a/client/src/protocol.rs
+++ b/client/src/protocol.rs
@@ -1,0 +1,274 @@
+// Copyright 2022 Oxide Computer Company
+use anyhow::bail;
+use bytes::{Buf, BufMut, BytesMut};
+use serde::{Deserialize, Serialize};
+use tokio_util::codec::{Decoder, Encoder};
+use uuid::Uuid;
+
+use super::*;
+
+const MAX_FRM_LEN: usize = 100 * 1024 * 1024; // 100M
+
+use crucible_common::CrucibleError;
+
+/// Messages sent between the CLI client and the CLI server.
+/// Note that the server does the work, sends any write data,
+/// checks any read data.
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub enum CliMessage {
+    Uuid,
+    MyUuid(Uuid),
+    InfoPlease,
+    Info(u64, u64, u64),
+    Error(CrucibleError),
+    Activate(u64),
+    IsActive,
+    ActiveIs(bool),
+    Deactivate,
+    // Generic command success
+    DoneOk,
+    Read(usize, usize),
+    RandRead,
+    ReadResponse(Result<Vec<u8>, CrucibleError>),
+    Write(usize, usize),
+    RandWrite,
+    Flush,
+    Unknown(u32, BytesMut),
+}
+
+#[derive(Debug)]
+pub struct CliEncoder {}
+
+impl CliEncoder {
+    pub fn new() -> Self {
+        CliEncoder {}
+    }
+
+    fn serialized_size<T: serde::Serialize>(
+        m: T,
+    ) -> Result<usize, anyhow::Error> {
+        let serialized_len: usize = bincode::serialized_size(&m)? as usize;
+        let len = serialized_len + 4;
+
+        Ok(len)
+    }
+}
+
+impl Default for CliEncoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/*
+ * A frame is [len | serialized message].
+ */
+
+impl Encoder<CliMessage> for CliEncoder {
+    type Error = anyhow::Error;
+
+    fn encode(
+        &mut self,
+        m: CliMessage,
+        dst: &mut BytesMut,
+    ) -> Result<(), Self::Error> {
+        let len = CliEncoder::serialized_size(&m)?;
+
+        dst.reserve(len);
+        dst.put_u32_le(len as u32);
+        bincode::serialize_into(dst.writer(), &m)?;
+
+        Ok(())
+    }
+}
+
+impl Encoder<&CliMessage> for CliEncoder {
+    type Error = anyhow::Error;
+
+    fn encode(
+        &mut self,
+        m: &CliMessage,
+        dst: &mut BytesMut,
+    ) -> Result<(), Self::Error> {
+        let len = CliEncoder::serialized_size(&m)?;
+
+        dst.reserve(len);
+        dst.put_u32_le(len as u32);
+        bincode::serialize_into(dst.writer(), &m)?;
+
+        Ok(())
+    }
+}
+
+pub struct CliDecoder {}
+
+impl CliDecoder {
+    pub fn new() -> Self {
+        CliDecoder {}
+    }
+}
+
+impl Default for CliDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Decoder for CliDecoder {
+    type Item = CliMessage;
+    type Error = anyhow::Error;
+
+    fn decode(
+        &mut self,
+        src: &mut BytesMut,
+    ) -> Result<Option<Self::Item>, Self::Error> {
+        if src.len() < 4 {
+            /*
+             * Wait for the u32 length prefix.
+             */
+            return Ok(None);
+        }
+
+        /*
+         * Get the length prefix from the frame.
+         */
+        let mut length_bytes = [0u8; 4];
+        length_bytes.copy_from_slice(&src[0..4]);
+        let len = u32::from_le_bytes(length_bytes) as usize;
+
+        if len > MAX_FRM_LEN {
+            bail!("frame is {} bytes, more than maximum {}", len, MAX_FRM_LEN);
+        }
+
+        if src.len() < len {
+            /*
+             * Wait for an entire frame.  Expand the buffer to fit.
+             */
+            src.reserve(len);
+            return Ok(None);
+        }
+
+        src.advance(4);
+
+        let message = bincode::deserialize_from(src.reader());
+
+        Ok(Some(message?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+
+    fn round_trip(input: &CliMessage) -> Result<CliMessage> {
+        let mut enc = CliEncoder::new();
+        let mut buf = BytesMut::new();
+        enc.encode(input.clone(), &mut buf)?;
+
+        let mut dec = CliDecoder::new();
+        let output = dec.decode(&mut buf)?;
+        if let Some(output) = output {
+            Ok(output)
+        } else {
+            bail!("expected message, got None");
+        }
+    }
+
+    #[test]
+    fn rt_uuid() -> Result<()> {
+        let input = CliMessage::Uuid;
+        assert_eq!(input, round_trip(&input)?);
+        Ok(())
+    }
+
+    #[test]
+    fn rt_my_uuid() -> Result<()> {
+        let input = CliMessage::MyUuid(Uuid::new_v4());
+        assert_eq!(input, round_trip(&input)?);
+        Ok(())
+    }
+
+    #[test]
+    fn rt_info_please() -> Result<()> {
+        let input = CliMessage::InfoPlease;
+        assert_eq!(input, round_trip(&input)?);
+        Ok(())
+    }
+
+    #[test]
+    fn rt_info() -> Result<()> {
+        let input = CliMessage::Info(1, 2, 99);
+        assert_eq!(input, round_trip(&input)?);
+        Ok(())
+    }
+
+    #[test]
+    fn rt_activate() -> Result<()> {
+        let input = CliMessage::Activate(99);
+        assert_eq!(input, round_trip(&input)?);
+        Ok(())
+    }
+
+    #[test]
+    fn rt_deactivate() -> Result<()> {
+        let input = CliMessage::Deactivate;
+        assert_eq!(input, round_trip(&input)?);
+        Ok(())
+    }
+
+    #[test]
+    fn rt_done_ok() -> Result<()> {
+        let input = CliMessage::DoneOk;
+        assert_eq!(input, round_trip(&input)?);
+        Ok(())
+    }
+
+    #[test]
+    fn rt_is_active() -> Result<()> {
+        let input = CliMessage::IsActive;
+        assert_eq!(input, round_trip(&input)?);
+        Ok(())
+    }
+
+    #[test]
+    fn rt_read() -> Result<()> {
+        let input = CliMessage::Read(32, 22);
+        assert_eq!(input, round_trip(&input)?);
+        Ok(())
+    }
+
+    #[test]
+    fn rt_write() -> Result<()> {
+        let input = CliMessage::Write(32, 22);
+        assert_eq!(input, round_trip(&input)?);
+        Ok(())
+    }
+
+    // ZZZ tests for readresponse, Error
+    #[test]
+    fn correctly_detect_truncated_message() -> Result<()> {
+        let mut encoder = CliEncoder::new();
+        let mut decoder = CliDecoder::new();
+
+        let input = CliMessage::MyUuid(Uuid::new_v4());
+        let mut buffer = BytesMut::new();
+
+        encoder.encode(input, &mut buffer)?;
+
+        buffer.truncate(buffer.len() - 1);
+
+        let result = decoder.decode(&mut buffer);
+
+        match result {
+            Err(_) => {
+                result?;
+            }
+            Ok(v) => {
+                assert_eq!(v, None);
+            }
+        };
+
+        Ok(())
+    }
+}

--- a/tools/downstairs_daemon.sh
+++ b/tools/downstairs_daemon.sh
@@ -138,9 +138,8 @@ else
 fi
 
 cds="./target/debug/crucible-downstairs"
-cc="./target/debug/crucible-client"
-if [[ ! -f ${cds} ]] || [[ ! -f ${cc} ]]; then
-    echo "Can't find crucible binary at $cds or $cc"
+if [[ ! -f ${cds} ]]; then
+    echo "Can't find crucible binary at $cds"
     exit 1
 fi
 

--- a/tools/test_reconnect.sh
+++ b/tools/test_reconnect.sh
@@ -43,7 +43,7 @@ for (( i = 0; i < 3; i++ )); do
 done
 
 # Initial seed for verify file
-if ! cargo run -q -p crucible-client -- "${args[@]}" -w one -q \
+if ! cargo run -q -p crucible-client -- one "${args[@]}" -q \
           --verify-out alan --retry-activate >> "$test_log" 2>&1 ; then
     echo Failed on initial verify seed, check "$test_log"
     touch /var/tmp/ds_test/stop
@@ -56,8 +56,8 @@ do
     SECONDS=0
     echo "" > "$test_log"
     echo "New loop starts now $(date)" >> "$test_log"
-    cargo run -q -p crucible-client -- "${args[@]}" \
-            -w one -q --verify-out alan \
+    cargo run -q -p crucible-client -- one "${args[@]}" \
+            -q --verify-out alan \
             --verify-in alan \
             --retry-activate >> "$test_log" 2>&1
     result=$?

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -82,8 +82,8 @@ test_list="one span big dep deactivate balloon"
 for tt in ${test_list}; do
     echo ""
     echo "Running test: $tt"
-    echo "$cc" -q -w "$tt" "${args[@]}"
-    if ! "$cc" -q -w "$tt" "${args[@]}"; then
+    echo "$cc" "$tt" -q "${args[@]}"
+    if ! "$cc" "$tt" -q "${args[@]}"; then
         (( res += 1 ))
         echo ""
         echo "Failed crucible-client $tt test"
@@ -104,15 +104,15 @@ fi
 echo ""
 echo "Running verify test: $tt"
 vfile="${testdir}/verify"
-echo "$cc" -q -w rand --verify-out "$vfile" "${args[@]}"
-if ! "$cc" -q -w rand --verify-out "$vfile" "${args[@]}"; then
+echo "$cc" rand -q --verify-out "$vfile" "${args[@]}"
+if ! "$cc" rand -q --verify-out "$vfile" "${args[@]}"; then
     (( res += 1 ))
     echo ""
     echo "Failed crucible-client rand verify test"
     echo ""
 else
-    echo "$cc" -q -w rand --verify-in "$vfile" "${args[@]}"
-    if ! "$cc" -q -w rand --verify-in "$vfile" "${args[@]}"; then
+    echo "$cc" rand -q --verify-in "$vfile" "${args[@]}"
+    if ! "$cc" rand -q --verify-in "$vfile" "${args[@]}"; then
         (( res += 1 ))
         echo ""
         echo "Failed crucible-client rand verify part 2 test"


### PR DESCRIPTION
This is very similar to the nbd_server idea, but instead of nbd, I just made a CLI
that you can send specific commands to.  I sometimes what to send just a deactivate, or just
a read of a specific block, and I wanted an interface to do that without having to make a
custom program for it.

This ended up being more work than I thought, and It is still not done, but what I have here
is functional and I can iterate on it to add functionality and make some of the giant loops
into sub-functions or methods or types, depending.  There are more commands to handle
as well.

From the commit:
A super simple crucible-client server and cli program.
This is two programs based on the crucible-client test program.
A cli-server, which starts crucible-client, creates the runtime
and start the Upstairs.  This cli-sever opens a port and listens
for commands to come it, sending them to the upstairs (via the guest
methods).  Results are reported back to the CLI.

Some state is kept in the cli-server side.

The cli-client just takes a list of supported commands and sends
them over the socket to the server, reporting back their result.