### PR TITLE
track tracing 0.1 instead of 0.1.34

### DIFF
--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -37,7 +37,7 @@ structopt = "0.3"
 tokio = { version = "1.17.0", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"]}
 tokio-rustls = { version = "0.23.3" }
-tracing = "0.1.34"
+tracing = "0.1"
 toml = "0.5"
 opentelemetry = "0.17.0"
 opentelemetry-jaeger = { version = "0.16.0" }

--- a/upstairs/Cargo.toml
+++ b/upstairs/Cargo.toml
@@ -32,7 +32,7 @@ tokio = { version = "1.17.0", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"]}
 tokio-rustls = { version = "0.23.3" }
 toml = "0.5"
-tracing = "0.1.34"
+tracing = "0.1"
 usdt = "0.3.2"
 uuid = { version = "0.8", features = [ "serde", "v4" ] }
 aes-gcm-siv = "0.10.3"


### PR DESCRIPTION
fixes build conflict with latest omicron