### PR TITLE
more fixes for omicron integration

### DIFF
--- a/agent/smf/agent.xml
+++ b/agent/smf/agent.xml
@@ -18,8 +18,6 @@
       -D /opt/oxide/crucible/bin/crucible-downstairs
       --dataset %{config/dataset}
       -l %{config/listen}
-      -i %{config/uuid}
-      -n %{config/nexus}
       -P %{config/portbase}
       -p %{config/downstairs_prefix}
       -s %{config/snapshot_prefix}'

--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -6,6 +6,7 @@ use crucible_common::write_json;
 use serde::{Deserialize, Serialize};
 use slog::{crit, error, info, Logger};
 use std::collections::BTreeMap;
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Condvar, Mutex, MutexGuard};
@@ -18,6 +19,7 @@ pub struct DataFile {
     log: Logger,
     base_path: PathBuf,
     conf_path: PathBuf,
+    listen: SocketAddr,
     port_min: u16,
     port_max: u16,
     bell: Condvar,
@@ -35,6 +37,7 @@ impl DataFile {
     pub fn new(
         log: Logger,
         base_path: &Path,
+        listen: SocketAddr,
         port_min: u16,
         port_max: u16,
     ) -> Result<DataFile> {
@@ -56,11 +59,16 @@ impl DataFile {
             log,
             base_path: base_path.to_path_buf(),
             conf_path: conf_path.to_path_buf(),
+            listen,
             port_min,
             port_max,
             bell: Condvar::new(),
             inner: Mutex::new(inner),
         })
+    }
+
+    pub fn get_listen_addr(&self) -> SocketAddr {
+        self.listen
     }
 
     pub fn regions(&self) -> Vec<Region> {

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -546,7 +546,8 @@ fn apply_smf(
             let properties = {
                 let mut properties = snapshot.get_smf_properties(&dir);
 
-                // The downstairs process will listen on the same IP as the agent
+                // The downstairs process will listen on the same IP as the
+                // agent
                 properties.push(crate::model::SmfProperty {
                     name: "address",
                     typ: crucible_smf::scf_type_t::SCF_TYPE_ASTRING,

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -403,7 +403,11 @@ fn apply_smf(
         let properties = {
             let mut properties = r.get_smf_properties(&dir);
 
-            // The downstairs process will listen on the same IP as the agent
+            // Instruct downstairs process to listen on the same IP as the
+            // agent, because there is currently only one address in the
+            // crucible zone that both processes must share and that address is
+            // what will be used by other zones. In the future this could be a
+            // parameter that comes along with the region POST parameters.
             properties.push(crate::model::SmfProperty {
                 name: "address",
                 typ: crucible_smf::scf_type_t::SCF_TYPE_ASTRING,
@@ -546,8 +550,12 @@ fn apply_smf(
             let properties = {
                 let mut properties = snapshot.get_smf_properties(&dir);
 
-                // The downstairs process will listen on the same IP as the
-                // agent
+                // Instruct downstairs process to listen on the same IP as the
+                // agent, because there is currently only one address in the
+                // crucible zone that both processes must share and that address
+                // is what will be used by other zones. In the future this could
+                // be a parameter that comes along with the region POST
+                // parameters.
                 properties.push(crate::model::SmfProperty {
                     name: "address",
                     typ: crucible_smf::scf_type_t::SCF_TYPE_ASTRING,

--- a/agent/src/model.rs
+++ b/agent/src/model.rs
@@ -3,9 +3,9 @@
 use std::path::Path;
 
 use chrono::prelude::*;
+use crucible_smf::scf_type_t::{self, *};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use crucible_smf::scf_type_t::{self, *};
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]

--- a/agent/src/model.rs
+++ b/agent/src/model.rs
@@ -1,8 +1,11 @@
 // Copyright 2021 Oxide Computer Company
 
+use std::path::Path;
+
 use chrono::prelude::*;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use crucible_smf::scf_type_t::{self, *};
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
@@ -36,9 +39,6 @@ pub struct Region {
 
     pub root_pem: Option<String>,
 }
-
-use crucible_smf::scf_type_t::{self, *};
-use std::path::Path;
 
 pub struct SmfProperty<'a> {
     pub name: &'a str,


### PR DESCRIPTION
remove deleted parameters from smf

the agent should set downstairs listen addresses to same as the agent