### PR TITLE
Implement snapshots, and update the crucible agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,7 @@ name = "crucible-agent-client"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "chrono",
  "percent-encoding",
  "progenitor",
  "reqwest",
@@ -513,8 +514,12 @@ dependencies = [
  "rand_chacha 0.3.1",
  "ringbuffer",
  "rusqlite",
+ "schemars",
  "serde",
  "sha2 0.10.1",
+ "slog",
+ "slog-async",
+ "slog-term",
  "structopt",
  "tempfile",
  "tokio",

--- a/agent-client/Cargo.toml
+++ b/agent-client/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+chrono = { version = "0.4", features = [ "serde" ] }
 percent-encoding = "2.1"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }

--- a/agent/agent.xml
+++ b/agent/agent.xml
@@ -21,7 +21,8 @@
       -i %{config/uuid}
       -n %{config/nexus}
       -P %{config/portbase}
-      -p %{config/prefix}'
+      -p %{config/downstairs_prefix}
+      -s %{config/snapshot_prefix}'
     timeout_seconds='30'
     />
 
@@ -37,7 +38,8 @@
     <propval name='uuid' type='astring' value='' />
     <propval name='nexus' type='astring' value='127.0.0.1:12221' />
     <propval name='portbase' type='astring' value='19000' />
-    <propval name='prefix' type='astring' value='downstairs' />
+    <propval name='downstairs_prefix' type='astring' value='downstairs' />
+    <propval name='snapshot_prefix' type='astring' value='snapshot' />
   </property_group>
 
   <stability value='Unstable' />

--- a/agent/downstairs.xml
+++ b/agent/downstairs.xml
@@ -14,9 +14,7 @@
   </dependency>
 
   <exec_method type='method' name='start'
-    exec='/opt/oxide/crucible/bin/downstairs
-      --data %{config/directory}
-      --port %{config/port}'
+    exec='/opt/oxide/crucible/bin/downstairs_method_script.sh'
     timeout_seconds='30'
     />
 
@@ -29,6 +27,10 @@
   <property_group name='config' type='application'>
     <propval name='directory' type='astring' value='/dev/null' />
     <propval name='port' type='count' value='0' />
+    <propval name='mode' type='astring' value='rw' />
+    <propval name='cert_pem_path' type='astring' value='' />
+    <propval name='key_pem_path' type='astring' value='' />
+    <propval name='root_pem_path' type='astring' value='' />
   </property_group>
 
   <stability value='Unstable' />

--- a/agent/downstairs_method_script.sh
+++ b/agent/downstairs_method_script.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+
+args=(
+        '--data' "$(svcprop -p config/directory "${SMF_FMRI}")"
+        '--port' "$(svcprop -p config/port "${SMF_FMRI}")"
+        '--mode' "$(svcprop -p config/mode "${SMF_FMRI}")"
+)
+
+val="$(svcprop -p config/cert_pem_path "${SMF_FMRI}")"
+if [[ -n "$val" ]]; then
+        args+=( '--cert-pem' )
+        args+=( "$val" )
+fi
+
+val="$(svcprop -p config/key_pem_path "${SMF_FMRI}")"
+if [[ -n "$val" ]]; then
+        args+=( '--key-pem' )
+        args+=( "$val" )
+fi
+
+val="$(svcprop -p config/root_pem_path "${SMF_FMRI}")"
+if [[ -n "$val" ]]; then
+        args+=( '--root-cert-pem' )
+        args+=( "$val" )
+fi
+
+exec /opt/oxide/crucible/bin/downstairs run "${args[@]}"

--- a/agent/downstairs_method_script.sh
+++ b/agent/downstairs_method_script.sh
@@ -4,24 +4,24 @@ set -o errexit
 set -o pipefail
 
 args=(
-        '--data' "$(svcprop -p config/directory "${SMF_FMRI}")"
-        '--port' "$(svcprop -p config/port "${SMF_FMRI}")"
-        '--mode' "$(svcprop -p config/mode "${SMF_FMRI}")"
+        '--data' "$(svcprop -c -p config/directory "${SMF_FMRI}")"
+        '--port' "$(svcprop -c -p config/port "${SMF_FMRI}")"
+        '--mode' "$(svcprop -c -p config/mode "${SMF_FMRI}")"
 )
 
-val="$(svcprop -p config/cert_pem_path "${SMF_FMRI}")"
+val="$(svcprop -c -p config/cert_pem_path "${SMF_FMRI}")"
 if [[ -n "$val" ]]; then
         args+=( '--cert-pem' )
         args+=( "$val" )
 fi
 
-val="$(svcprop -p config/key_pem_path "${SMF_FMRI}")"
+val="$(svcprop -c -p config/key_pem_path "${SMF_FMRI}")"
 if [[ -n "$val" ]]; then
         args+=( '--key-pem' )
         args+=( "$val" )
 fi
 
-val="$(svcprop -p config/root_pem_path "${SMF_FMRI}")"
+val="$(svcprop -c -p config/root_pem_path "${SMF_FMRI}")"
 if [[ -n "$val" ]]; then
         args+=( '--root-cert-pem' )
         args+=( "$val" )

--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -1,53 +1,67 @@
 // Copyright 2021 Oxide Computer Company
 
-use super::model::{CreateRegion, Region, RegionId, State};
+use super::model::*;
 use anyhow::{anyhow, bail, Result};
 use crucible_common::write_json;
-use slog::{crit, info, Logger};
+use serde::{Deserialize, Serialize};
+use slog::{crit, error, info, Logger};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::{Condvar, Mutex, MutexGuard};
+
+use chrono::{TimeZone, Utc};
 
 pub struct DataFile {
     log: Logger,
-    path: PathBuf,
+    base_path: PathBuf,
+    conf_path: PathBuf,
     port_min: u16,
     port_max: u16,
     bell: Condvar,
     inner: Mutex<Inner>,
 }
 
