### PR TITLE
Add more colors to crucible downstairs dump output

### DIFF
--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -173,20 +173,30 @@ pub fn dump_region(
             for dir_index in 0..dir_count {
                 if let Some(em) = ei.ei_hm.get(&(dir_index as u32)) {
                     gen_vec.insert(dir_index, em.gen_number);
-                    if gen_vec[0] != em.gen_number { different = true; }
-                    if em.gen_number > max_gen { max_gen = em.gen_number; }
+                    if gen_vec[0] != em.gen_number {
+                        different = true;
+                    }
+                    if em.gen_number > max_gen {
+                        max_gen = em.gen_number;
+                    }
                     flush_vec.insert(dir_index, em.flush_number);
-                    if flush_vec[0] != em.flush_number { different = true; }
-                    if em.flush_number > max_flush { max_flush = em.flush_number; }
+                    if flush_vec[0] != em.flush_number {
+                        different = true;
+                    }
+                    if em.flush_number > max_flush {
+                        max_flush = em.flush_number;
+                    }
                     dirty_vec.insert(dir_index, em.dirty);
-                    if dirty_vec[0] != em.dirty { different = true; }
+                    if dirty_vec[0] != em.dirty {
+                        different = true;
+                    }
                 } else {
                     println!("{:3}  column {} bad", en, dir_index);
                     bad_extent = true;
                 }
             }
             if bad_extent || (only_show_differences && !different) {
-                continue
+                continue;
             }
 
             print!("{:3} ", en);
@@ -273,7 +283,6 @@ fn color_vec(compare: &[u64]) -> Vec<u8> {
         if compare[2] < compare[1] {
             colors[2] = 31;
         }
-
     }
     colors
 }


### PR DESCRIPTION
Updated crucible-downstairs dump command for the default extent metadata
dumping to include colors.  The highest gen and flush is now in green
and anything less is red.  For dirty bits, any set are red.

```
cargo run -p crucible-downstairs -- dump -d var/8801 -d var/8802 -d var/8803

EXT  GEN0 GEN1 GEN2   FL0  FL1  FL2  D0 D1 D2
  0   200  199  200  1475 1472 1475   F  F  F
  1   199  199  199  1474 1474 1474   F  F  F
  2   199  199  199  1472 1472 1472   F  F  F
  3   200  198  200  1475 1471 1475   F  F  F
  4   200  192  200  1475 1451 1475   F  F  F
  5     1    1    1  1480 1480 1480   F  F  F
  6   199  199  199  1472 1472 1472   F  F  F
  7   195  195  195  1458 1458 1458   F  F  F
  8     1    1    1  1481 1481 1481   F  F  F
  9   196  196  196  1462 1462 1462   F  F  F
 10   200  199  200  1475 1474 1475   F  F  F
 11   199  199  199  1472 1472 1472   F  F  F
 12   200  197  200  1475 1463 1475   F  F  F
 13   199  199  199  1473 1473 1473   F  F  F
 14     1    1    1  1481 1481 1481   F  F  F
 15     1    1    1  1480 1480 1480   F  F  F
 16   200  198  200  1475 1469 1475   F  F  F
 17   198  198  198  1469 1469 1469   F  F  F
 18     1    1    1  1476 1476 1476   F  F  F
 19     1    1    1  1481 1481 1481   F  F  F
Max gen: 200,  Max flush: 1481
```

No color in that, let me add a screen shot:
<img width="474" alt="Crucible-Dump-extent" src="https://user-images.githubusercontent.com/9903989/159082653-aad57d67-6980-489a-8706-88f66aff84fb.png">

It also works with `-o` flag (trust me)
