### PR TITLE
More client tests, other cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "terminal_size",
+ "winapi",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +406,31 @@ checksum = "fdbfe11fe19ff083c48923cf179540e8cd0535903dc35e178a1fdeeb59aef51f"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+dependencies = [
+ "autocfg 1.1.0",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
 ]
 
 [[package]]
@@ -499,6 +537,7 @@ dependencies = [
  "crucible-scope",
  "futures",
  "futures-core",
+ "indicatif",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "ringbuffer",
@@ -846,6 +885,18 @@ name = "dyn-clone"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1345,6 +1396,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "rayon",
+ "regex",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,6 +1803,12 @@ checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "omicron-common"
@@ -2474,6 +2544,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg 1.1.0",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
 ]
 
 [[package]]
@@ -3250,6 +3345,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -15,6 +15,7 @@ crucible-protocol = { path = "../protocol" }
 crucible-scope = { path = "../scope" }
 futures = "0.3"
 futures-core = "0.3"
+indicatif = { version = "0.16.2", features = ["rayon"] }
 ringbuffer = "0.8"
 rand = "0.8.5"
 rand_chacha = "0.3.1"

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -43,10 +43,12 @@ enum Workload {
     Demo,
     Dep,
     Dirty,
+    Fill,
     Generic,
     Nothing,
     One,
     Rand,
+    Repair,
     Span,
     Verify,
 }