+#[derive(Serialize, Deserialize, Default)]
 struct Inner {
     regions: BTreeMap<RegionId, Region>,
+    // indexed by region id and snapshot name
+    running_snapshots: BTreeMap<RegionId, BTreeMap<String, RunningSnapshot>>,
 }
 
 impl DataFile {
     pub fn new(
         log: Logger,
-        path: &Path,
+        base_path: &Path,
         port_min: u16,
         port_max: u16,
     ) -> Result<DataFile> {
+        let mut conf_path = base_path.to_path_buf();
+        conf_path.push("crucible.json");
+
         /*
          * Open data file, load contents.
          */
-        let regions = match crucible_common::read_json_maybe(path) {
-            Ok(Some(regions)) => regions,
-            Ok(None) => BTreeMap::new(),
-            Err(e) => bail!("failed to load data file {:?}: {:?}", path, e),
+        let inner = match crucible_common::read_json_maybe(&conf_path) {
+            Ok(Some(inner)) => inner,
+            Ok(None) => Inner::default(),
+            Err(e) => {
+                bail!("failed to load data file {:?}: {:?}", conf_path, e)
+            }
         };
 
         Ok(DataFile {
             log,
-            path: path.to_path_buf(),
+            base_path: base_path.to_path_buf(),
+            conf_path: conf_path.to_path_buf(),
             port_min,
             port_max,
             bell: Condvar::new(),
-            inner: Mutex::new(Inner { regions }),
+            inner: Mutex::new(inner),
         })
     }
 
-    pub fn all(&self) -> Vec<Region> {
+    pub fn regions(&self) -> Vec<Region> {
         self.inner
             .lock()
             .unwrap()
@@ -55,6 +69,12 @@ impl DataFile {
             .values()
             .cloned()
             .collect()
+    }
+
+    pub fn running_snapshots(
+        &self,
+    ) -> BTreeMap<RegionId, BTreeMap<String, RunningSnapshot>> {
+        self.inner.lock().unwrap().running_snapshots.clone()
     }
 
     pub fn get(&self, id: &RegionId) -> Option<Region> {
@@ -66,7 +86,7 @@ impl DataFile {
      */
     fn store(&self, inner: MutexGuard<Inner>) {
         loop {
-            match write_json(&self.path, &inner.regions, true) {
+            match write_json(&self.conf_path, &*inner, true) {
                 Ok(()) => return,
                 Err(e) => {
                     /*
@@ -75,13 +95,64 @@ impl DataFile {
                     crit!(
                         self.log,
                         "could not write data file {:?} (will retry): {:?}",
-                        &self.path,
+                        &self.conf_path,
                         e
                     );
                     std::thread::sleep(std::time::Duration::from_secs(1));
                 }
             }
         }
+    }
+
+    fn get_free_port(&self, inner: &MutexGuard<Inner>) -> Result<u16> {
+        for port_number in self.port_min..=self.port_max {
+            let mut region_uses_port = false;
+            let mut running_snapshot_uses_port = false;
+
+            for region in inner.regions.values() {
+                /*
+                 * We can ignore any completely destroyed region. We choose
+                 * not to ignore regions in the failed state
+                 * for now, as they may still prevent use of
+                 * their assigned port number.
+                 */
+                if region.state == State::Destroyed {
+                    continue;
+                }
+
+                if port_number == region.port_number {
+                    region_uses_port = true;
+                    break;
+                }
+            }
+
+            if region_uses_port {
+                continue;
+            }
+
+            'outer: for running_snapshot_regions in
+                inner.running_snapshots.values()
+            {
+                for running_snapshot in running_snapshot_regions.values() {
+                    if running_snapshot.state == State::Destroyed {
+                        continue;
+                    }
+
+                    if port_number == running_snapshot.port_number {
+                        running_snapshot_uses_port = true;
+                        break 'outer;
+                    }
+                }
+            }
+
+            if running_snapshot_uses_port {
+                continue;
+            }
+
+            return Ok(port_number);
+        }
+
+        bail!("no free port numbers");
     }
 
     /**
@@ -92,7 +163,10 @@ impl DataFile {
      *
      * The actual heavy lifting is performed in a worker thread.
      */
-    pub fn request(&self, create: CreateRegion) -> Result<Region> {
+    pub fn create_region_request(
+        &self,
+        create: CreateRegion,
+    ) -> Result<Region> {
         let mut inner = self.inner.lock().unwrap();
 
         /*
@@ -117,33 +191,22 @@ impl DataFile {
         /*
          * Allocate a port number that is not yet in use.
          */
-        let port_number = (self.port_min..=self.port_max)
-            .find(|n| {
-                !inner
-                    .regions
-                    .values()
-                    .filter(|r| {
-                        /*
-                         * We can ignore any completely destroyed region.  We
-                         * choose not to ignore regions in the failed state
-                         * for now, as they may still
-                         * prevent use of their assigned
-                         * port number.
-                         */
-                        r.state != State::Destroyed
-                    })
-                    .any(|r| r.port_number == *n)
-            })
-            .ok_or_else(|| anyhow!("no free port numbers"))?;
+        let port_number = self.get_free_port(&inner)?;
 
         let r = Region {
             id: create.id.clone(),
             volume_id: create.volume_id,
+            state: State::Requested,
+
             block_size: create.block_size,
             extent_size: create.extent_size,
             extent_count: create.extent_count,
+            encrypted: create.encrypted,
+
             port_number,
-            state: State::Requested,
+            cert_pem: create.cert_pem,
+            key_pem: create.key_pem,
+            root_pem: create.root_pem,
         };
 
         info!(self.log, "region {} state: {:?}", r.id.0, r.state);
@@ -158,6 +221,178 @@ impl DataFile {
         self.store(inner);
 
         Ok(r)
+    }
+
+    pub fn create_running_snapshot_request(
+        &self,
+        request: CreateRunningSnapshotRequest,
+    ) -> Result<RunningSnapshot> {
+        let mut inner = self.inner.lock().unwrap();
+
+        /*
+         * Look for an existing running snapshot.
+         */
+        if inner
+            .running_snapshots
+            .entry(request.id.clone())
+            .or_insert_with(BTreeMap::default)
+            .contains_key(&request.name)
+        {
+            bail!("already running snapshot {} {}", request.id.0, request.name);
+        }
+
+        /*
+         * Allocate a port number that is not yet in use.
+         */
+        let port_number = self.get_free_port(&inner)?;
+
+        let s = RunningSnapshot {
+            id: request.id.clone(),
+            name: request.name.clone(),
+            port_number,
+            state: State::Created, // no work to do, just run smf
+        };
+
+        info!(
+            self.log,
+            "requesting running snapshot {}-{} state: {:?}",
+            s.id.0,
+            s.name,
+            s.state,
+        );
+
+        inner
+            .running_snapshots
+            .get_mut(&request.id)
+            .unwrap()
+            .insert(request.name, s.clone());
+
+        /*
+         * Wake the worker thread to look at the snapshot we've created.
+         */
+        self.bell.notify_all();
+
+        self.store(inner);
+
+        Ok(s)
+    }
+
+    pub fn delete_running_snapshot_request(
+        &self,
+        request: DeleteRunningSnapshotRequest,
+    ) -> Result<()> {
+        let mut inner = self.inner.lock().unwrap();
+
+        /*
+         * Look for an existing running snapshot.
+         */
+        if inner.running_snapshots.get(&request.id).is_none() {
+            bail!("no running snapshots for region {}", request.id.0);
+        }
+
+        let running_snapshots =
+            inner.running_snapshots.get_mut(&request.id).unwrap();
+
+        if running_snapshots.get(&request.name).is_none() {
+            bail!(
+                "not running for region {} snapshot {}",
+                request.id.0,
+                request.name
+            );
+        }
+
+        info!(
+            self.log,
+            "removing snapshot {}-{}", request.id.0, request.name
+        );
+
+        running_snapshots.remove(&request.name);
+
+        if running_snapshots.is_empty() {
+            inner.running_snapshots.remove(&request.id);
+        }
+
+        /*
+         * Wake the worker thread to remove the snapshot we've created.
+         */
+        self.bell.notify_all();
+
+        self.store(inner);
+
+        Ok(())
+    }
+
+    pub fn delete_snapshot(
+        &self,
+        request: DeleteSnapshotRequest,
+    ) -> Result<()> {
+        let inner = self.inner.lock().unwrap();
+
+        /*
+         * Are we running this snapshot? Fail if so.
+         */
+        if let Some(running_snapshots) =
+            inner.running_snapshots.get(&request.id)
+        {
+            if running_snapshots.get(&request.name).is_some() {
+                bail!(
+                    "downstairs running for region {} snapshot {}",
+                    request.id.0,
+                    request.name
+                );
+            }
+        }
+
+        // zfs delete snapshot
+        let mut path = self.base_path.to_path_buf();
+        path.push("regions");
+        path.push(request.id.0.clone());
+        path.push(".zfs");
+        path.push("snapshot");
+        path.push(request.name.clone());
+
+        info!(self.log, "checking path {:?}", path);
+
+        let path = std::fs::metadata(path)?;
+        if !path.is_dir() {
+            bail!("snapshot does not exist!");
+        }
+
+        let dataset_name = {
+            let mut path = self.base_path.to_path_buf();
+            path.push("regions");
+            path.push(request.id.0.clone());
+
+            let path = path.to_str().unwrap().to_string();
+
+            let mut chars = path.chars();
+            chars.next();
+            chars.as_str().to_string()
+        };
+
+        let snapshot_name = format!("{}@{}", dataset_name, request.name);
+
+        let cmd = Command::new("zfs")
+            .arg("destroy")
+            .arg(snapshot_name.clone())
+            .output()?;
+
+        if !cmd.status.success() {
+            let err = String::from_utf8_lossy(&cmd.stderr);
+            let out = String::from_utf8_lossy(&cmd.stdout);
+
+            error!(
+                self.log,
+                "zfs snapshot {:?} delete failed: out {:?} err {:?}",
+                snapshot_name,
+                out,
+                err,
+            );
+
+            bail!("zfs snapshot delete failure");
+        }
+
+        Ok(())
     }
 
     /**
@@ -230,12 +465,16 @@ impl DataFile {
         );
         r.state = nstate;
 
+        // XXX shouldn't this remove the record?
+
         self.store(inner);
         Ok(())
     }
 
     /**
-     * Nexus has requested that we destroy this particular region.
+     * Nexus has requested that we destroy this particular region. Returns
+     * true if the region is already destroyed, false if not destroyed
+     * yet.
      */
     pub fn destroy(&self, id: &RegionId) -> Result<bool> {
         let mut inner = self.inner.lock().unwrap();
@@ -293,30 +532,202 @@ impl DataFile {
      * particular state.  If there are no tasks in the provided state,
      * we sleep waiting for work to do.
      */
-    pub fn first_in_states(&self, states: &[State]) -> Region {
-        let mut inner = self.inner.lock().unwrap();
+    pub fn first_region_in_states(&self, states: &[State]) -> Option<Region> {
+        let inner = self.inner.lock().unwrap();
 
-        loop {
-            /*
-             * States are provided in priority order.  We check for regions
-             * in the first requested state before we check for
-             * regions in the second provided state, etc.  This
-             * allows us to focus on destroying tombstoned
-             * regions ahead of creating new regions.
-             */
-            for s in states {
-                for r in inner.regions.values() {
-                    if &r.state == s {
-                        return r.clone();
-                    }
+        /*
+         * States are provided in priority order.  We check for regions
+         * in the first requested state before we check for
+         * regions in the second provided state, etc.  This
+         * allows us to focus on destroying tombstoned
+         * regions ahead of creating new regions.
+         */
+        for s in states {
+            for r in inner.regions.values() {
+                if &r.state == s {
+                    return Some(r.clone());
                 }
             }
-
-            /*
-             * If we did not find any regions in the specified state, sleep
-             * on the condvar.
-             */
-            inner = self.bell.wait(inner).unwrap();
         }
+
+        None
+    }
+
+    pub fn wait_on_bell(&self) {
+        let inner = self.inner.lock().unwrap();
+        let _guard = self.bell.wait(inner).unwrap();
+    }
+
+    /**
+     * Get snapshots for a region
+     */
+    pub fn get_snapshots_for_region(
+        &self,
+        region_id: &RegionId,
+    ) -> Result<Vec<Snapshot>> {
+        let region = self.get(region_id);
+
+        if region.is_none() {
+            bail!("region {:?} does not exist", region_id);
+        }
+
+        let region = region.unwrap();
+
+        if region.state != State::Created {
+            bail!("region.state is {:?}", region.state);
+        }
+
+        let mut path = self.base_path.to_path_buf();
+        path.push("regions");
+        path.push(region_id.0.clone());
+        path.push(".zfs");
+        path.push("snapshot");
+
+        info!(self.log, "checking if path {:?} exists", path);
+
+        if !path.exists() {
+            // No snapshots directory
+            return Ok(vec![]);
+        }
+
+        info!(self.log, "checking path {:?}", path);
+
+        let paths = std::fs::read_dir(&path);
+        if paths.is_err() {
+            bail!(paths.err().unwrap());
+        }
+
+        let mut results: Vec<Snapshot> = vec![];
+        for path in paths.unwrap() {
+            if path.is_err() {
+                bail!(path.err().unwrap());
+            }
+
+            let path = path.unwrap().path();
+
+            if path.is_dir() {
+                let dir_name = path
+                    .file_name()
+                    .ok_or_else(|| {
+                        anyhow!("could not turn {:?} into filename!", path)
+                    })?
+                    .to_str()
+                    .ok_or_else(|| {
+                        anyhow!("could not turn {:?} into str!", path)
+                    })?
+                    .to_string();
+
+                // Creation time of a .zfs/snapshot/<folder> as retrieved by
+                // stat doesn't make sense. Use `zfs get`:
+                //
+                //   # zfs get -pH -o value creation \
+                //     data/crucible/regions/
+                // 0d052762-10dd-4481-9a1a-1d36b9799f51@before_sync
+                //   1644441276
+
+                let dataset_name = {
+                    let mut path = self.base_path.clone().to_path_buf();
+                    path.push("regions");
+                    path.push(region_id.0.clone());
+
+                    let path = path.to_str().unwrap().to_string();
+
+                    let mut chars = path.chars();
+                    chars.next();
+                    chars.as_str().to_string()
+                };
+
+                let snapshot_name = format!("{}@{}", dataset_name, dir_name);
+
+                let mut cmd = Command::new("zfs");
+                cmd.arg("get");
+                cmd.arg("-pH");
+                cmd.arg("-o");
+                cmd.arg("value");
+                cmd.arg("creation");
+                cmd.arg(snapshot_name);
+
+                info!(
+                    self.log,
+                    "command {:?} {:?}",
+                    cmd.get_program(),
+                    cmd.get_args()
+                );
+
+                let cmd = cmd.output()?;
+
+                if !cmd.status.success() {
+                    bail!("stat didn't work!");
+                }
+
+                let cmd_stdout = {
+                    let cmd_stdout = String::from_utf8_lossy(&cmd.stdout);
+
+                    // Remove newline
+                    let cmd_stdout = cmd_stdout.trim_end().to_string();
+
+                    cmd_stdout
+                };
+
+                info!(self.log, "stdout is {}", &cmd_stdout);
+
+                results.push(Snapshot {
+                    name: dir_name,
+                    created: Utc.timestamp(cmd_stdout.parse()?, 0),
+                });
+            }
+        }
+
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use anyhow::{bail, Result};
+    use chrono::{DateTime, TimeZone, Utc};
+    use std::process::Command;
+
+    #[test]
+    fn test_stat_parsing() -> Result<()> {
+        // Test round trip
+
+        // $ date --utc -d @"1644356407" --rfc-3339=seconds
+        // 2022-02-08 21:40:07+00:00
+        let expected: DateTime<Utc> =
+            DateTime::parse_from_rfc3339("2022-02-08T21:40:07+00:00")?.into();
+
+        let fake_stdout = "1644356407".as_bytes().to_vec();
+
+        assert_eq!(
+            String::from_utf8_lossy(&fake_stdout),
+            "1644356407".to_string(),
+        );
+
+        let actual =
+            Utc.timestamp(String::from_utf8_lossy(&fake_stdout).parse()?, 0);
+
+        assert_eq!(expected, actual);
+
+        // Test parsing from Command output
+
+        let cmd = Command::new("date").arg("+%s").output()?;
+
+        if !cmd.status.success() {
+            bail!("date didn't work!");
+        }
+
+        let cmd_stdout = {
+            let cmd_stdout = String::from_utf8_lossy(&cmd.stdout);
+
+            // Remove newline
+            let cmd_stdout = cmd_stdout.trim_end().to_string();
+
+            cmd_stdout
+        };
+
+        let _date = Utc.timestamp(cmd_stdout.parse()?, 0);
+
+        Ok(())
     }
 }

--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -529,8 +529,7 @@ impl DataFile {
 
     /**
      * The worker thread will request the first region that is in a
-     * particular state.  If there are no tasks in the provided state,
-     * we sleep waiting for work to do.
+     * particular state.
      */
     pub fn first_region_in_states(&self, states: &[State]) -> Option<Region> {
         let inner = self.inner.lock().unwrap();

--- a/agent/src/model.rs
+++ b/agent/src/model.rs
@@ -1,5 +1,6 @@
 // Copyright 2021 Oxide Computer Company
 
+use chrono::prelude::*;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -17,13 +18,92 @@ pub enum State {
 pub struct Region {
     pub id: RegionId,
     pub volume_id: String,
+    pub state: State,
 
+    // Creation parameters
     pub block_size: u64,
     pub extent_size: u64,
     pub extent_count: u64,
+    pub encrypted: bool,
 
+    // Run-time parameters
     pub port_number: u16,
-    pub state: State,
+    pub cert_pem: Option<String>,
+
+    // TODO should skip serializing this on list regions response, but this
+    // causes crucible.json to not have it
+    // #[serde(skip_serializing)]
+    pub key_pem: Option<String>,
+
+    pub root_pem: Option<String>,
+}
+
+use crucible_smf::scf_type_t::{self, *};
+use std::path::Path;
+
+pub struct SmfProperty<'a> {
+    pub name: &'a str,
+    pub typ: scf_type_t,
+    pub val: String,
+}
+
+impl Region {
+    /**
+     * Given a root directory, return a list of SMF properties to ensure for
+     * the corresponding running instance.
+     */
+    pub fn get_smf_properties(&self, dir: &Path) -> Vec<SmfProperty> {
+        let mut results = vec![
+            SmfProperty {
+                name: "directory",
+                typ: SCF_TYPE_ASTRING,
+                val: dir.to_str().unwrap().to_string(),
+            },
+            SmfProperty {
+                name: "port",
+                typ: SCF_TYPE_COUNT,
+                val: self.port_number.to_string(),
+            },
+        ];
+
+        if self.cert_pem.is_some() {
+            let mut path = dir.to_path_buf();
+            path.push("cert.pem");
+            let path = path.into_os_string().into_string().unwrap();
+
+            results.push(SmfProperty {
+                name: "cert_pem_path",
+                typ: SCF_TYPE_ASTRING,
+                val: path,
+            });
+        }
+
+        if self.key_pem.is_some() {
+            let mut path = dir.to_path_buf();
+            path.push("key.pem");
+            let path = path.into_os_string().into_string().unwrap();
+
+            results.push(SmfProperty {
+                name: "key_pem_path",
+                typ: SCF_TYPE_ASTRING,
+                val: path,
+            });
+        }
+
+        if self.root_pem.is_some() {
+            let mut path = dir.to_path_buf();
+            path.push("root.pem");
+            let path = path.into_os_string().into_string().unwrap();
+
+            results.push(SmfProperty {
+                name: "root_pem_path",
+                typ: SCF_TYPE_ASTRING,
+                val: path,
+            });
+        }
+
+        results
+    }
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug, PartialEq, Clone)]
@@ -34,6 +114,12 @@ pub struct CreateRegion {
     pub block_size: u64,
     pub extent_size: u64,
     pub extent_count: u64,
+    pub encrypted: bool,
+
+    pub cert_pem: Option<String>,
+    pub key_pem: Option<String>,
+    pub root_pem: Option<String>,
+    // TODO base64 encoded der too?
 }
 
 impl CreateRegion {
@@ -58,6 +144,11 @@ impl CreateRegion {
                 "extent count {} instead of requested {}",
                 self.extent_count, r.extent_count
             ))
+        } else if self.encrypted != r.encrypted {
+            Some(format!(
+                "encrypted {} instead of requested {}",
+                self.encrypted, r.encrypted
+            ))
         } else {
             None
         }
@@ -77,6 +168,108 @@ impl CreateRegion {
 )]
 pub struct RegionId(pub String);
 
+#[derive(Serialize, Deserialize, JsonSchema, Debug, PartialEq, Clone)]
+pub struct Snapshot {
+    pub name: String,
+    pub created: DateTime<Utc>,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, PartialEq, Clone)]
+pub struct RunningSnapshot {
+    pub id: RegionId,
+    pub name: String,
+    pub port_number: u16,
+    pub state: State,
+}
+
+impl RunningSnapshot {
+    /**
+     * Given a root directory, return a list of SMF properties to ensure for
+     * the corresponding running instance.
+     */
+    pub fn get_smf_properties(&self, dir: &Path) -> Vec<SmfProperty> {
+        let mut results = vec![
+            SmfProperty {
+                name: "directory",
+                typ: SCF_TYPE_ASTRING,
+                val: dir.to_str().unwrap().to_string(),
+            },
+            SmfProperty {
+                name: "port",
+                typ: SCF_TYPE_COUNT,
+                val: self.port_number.to_string(),
+            },
+        ];
+
+        // Test for X509 files in snapshot - note this means that running
+        // snapshots will use the X509 information in the snapshot, not a new
+        // set.
+        {
+            let mut path = dir.to_path_buf();
+            path.push("cert.pem");
+            let path = path.into_os_string().into_string().unwrap();
+
+            if Path::new(&path).exists() {
+                results.push(SmfProperty {
+                    name: "cert_pem_path",
+                    typ: SCF_TYPE_ASTRING,
+                    val: path,
+                });
+            }
+        }
+
+        {
+            let mut path = dir.to_path_buf();
+            path.push("key.pem");
+            let path = path.into_os_string().into_string().unwrap();
+
+            if Path::new(&path).exists() {
+                results.push(SmfProperty {
+                    name: "key_pem_path",
+                    typ: SCF_TYPE_ASTRING,
+                    val: path,
+                });
+            }
+        }
+
+        {
+            let mut path = dir.to_path_buf();
+            path.push("root.pem");
+            let path = path.into_os_string().into_string().unwrap();
+
+            if Path::new(&path).exists() {
+                results.push(SmfProperty {
+                    name: "root_pem_path",
+                    typ: SCF_TYPE_ASTRING,
+                    val: path,
+                });
+            }
+        }
+
+        results
+    }
+}
+
+pub struct CreateRunningSnapshotRequest {
+    pub id: RegionId,
+    pub name: String,
+    pub cert_pem: Option<String>,
+    pub key_pem: Option<String>,
+    pub root_pem: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, PartialEq, Clone)]
+pub struct DeleteRunningSnapshotRequest {
+    pub id: RegionId,
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, PartialEq, Clone)]
+pub struct DeleteSnapshotRequest {
+    pub id: RegionId,
+    pub name: String,
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -91,6 +284,10 @@ mod test {
             block_size: 4096,
             extent_size: 4096,
             extent_count: 100,
+            encrypted: false,
+            cert_pem: None,
+            key_pem: None,
+            root_pem: None,
         };
 
         let s = serde_json::to_string(&r).expect("serialise");

--- a/agent/src/model.rs
+++ b/agent/src/model.rs
@@ -199,6 +199,11 @@ impl RunningSnapshot {
                 typ: SCF_TYPE_COUNT,
                 val: self.port_number.to_string(),
             },
+            SmfProperty {
+                name: "mode",
+                typ: SCF_TYPE_ASTRING,
+                val: "ro".to_string(),
+            },
         ];
 
         // Test for X509 files in snapshot - note this means that running

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -282,10 +282,11 @@ async fn region_run_snapshot(
         ));
     }
 
+    // TODO support running snapshots with their own X509 creds
     let create = model::CreateRunningSnapshotRequest {
         id: p.id,
         name: p.name,
-        cert_pem: None, // XXX
+        cert_pem: None,
         key_pem: None,
         root_pem: None,
     };

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -1,5 +1,4 @@
 // Copyright 2021 Oxide Computer Company
-
 use super::datafile::DataFile;
 use super::model;
 use anyhow::{anyhow, Result};
@@ -8,8 +7,9 @@ use dropshot::{
     Path as TypedPath, RequestContext, TypedBody,
 };
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use slog::{o, Logger};
+use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::result::Result as SResult;
 use std::sync::Arc;
@@ -31,7 +31,7 @@ impl<T> AnyhowFromString<T> for SResult<T, String> {
 async fn region_list(
     rc: Arc<RequestContext<Arc<DataFile>>>,
 ) -> SResult<HttpResponseOk<Vec<model::Region>>, HttpError> {
-    Ok(HttpResponseOk(rc.context().all()))
+    Ok(HttpResponseOk(rc.context().regions()))
 }
 
 #[endpoint {
@@ -44,7 +44,7 @@ async fn region_create(
 ) -> SResult<HttpResponseOk<model::Region>, HttpError> {
     let create = body.into_inner();
 
-    match rc.context().request(create) {
+    match rc.context().create_region_request(create) {
         Ok(r) => Ok(HttpResponseOk(r)),
         Err(e) => Err(HttpError::for_internal_error(format!(
             "region create failure: {:?}",
@@ -87,20 +87,291 @@ async fn region_delete(
 ) -> SResult<HttpResponseDeleted, HttpError> {
     let p = path.into_inner();
 
+    // Cannot delete a region that's backed by a ZFS dataset if there are
+    // snapshots.
+
+    let snapshots = match rc.context().get_snapshots_for_region(&p.id) {
+        Ok(results) => results,
+        Err(e) => {
+            return Err(HttpError::for_internal_error(e.to_string()));
+        }
+    };
+
+    if !snapshots.is_empty() {
+        return Err(HttpError::for_bad_request(
+            None,
+            "must delete snapshots first!".to_string(),
+        ));
+    }
+
     match rc.context().destroy(&p.id) {
         Ok(_) => Ok(HttpResponseDeleted()),
         Err(e) => Err(HttpError::for_bad_request(None, e.to_string())),
     }
 }
 
+#[derive(Serialize, JsonSchema)]
+pub struct GetSnapshotResponse {
+    snapshots: Vec<model::Snapshot>,
+    running_snapshots: BTreeMap<String, model::RunningSnapshot>,
+}
+
+#[endpoint {
+    method = GET,
+    path = "/crucible/0/regions/{id}/snapshots",
+}]
+async fn region_get_snapshots(
+    rc: Arc<RequestContext<Arc<DataFile>>>,
+    path: TypedPath<RegionPath>,
+) -> Result<HttpResponseOk<GetSnapshotResponse>, HttpError> {
+    let p = path.into_inner();
+
+    match rc.context().get(&p.id) {
+        Some(_) => (),
+        None => {
+            return Err(HttpError::for_not_found(
+                None,
+                format!("region {:?} not found", p.id),
+            ));
+        }
+    }
+
+    let snapshots = match rc.context().get_snapshots_for_region(&p.id) {
+        Ok(results) => results,
+        Err(e) => {
+            return Err(HttpError::for_internal_error(e.to_string()));
+        }
+    };
+
+    let running_snapshots = rc
+        .context()
+        .running_snapshots()
+        .get(&p.id)
+        .cloned()
+        .unwrap_or_default();
+
+    Ok(HttpResponseOk(GetSnapshotResponse {
+        snapshots,
+        running_snapshots,
+    }))
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct GetSnapshotPath {
+    id: model::RegionId,
+    name: String,
+}
+
+#[endpoint {
+    method = GET,
+    path = "/crucible/0/regions/{id}/snapshots/{name}",
+}]
+async fn region_get_snapshot(
+    rc: Arc<RequestContext<Arc<DataFile>>>,
+    path: TypedPath<GetSnapshotPath>,
+) -> Result<HttpResponseOk<model::Snapshot>, HttpError> {
+    let p = path.into_inner();
+
+    match rc.context().get(&p.id) {
+        Some(_) => (),
+        None => {
+            return Err(HttpError::for_not_found(
+                None,
+                format!("region {:?} not found", p.id),
+            ));
+        }
+    }
+
+    let snapshots_for_region =
+        match rc.context().get_snapshots_for_region(&p.id) {
+            Ok(results) => results,
+            Err(e) => {
+                return Err(HttpError::for_internal_error(e.to_string()));
+            }
+        };
+
+    for snapshot in &snapshots_for_region {
+        if snapshot.name == p.name {
+            return Ok(HttpResponseOk(snapshot.clone()));
+        }
+    }
+
+    Err(HttpError::for_not_found(
+        None,
+        format!("region {:?} snapshot {:?} not found", p.id, p.name),
+    ))
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct DeleteSnapshotPath {
+    id: model::RegionId,
+    name: String,
+}
+
+#[endpoint {
+    method = DELETE,
+    path = "/crucible/0/regions/{id}/snapshots/{name}",
+}]
+async fn region_delete_snapshot(
+    rc: Arc<RequestContext<Arc<DataFile>>>,
+    path: TypedPath<DeleteSnapshotPath>,
+) -> Result<HttpResponseDeleted, HttpError> {
+    let p = path.into_inner();
+
+    match rc.context().get(&p.id) {
+        Some(_) => (),
+        None => {
+            return Err(HttpError::for_not_found(
+                None,
+                format!("region {:?} not found", p.id),
+            ));
+        }
+    }
+
+    let request = model::DeleteSnapshotRequest {
+        id: p.id.clone(),
+        name: p.name,
+    };
+
+    match rc.context().delete_snapshot(request) {
+        Ok(_) => Ok(HttpResponseDeleted()),
+        Err(e) => Err(HttpError::for_internal_error(e.to_string())),
+    }
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct RunSnapshotPath {
+    id: model::RegionId,
+    name: String,
+}
+
+#[endpoint {
+    method = POST,
+    path = "/crucible/0/regions/{id}/snapshots/{name}/run",
+}]
+async fn region_run_snapshot(
+    rc: Arc<RequestContext<Arc<DataFile>>>,
+    path: TypedPath<RunSnapshotPath>,
+) -> Result<HttpResponseOk<model::RunningSnapshot>, HttpError> {
+    let p = path.into_inner();
+
+    match rc.context().get(&p.id) {
+        Some(_) => (),
+        None => {
+            return Err(HttpError::for_not_found(
+                None,
+                format!("region {:?} not found", p.id),
+            ));
+        }
+    }
+
+    let snapshots = match rc.context().get_snapshots_for_region(&p.id) {
+        Ok(results) => results,
+        Err(e) => {
+            return Err(HttpError::for_internal_error(e.to_string()));
+        }
+    };
+
+    let snapshot_names: Vec<String> =
+        snapshots.iter().map(|s| s.name.clone()).collect();
+
+    if !snapshot_names.contains(&p.name) {
+        return Err(HttpError::for_not_found(
+            None,
+            format!("snapshot {:?} not found", p.name),
+        ));
+    }
+
+    let create = model::CreateRunningSnapshotRequest {
+        id: p.id,
+        name: p.name,
+        cert_pem: None, // XXX
+        key_pem: None,
+        root_pem: None,
+    };
+
+    match rc.context().create_running_snapshot_request(create) {
+        Ok(r) => Ok(HttpResponseOk(r)),
+        Err(e) => Err(HttpError::for_internal_error(format!(
+            "running snapshot create failure: {:?}",
+            e
+        ))),
+    }
+}
+
+#[endpoint {
+    method = DELETE,
+    path = "/crucible/0/regions/{id}/snapshots/{name}/run",
+}]
+async fn region_delete_running_snapshot(
+    rc: Arc<RequestContext<Arc<DataFile>>>,
+    path: TypedPath<RunSnapshotPath>,
+) -> Result<HttpResponseDeleted, HttpError> {
+    let p = path.into_inner();
+
+    match rc.context().get(&p.id) {
+        Some(_) => (),
+        None => {
+            return Err(HttpError::for_not_found(
+                None,
+                format!("region {:?} not found", p.id),
+            ));
+        }
+    }
+
+    let snapshots = match rc.context().get_snapshots_for_region(&p.id) {
+        Ok(results) => results,
+        Err(e) => {
+            return Err(HttpError::for_internal_error(e.to_string()));
+        }
+    };
+
+    let snapshot_names: Vec<String> =
+        snapshots.iter().map(|s| s.name.clone()).collect();
+
+    if !snapshot_names.contains(&p.name) {
+        return Err(HttpError::for_not_found(
+            None,
+            format!("snapshot {:?} not found", p.name),
+        ));
+    }
+
+    let request = model::DeleteRunningSnapshotRequest {
+        id: p.id,
+        name: p.name,
+    };
+
+    match rc.context().delete_running_snapshot_request(request) {
+        Ok(_) => Ok(HttpResponseDeleted()),
+        Err(e) => Err(HttpError::for_internal_error(format!(
+            "running snapshot create failure: {:?}",
+            e
+        ))),
+    }
+}
+
 pub fn make_api() -> Result<dropshot::ApiDescription<Arc<DataFile>>> {
     let mut api = dropshot::ApiDescription::new();
+
     api.register(region_list).or_bail("registration failure")?;
     api.register(region_create)
         .or_bail("registration failure")?;
     api.register(region_get).or_bail("registration failure")?;
     api.register(region_delete)
         .or_bail("registration failure")?;
+
+    api.register(region_get_snapshots)
+        .or_bail("registration failure")?;
+    api.register(region_get_snapshot)
+        .or_bail("registration failure")?;
+    api.register(region_delete_snapshot)
+        .or_bail("registration failure")?;
+
+    api.register(region_run_snapshot)
+        .or_bail("registration failure")?;
+    api.register(region_delete_running_snapshot)
+        .or_bail("registration failure")?;
+
     Ok(api)
 }
 
@@ -114,6 +385,7 @@ pub async fn run_server(
     let server = dropshot::HttpServerStarter::new(
         &dropshot::ConfigDropshot {
             bind_address,
+            request_body_max_bytes: 1024 * 10,
             ..Default::default()
         },
         api,

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -526,7 +526,7 @@ pub async fn start_cli_server(
                             }
                         },
                         Some(CliMessage::Flush) => {
-                            match guest.flush() {
+                            match guest.flush(None) {
                                 Ok(_) => {
                                     fw.send(CliMessage::DoneOk).await?;
                                 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -120,9 +120,9 @@ pub struct Opt {
     #[structopt(long)]
     root_cert_pem: Option<String>,
 
-    /// Start upstairs info server
+    /// Start upstairs http server
     #[structopt(long, global = true)]
-    info: Option<SocketAddr>,
+    http: Option<SocketAddr>,
 }
 
 pub fn opts() -> Result<Opt> {
@@ -264,7 +264,7 @@ fn main() -> Result<()> {
         cert_pem: opt.cert_pem,
         key_pem: opt.key_pem,
         root_cert_pem: opt.root_cert_pem,
-        info: opt.info,
+        http: opt.http,
     };
 
     /*

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -673,7 +673,7 @@ async fn balloon_workload(
             let mut waiter = guest.write(offset, data)?;
             waiter.block_wait()?;
 
-            let mut waiter = guest.flush()?;
+            let mut waiter = guest.flush(None)?;
             waiter.block_wait()?;
 
             let length: usize = size * ri.block_size as usize;
@@ -732,7 +732,7 @@ async fn generic_workload(
         if op == 0 {
             // flush
             println!("{:4}/{:4} FLUSH", i, count);
-            let mut waiter = guest.flush()?;
+            let mut waiter = guest.flush(None)?;
             waiter.block_wait()?;
         } else {
             // Read or Write both need this
@@ -903,7 +903,7 @@ async fn one_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
     }
 
     println!("Flush");
-    let mut waiter = guest.flush()?;
+    let mut waiter = guest.flush(None)?;
     waiter.block_wait()?;
 
     Ok(())
@@ -1011,7 +1011,7 @@ async fn rand_workload(
         let mut waiter = guest.write(offset, data)?;
         waiter.block_wait()?;
 
-        let mut waiter = guest.flush()?;
+        let mut waiter = guest.flush(None)?;
         waiter.block_wait()?;
 
         let length: usize = size * ri.block_size as usize;
@@ -1098,7 +1098,7 @@ async fn demo_workload(
         let op = rng.gen_range(0..10);
         if op == 0 {
             // flush
-            let waiter = guest.flush()?;
+            let waiter = guest.flush(None)?;
             waiterlist.push(waiter);
         } else {
             // Read or Write both need this
@@ -1193,7 +1193,7 @@ fn span_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
     waiter.block_wait()?;
 
     println!("Sending a flush");
-    let mut waiter = guest.flush()?;
+    let mut waiter = guest.flush(None)?;
     waiter.block_wait()?;
 
     let length: usize = 2 * ri.block_size as usize;
@@ -1233,7 +1233,7 @@ fn big_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
         let mut waiter = guest.write(offset, data)?;
         waiter.block_wait()?;
 
-        let mut waiter = guest.flush()?;
+        let mut waiter = guest.flush(None)?;
         waiter.block_wait()?;
 
         let length: usize = ri.block_size as usize;
@@ -1347,7 +1347,7 @@ async fn dep_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
         // last command is a write or read and we have to wait x seconds for the
         // flush check to trigger.
         println!("Loop:{} send a final flush and wait", my_count);
-        let mut flush_waiter = guest.flush()?;
+        let mut flush_waiter = guest.flush(None)?;
         flush_waiter.block_wait()?;
 
         println!("Loop:{} loop over {} waiters", my_count, waiterlist.len());
@@ -1396,7 +1396,7 @@ async fn _run_scope(guest: Arc<Guest>) -> Result<()> {
 
         // scope.wait_for("Flush step").await;
         println!("send flush");
-        guest.flush()?;
+        guest.flush(None)?;
 
         let mut data = BytesMut::with_capacity(512);
         data.put(&[0xbb; 512][..]);

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -81,6 +81,15 @@ pub enum CrucibleError {
 
     #[error("Cannot receive blocks: {0}")]
     CannotReceiveBlocks(String),
+
+    #[error("Snapshot failed! {0}")]
+    SnapshotFailed(String),
+
+    #[error("Snapshot {0} exists already")]
+    SnapshotExistsAlready(String),
+
+    #[error("Attempting to modify read-only region!")]
+    ModifyingReadOnlyRegion,
 }
 
 impl From<std::io::Error> for CrucibleError {

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -14,6 +14,10 @@ crucible = { path = "../upstairs" }
 crucible-common = { path = "../common" }
 crucible-protocol = { path = "../protocol" }
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
+slog = { version = "2.7" }
+slog-term = { version = "2.8" }
+slog-async = { version = "2.7" }
+schemars = { version = "0.8", features = [ "chrono", "uuid" ] }
 futures = "0.3"
 futures-core = "0.3"
 omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
@@ -41,3 +45,6 @@ sha2 = "0.10"
 tempfile = "3"
 rand_chacha = "0.3.1"
 
+[features]
+default = []
+zfs_snapshot = []

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -35,7 +35,8 @@ pub fn dump_region(
     let mut total_extents = 0;
 
     for (index, dir) in region_dir.iter().enumerate() {
-        let region = Region::open(&dir, Default::default(), false)?;
+        // Open Region read only
+        let region = Region::open(&dir, Default::default(), false, true)?;
 
         blocks_per_extent = region.def().extent_size().value;
         total_extents = region.def().extent_count();
@@ -338,7 +339,8 @@ fn show_extent(
          * in the Vec based on index.
          */
         for (index, dir) in region_dir.iter().enumerate() {
-            let region = Region::open(&dir, Default::default(), false)?;
+            // Open Region read only
+            let region = Region::open(&dir, Default::default(), false, true)?;
 
             let mut responses = region.region_read(&[ReadRequest {
                 eid: cmp_extent as u64,
@@ -453,7 +455,8 @@ fn show_extent_block(
      * in the Vec based on index.
      */
     for (index, dir) in region_dir.iter().enumerate() {
-        let region = Region::open(&dir, Default::default(), false)?;
+        // Open Region read only
+        let region = Region::open(&dir, Default::default(), false, true)?;
 
         let mut responses = region.region_read(&[ReadRequest {
             eid: cmp_extent as u64,

--- a/downstairs/src/http.rs
+++ b/downstairs/src/http.rs
@@ -9,6 +9,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 pub struct ServerContext {
+    // Region UUID -> a running Downstairs
     downstairs: Mutex<HashMap<Uuid, Arc<Mutex<Downstairs>>>>,
 }
 

--- a/downstairs/src/http.rs
+++ b/downstairs/src/http.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 use super::*;
 
 use dropshot::{

--- a/downstairs/src/http.rs
+++ b/downstairs/src/http.rs
@@ -59,7 +59,7 @@ pub async fn run_downstairs_for_region(
         ));
     }
 
-    let d = create_downstairs(
+    let d = build_downstairs_for_region(
         &run_params.data,
         run_params.lossy,
         run_params.return_errors,

--- a/downstairs/src/http.rs
+++ b/downstairs/src/http.rs
@@ -1,0 +1,128 @@
+// Copyright 2021 Oxide Computer Company
+use super::*;
+
+use dropshot::{
+    endpoint, ApiDescription, ConfigDropshot, HttpError, HttpResponseCreated,
+    HttpServerStarter, Path, RequestContext, TypedBody,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+pub struct ServerContext {
+    downstairs: Mutex<HashMap<Uuid, Arc<Mutex<Downstairs>>>>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct RunDownstairsForRegionParams {
+    address: IpAddr,
+    data: PathBuf,
+    oximeter: Option<SocketAddr>,
+    lossy: bool,
+    port: u16,
+    return_errors: bool,
+    cert_pem: Option<String>,
+    key_pem: Option<String>,
+    root_cert_pem: Option<String>,
+    read_only: bool,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct RunDownstairsforRegionPath {
+    uuid: Uuid,
+}
+
+#[derive(Serialize, JsonSchema)]
+pub struct DownstairsRunningResponse {
+    uuid: Uuid,
+}
+
+#[endpoint {
+    method = POST,
+    path = "/regions/{uuid}/downstairs"
+}]
+pub async fn run_downstairs_for_region(
+    rqctx: Arc<RequestContext<Arc<ServerContext>>>,
+    run_params: TypedBody<RunDownstairsForRegionParams>,
+    path_param: Path<RunDownstairsforRegionPath>,
+) -> Result<HttpResponseCreated<DownstairsRunningResponse>, HttpError> {
+    let apictx = rqctx.context();
+    let run_params = run_params.into_inner();
+    let uuid = path_param.into_inner().uuid;
+
+    let mut downstairs = apictx.downstairs.lock().await;
+
+    if downstairs.contains_key(&uuid) {
+        return Err(HttpError::for_bad_request(
+            Some(String::from("BadInput")),
+            format!("downstairs {} running already", uuid),
+        ));
+    }
+
+    let d = create_downstairs(
+        &run_params.data,
+        run_params.lossy,
+        run_params.return_errors,
+        run_params.read_only,
+    )
+    .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
+
+    let dd = d.clone();
+    tokio::spawn(async move {
+        // XXX result eaten here!
+        let _ = start_downstairs(
+            dd,
+            run_params.address,
+            run_params.oximeter,
+            run_params.port,
+            run_params.cert_pem,
+            run_params.key_pem,
+            run_params.root_cert_pem,
+        )
+        .await;
+    });
+
+    downstairs.insert(uuid, d);
+
+    Ok(HttpResponseCreated(DownstairsRunningResponse { uuid }))
+}
+
+fn register_endpoints(
+    api_description: &mut ApiDescription<Arc<ServerContext>>,
+) -> Result<(), String> {
+    api_description.register(run_downstairs_for_region)?;
+
+    Ok(())
+}
+
+pub async fn run_dropshot(
+    bind_address: SocketAddr,
+    log: &slog::Logger,
+) -> Result<()> {
+    let config = ConfigDropshot {
+        bind_address,
+        ..Default::default()
+    };
+
+    let mut api_description = ApiDescription::<Arc<ServerContext>>::new();
+
+    if let Err(s) = register_endpoints(&mut api_description) {
+        anyhow::bail!("Error from register_endpoints: {}", s);
+    }
+
+    let ctx = Arc::new(ServerContext {
+        downstairs: Mutex::new(HashMap::default()),
+    });
+
+    let http_server =
+        HttpServerStarter::new(&config, api_description, Arc::clone(&ctx), log);
+
+    if let Err(e) = http_server {
+        anyhow::bail!("Error from HttpServerStarter::new: {:?}", e);
+    }
+
+    if let Err(s) = http_server.unwrap().start().await {
+        anyhow::bail!("Error from start(): {}", s);
+    }
+
+    Ok(())
+}

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -549,7 +549,9 @@ where
             println!("{} Reopen extent {}", rep_id, eid);
             let msg = {
                 let mut d = ad.lock().await;
-                match d.region.reopen_extent(*eid as usize) {
+                // If we're performing this action, then the extent should be
+                // opened rw.
+                match d.region.reopen_extent(*eid as usize, false) {
                     Ok(()) => Message::ExtentReopenAck(*rep_id),
                     Err(e) => Message::ExtentError(*rep_id, *eid, e),
                 }
@@ -1310,9 +1312,10 @@ impl Downstairs {
         work.last_flush = 0;
 
         /*
-         * Re-open any closed extents
+         * Re-open any closed extents - if performing this type of
+         * reconciliation, then we're opening them rw
          */
-        self.region.reopen_all_extents()?;
+        self.region.reopen_all_extents(false)?;
 
         println!("{:?} is now active", uuid);
 

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -1738,7 +1738,12 @@ async fn main() -> Result<()> {
             }
 
             let read_only = mode == Mode::Ro;
-            let d = create_downstairs(&data, lossy, return_errors, read_only)?;
+            let d = build_downstairs_for_region(
+                &data,
+                lossy,
+                return_errors,
+                read_only,
+            )?;
 
             start_downstairs(
                 d,
@@ -1818,7 +1823,7 @@ fn create_region(
     Ok(region)
 }
 
-fn create_downstairs(
+fn build_downstairs_for_region(
     data: &Path,
     lossy: bool,
     return_errors: bool,

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -549,9 +549,7 @@ where
             println!("{} Reopen extent {}", rep_id, eid);
             let msg = {
                 let mut d = ad.lock().await;
-                // If we're performing this action, then the extent should be
-                // opened rw.
-                match d.region.reopen_extent(*eid as usize, false) {
+                match d.region.reopen_extent(*eid as usize) {
                     Ok(()) => Message::ExtentReopenAck(*rep_id),
                     Err(e) => Message::ExtentError(*rep_id, *eid, e),
                 }
@@ -1312,10 +1310,9 @@ impl Downstairs {
         work.last_flush = 0;
 
         /*
-         * Re-open any closed extents - if performing this type of
-         * reconciliation, then we're opening them rw
+         * Re-open any closed extents
          */
-        self.region.reopen_all_extents(false)?;
+        self.region.reopen_all_extents()?;
 
         println!("{:?} is now active", uuid);
 

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -926,7 +926,7 @@ impl Region {
      * Walk the list of all extents and find any that are not open.
      * Open any extents that are not.
      */
-    pub fn reopen_all_extents(&mut self) -> Result<()> {
+    pub fn reopen_all_extents(&mut self, read_only: bool) -> Result<()> {
         let mut to_open = Vec::new();
         for (i, extent) in self.extents.iter().enumerate() {
             if extent.inner.is_none() {
@@ -935,7 +935,7 @@ impl Region {
         }
 
         for eid in to_open {
-            self.reopen_extent(eid as usize)?;
+            self.reopen_extent(eid as usize, read_only)?;
         }
 
         Ok(())
@@ -944,14 +944,19 @@ impl Region {
     /**
      * Re open an extent that was previously closed
      */
-    pub fn reopen_extent(&mut self, eid: usize) -> Result<(), CrucibleError> {
+    pub fn reopen_extent(
+        &mut self,
+        eid: usize,
+        read_only: bool,
+    ) -> Result<(), CrucibleError> {
         /*
          * Make sure the extent is currently closed, and matches our eid
          */
         println!("reopen extent {}  {:?}", eid, self.extents[eid].inner);
         assert!(!self.extents[eid].inner.is_some());
         assert_eq!(self.extents[eid].number, eid as u32);
-        let new_extent = Extent::open(&self.dir, &self.def, eid as u32)?;
+        let new_extent =
+            Extent::open(&self.dir, &self.def, eid as u32, read_only)?;
         self.extents[eid] = new_extent;
         Ok(())
     }
@@ -1272,7 +1277,7 @@ mod test {
         assert!(!ext_one.inner.is_some());
 
         // Reopen extent 1
-        region.reopen_extent(1)?;
+        region.reopen_extent(1, false)?;
 
         // Verify extent one is valid
         let ext_one = &mut region.extents[1];
@@ -1302,7 +1307,7 @@ mod test {
         assert!(!ext_four.inner.is_some());
 
         // Reopen all extents
-        region.reopen_all_extents()?;
+        region.reopen_all_extents(false)?;
 
         // Verify extent one is valid
         let ext_one = &mut region.extents[1];

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -9,7 +9,7 @@ use std::sync::{Mutex, MutexGuard};
 
 use anyhow::{bail, Result};
 use crucible_common::*;
-use crucible_protocol::EncryptionContext;
+use crucible_protocol::{EncryptionContext, SnapshotDetails};
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
@@ -425,6 +425,7 @@ impl Extent {
         dir: P,
         def: &RegionDefinition,
         number: u32,
+        read_only: bool,
     ) -> Result<Extent> {
         /*
          * Store extent data in files within a directory hierarchy so that
@@ -438,22 +439,23 @@ impl Extent {
         /*
          * Open the extent file and verify the size is as we expect.
          */
-        let file = match OpenOptions::new().read(true).write(true).open(&path) {
-            Err(e) => {
-                bail!("Error: e {} No extent file found for {:?}", e, path);
-            }
-            Ok(f) => {
-                let cur_size = f.metadata().unwrap().len();
-                if size != cur_size {
-                    bail!(
-                        "File size {:?} does not match expected {:?}",
-                        size,
-                        cur_size
-                    );
+        let file =
+            match OpenOptions::new().read(true).write(!read_only).open(&path) {
+                Err(e) => {
+                    bail!("Error: e {} No extent file found for {:?}", e, path);
                 }
-                f
-            }
-        };
+                Ok(f) => {
+                    let cur_size = f.metadata().unwrap().len();
+                    if size != cur_size {
+                        bail!(
+                            "File size {:?} does not match expected {:?}",
+                            size,
+                            cur_size
+                        );
+                    }
+                    f
+                }
+            };
 
         /*
          * Open a connection to the metadata db
@@ -790,6 +792,7 @@ pub struct Region {
     dir: PathBuf,
     def: RegionDefinition,
     pub extents: Vec<Extent>,
+    read_only: bool,
 }
 
 impl Region {
@@ -823,6 +826,7 @@ impl Region {
             dir: dir.as_ref().to_path_buf(),
             def,
             extents: Vec::new(),
+            read_only: false,
         };
 
         region.open_extents(true)?;
@@ -837,6 +841,7 @@ impl Region {
         dir: P,
         options: RegionOptions,
         verbose: bool,
+        read_only: bool,
     ) -> Result<Region> {
         options.validate()?;
 
@@ -853,6 +858,7 @@ impl Region {
         if verbose {
             println!("Opened existing region file {:?}", cp);
         }
+
         /*
          * Open every extent that presently exists.
          */
@@ -860,6 +866,7 @@ impl Region {
             dir: dir.as_ref().to_path_buf(),
             def,
             extents: Vec::new(),
+            read_only,
         };
 
         region.open_extents(false)?;
@@ -885,7 +892,8 @@ impl Region {
             if create {
                 new_extent = Extent::create(&self.dir, &self.def, eid)?;
             } else {
-                new_extent = Extent::open(&self.dir, &self.def, eid)?;
+                new_extent =
+                    Extent::open(&self.dir, &self.def, eid, self.read_only)?;
             }
             self.extents.push(new_extent);
             assert_eq!(self.extents[eid as usize].number, eid);
@@ -899,6 +907,11 @@ impl Region {
      * and what is requested, go out and create the new extent files.
      */
     pub fn extend(&mut self, newsize: u32) -> Result<()> {
+        if self.read_only {
+            // XXX return CrucibleError instead of anyhow?
+            bail!(CrucibleError::ModifyingReadOnlyRegion.to_string());
+        }
+
         if newsize < self.def.extent_count() {
             bail!(
                 "will not truncate {} -> {} for now",
@@ -987,6 +1000,10 @@ impl Region {
         &self,
         writes: &[crucible_protocol::Write],
     ) -> Result<(), CrucibleError> {
+        if self.read_only {
+            crucible_bail!(ModifyingReadOnlyRegion);
+        }
+
         /*
          * Before anything, validate hashes
          */
@@ -1070,12 +1087,69 @@ impl Region {
         &self,
         flush_number: u64,
         gen_number: u64,
+        snapshot_details: &Option<SnapshotDetails>,
     ) -> Result<(), CrucibleError> {
+        // It should be ok to Flush a read-only region, but not take a snapshot.
+        // Most likely this read-only region *is* a snapshot, so that's
+        // redundant :)
+        if self.read_only && snapshot_details.is_some() {
+            crucible_bail!(ModifyingReadOnlyRegion);
+        }
+
         // XXX How to we convert between usize and u32 correctly?
         for eid in 0..self.def.extent_count() {
             let extent = &self.extents[eid as usize];
             extent.flush_block(flush_number, gen_number)?;
         }
+
+        // snapshots currently only work with ZFS
+        if cfg!(feature = "zfs_snapshot") {
+            if let Some(snapshot_details) = snapshot_details {
+                // Check if the path exists, return an error if it does
+                let test_path = format!(
+                    "{}/.zfs/snapshot/{}",
+                    self.dir.clone().into_os_string().into_string().unwrap(),
+                    snapshot_details.snapshot_name,
+                );
+
+                if std::path::Path::new(&test_path).is_dir() {
+                    crucible_bail!(
+                        SnapshotExistsAlready,
+                        "{}",
+                        snapshot_details.snapshot_name,
+                    );
+                }
+
+                // Drop leading slash
+                let fs =
+                    self.dir.clone().into_os_string().into_string().unwrap();
+                let mut chars = fs.chars();
+                chars.next();
+                let fs = chars.as_str();
+
+                let output = std::process::Command::new("zfs")
+                    .args([
+                        "snapshot",
+                        format!("{}@{}", fs, snapshot_details.snapshot_name)
+                            .as_str(),
+                    ])
+                    .output()
+                    .map_err(|e| {
+                        CrucibleError::SnapshotFailed(e.to_string())
+                    })?;
+
+                if !output.status.success() {
+                    crucible_bail!(
+                        SnapshotFailed,
+                        "{}",
+                        std::str::from_utf8(&output.stderr).map_err(|e| {
+                            CrucibleError::GenericError(e.to_string())
+                        })?,
+                    );
+                }
+            }
+        }
+
         Ok(())
     }
 }
@@ -1142,7 +1216,7 @@ mod test {
     fn new_existing_region() -> Result<()> {
         let dir = tempdir()?;
         let _ = Region::create(&dir, new_region_options());
-        let _ = Region::open(&dir, new_region_options(), false);
+        let _ = Region::open(&dir, new_region_options(), false, false);
         Ok(())
     }
 
@@ -1152,6 +1226,7 @@ mod test {
         let _ = Region::open(
             &"/tmp/12345678-1111-2222-3333-123456789999/notadir",
             new_region_options(),
+            false,
             false,
         )
         .unwrap();

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -55,9 +55,9 @@ pub struct Opt {
     #[structopt(long)]
     root_cert_pem: Option<String>,
 
-    // Start upstairs info server
+    // Start upstairs http server
     #[structopt(long)]
-    info: Option<SocketAddr>,
+    http: Option<SocketAddr>,
 }
 
 pub fn opts() -> Result<Opt> {
@@ -85,7 +85,7 @@ fn main() -> Result<()> {
         cert_pem: opt.cert_pem,
         key_pem: opt.key_pem,
         root_cert_pem: opt.root_cert_pem,
-        info: opt.info,
+        http: opt.http,
     };
     let mut generation_number = opt.gen;
 

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -76,7 +76,7 @@ fn main() -> Result<()> {
         cert_pem: opt.cert_pem,
         key_pem: opt.key_pem,
         root_cert_pem: opt.root_cert_pem,
-        info: None,
+        http: None,
     };
 
     /*

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -205,7 +205,7 @@ fn main() -> Result<()> {
     }
 
     // One last flush
-    guest.flush()?;
+    guest.flush(None)?;
 
     println!("Done ok, waiting on show_work");
 

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -50,9 +50,9 @@ pub struct Opt {
     #[structopt(long)]
     root_cert_pem: Option<String>,
 
-    // Start upstairs info server
+    // Start upstairs http server
     #[structopt(long)]
-    info: Option<SocketAddr>,
+    http: Option<SocketAddr>,
 }
 
 pub fn opts() -> Result<Opt> {
@@ -75,7 +75,7 @@ fn main() -> Result<()> {
         cert_pem: opt.cert_pem,
         key_pem: opt.key_pem,
         root_cert_pem: opt.root_cert_pem,
-        info: opt.info,
+        http: opt.http,
     };
 
     /*

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -110,6 +110,7 @@ fn main() -> Result<()> {
     let listener = TcpListener::bind("127.0.0.1:10809").unwrap();
 
     // sent to NBD client during handshake through Export struct
+    cpf.activate(opt.gen)?;
     println!("NBD advertised size as {} bytes", cpf.sz());
 
     for stream in listener.incoming() {

--- a/openapi/crucible-agent.json
+++ b/openapi/crucible-agent.json
@@ -97,6 +97,164 @@
           }
         }
       }
+    },
+    "/crucible/0/regions/{id}/snapshots": {
+      "get": {
+        "operationId": "region_get_snapshots",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RegionId"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSnapshotResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/crucible/0/regions/{id}/snapshots/{name}": {
+      "get": {
+        "operationId": "region_get_snapshot",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RegionId"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Snapshot"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "region_delete_snapshot",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RegionId"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          }
+        }
+      }
+    },
+    "/crucible/0/regions/{id}/snapshots/{name}/run": {
+      "post": {
+        "operationId": "region_run_snapshot",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RegionId"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunningSnapshot"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "region_delete_running_snapshot",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RegionId"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -109,6 +267,13 @@
             "format": "uint64",
             "minimum": 0
           },
+          "cert_pem": {
+            "nullable": true,
+            "type": "string"
+          },
+          "encrypted": {
+            "type": "boolean"
+          },
           "extent_count": {
             "type": "integer",
             "format": "uint64",
@@ -122,16 +287,46 @@
           "id": {
             "$ref": "#/components/schemas/RegionId"
           },
+          "key_pem": {
+            "nullable": true,
+            "type": "string"
+          },
+          "root_pem": {
+            "nullable": true,
+            "type": "string"
+          },
           "volume_id": {
             "type": "string"
           }
         },
         "required": [
           "block_size",
+          "encrypted",
           "extent_count",
           "extent_size",
           "id",
           "volume_id"
+        ]
+      },
+      "GetSnapshotResponse": {
+        "type": "object",
+        "properties": {
+          "running_snapshots": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/RunningSnapshot"
+            }
+          },
+          "snapshots": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Snapshot"
+            }
+          }
+        },
+        "required": [
+          "running_snapshots",
+          "snapshots"
         ]
       },
       "Region": {
@@ -142,6 +337,13 @@
             "format": "uint64",
             "minimum": 0
           },
+          "cert_pem": {
+            "nullable": true,
+            "type": "string"
+          },
+          "encrypted": {
+            "type": "boolean"
+          },
           "extent_count": {
             "type": "integer",
             "format": "uint64",
@@ -155,10 +357,18 @@
           "id": {
             "$ref": "#/components/schemas/RegionId"
           },
+          "key_pem": {
+            "nullable": true,
+            "type": "string"
+          },
           "port_number": {
             "type": "integer",
             "format": "uint16",
             "minimum": 0
+          },
+          "root_pem": {
+            "nullable": true,
+            "type": "string"
           },
           "state": {
             "$ref": "#/components/schemas/State"
@@ -169,6 +379,7 @@
         },
         "required": [
           "block_size",
+          "encrypted",
           "extent_count",
           "extent_size",
           "id",
@@ -179,6 +390,47 @@
       },
       "RegionId": {
         "type": "string"
+      },
+      "RunningSnapshot": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RegionId"
+          },
+          "name": {
+            "type": "string"
+          },
+          "port_number": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "state": {
+            "$ref": "#/components/schemas/State"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "port_number",
+          "state"
+        ]
+      },
+      "Snapshot": {
+        "type": "object",
+        "properties": {
+          "created": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "created",
+          "name"
+        ]
       },
       "State": {
         "type": "string",

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -155,7 +155,7 @@ pub enum Message {
 
     /*
      * Flush: Uuid, job id, dependencies, flush number generation number,
-     * and        optional snapshot details
+     *        and optional snapshot details
      * FlushAck: Uuid, job id, result
      */
     Flush(Uuid, u64, Vec<u64>, u64, u64, Option<SnapshotDetails>),

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -102,6 +102,11 @@ impl ReadResponse {
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct SnapshotDetails {
+    pub snapshot_name: String,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum Message {
     /*
      * Initial negotiation: version, upstairs uuid.
@@ -148,7 +153,12 @@ pub enum Message {
     Write(Uuid, u64, Vec<u64>, Vec<Write>),
     WriteAck(Uuid, u64, Result<(), CrucibleError>),
 
-    Flush(Uuid, u64, Vec<u64>, u64, u64),
+    /*
+     * Flush: Uuid, job id, dependencies, flush number generation number,
+     * and        optional snapshot details
+     * FlushAck: Uuid, job id, result
+     */
+    Flush(Uuid, u64, Vec<u64>, u64, u64, Option<SnapshotDetails>),
     FlushAck(Uuid, u64, Result<(), CrucibleError>),
 
     /*

--- a/smf/src/lib.rs
+++ b/smf/src/lib.rs
@@ -34,7 +34,7 @@ mod value;
 pub use value::{Value, Values};
 
 mod transaction;
-pub use transaction::{CommitResult, Transaction, TransactionEntry};
+pub use transaction::{CommitResult, Transaction};
 
 pub type Result<T> = std::result::Result<T, ScfError>;
 

--- a/smf/src/scf_sys.rs
+++ b/smf/src/scf_sys.rs
@@ -72,7 +72,7 @@ pub enum scf_error_t {
     SCF_ERROR_INTERNAL = 1101,        /* internal error */
 }
 
-#[derive(Debug, FromPrimitive, ToPrimitive)]
+#[derive(Debug, FromPrimitive, ToPrimitive, Clone, Copy)]
 #[repr(C)]
 pub enum scf_type_t {
     SCF_TYPE_INVALID = 0,

--- a/smf/src/transaction.rs
+++ b/smf/src/transaction.rs
@@ -2,14 +2,21 @@
 
 use std::ffi::CString;
 use std::ptr::NonNull;
+use std::sync::Mutex;
 
 use super::scf_sys::*;
-use super::{PropertyGroup, Result, ScfError, Value};
+use super::{PropertyGroup, Result, Scf, ScfError, Value};
 
 #[derive(Debug)]
 pub struct Transaction<'a> {
     pub(crate) pg: &'a PropertyGroup<'a>,
     pub(crate) transaction: NonNull<scf_transaction_t>,
+
+    /*
+     * Keep TransactionEntry objects around - if they are dropped, then the
+     * transaction is invalidated.
+     */
+    transaction_entries: Mutex<Vec<TransactionEntry<'a>>>,
 }
 
 pub enum CommitResult {
@@ -24,7 +31,11 @@ impl<'a> Transaction<'a> {
         if let Some(transaction) =
             NonNull::new(unsafe { scf_transaction_create(scf.handle.as_ptr()) })
         {
-            Ok(Transaction { pg, transaction })
+            Ok(Transaction {
+                pg,
+                transaction,
+                transaction_entries: Mutex::new(vec![]),
+            })
         } else {
             Err(ScfError::last())
         }
@@ -60,9 +71,9 @@ impl<'a> Transaction<'a> {
         unsafe { scf_transaction_reset_all(self.transaction.as_ptr()) };
     }
 
-    pub fn property_delete(&self, name: &str) -> Result<TransactionEntry> {
+    pub fn property_delete(&self, name: &str) -> Result<()> {
         let name = CString::new(name).unwrap();
-        let ent = TransactionEntry::new(self)?;
+        let ent = TransactionEntry::new(self.pg.scf)?;
 
         let ret = unsafe {
             scf_transaction_property_delete(
@@ -72,20 +83,22 @@ impl<'a> Transaction<'a> {
             )
         };
 
+        self.transaction_entries.lock().unwrap().push(ent);
+
         if ret == 0 {
-            Ok(ent)
+            Ok(())
         } else {
             Err(ScfError::last())
         }
     }
 
-    pub fn property_new(
+    fn property_new(
         &self,
         name: &str,
         typ: scf_type_t,
-    ) -> Result<TransactionEntry> {
+    ) -> Result<TransactionEntry<'a>> {
         let name = CString::new(name).unwrap();
-        let ent = TransactionEntry::new(self)?;
+        let ent = TransactionEntry::new(self.pg.scf)?;
 
         let ret = unsafe {
             scf_transaction_property_new(
@@ -103,13 +116,13 @@ impl<'a> Transaction<'a> {
         }
     }
 
-    pub fn property_change(
+    fn property_change(
         &self,
         name: &str,
         typ: scf_type_t,
-    ) -> Result<TransactionEntry> {
+    ) -> Result<TransactionEntry<'a>> {
         let name = CString::new(name).unwrap();
-        let ent = TransactionEntry::new(self)?;
+        let ent = TransactionEntry::new(self.pg.scf)?;
 
         let ret = unsafe {
             scf_transaction_property_change(
@@ -126,6 +139,27 @@ impl<'a> Transaction<'a> {
             Err(ScfError::last())
         }
     }
+
+    /**
+     * Either add or change an existing property.
+     */
+    pub fn property_ensure(
+        &self,
+        name: &str,
+        typ: scf_type_t,
+        val: &str,
+    ) -> Result<()> {
+        let mut e = if self.pg.get_property(name)?.is_some() {
+            self.property_change(name, typ)?
+        } else {
+            self.property_new(name, typ)?
+        };
+        e.add_from_string(typ, val)?;
+
+        self.transaction_entries.lock().unwrap().push(e);
+
+        Ok(())
+    }
 }
 
 impl Drop for Transaction<'_> {
@@ -140,21 +174,19 @@ impl Drop for Transaction<'_> {
 }
 
 #[derive(Debug)]
-pub struct TransactionEntry<'a> {
-    pub(crate) transaction: &'a Transaction<'a>,
+struct TransactionEntry<'a> {
+    pub(crate) scf: &'a Scf,
     pub(crate) entry: NonNull<scf_transaction_entry_t>,
     values: Vec<Value<'a>>,
 }
 
 impl<'a> TransactionEntry<'a> {
-    pub(crate) fn new(tx: &'a Transaction<'a>) -> Result<TransactionEntry> {
-        let scf = tx.pg.scf;
-
+    pub(crate) fn new(scf: &'a Scf) -> Result<TransactionEntry> {
         if let Some(entry) =
             NonNull::new(unsafe { scf_entry_create(scf.handle.as_ptr()) })
         {
             Ok(TransactionEntry {
-                transaction: tx,
+                scf,
                 entry,
                 values: Vec::new(),
             })
@@ -168,7 +200,7 @@ impl<'a> TransactionEntry<'a> {
         typ: scf_type_t,
         val: &str,
     ) -> Result<()> {
-        let v = Value::new(self.transaction.pg.scf)?;
+        let v = Value::new(self.scf)?;
         v.set_from_string(typ, val)?;
         if unsafe { scf_entry_add_value(self.entry.as_ptr(), v.value.as_ptr()) }
             == 0

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -57,8 +57,8 @@ for (( i = 0; i < 3; i++ )); do
             ${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10
             ;;
         "encrypted")
-            echo ${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10 --encrypted
-            ${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10 --encrypted
+            echo ${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10 --encrypted=true
+            ${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10 --encrypted=true
             ;;
     esac
     echo ${cds} run -p "$port" -d "$dir"

--- a/upstairs/src/block_io.rs
+++ b/upstairs/src/block_io.rs
@@ -90,7 +90,10 @@ impl BlockIO for FileBlockIO {
         BlockReqWaiter::immediate()
     }
 
-    fn flush(&self) -> Result<BlockReqWaiter, CrucibleError> {
+    fn flush(
+        &self,
+        _snapshot_details: Option<SnapshotDetails>,
+    ) -> Result<BlockReqWaiter, CrucibleError> {
         let mut file = self.file.lock().unwrap();
         file.flush()?;
         BlockReqWaiter::immediate()
@@ -226,7 +229,10 @@ impl BlockIO for ReqwestBlockIO {
         unimplemented!();
     }
 
-    fn flush(&self) -> Result<BlockReqWaiter, CrucibleError> {
+    fn flush(
+        &self,
+        _snapshot_details: Option<SnapshotDetails>,
+    ) -> Result<BlockReqWaiter, CrucibleError> {
         BlockReqWaiter::immediate()
     }
 

--- a/upstairs/src/http.rs
+++ b/upstairs/src/http.rs
@@ -18,7 +18,9 @@ use std::sync::Arc;
 use super::*;
 
 /**
- * Publish some stats on a http port from the upstairs internal struct.
+ * Start up a dropshot server along side the Upstairs. This offers a way for
+ * Nexus or Propolis to send Snapshot commands. Also, publish some stats on
+ * a `/info` from the Upstairs internal struct.
  */
 pub async fn start(up: &Arc<Upstairs>, addr: SocketAddr) -> Result<(), String> {
     /*

--- a/upstairs/src/http.rs
+++ b/upstairs/src/http.rs
@@ -5,9 +5,11 @@ use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
 use dropshot::ConfigLoggingLevel;
 use dropshot::HttpError;
+use dropshot::HttpResponseCreated;
 use dropshot::HttpResponseOk;
 use dropshot::HttpServerStarter;
 use dropshot::RequestContext;
+use dropshot::TypedBody;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
@@ -18,10 +20,7 @@ use super::*;
 /**
  * Publish some stats on a http port from the upstairs internal struct.
  */
-pub async fn start_info(
-    up: &Arc<Upstairs>,
-    addr: SocketAddr,
-) -> Result<(), String> {
+pub async fn start(up: &Arc<Upstairs>, addr: SocketAddr) -> Result<(), String> {
     /*
      * Setup dropshot
      */
@@ -47,6 +46,7 @@ pub async fn start_info(
      */
     let mut api = ApiDescription::new();
     api.register(upstairs_fill_info).unwrap();
+    api.register(take_snapshot).unwrap();
 
     /*
      * The functions that implement our API endpoints will share this
@@ -119,5 +119,47 @@ async fn upstairs_fill_info(
         state: act,
         up_jobs,
         ds_jobs,
+    }))
+}
+
+/**
+ * Signal to the Upstairs to take a snapshot
+ */
+#[derive(Deserialize, JsonSchema)]
+pub struct TakeSnapshotParams {
+    snapshot_name: String,
+}
+
+#[derive(Serialize, JsonSchema)]
+pub struct TakeSnapshotResponse {
+    snapshot_name: String,
+}
+
+#[endpoint {
+    method = POST,
+    path = "/snapshot"
+}]
+async fn take_snapshot(
+    rqctx: Arc<RequestContext<UpstairsInfo>>,
+    take_snapshot_params: TypedBody<TakeSnapshotParams>,
+) -> Result<HttpResponseCreated<TakeSnapshotResponse>, HttpError> {
+    let apictx = rqctx.context();
+    let take_snapshot_params = take_snapshot_params.into_inner();
+
+    let mut waiter = apictx
+        .up
+        .guest
+        .flush(Some(SnapshotDetails {
+            snapshot_name: take_snapshot_params.snapshot_name.clone(),
+        }))
+        .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
+
+    tokio::task::block_in_place(|| -> Result<(), CrucibleError> {
+        waiter.block_wait()
+    })
+    .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
+
+    Ok(HttpResponseCreated(TakeSnapshotResponse {
+        snapshot_name: take_snapshot_params.snapshot_name,
     }))
 }

--- a/upstairs/src/in_memory.rs
+++ b/upstairs/src/in_memory.rs
@@ -80,7 +80,10 @@ impl BlockIO for InMemoryBlockIO {
         BlockReqWaiter::immediate()
     }
 
-    fn flush(&self) -> Result<BlockReqWaiter, CrucibleError> {
+    fn flush(
+        &self,
+        _snapshot_details: Option<SnapshotDetails>,
+    ) -> Result<BlockReqWaiter, CrucibleError> {
         BlockReqWaiter::immediate()
     }
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -134,7 +134,7 @@ pub struct CrucibleOpts {
     pub cert_pem: Option<String>,
     pub key_pem: Option<String>,
     pub root_cert_pem: Option<String>,
-    pub info: Option<SocketAddr>,
+    pub http: Option<SocketAddr>,
 }
 
 impl CrucibleOpts {
@@ -2413,7 +2413,7 @@ impl Upstairs {
             cert_pem: None,
             key_pem: None,
             root_cert_pem: None,
-            info: None,
+            http: None,
         };
         Self::new(
             &opts,
@@ -5676,12 +5676,12 @@ pub async fn up_main(opt: CrucibleOpts, guest: Arc<Guest>) -> Result<()> {
     drop(ds_done_tx);
     drop(ds_status_tx);
 
-    // If requested, start the info server on the given address:port
-    if let Some(info) = opt.info {
+    // If requested, start the http server on the given address:port
+    if let Some(http) = opt.http {
         let upi = Arc::clone(&up);
         tokio::spawn(async move {
-            let r = http::start(&upi, info).await;
-            println!("Info task finished with {:?}", r);
+            let r = http::start(&upi, http).await;
+            println!("HTTP task finished with {:?}", r);
         });
     }
     /*

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -37,7 +37,6 @@ use aes_gcm_siv::{Aes256GcmSiv, Key, Nonce, Tag};
 use rand_chacha::ChaCha20Rng;
 
 mod http;
-mod mend;
 mod pseudo_file;
 mod test;
 

--- a/upstairs/src/main.rs
+++ b/upstairs/src/main.rs
@@ -193,7 +193,7 @@ fn run_single_workload(guest: &Arc<Guest>) -> Result<()> {
         .block_wait()?;
 
     println!("send a flush");
-    guest.flush()?.block_wait()?;
+    guest.flush(None)?.block_wait()?;
 
     let read_offset = my_offset;
     const READ_SIZE: usize = 1024;

--- a/upstairs/src/main.rs
+++ b/upstairs/src/main.rs
@@ -32,9 +32,9 @@ pub struct Opt {
     #[structopt(long)]
     root_cert_pem: Option<String>,
 
-    // Start upstairs info server
+    // Start upstairs http server
     #[structopt(long)]
-    info: Option<SocketAddr>,
+    http: Option<SocketAddr>,
 }
 
 pub fn opts() -> Result<Opt> {
@@ -143,7 +143,7 @@ fn main() -> Result<()> {
         cert_pem: opt.cert_pem,
         key_pem: opt.key_pem,
         root_cert_pem: opt.root_cert_pem,
-        info: opt.info,
+        http: opt.http,
     };
 
     let runtime = Builder::new_multi_thread()

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -322,7 +322,7 @@ impl<T: BlockIO> CruciblePseudoFile<T> {
     fn _flush(&mut self) -> Result<(), CrucibleError> {
         let _guard = self.rmw_lock.write().unwrap();
 
-        let mut waiter = self.block_io.flush()?;
+        let mut waiter = self.block_io.flush(None)?;
         waiter.block_wait()?;
 
         Ok(())

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -457,7 +457,7 @@ mod test {
 
         let next_id = work.next_id();
 
-        let op = create_flush(next_id, vec![], 10, 0, 0);
+        let op = create_flush(next_id, vec![], 10, 0, 0, None);
 
         work.enqueue(op);
 
@@ -520,7 +520,7 @@ mod test {
 
         let next_id = work.next_id();
 
-        let op = create_flush(next_id, vec![], 10, 0, 0);
+        let op = create_flush(next_id, vec![], 10, 0, 0, None);
 
         work.enqueue(op);
 
@@ -583,7 +583,7 @@ mod test {
 
         let next_id = work.next_id();
 
-        let op = create_flush(next_id, vec![], 10, 0, 0);
+        let op = create_flush(next_id, vec![], 10, 0, 0, None);
 
         work.enqueue(op);
 
@@ -1391,7 +1391,7 @@ mod test {
         // A flush is required to move work to completed
         // Create the flush then send it to all downstairs.
         let next_id = work.next_id();
-        let op = create_flush(next_id, vec![], 10, 0, 0);
+        let op = create_flush(next_id, vec![], 10, 0, 0, None);
 
         work.enqueue(op);
 
@@ -1552,7 +1552,7 @@ mod test {
 
         // Create the flush, put on the work queue
         let flush_id = work.next_id();
-        let op = create_flush(flush_id, vec![], 10, 0, 0);
+        let op = create_flush(flush_id, vec![], 10, 0, 0, None);
         work.enqueue(op);
 
         // Simulate sending the flush to downstairs 0 and 1
@@ -1724,7 +1724,7 @@ mod test {
 
         // Create the flush IO
         let next_id = work.next_id();
-        let op = create_flush(next_id, vec![], 10, 0, 0);
+        let op = create_flush(next_id, vec![], 10, 0, 0, None);
         work.enqueue(op);
 
         // Submit the flush to all three downstairs.
@@ -1882,7 +1882,7 @@ mod test {
 
         // Create and enqueue the flush.
         let flush_id = work.next_id();
-        let op = create_flush(flush_id, vec![], 10, 0, 0);
+        let op = create_flush(flush_id, vec![], 10, 0, 0, None);
         work.enqueue(op);
 
         // Send the flush to two downstairs.
@@ -3203,9 +3203,15 @@ mod test {
         guest.set_iop_limit(16000, 0);
         assert!(guest.consume_req().is_none());
 
-        let _ = guest.send(BlockOp::Flush);
-        let _ = guest.send(BlockOp::Flush);
-        let _ = guest.send(BlockOp::Flush);
+        let _ = guest.send(BlockOp::Flush {
+            snapshot_details: None,
+        });
+        let _ = guest.send(BlockOp::Flush {
+            snapshot_details: None,
+        });
+        let _ = guest.send(BlockOp::Flush {
+            snapshot_details: None,
+        });
 
         assert!(guest.consume_req().is_some());
         assert!(guest.consume_req().is_some());
@@ -3275,9 +3281,15 @@ mod test {
         guest.set_bw_limit(0);
         assert!(guest.consume_req().is_none());
 
-        let _ = guest.send(BlockOp::Flush);
-        let _ = guest.send(BlockOp::Flush);
-        let _ = guest.send(BlockOp::Flush);
+        let _ = guest.send(BlockOp::Flush {
+            snapshot_details: None,
+        });
+        let _ = guest.send(BlockOp::Flush {
+            snapshot_details: None,
+        });
+        let _ = guest.send(BlockOp::Flush {
+            snapshot_details: None,
+        });
 
         assert!(guest.consume_req().is_some());
         assert!(guest.consume_req().is_some());

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -451,9 +451,12 @@ impl BlockIO for Volume {
         BlockReqWaiter::immediate()
     }
 
-    fn flush(&self) -> Result<BlockReqWaiter, CrucibleError> {
+    fn flush(
+        &self,
+        snapshot_details: Option<SnapshotDetails>,
+    ) -> Result<BlockReqWaiter, CrucibleError> {
         for sub_volume in &self.sub_volumes {
-            let mut waiter = sub_volume.flush()?;
+            let mut waiter = sub_volume.flush(snapshot_details.clone())?;
             waiter.block_wait()?;
         }
 
@@ -610,8 +613,11 @@ impl BlockIO for SubVolume {
         self.block_io.write(offset, data)
     }
 
-    fn flush(&self) -> Result<BlockReqWaiter, CrucibleError> {
-        self.block_io.flush()
+    fn flush(
+        &self,
+        snapshot_details: Option<SnapshotDetails>,
+    ) -> Result<BlockReqWaiter, CrucibleError> {
+        self.block_io.flush(snapshot_details)
     }
 
     fn show_work(&self) -> Result<WQCounts, CrucibleError> {

--- a/x509/gen_certs.sh
+++ b/x509/gen_certs.sh
@@ -113,3 +113,21 @@ cat > selfsigned-csr.json <<EOF
 EOF
 
 cfssl gencert -initca selfsigned-csr.json | cfssljson -bare selfsigned -
+
+cat > bad-upstairs-csr.json <<EOF
+{
+    "CN": "badupstairs",
+    "hosts": [
+        "badupstairs"
+    ],
+    "key": {
+        "algo": "rsa",
+        "size": 2048
+    }
+}
+EOF
+
+cat bad-upstairs-csr.json
+
+cfssl genkey bad-upstairs-csr.json | cfssljson -bare bad-upstairs -
+cfssl sign -ca selfsigned.pem -ca-key selfsigned-key.pem bad-upstairs.csr | cfssljson -bare bad-upstairs -


### PR DESCRIPTION
Add ability to snapshot during flush by specifying an optional
"SnapshotDetails" struct, dictating that the Downstairs should take a
ZFS snapshot.

Teach the Downstairs how to serve from a read only filesystem, so it can
serve out of the ".zfs/snapshot/<name>" directory. A new "--mode"
argument can be "ro" or "rw" appropriately.

In the agent directory, update downstairs.xml for the change in how the
binary accepts arguments.

Update the agent. The agent now:

- correctly creates regions
- constructs ZFS datasets for the parent directory, and each region.
- knows to create regions with --encrypted as appropriate
- sets mode for downstairs SMF when booting snapshots
- can list snapshots, gets individual snapshot details, and delete
  snapshots
- can launch downstairs in read only mode for those snapshots, and
  delete the running snapshot downstairs as appropriate
- correctly deletes regions (have to disable downstairs smf instance
  first!)
- can accept X509 information in the region request to launch downstairs
  with TLS

Part of the agent update included changing the smf crate's Transaction
to hold on to TransactionEntries inside the Transaction itself.

This commit also adds the "serve" option to the downstairs: Josh
mentioned in one of the storage huddles that we may want to explore
running multiple regions off the same downstairs, so "serve" runs a
dropshot server that the agent can POST to run another instance of the
downstairs, instead of being required to run another SMF instance.

In upstairs, rename info.rs to http.rs, because now theres more
endpoints.