### PR TITLE
Updates for Crucible CLI and a few test scripts

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -927,11 +927,12 @@ async fn deactivate_workload(
     ri: &mut RegionInfo,
     mut gen: u64,
 ) -> Result<()> {
-    for c in 0..count {
+    for c in 1..=count {
         println!("{}/{} CLIENT: run rand test", c, count);
         generic_workload(guest, 20, ri).await?;
         println!("{}/{} CLIENT: Now disconnect", c, count);
         let mut waiter = guest.deactivate()?;
+        println!("{}/{} CLIENT: Now disconnect wait", c, count);
         waiter.block_wait()?;
         println!("{}/{} CLIENT: Now disconnect done.", c, count);
         let wc = guest.show_work()?;
@@ -953,6 +954,7 @@ async fn deactivate_workload(
     println!("One final");
     generic_workload(guest, 20, ri).await?;
 
+    println!("final verify");
     if let Err(e) = verify_volume(guest, ri) {
         bail!("Final volume verify failed: {:?}", e)
     }
@@ -976,7 +978,7 @@ async fn rand_workload(
     /*
      * TODO: Let the user select the number of loops
      */
-    for c in 0..count {
+    for c in 1..=count {
         /*
          * Pick a random size (in blocks) for the IO, up to the size of the
          * entire region.
@@ -1055,7 +1057,7 @@ async fn burst_workload(
     verify_out: &Option<PathBuf>,
 ) -> Result<()> {
     // TODO: let user pick loop count
-    for c in 0..count {
+    for c in 1..=count {
         demo_workload(guest, demo_count, ri).await?;
         let mut wc = guest.show_work()?;
         while wc.up_count + wc.ds_count != 0 {
@@ -1100,7 +1102,7 @@ async fn demo_workload(
     let mut waiterlist = Vec::new();
     // TODO: Let the user select the number of loops
     // TODO: Allow user to request r/w/f percentage (how???)
-    for i in 0..count {
+    for i in 1..=count {
         let op = rng.gen_range(0..10);
         if op == 0 {
             // flush

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -301,7 +301,12 @@ fn main() -> Result<()> {
     println!("Crucible runtime is spawned");
 
     if let Workload::CliServer { listen, port } = opt.workload {
-        runtime.block_on(cli::start_cli_server(&guest, listen, port))?;
+        runtime.block_on(cli::start_cli_server(
+            &guest,
+            listen,
+            port,
+            opt.verify_in,
+        ))?;
         return Ok(());
     }
 

--- a/client/src/protocol.rs
+++ b/client/src/protocol.rs
@@ -30,7 +30,7 @@ pub enum CliMessage {
     Generic,
     Read(usize, usize),
     RandRead,
-    ReadResponse(Result<Vec<u8>, CrucibleError>),
+    ReadResponse(usize, Result<Vec<u8>, CrucibleError>),
     Write(usize, usize),
     RandWrite,
     Flush,

--- a/client/src/protocol.rs
+++ b/client/src/protocol.rs
@@ -27,6 +27,7 @@ pub enum CliMessage {
     Deactivate,
     // Generic command success
     DoneOk,
+    Generic,
     Read(usize, usize),
     RandRead,
     ReadResponse(Result<Vec<u8>, CrucibleError>),
@@ -241,6 +242,13 @@ mod tests {
     #[test]
     fn rt_write() -> Result<()> {
         let input = CliMessage::Write(32, 22);
+        assert_eq!(input, round_trip(&input)?);
+        Ok(())
+    }
+
+    #[test]
+    fn rt_generic() -> Result<()> {
+        let input = CliMessage::Generic;
         assert_eq!(input, round_trip(&input)?);
         Ok(())
     }

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -41,8 +41,22 @@ if [[ -d ${testdir} ]]; then
     rm -rf ${testdir}
 fi
 
-uuidprefix="12345678-1234-1234-1234-00000000"
 args=()
+
+case ${1} in
+    "unencrypted")
+        ;;
+    "encrypted")
+        args+=( --key "$(openssl rand -base64 32)" )
+        ;;
+    *)
+        echo "Usage: $0 encrypted|unencrypted"
+        echo " encrypted or unencrypted are the only valid choices"
+        exit 1
+        ;;
+esac
+
+uuidprefix="12345678-1234-1234-1234-00000000"
 downstairs=()
 port_base=8801
 for (( i = 0; i < 3; i++ )); do
@@ -66,16 +80,6 @@ for (( i = 0; i < 3; i++ )); do
     downstairs[$i]=$!
     set +o errexit
 done
-
-case ${1} in
-    "unencrypted")
-        ;;
-    "encrypted")
-        args+=( --key "$(openssl rand -base64 32)" )
-        ;;
-    *)
-        ;;
-esac
 
 res=0
 test_list="one span big dep deactivate balloon"


### PR DESCRIPTION
Crucible client, CLI, and tools updates

Updated a bunch of loops in crucible-client from 0..end to 1..=end   This looks much nicer
when I print out current loop index.

CLI updates:
   * Added a quit command to the CLI
   * Print the block read as part of read results.  Include the read block
     number in the ReadResponse protocol message.
   * Moved server side processing of client commands to a new function.
   * Add support for having the cli-server read in previous write counts
     from a file.
  *  Include the generic test as a CLI option.

Updates for tools/create-generic-ds.sh:
   * Allow deletion of region files if they exist.
   * Supply extent size and extent count.
   * Enable and expect encryption on the region.

Added a check in test_up.sh to verify command line args are valid.