### PR TITLE
Update tests to have a port gap between downstairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,19 @@ different window) on the same machine.  Each should have a unique UUID, port,
 and directory where the region files will be.  Once each is created we will
 then `run` them.
 ```
-$ cargo run -q -p crucible-downstairs -- create -u $(uuidgen) -d var/3801
-$ cargo run -q -p crucible-downstairs -- run -p 3801 -d var/3801
+$ cargo run -q -p crucible-downstairs -- create -u $(uuidgen) -d var/3810
+$ cargo run -q -p crucible-downstairs -- run -p 3810 -d var/3810
 ...
 ```
 
 ```
-$ cargo run -q -p crucible-downstairs -- create -u $(uuidgen) -d var/3802
-$ cargo run -q -p crucible-downstairs -- run -p 3802 -d var/3802
+$ cargo run -q -p crucible-downstairs -- create -u $(uuidgen) -d var/3820
+$ cargo run -q -p crucible-downstairs -- run -p 3820 -d var/3820
 ```
 
 ```
-$ cargo run -q -p crucible-downstairs -- create -u $(uuidgen) -d var/3803
-$ cargo run -q -p crucible-downstairs -- run -p 3803 -d var/3803
+$ cargo run -q -p crucible-downstairs -- create -u $(uuidgen) -d var/3830
+$ cargo run -q -p crucible-downstairs -- run -p 3830 -d var/3830
 ```
 
 Once all three are started, you can connect to them by using the crucible
@@ -46,25 +46,25 @@ client program that will start the upstairs side of crucible for you, run
 a write/flush/read, then exit.
 
 ```
-$ cargo run -q -p crucible -- -t 127.0.0.1:3803 -t 127.0.0.1:3802 -t 127.0.0.1:3801
-raw options: Opt { target: [127.0.0.1:3803, 127.0.0.1:3802, 127.0.0.1:3801] }
+$ cargo run -q -p crucible -- -t 127.0.0.1:3830 -t 127.0.0.1:3820 -t 127.0.0.1:3810
+raw options: Opt { target: [127.0.0.1:3830, 127.0.0.1:3820, 127.0.0.1:3810] }
 runtime is spawned
 DTrace probes registered ok
-127.0.0.1:3802[1] connecting to 127.0.0.1:3802
-127.0.0.1:3803[0] connecting to 127.0.0.1:3803
-127.0.0.1:3801[2] connecting to 127.0.0.1:3801
-127.0.0.1:3802[1] ok, connected to 127.0.0.1:3802
-127.0.0.1:3803[0] ok, connected to 127.0.0.1:3803
-127.0.0.1:3801[2] ok, connected to 127.0.0.1:3801
-127.0.0.1:3801 Evaluate new downstairs : bs:512 es:100 ec:10 versions: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+127.0.0.1:3820[1] connecting to 127.0.0.1:3820
+127.0.0.1:3830[0] connecting to 127.0.0.1:3830
+127.0.0.1:3810[2] connecting to 127.0.0.1:3810
+127.0.0.1:3820[1] ok, connected to 127.0.0.1:3820
+127.0.0.1:3830[0] ok, connected to 127.0.0.1:3830
+127.0.0.1:3810[2] ok, connected to 127.0.0.1:3810
+127.0.0.1:3810 Evaluate new downstairs : bs:512 es:100 ec:10 versions: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 Set inital Extent versions to [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 Next flush: 1
 Global using: bs:512 es:100 ec:10
-127.0.0.1:3803 Evaluate new downstairs : bs:512 es:100 ec:10 versions: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-#### 127.0.0.1:3801 #### CONNECTED ######## 1/3
-#### 127.0.0.1:3803 #### CONNECTED ######## 2/3
-127.0.0.1:3802 Evaluate new downstairs : bs:512 es:100 ec:10 versions: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-#### 127.0.0.1:3802 #### CONNECTED ######## 3/3
+127.0.0.1:3830 Evaluate new downstairs : bs:512 es:100 ec:10 versions: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+#### 127.0.0.1:3810 #### CONNECTED ######## 1/3
+#### 127.0.0.1:3830 #### CONNECTED ######## 2/3
+127.0.0.1:3820 Evaluate new downstairs : bs:512 es:100 ec:10 versions: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+#### 127.0.0.1:3820 #### CONNECTED ######## 3/3
 send a write
 send a flush
 nwo: [(0, 99, 512), (1, 0, 512)] from offset:50688 data: 0x7fb053008200 len:1024
@@ -106,12 +106,12 @@ On the console of each Downstairs, you will see a connection; e.g.,
 
 ```
 ...
