### PR TITLE
Implement VolumeConstructionRequest

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -126,7 +126,7 @@ mod cdt {
     fn ds__flush__io__done(_: u64, _: u64) {}
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CrucibleOpts {
     pub target: Vec<SocketAddr>,
     pub lossy: bool,

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -41,7 +41,7 @@ mod pseudo_file;
 mod test;
 
 pub mod volume;
-pub use volume::Volume;
+pub use volume::{Volume, VolumeConstructionRequest};
 
 pub mod in_memory;
 pub use in_memory::InMemoryBlockIO;


### PR DESCRIPTION
Because a volume can be arbitrarily deep, the intention is that Nexus
will store a JSON document in the database corresponding to a volume,
and POST that document to propolis when constructing a volume.

Implement VolumeConstructionRequest, a serializable/deserializable enum
that represents the volume to construct. All consumers (aka propolis)
have to do is pass this to Volume::construct, and they get a volume out
of it, and Nexus can store this in a JSONB column.