### PR TITLE
Perf test for crucible-client, other test tool updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,7 @@ dependencies = [
  "ringbuffer",
  "serde",
  "serde_json",
+ "statistical",
  "structopt",
  "tokio",
  "tokio-util 0.7.0",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -23,6 +23,7 @@ rand_chacha = "0.3.1"
 reedline = "0.3.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+statistical = "1.0.0"
 structopt = "0.3"
 tokio = { version = "1.17.0", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"]}

--- a/tools/create-generic-ds.sh
+++ b/tools/create-generic-ds.sh
@@ -53,9 +53,9 @@ else
     fi
 fi
 
-cds="./target/debug/crucible-downstairs"
+cds="./target/release/crucible-downstairs"
 if [[ ! -f ${cds} ]]; then
-    cds="./target/release/crucible-downstairs"
+    cds="./target/debug/crucible-downstairs"
     if [[ ! -f ${cds} ]]; then
         echo "Can't find crucible binary at $cds"
         exit 1

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -5279,10 +5279,6 @@ impl GuestWork {
         id
     }
 
-    fn _active_count(&mut self) -> usize {
-        self.active.len()
-    }
-
     /**
      * Move a GtoS job from the active to completed.
      * At this point we should have already sent the guest a message

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -5037,7 +5037,7 @@ enum BlockOp {
         data: Arc<Mutex<Block>>,
     },
     QueryWorkQueue {
-        data: Arc<Mutex<usize>>,
+        data: Arc<Mutex<WQCounts>>,
     },
     // Send an update to all tasks that there is work on the queue.
     Commit,
@@ -5279,7 +5279,7 @@ impl GuestWork {
         id
     }
 
-    fn active_count(&mut self) -> usize {
+    fn _active_count(&mut self) -> usize {
         self.active.len()
     }
 
@@ -5876,15 +5876,21 @@ impl Guest {
         return Ok(*data.lock().map_err(|_| CrucibleError::DataLockError)?);
     }
 
-    pub fn query_work_queue(&self) -> Result<usize, CrucibleError> {
+    pub fn query_work_queue(&self) -> Result<WQCounts, CrucibleError> {
         if !self.is_active() {
             return Err(CrucibleError::UpstairsInactive);
         }
+        let wc = WQCounts {
+            up_count: 0,
+            ds_count: 0,
+        };
 
-        let data = Arc::new(Mutex::new(0));
-        let work_queue_query = BlockOp::QueryWorkQueue { data: data.clone() };
-        self.send(work_queue_query).block_wait()?;
-        return Ok(*data.lock().map_err(|_| CrucibleError::DataLockError)?);
+        let data = Arc::new(Mutex::new(wc));
+        let qwq = BlockOp::QueryWorkQueue { data: data.clone() };
+        self.send(qwq).block_wait().unwrap();
+
+        let wc = data.lock().unwrap();
+        Ok(*wc)
     }
 
     pub fn commit(&self) -> Result<(), CrucibleError> {
@@ -6291,8 +6297,10 @@ async fn process_new_io(
             let _ = req.send.send(Ok(()));
         }
         BlockOp::QueryWorkQueue { data } => {
-            *data.lock().unwrap() =
-                up.guest.guest_work.lock().unwrap().active_count();
+            *data.lock().unwrap() = WQCounts {
+                up_count: up.guest.guest_work.lock().unwrap().active.len(),
+                ds_count: up.downstairs.lock().unwrap().active.len(),
+            };
             let _ = req.send.send(Ok(()));
         }
         BlockOp::ShowWork { data } => {


### PR DESCRIPTION
Created a new simple perf test in crucible-client.  Measure 100% writes
then 100% reads.  Caller can select io_size (blocks) and io_depth.

Updated create-generic-ds.sh to look for release binary before debug.

Updated downstairs-daemon.sh to use release binaries when requested.

Changed the Crucible QueryWorkQueue to return counts for both the
upstairs and the downstairs instead of just the upstairs.  This allows us
in a test to verify that all outstanding IOs have completed on all.
This is useful to prevent a previous test from interfering with a
test about to run.