-raw options: Opt { address: 0.0.0.0, port: 3801, data: "var/3801", create: true }
+raw options: Opt { address: 0.0.0.0, port: 3810, data: "var/3810", create: true }
 Create new extent directory
-created new region file "var/3801/region.json"
+created new region file "var/3810/region.json"
 Current flush_numbers: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 Startup Extent values: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-listening on 0.0.0.0:3801
+listening on 0.0.0.0:3810
 connection from 127.0.0.1:65030  connections count:1
 Current flush_numbers: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 Write       rn:1000 eid:0 dep:[] bo:99
@@ -177,7 +177,7 @@ Run a Jaeger container in order to collect and visualize traces:
 
 Pass an option to crucible-downstairs to send traces to Jaeger:
 
-    $ cargo run -q -p crucible-downstairs -- run -p 3803 -d var/3803 --trace-endpoint localhost:6831
+    $ cargo run -q -p crucible-downstairs -- run -p 3830 -d var/3830 --trace-endpoint localhost:6831
 
 Then, go to `http://localhost:16686` to see the Jaeger UI.
 
@@ -196,13 +196,13 @@ Replace the UUID below with the UUID for the downstairs you wish to view.
 The available stats are: connect, flush, read, write.
 
 ```
-cargo run --bin oxdb -- query crucible_downstairs:flush downstairs_uuid==12345678-3801-3801-3801-000000003801 | jq
+cargo run --bin oxdb -- query crucible_downstairs:flush downstairs_uuid==12345678-3810-3810-3810-000000003810 | jq
 ```
 
 Here is a deeper example, to just print the latest count for flush:
 ```
-LAST_FLUSH=$(cargo run --bin oxdb -- query crucible_downstairs:flush downstairs_uuid==12345678-3801-3801-3801-000000003801 | jq '.[].measurements[].timestamp '| sort -n | tail -1)
-cargo run --bin oxdb -- query crucible_downstairs:flush downstairs_uuid==12345678-3801-3801-3801-000000003801 | jq ".[].measurements[] | select(.timestamp == $LAST_FLUSH) | .datum.CumulativeI64.value"
+LAST_FLUSH=$(cargo run --bin oxdb -- query crucible_downstairs:flush downstairs_uuid==12345678-3810-3810-3810-000000003810 | jq '.[].measurements[].timestamp '| sort -n | tail -1)
+cargo run --bin oxdb -- query crucible_downstairs:flush downstairs_uuid==12345678-3810-3810-3810-000000003810 | jq ".[].measurements[] | select(.timestamp == $LAST_FLUSH) | .datum.CumulativeI64.value"
 ```
 
 ## License

--- a/tools/README.md
+++ b/tools/README.md
@@ -3,7 +3,7 @@
 Various scripts used for Crucible
 
 ## create-generic-sd.sh
-A simple script to create three downstairs regions at var/380[1-3]
+A simple script to create three downstairs regions at var/88[1-3]0
 
 ## downstairs_daemon.sh
 A highly custom script that starts three downstairs in a loop and will
@@ -42,7 +42,7 @@ alan@cat:crucible$ pfexec dtrace -s tools/ds_state.d
 
 ## hammer-loop.sh
 A loop test that runs the crucible-hammer test in a loop.  It is expected
-that you already have downstairs running on port 380[1-3].
+that you already have downstairs running on port 88[1-3]0.
 The test will check for panic or assert in the output and stop if it
 detects them or a test exits with an error.
 

--- a/tools/create-generic-ds.sh
+++ b/tools/create-generic-ds.sh
@@ -41,10 +41,10 @@ while getopts 'c:des:' opt; do
 done
 
 if [[ $delete -eq 1 ]]; then
-    rm -rf var/8801 var/8802 var/8803
+    rm -rf var/8810 var/8820 var/8830
 else
-    if [[ -d var/8801 ]] || [[ -d var/8802 ]] || [[ -d var/8803 ]]; then
-        echo " var/880* directories are already present"
+    if [[ -d var/8810 ]] || [[ -d var/8820 ]] || [[ -d var/8830 ]]; then
+        echo " var/88.. directories are already present"
         exit 1
     fi
 fi
@@ -59,7 +59,7 @@ if [[ ! -f ${cds} ]]; then
 fi
 
 res=0
