### PR TITLE
buildomat: first cut at zone image publish job

### DIFF
--- a/.github/buildomat/jobs/image.sh
+++ b/.github/buildomat/jobs/image.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#:
+#: name = "image"
+#: variety = "basic"
+#: target = "helios"
+#: rust_toolchain = "nightly"
+#: output_rules = [
+#:	"/out/*",
+#: ]
+#:
+#: [[publish]]
+#: series = "image"
+#: name = "crucible.tar.gz"
+#: from_output = "/out/crucible.tar.gz"
+#:
+#: [[publish]]
+#: series = "image"
+#: name = "crucible.sha256.txt"
+#: from_output = "/out/crucible.sha256.txt"
+#:
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+cargo --version
+rustc --version
+
+banner build
+ptime -m cargo build --release --verbose
+
+banner image
+ptime -m cargo run --bin crucible-package
+
+banner contents
+tar tvfz out/crucible.tar.gz
+
+banner copy
+pfexec mkdir -p /out
+pfexec chown "$UID" /out
+mv out/crucible.tar.gz /out/crucible.tar.gz
+cd /out
+digest -a sha256 crucible.tar.gz > crucible.sha256.txt


### PR DESCRIPTION
This adds a new buildomat job that uses an experimental feature: publishing a built artefact at a predictable download URL.  In general the URL will be of the form:

```
https://buildomat.eng.oxide.computer/public/file/OWNER/REPO/SERIES/VERSION/NAME
```

For output artefacts published this way, `OWNER/REPO` will be `oxidecomputer/crucible`.  The `SERIES` and `NAME` will come from the `publish` directives in the TOML frontmatter, and the `VERSION` is just the GitHub commit SHA.  So, when I submitted this PR it had already published:

https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/195a5544f4cde7dad47304061a954aa9a7e753ed/crucible.tar.gz

and

https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/195a5544f4cde7dad47304061a954aa9a7e753ed/crucible.sha256.txt

cc @smklein