### PR TITLE
Updates for downstairs dump command

### DIFF
--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -71,7 +71,6 @@ pub fn dump_region(
                             total_extents as u64 * blocks_per_extent - 1,
                         );
                     }
-                    println!("block {} is extent {}", b, ce);
                     cmp_extent = Some(ce);
                 }
             }

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -18,10 +18,13 @@ struct ExtInfo {
  */
 pub fn dump_region(
     region_dir: Vec<PathBuf>,
-    cmp_extent: Option<u32>,
+    mut cmp_extent: Option<u32>,
     block: Option<u64>,
     only_show_differences: bool,
 ) -> Result<()> {
+    if cmp_extent.is_some() && block.is_some() {
+        bail!("Either a specific block, or a specific extent, not both");
+    }
     /*
      * We are building a two level hashmap.
      * The first level index is the extent number.
@@ -35,6 +38,7 @@ pub fn dump_region(
     let mut blocks_per_extent = 0;
     let mut total_extents = 0;
 
+    assert!(!region_dir.is_empty());
     for (index, dir) in region_dir.iter().enumerate() {
         // Open Region read only
         let region = Region::open(&dir, Default::default(), false, true)?;
@@ -50,6 +54,27 @@ pub fn dump_region(
          */
         for e in &region.extents {
             let en = e.number();
+
+            /*
+             * If we want just a specific block, then figure out what extent
+             * that block belongs to so we can just display the
+             * requested information. We only need to do this
+             * once.
+             */
+            if cmp_extent.is_none() {
+                if let Some(b) = block {
+                    let ce = (b / blocks_per_extent) as u32;
+                    if ce >= total_extents {
+                        bail!(
+                            "Requested block {} > max block {}",
+                            b,
+                            total_extents as u64 * blocks_per_extent - 1,
+                        );
+                    }
+                    println!("block {} is extent {}", b, ce);
+                    cmp_extent = Some(ce);
+                }
+            }
 
             /*
              * If we are looking at one extent in detail, we skip all the
@@ -108,18 +133,11 @@ pub fn dump_region(
          * If we only want details about one block, show that
          */
         if let Some(block) = block {
-            if block >= blocks_per_extent {
-                bail!(
-                    "Requested block {} is higher than {}!",
-                    block,
-                    blocks_per_extent
-                );
-            }
-
             return show_extent_block(
                 region_dir,
                 ce,
                 block,
+                blocks_per_extent,
                 only_show_differences,
             );
         }
@@ -142,6 +160,7 @@ pub fn dump_region(
     ext_num.sort_unstable();
 
     print!("EXT ");
+    print!("   BLOCKS");
     for i in 0..dir_count {
         print!(" GEN{}", i);
     }
@@ -200,6 +219,11 @@ pub fn dump_region(
             }
 
             print!("{:3} ", en);
+            print!(
+                "{:04}-{:04}",
+                blocks_per_extent * (**en as u64),
+                blocks_per_extent * (**en as u64) + blocks_per_extent - 1
+            );
 
             let color = color_vec(&gen_vec);
             for i in 0..dir_count {
@@ -480,8 +504,9 @@ fn show_extent(
         let different = data_different || ec_different || hashes_different;
 
         // Now that we have collected all the results, print them
+        let real_block = (blocks_per_extent * cmp_extent as u64) + block;
         if !only_show_differences || different {
-            print!("{:5} ", block);
+            print!("{:5} ", real_block);
 
             for column in data_columns.iter().take(dir_count) {
                 print!("  {}", column);
@@ -523,9 +548,14 @@ fn show_extent_block(
     region_dir: Vec<PathBuf>,
     cmp_extent: u32,
     block: u64,
+    blocks_per_extent: u64,
     only_show_differences: bool,
 ) -> Result<()> {
-    println!("Extent {} Block {}", cmp_extent, block);
+    let block_in_extent = block % blocks_per_extent;
+    println!(
+        "Extent {} Block in extent {}  Actual block {}",
+        cmp_extent, block_in_extent, block,
+    );
     println!();
 
     let dir_count = region_dir.len();
@@ -546,7 +576,7 @@ fn show_extent_block(
 
         let mut responses = region.region_read(&[ReadRequest {
             eid: cmp_extent as u64,
-            offset: Block::new_with_ddef(block, &region.def()),
+            offset: Block::new_with_ddef(block_in_extent, &region.def()),
             num_blocks: 1,
         }])?;
         let response = responses.pop().unwrap();

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -196,9 +196,19 @@ else
     echo "dump test passed"
 fi
 
-args+=( -e 1 )
-echo "$cds" dump "${args[@]}"
-if ! "$cds" dump "${args[@]}"; then
+echo "$cds" dump "${args[@]}" -e 1
+if ! "$cds" dump "${args[@]}" -e 1; then
+    (( res += 1 ))
+    echo ""
+    echo "Failed crucible-client dump test 2"
+    echo "Failed crucible-client dump test 2" >> /tmp/test_fail.txt
+    echo ""
+else
+    echo "dump test 2 passed"
+fi
+
+echo "$cds" dump "${args[@]}" -b 20
+if ! "$cds" dump "${args[@]}" -b 20 ; then
     (( res += 1 ))
     echo ""
     echo "Failed crucible-client dump test 2"


### PR DESCRIPTION
Add the overall block range of the region when printing out an extent.

Update dump block option to take a specific block with respect to the whole
region, not specific to the given extent.

Added the specific block option to the test_up.sh script.

Here is how the new stuff looks:
```
$ cargo run -p crucible-downstairs -- dump -d var/8810 -d var/8820 -d var/8830
    Finished dev [unoptimized + debuginfo] target(s) in 0.24s
     Running `target/debug/crucible-downstairs dump -d var/8810 -d var/8820 -d var/8830`
EXT    BLOCKS GEN0 GEN1 GEN2   FL0  FL1  FL2  D0 D1 D2
  0 0000-0003    2    2    2    16   16   16   F  F  F
  1 0004-0007    2    2    2    19   19   19   F  F  F
  2 0008-0011    2    2    2    19   19   19   F  F  F
  3 0012-0015    2    2    2    20   20   20   F  F  F
  4 0016-0019    2    2    2    20   20   20   F  F  F
Max gen: 2,  Max flush: 20
```
With just a specific extent
```
$ cdump.sh -e 2
cargo run -p crucible-downstairs -- dump -d var/8810 -d var/8820 -d var/8830 -e 2
    Finished dev [unoptimized + debuginfo] target(s) in 0.23s
     Running `target/debug/crucible-downstairs dump -d var/8810 -d var/8820 -d var/8830 -e 2`
           Extent 2
GEN             2        2        2
FLUSH_ID       19       19       19
DIRTY

BLOCK  D0 D1 D2  E0 E1 E2  H0 H1 H2 DIFF
    8   A  A  A   A  A  A   A  A  A
    9   A  A  A   A  A  A   A  A  A
   10   A  A  A   A  A  A   A  A  A
   11   A  A  A   A  A  A   A  A  A
```
And finally, with the specific block
```
$ cargo run -p crucible-downstairs -- dump -d var/8810 -d var/8820 -d var/8830 -b 17
    Finished dev [unoptimized + debuginfo] target(s) in 0.24s
     Running `target/debug/crucible-downstairs dump -d var/8810 -d var/8820 -d var/8830 -b 17`
Extent 4 Block in extent 1  Actual block 17

  DATA  SHA256                                                            VER
------  ----------------------------------------------------------------  ---
     0  055ed00b97153f77b53e845a455a677a45bff8d5e909c0a0727a1460e10383b3  A
     1  055ed00b97153f77b53e845a455a677a45bff8d5e909c0a0727a1460e10383b3  A
     2  055ed00b97153f77b53e845a455a677a45bff8d5e909c0a0727a1460e10383b3  A

NONCES             0                        1                        2              DIFF
------  ------------------------ ------------------------ ------------------------ -----

  TAGS                 0                                1                                2                  DIFF
------  -------------------------------- -------------------------------- -------------------------------- -----

HASHES         0                1                2          DIFF
------  ---------------- ---------------- ---------------- -----
     0  a9ecb56a1823f982 a9ecb56a1823f982 a9ecb56a1823f982
```