-for port in 8801 8802 8803; do
+for port in 8810 8820 8830; do
     if [[ $encryption -eq 0 ]]; then
         if ! cargo run -q -p crucible-downstairs -- create -u 12345678-"$port"-"$port"-"$port"-00000000"$port" -d var/"$port" --extent-count "$extent_count" --extent-size "$extent_size"; then
             echo "Failed to create downstairs $port"

--- a/tools/downstairs_daemon.sh
+++ b/tools/downstairs_daemon.sh
@@ -119,10 +119,11 @@ if ! cargo build; then
 fi
 
 # If this port base is different than default, then good luck..
-port_base=8801
+port_base=8810
 missing=0
 for (( i = 0; i < 3; i++ )); do
-    (( port = port_base + i ))
+    (( port_step = i * 10 ))
+    (( port = port_base + port_step ))
     if [[ ! -d var/${port} ]]; then
         echo "Missing var/${port} directory"
         missing=1
@@ -150,12 +151,12 @@ if [[ -d ${testdir} ]]; then
 fi
 
 mkdir -p ${testdir}
-downstairs_daemon 8801 2>/dev/null &
-dsd_pid[0]=$!
-downstairs_daemon 8802 2>/dev/null &
-dsd_pid[1]=$!
-downstairs_daemon 8803 2>/dev/null &
-dsd_pid[2]=$!
+for (( i = 0; i < 3; i++ )); do
+    (( port_step = i * 10 ))
+    (( port = port_base + port_step ))
+    downstairs_daemon "$port" 2>/dev/null &
+    dsd_pid["$i"]=$!
+done
 
 echo "Downstairs have been started"
 

--- a/tools/hammer_loop.sh
+++ b/tools/hammer_loop.sh
@@ -20,8 +20,8 @@ do
     SECONDS=0
     echo "" > "$test_log"
     echo "New loop starts now $(date)" >> "$test_log"
-    cargo run -q -p crucible-hammer -- -t 127.0.0.1:8801 -t 127.0.0.1:8802 \
-        -t 127.0.0.1:8803 >> "$test_log" 2>&1
+    cargo run -q -p crucible-hammer -- -t 127.0.0.1:8810 -t 127.0.0.1:8820 \
+        -t 127.0.0.1:8830 >> "$test_log" 2>&1
     result=$?
     if [[ $result -ne 0 ]]; then
         touch /tmp/ds_test/up 2> /dev/null

--- a/tools/test_reconnect.sh
+++ b/tools/test_reconnect.sh
@@ -36,8 +36,8 @@ if ! ps -p $dsd_pid > /dev/null; then
 fi
 
 args=()
-port_base=8801
-for (( i = 0; i < 3; i++ )); do
+port_base=8810
+for (( i = 0; i < 30; i += 10 )); do
     (( port = port_base + i ))
     args+=( -t "127.0.0.1:$port" )
 done

--- a/tools/test_repair_reconnect.sh
+++ b/tools/test_repair_reconnect.sh
@@ -68,8 +68,8 @@ if ! ps -p $dsd_pid > /dev/null; then
 fi
 
 args=()
-port_base=8801
-for (( i = 0; i < 3; i++ )); do
+port_base=8810
+for (( i = 0; i < 30; i += 10 )); do
     (( port = port_base + i ))
     args+=( -t "127.0.0.1:$port" )
 done
@@ -83,7 +83,7 @@ done
 ##fi
 
 # Now run the nothing client test in a loop
-for i in {1..1000}
+for i in {1..10}
 do
     SECONDS=0
     echo "" > "$test_log"

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -59,9 +59,10 @@ esac
 
 uuidprefix="12345678-1234-1234-1234-00000000"
 downstairs=()
-port_base=8801
+port_base=8810
 for (( i = 0; i < 3; i++ )); do
-    (( port = port_base + i ))
+    (( port_step = i * 10 ))
+    (( port = port_base + port_step ))
     dir="${testdir}/$port"
     uuid="${uuidprefix}${port}"
     args+=( -t "127.0.0.1:$port" )
@@ -179,7 +180,7 @@ fi
 
 # The dump args look different than other downstairs commands
 args=()
-for (( i = 0; i < 3; i++ )); do
+for (( i = 0; i < 30; i += 10 )); do
     (( port = port_base + i ))
     dir="${testdir}/$port"
     args+=( -d "$dir" )


### PR DESCRIPTION
The localhost tests for crucible used three ports in succession for
all the tests.  Give a 10 port space between each to allow for a
repair/control port in the future.

This will allow us (in future commits) to have the repair port for downstairs be +1 of the
port used by the upstairs, if it ends up being what we want.