### PR TITLE
Add ds_repair field to downstairs struct

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -17,6 +17,8 @@ pub use region::{
 
 pub mod x509;
 
+pub const REPAIR_PORT_OFFSET: u16 = 4000;
+
 #[derive(thiserror::Error, Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum CrucibleError {
     #[error("Error: {0}")]

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1650,8 +1650,8 @@ impl Downstairs {
         // addresses from each downstairs.
         let mut ds_repair = HashMap::new();
         for (i, addr) in target.iter().enumerate() {
-            assert!(addr.port() < u16::MAX - 4000);
-            let port = addr.port() + 4000;
+            assert!(addr.port() < u16::MAX - REPAIR_PORT_OFFSET);
+            let port = addr.port() + REPAIR_PORT_OFFSET;
             let repair_addr = SocketAddr::new(addr.ip(), port);
             ds_repair.insert(i as u8, repair_addr);
         }


### PR DESCRIPTION
Added a new field to the Downstairs struct.
This filed contains the address that reconciliation should use when
repairing extents.  This will be used in the coming reconciliation
changes.