@@ -98,9 +100,17 @@ pub struct Opt {
     #[structopt(long, global = true)]
     retry_activate: bool,
 
-    /*
+    /**
+     * In addition to any tests, verify the volume on startup.
+     * This only has value if verify_in is also set.
+     */
+    #[structopt(long, global = true)]
+    verify: bool,
+
+    /**
      * For tests that support it, load the expected write count from
-     * the provided file.
+     * the provided file.  The addition of a --verify option will also
+     * have the test verify what it imports from the file is valid.
      */
     #[structopt(long, global = true, parse(from_os_str), name = "INFILE")]
     verify_in: Option<PathBuf>,
@@ -256,6 +266,9 @@ fn main() -> Result<()> {
     if opt.workload == Workload::Verify && opt.verify_in.is_none() {
         bail!("Verify requires verify_in file");
     }
+    if opt.verify && opt.verify_in.is_none() {
+        bail!("Initial verify requires verify_in file");
+    }
 
     let crucible_opts = CrucibleOpts {
         target: opt.target,
@@ -343,7 +356,7 @@ fn main() -> Result<()> {
      * info from the verify file, and verify it matches what we expect
      * if we are expecting anything.
      */
-    update_region_info(&guest, &mut region_info, opt.verify_in, true)?;
+    update_region_info(&guest, &mut region_info, opt.verify_in, opt.verify)?;
 
     /*
      * Call the function for the workload option passed from the command
@@ -411,7 +424,18 @@ fn main() -> Result<()> {
 
         Workload::Dirty => {
             println!("Run dirty test");
-            runtime.block_on(dirty_workload(&guest, &mut region_info))?;
+            let count = {
+                if opt.count == 0 {
+                    10
+                } else {
+                    opt.count
+                }
+            };
+            runtime.block_on(dirty_workload(
+                &guest,
+                &mut region_info,
+                count,
+            ))?;
 
             /*
              * Saving state here when we have not waited for a flush
@@ -428,10 +452,22 @@ fn main() -> Result<()> {
             return Ok(());
         }
 
+        Workload::Fill => {
+            println!("Fill test");
+            runtime.block_on(fill_workload(&guest, &mut region_info))?;
+        }
+
         Workload::Generic => {
+            let count = {
+                if opt.count == 0 {
+                    500
+                } else {
+                    opt.count
+                }
+            };
             runtime.block_on(generic_workload(
                 &guest,
-                500,
+                count,
                 &mut region_info,
             ))?;
         }
@@ -454,7 +490,36 @@ fn main() -> Result<()> {
         }
         Workload::Rand => {
             println!("Run random test");
-            runtime.block_on(rand_workload(&guest, 1000, &mut region_info))?;
+            let count = {
+                if opt.count == 0 {
+                    10
+                } else {
+                    opt.count
+                }
+            };
+            runtime.block_on(rand_workload(&guest, count, &mut region_info))?;
+        }
+        Workload::Repair => {
+            println!("Run Repair workload");
+            let count = {
+                if opt.count == 0 {
+                    10
+                } else {
+                    opt.count
+                }
+            };
+            runtime.block_on(repair_workload(
+                &guest,
+                count,
+                &mut region_info,
+            ))?;
+            drop(guest);
+            if let Some(vo) = &opt.verify_out {
+                let cp = history_file(vo);
+                write_json(&cp, &region_info.write_count, true)?;
+                println!("Wrote out file {:?}", cp);
+            }
+            return Ok(());
         }
         Workload::Span => {
             println!("Span test");
@@ -466,8 +531,13 @@ fn main() -> Result<()> {
              * this turns into a read verify loop, sleep for some duration
              * and then re-check the volume.
              */
+            if !opt.verify {
+                if let Err(e) = verify_volume(&guest, &mut region_info) {
+                    bail!("Initial volume verify failed: {:?}", e)
+                }
+            }
             if opt.quit {
-                println!("Verify test completed at import");
+                println!("Verify test completed");
             } else {
                 println!("Verify read loop begins");
                 loop {
@@ -706,6 +776,35 @@ async fn balloon_workload(
 }
 
 /*
+ * Write then read (and verify) to every possible block.
+ */
+async fn fill_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
+    for block_index in 0..ri.total_blocks {
+        ri.write_count[block_index] += 1;
+
+        let vec = fill_vec(block_index, 1, &ri.write_count, ri.block_size);
+        let data = Bytes::from(vec);
+        /*
+         * Convert block_index to its byte value.
+         */
+        let offset =
+            Block::new(block_index as u64, ri.block_size.trailing_zeros());
+
+        if block_index % 100 == 0 {
+            println!("Write at block:{}/{}", block_index, ri.total_blocks);
+        }
+        let mut waiter = guest.write(offset, data)?;
+        waiter.block_wait()?;
+    }
+
+    let mut waiter = guest.flush(None)?;
+    waiter.block_wait()?;
+
+    verify_volume(guest, ri)?;
+    Ok(())
+}
+
+/*
  * Print out the contents of the write count vector where each line
  * is an extent and each column is a block.
  */
@@ -735,9 +834,6 @@ async fn generic_workload(
      */
     let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
 
-    /*
-     * TODO: Let the user select the number of loops
-     */
     for i in 0..count {
         let op = rng.gen_range(0..10);
         if op == 0 {
@@ -816,7 +912,11 @@ async fn generic_workload(
  * We are trying to leave extents "dirty" so we want to exit before the
  * automatic flush can come through and sync our data.
  */
-async fn dirty_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
+async fn dirty_workload(
+    guest: &Arc<Guest>,
+    ri: &mut RegionInfo,
+    count: u32,
+) -> Result<()> {
     /*
      * TODO: Allow the user to specify a seed here.
      */
@@ -834,7 +934,7 @@ async fn dirty_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
      * IO size.
      */
     let block_max = ri.total_blocks - size + 1;
-    for _ in 0..10 {
+    for c in 1..=count {
         let block_index = rng.gen_range(0..block_max) as usize;
         /*
          * Convert offset and length to their byte values.
@@ -850,7 +950,13 @@ async fn dirty_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
         let vec = fill_vec(block_index, size, &ri.write_count, ri.block_size);
         let data = Bytes::from(vec);
 
-        println!("Write at block {}, len:{}", offset.value, data.len());
+        println!(
+            "[{}/{}] Write at block {}, len:{}",
+            c,
+            count,
+            offset.value,
+            data.len()
+        );
 
         let waiter = guest.write(offset, data)?;
         waiterlist.push(waiter);
@@ -980,9 +1086,6 @@ async fn rand_workload(
      */
     let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
 
-    /*
-     * TODO: Let the user select the number of loops
-     */
     for c in 1..=count {
         /*
          * Pick a random size (in blocks) for the IO, up to the size of the
@@ -1088,6 +1191,87 @@ async fn burst_workload(
         );
         std::thread::sleep(std::time::Duration::from_secs(5));
     }
+    Ok(())
+}
+
+/*
+ * issue some random number of IOs, then wait for an ACK for all.
+ * We try to exit this test and leave jobs outstanding.
+ */
+async fn repair_workload(
+    guest: &Arc<Guest>,
+    count: u32,
+    ri: &mut RegionInfo,
+) -> Result<()> {
+    // TODO: Allow the user to specify a seed here.
+    let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
+
+    let mut waiterlist = Vec::new();
+    // TODO: Allow user to request r/w/f percentage (how???)
+    for c in 1..=count {
+        let op = rng.gen_range(0..10);
+        if op == 0 {
+            // flush
+            println!("{:4}/{:4} Flush", c, count);
+            let waiter = guest.flush(None)?;
+            waiterlist.push(waiter);
+        } else {
+            // Read or Write both need this
+            // Pick a random size (in blocks) for the IO, up to 10
+            let size = rng.gen_range(1..=10) as usize;
+
+            // Once we have our IO size, decide where the starting offset should
+            // be, which is the total possible size minus the randomly chosen
+            // IO size.
+            let block_max = ri.total_blocks - size + 1;
+            let block_index = rng.gen_range(0..block_max) as usize;
+
+            // Convert offset and length to their byte values.
+            let offset =
+                Block::new(block_index as u64, ri.block_size.trailing_zeros());
+
+            if op <= 4 {
+                // Write
+                // Update the write count for all blocks we plan to write to.
+                for i in 0..size {
+                    ri.write_count[block_index + i] += 1;
+                }
+
+                let vec =
+                    fill_vec(block_index, size, &ri.write_count, ri.block_size);
+                let data = Bytes::from(vec);
+
+                println!(
+                    "{:4}/{:4} Write at block {:5}, len:{:7}",
+                    c,
+                    count,
+                    offset.value,
+                    data.len()
+                );
+                let waiter = guest.write(offset, data)?;
+                waiterlist.push(waiter);
+            } else {
+                // Read
+                let length: usize = size * ri.block_size as usize;
+                let vec: Vec<u8> = vec![255; length];
+                let data = crucible::Buffer::from_vec(vec);
+                println!(
+                    "{:4}/{:4} Read  at block {:5}, len:{:7}",
+                    c,
+                    count,
+                    offset.value,
+                    data.len()
+                );
+                let waiter = guest.read(offset, data.clone())?;
+                waiterlist.push(waiter);
+            }
+        }
+    }
+    println!("loop over {} waiters", waiterlist.len());
+    for wa in waiterlist.iter_mut() {
+        wa.block_wait()?;
+    }
+
     Ok(())
 }
 

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -211,8 +211,8 @@ pub fn dump_region(
                 print!(" {}{:4}", sgr(color[i]), flush_vec[i]);
             }
             print!("{} ", sgr(0));
-            for i in 0..dir_count {
-                if dirty_vec[i] {
+            for dv in dirty_vec.iter().take(dir_count) {
+                if *dv {
                     print!("  {}T", sgr(31));
                 } else {
                     print!("  {}F", sgr(32));

--- a/tools/create-generic-ds.sh
+++ b/tools/create-generic-ds.sh
@@ -16,12 +16,16 @@ if ! cargo build; then
     exit 1
 fi
 
+block_size=512
 delete=0
 encryption=0
 extent_size=100
 extent_count=20
-while getopts 'c:des:' opt; do
+while getopts 'b:c:des:' opt; do
     case "$opt" in
+        b)  block_size=$OPTARG
+            echo "Using block size $block_size"
+            ;;
         c)  extent_count=$OPTARG
             echo "Using extent count $extent_count"
             ;;
@@ -61,12 +65,12 @@ fi
 res=0
 for port in 8810 8820 8830; do
     if [[ $encryption -eq 0 ]]; then
-        if ! cargo run -q -p crucible-downstairs -- create -u 12345678-"$port"-"$port"-"$port"-00000000"$port" -d var/"$port" --extent-count "$extent_count" --extent-size "$extent_size"; then
+        if ! cargo run -q -p crucible-downstairs -- create -u 12345678-"$port"-"$port"-"$port"-00000000"$port" -d var/"$port" --extent-count "$extent_count" --extent-size "$extent_size" --block-size "$block_size"; then
             echo "Failed to create downstairs $port"
             res=1
         fi
     else
-        if ! cargo run -q -p crucible-downstairs -- create -u 12345678-"$port"-"$port"-"$port"-00000000"$port" -d var/"$port" --extent-count "$extent_count" --extent-size "$extent_size" --encrypted=true; then
+        if ! cargo run -q -p crucible-downstairs -- create -u 12345678-"$port"-"$port"-"$port"-00000000"$port" -d var/"$port" --extent-count "$extent_count" --extent-size "$extent_size"  --block-size "$block_size" --encrypted=true; then
             echo "Failed to create downstairs $port"
             res=1
         fi

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -6416,8 +6416,6 @@ async fn up_listen(
                  * than necessary.
                  */
                 if up.flush_needed() {
-                    println!("Need a flush");
-
                     if let Err(e) = up.submit_flush(None, None) {
                         println!("flush send failed:{:?}", e);
                         // XXX What to do here?


### PR DESCRIPTION
Created a new fill test and a repair test.
The fill test just does a single write to every block in the
region one after the other.
The repair test does some random set of IOs, then exits as soon
as it can after getting an ack from all outstanding IOs.

Updated the logic around when to verify a volume, and by default
if you include a verify file it will not auto verify.  A new
verify option is enabled for that purpose.  Updated the verify
test to use this method.  By changing this, we can load a verify
file and not be required to also verify the entire volume.

Updated some tests to take the count option.

Fixed a clippy message from downstairs dump.

Updated the create-generic-ds.sh script to take block size as
an option.