### PR TITLE
More CLI work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6945cc5422176fc5e602e590c2878d2c2acd9a4fe20a4baa7c28022521698ec6"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,17 +332,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clipboard-win"
-version = "4.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3e1238132dc01f081e1cbb9dace14e5ef4c3a51ee244bd982275fb514605db"
-dependencies = [
- "error-code",
- "str-buf",
- "winapi",
-]
-
-[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +439,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fd7173631a4e9e2ca8b32ae2fad58aab9843ea5aaf56642661937d87e28a3e"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.7.14",
+ "parking_lot 0.12.0",
+ "serde",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crucadm"
 version = "0.1.0"
 dependencies = [
@@ -531,6 +552,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "bytes",
+ "crossterm",
  "crucible",
  "crucible-common",
  "crucible-protocol",
@@ -540,8 +562,8 @@ dependencies = [
  "indicatif",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "reedline",
  "ringbuffer",
- "rustyline",
  "serde",
  "serde_json",
  "structopt",
@@ -908,12 +930,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,16 +948,6 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "error-code"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
-dependencies = [
- "libc",
- "str-buf",
 ]
 
 [[package]]
@@ -1588,6 +1594,19 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "mio"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba42135c6a5917b9db9cd7b293e5409e1c6b041e6f9825e92e55a894c63b6f8"
@@ -1667,33 +1686,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
-name = "nix"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "memoffset",
-]
-
-[[package]]
 name = "ntapi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7bca0d33a384280d1563b97f49cb95303df9fa22588739a04b7d8015c1ccd50"
+dependencies = [
+ "overload",
  "winapi",
 ]
 
@@ -2002,6 +2009,12 @@ checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "oximeter"
@@ -2401,16 +2414,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
-
-[[package]]
 name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2600,6 +2603,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "reedline"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ba0eb9271feb2de4b1516d651c96d80c892df24388e2711ef2495acc6ed9ce"
+dependencies = [
+ "chrono",
+ "crossterm",
+ "fd-lock",
+ "nu-ansi-term",
+ "serde",
+ "strip-ansi-escapes",
+ "strum",
+ "strum_macros",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2766,30 +2787,6 @@ name = "rustversion"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
-
-[[package]]
-name = "rustyline"
-version = "9.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7826789c0e25614b03e5a54a0717a86f9ff6e6e5247f92b369472869320039"
-dependencies = [
- "bitflags",
- "cfg-if",
- "clipboard-win",
- "dirs-next",
- "fd-lock",
- "libc",
- "log",
- "memchr",
- "nix",
- "radix_trie",
- "scopeguard",
- "smallvec",
- "unicode-segmentation",
- "unicode-width",
- "utf8parse",
- "winapi",
-]
 
 [[package]]
 name = "ryu"
@@ -3027,6 +3024,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "647c97df271007dcea485bb74ffdb57f2e683f1306c854f468a0c244badabf2d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio 0.7.14",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3183,12 +3201,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "str-buf"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44a3643b4ff9caf57abcee9c2c621d6c03d9135e0d8b589bd9afb5992cb176a"
-
-[[package]]
 name = "stringprep"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3196,6 +3208,15 @@ checksum = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+dependencies = [
+ "vte",
 ]
 
 [[package]]
@@ -3254,6 +3275,25 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
  "syn",
 ]
 
@@ -3487,7 +3527,7 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio",
+ "mio 0.8.1",
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.0",
@@ -3997,6 +4037,27 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "walkdir"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 anyhow = "1"
 bincode = "1.3.3"
 bytes = "1"
+crossterm = { version = "0.23.0" }
 crucible = { path = "../upstairs" }
 crucible-common = { path = "../common" }
 crucible-protocol = { path = "../protocol" }
@@ -19,7 +20,7 @@ indicatif = { version = "0.16.2", features = ["rayon"] }
 ringbuffer = "0.8"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
-rustyline = "9.1.2"
+reedline = "0.3.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 structopt = "0.3"

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -32,6 +32,15 @@ enum CliCommand {
     },
     /// Deactivate the upstairs
     Deactivate,
+    /// Report the expected read count for an offset.
+    Expected {
+        #[structopt(long, short)]
+        offset: usize,
+    },
+    /// Export the current write count to the verify out file
+    Export,
+    /// Run the fill then verify test.
+    Fill,
     /// Flush
     Flush,
     /// Run Generic workload
@@ -193,6 +202,15 @@ async fn cmd_to_msg(
         CliCommand::Deactivate => {
             fw.send(CliMessage::Deactivate).await?;
         }
+        CliCommand::Expected { offset } => {
+            fw.send(CliMessage::Expected(offset)).await?;
+        }
+        CliCommand::Export => {
+            fw.send(CliMessage::Export).await?;
+        }
+        CliCommand::Fill => {
+            fw.send(CliMessage::Fill).await?;
+        }
         CliCommand::Read { offset, len } => {
             fw.send(CliMessage::Read(offset, len)).await?;
         }
@@ -223,8 +241,7 @@ async fn cmd_to_msg(
             return Ok(());
         }
         CliCommand::Verify => {
-            println!("No support for {:?}", cmd);
-            return Ok(());
+            fw.send(CliMessage::Verify).await?;
         }
         _ => {
             println!("No support for {:?}", cmd);
@@ -244,6 +261,9 @@ async fn cmd_to_msg(
         }
         Some(CliMessage::DoneOk) => {
             println!("Ok");
+        }
+        Some(CliMessage::ExpectedResponse(offset, data)) => {
+            println!("[{}] Expt: {:?}", offset, data);
         }
         Some(CliMessage::ReadResponse(offset, resp)) => match resp {
             Ok(data) => {
@@ -378,6 +398,7 @@ async fn process_cli_command(
     ri: &mut RegionInfo,
     wc_filled: &mut bool,
     verify_input: Option<PathBuf>,
+    verify_output: Option<PathBuf>,
 ) -> Result<()> {
     match cmd {
         CliMessage::Activate(gen) => match guest.activate(gen) {
@@ -391,6 +412,50 @@ async fn process_cli_command(
             },
             Err(e) => fw.send(CliMessage::Error(e)).await,
         },
+        CliMessage::Expected(offset) => {
+            if !*wc_filled {
+                fw.send(CliMessage::Error(CrucibleError::GenericError(
+                    "Internal write count buffer not filled".to_string(),
+                )))
+                .await
+            } else if ri.write_count.is_empty() {
+                fw.send(CliMessage::Error(CrucibleError::GenericError(
+                    "Internal write count buffer empty".to_string(),
+                )))
+                .await
+            } else {
+                let mut vec: Vec<u8> = vec![255; 2];
+                vec[0] = (offset % 255) as u8;
+                vec[1] = (ri.write_count[offset] % 255) as u8;
+                fw.send(CliMessage::ExpectedResponse(offset, vec)).await
+            }
+        }
+        CliMessage::Export => {
+            if ri.write_count.is_empty() {
+                fw.send(CliMessage::Error(CrucibleError::GenericError(
+                    "Info not initialized".to_string(),
+                )))
+                .await
+            } else if let Some(vo) = verify_output {
+                println!("Exporting write history to {:?}", vo);
+                let cp = history_file(vo.clone());
+                match write_json(&cp, &ri.write_count, true) {
+                    Ok(_) => fw.send(CliMessage::DoneOk).await,
+                    Err(e) => {
+                        println!("Failed writing to {:?} with {}", vo, e);
+                        fw.send(CliMessage::Error(CrucibleError::GenericError(
+                            "Failed writing to file".to_string(),
+                        )))
+                        .await
+                    }
+                }
+            } else {
+                fw.send(CliMessage::Error(CrucibleError::GenericError(
+                    "No verify-out file provided".to_string(),
+                )))
+                .await
+            }
+        }
         CliMessage::Generic => {
             if ri.write_count.is_empty() {
                 fw.send(CliMessage::Error(CrucibleError::GenericError(
@@ -402,6 +467,23 @@ async fn process_cli_command(
                     Ok(_) => fw.send(CliMessage::DoneOk).await,
                     Err(e) => {
                         let msg = format!("{}", e);
+                        let e = CrucibleError::GenericError(msg);
+                        fw.send(CliMessage::Error(e)).await
+                    }
+                }
+            }
+        }
+        CliMessage::Fill => {
+            if ri.write_count.is_empty() {
+                fw.send(CliMessage::Error(CrucibleError::GenericError(
+                    "Info not initialized".to_string(),
+                )))
+                .await
+            } else {
+                match fill_workload(guest, ri).await {
+                    Ok(_) => fw.send(CliMessage::DoneOk).await,
+                    Err(e) => {
+                        let msg = format!("Fill/Verify failed with {}", e);
                         let e = CrucibleError::GenericError(msg);
                         fw.send(CliMessage::Error(e)).await
                     }
@@ -424,6 +506,12 @@ async fn process_cli_command(
                     let es = new_ri.extent_size.value;
                     let ts = new_ri.total_size;
                     *ri = new_ri;
+                    /*
+                     * We may only want to read input from the file once.
+                     * Maybe make a command to specifically do it, but it
+                     * seems like once we go active we won't need to run
+                     * it again.
+                     */
                     if !*wc_filled {
                         update_region_info(
                             guest,
@@ -495,6 +583,25 @@ async fn process_cli_command(
             let uuid = guest.query_upstairs_uuid()?;
             fw.send(CliMessage::MyUuid(uuid)).await
         }
+        CliMessage::Verify => {
+            if ri.write_count.is_empty() {
+                fw.send(CliMessage::Error(CrucibleError::GenericError(
+                    "Info not initialized".to_string(),
+                )))
+                .await
+            } else {
+                match verify_volume(guest, ri) {
+                    Ok(_) => fw.send(CliMessage::DoneOk).await,
+                    Err(e) => {
+                        println!("Verify failed with {:?}", e);
+                        fw.send(CliMessage::Error(CrucibleError::GenericError(
+                            "Verify failed".to_string(),
+                        )))
+                        .await
+                    }
+                }
+            }
+        }
         msg => {
             println!("No code written for {:?}", msg);
             Ok(())
@@ -516,6 +623,7 @@ pub async fn start_cli_server(
     address: IpAddr,
     port: u16,
     verify_input: Option<PathBuf>,
+    verify_output: Option<PathBuf>,
 ) -> Result<()> {
     let listen_on = match address {
         IpAddr::V4(ipv4) => SocketAddr::new(std::net::IpAddr::V4(ipv4), port),
@@ -528,6 +636,18 @@ pub async fn start_cli_server(
     println!("Listening for a CLI connection on: {:?}", listen_on);
     let listener = TcpListener::bind(&listen_on).await?;
 
+    /*
+     * If write_count len is zero, then the RegionInfo has
+     * not been filled.
+     */
+    let mut ri: RegionInfo = RegionInfo {
+        block_size: 0,
+        extent_size: Block::new_512(0),
+        total_size: 0,
+        total_blocks: 0,
+        write_count: Vec::new(),
+        max_block_io: 0,
+    };
     /*
      * If we have write info data from previous runs, we can't update our
      * internal region info struct until we actually connect to our
@@ -545,19 +665,6 @@ pub async fn start_cli_server(
         let mut fr = FramedRead::new(read, CliDecoder::new());
         let mut fw = FramedWrite::new(write, CliEncoder::new());
 
-        /*
-         * If write_count len is zero, then the RegionInfo has
-         * not been filled.
-         */
-        let mut ri: RegionInfo = RegionInfo {
-            block_size: 0,
-            extent_size: Block::new_512(0),
-            total_size: 0,
-            total_blocks: 0,
-            write_count: Vec::new(),
-            max_block_io: 0,
-        };
-
         loop {
             tokio::select! {
                 new_read = fr.next() => {
@@ -574,7 +681,9 @@ pub async fn start_cli_server(
                                 cmd,
                                 &mut ri,
                                 &mut wc_filled,
-                                verify_input.clone()).await?;
+                                verify_input.clone(),
+                                verify_output.clone()
+                            ).await?;
                         }
                     }
                 }

--- a/client/src/protocol.rs
+++ b/client/src/protocol.rs
@@ -16,25 +16,34 @@ use crucible_common::CrucibleError;
 /// checks any read data.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum CliMessage {
-    Uuid,
-    MyUuid(Uuid),
-    InfoPlease,
-    Info(u64, u64, u64),
-    Error(CrucibleError),
     Activate(u64),
-    IsActive,
     ActiveIs(bool),
     Deactivate,
     // Generic command success
     DoneOk,
+    Error(CrucibleError),
+    // Print the expected read count output for a block
+    Expected(usize),
+    ExpectedResponse(usize, Vec<u8>),
+    // Record the current write count to the verify-out file.
+    Export,
+    // Run the fill test.
+    Fill,
+    Flush,
     Generic,
+    Info(u64, u64, u64),
+    InfoPlease,
+    IsActive,
+    MyUuid(Uuid),
     Read(usize, usize),
     RandRead,
     ReadResponse(usize, Result<Vec<u8>, CrucibleError>),
-    Write(usize, usize),
     RandWrite,
-    Flush,
+    // Run the Verify test.
+    Verify,
+    Write(usize, usize),
     Unknown(u32, BytesMut),
+    Uuid,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Replace rustyline with reedline.  Reedline works on illumos which means I don't have
to debug the terminal problems.

Added commands to run crucible-client fill and verify tests.
Added command to dump expected value for a block.
Updated the CLI server to support importing and exporting the
internal write count, and commands in the CLI to call them.

Updated fill and verify functions to write to 100 blocks at a
time.  Trying to do a single block at a time was taking forever
on larger regions.

Moved some cli logic outside the inner loop to allow for state
to be remembered across cli client reconnects.

Fixed the biggest workload test to still do something if the
region size was smaller than the largest IO supported.  Also updated
the biggest workload test to use the internal write counter and
update it accordingly.