### PR TITLE
Add some colors to crucible-downstairs dump command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,7 @@ dependencies = [
  "slog-term",
  "structopt",
  "tempfile",
+ "termion",
  "tokio",
  "tokio-rustls",
  "tokio-util 0.7.0",
@@ -1745,6 +1746,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
 name = "omicron-common"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/omicron?branch=main#8663a7936277f637f09aef2b3d9e363bce833492"
@@ -2493,6 +2500,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
+dependencies = [
+ "redox_syscall",
 ]
 
 [[package]]
@@ -3259,6 +3275,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+dependencies = [
+ "libc",
+ "numtoa",
+ "redox_syscall",
+ "redox_termios",
 ]
 
 [[package]]

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -27,6 +27,7 @@ rand = "0.8.5"
 ringbuffer = "0.8"
 serde = { version = "1", features = ["derive"] }
 structopt = "0.3"
+termion = "1.5"
 tokio = { version = "1.17.0", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"]}
 tokio-rustls = { version = "0.23.2" }

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -369,10 +369,6 @@ fn show_extent(
         let (status_letters, data_different) =
             return_status_letters(&dvec, |x| &x.data);
 
-        // With color, we need a larger alignment value to get the letters
-        // to line up exactly.  Even though we only need six spaces, the color
-        // control codes require more.
-
         // Print the data status letters
         for dir_index in 0..dir_count {
             data_columns[dir_index] = status_letters[dir_index].to_string();


### PR DESCRIPTION
Changed the output a little for extent specific dumping.

```
cargo run -p crucible-downstairs -- dump -d var/8801 -d var/8802 -d var/8803
    Finished dev [unoptimized + debuginfo] target(s) in 0.27s
     Running `target/debug/crucible-downstairs dump -d var/8801 -d var/8802 -d var/8803 -e 0 -o`
           Extent 0
GEN           200      199      200
FLUSH_ID     1475     1472     1475
DIRTY

BLOCK  D0 D1 D2  E0 E1 E2  H0 H1 H2
   65   A  B  A   A  A  A   A  B  A
   66   A  B  A   A  A  A   A  B  A
   67   A  B  A   A  A  A   A  B  A
   68   A  B  A   A  A  A   A  B  A
   69   A  B  A   A  A  A   A  B  A
   70   A  B  A   A  A  A   A  B  A
```

Here are the color changes:
<img width="748" alt="Crucible-dump-1" src="https://user-images.githubusercontent.com/9903989/158227113-fab88900-9341-48ea-8573-035ab1931674.png">

And, if there are no differences, it's just all green:
<img width="382" alt="Crucible-dump-2" src="https://user-images.githubusercontent.com/9903989/158227162-f284623c-10b0-4aad-8081-839d5d820cae.png">

I did nothing for the block level dumping yet.