### PR TITLE
Create one seed db, copy that for each new extent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,6 @@ dependencies = [
  "oximeter-producer",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rayon",
  "repair-client",
  "reqwest",
  "ringbuffer",

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -47,7 +47,6 @@ uuid = { version = "0.8", features = [ "serde", "v4" ] }
 rusqlite = { version = "0.27" }
 hex = "0.4"
 sha2 = "0.10"
-rayon = "1.5.2"
 
 [dev-dependencies]
 rand_chacha = "0.3.1"

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1,5 +1,4 @@
 // Copyright 2021 Oxide Computer Company
-use rayon::prelude::*;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt;
@@ -570,6 +569,18 @@ pub fn validate_repair_files(eid: usize, files: &[String]) -> bool {
     files == some || files == all
 }
 
+/// Always open sqlite with journaling, and synchronous.
+/// Note: these pragma_updates are not durable
+fn open_sqlite_connection<P: AsRef<Path>>(path: &P) -> Result<Connection> {
+    let metadb = Connection::open(&path)?;
+
+    assert!(metadb.is_autocommit());
+    metadb.pragma_update(None, "journal_mode", &"WAL")?;
+    metadb.pragma_update(None, "synchronous", &"FULL")?;
+
+    Ok(metadb)
+}
+
 impl Extent {
     /**
      * Open an existing extent file at the location requested.
@@ -633,7 +644,7 @@ impl Extent {
          * Open a connection to the metadata db
          */
         path.set_extension("db");
-        let metadb = match Connection::open(&path) {
+        let metadb = match open_sqlite_connection(&path) {
             Err(e) => {
                 println!(
                     "Error: {} No extent#{} db file found for {:?}",
@@ -648,9 +659,6 @@ impl Extent {
             }
             Ok(m) => m,
         };
-        assert!(metadb.is_autocommit());
-        metadb.pragma_update(None, "journal_mode", &"WAL")?;
-        metadb.pragma_update(None, "synchronous", &"FULL")?;
 
         // XXX: schema updates?
 
@@ -709,67 +717,112 @@ impl Extent {
         file.set_len(size)?;
         file.seek(SeekFrom::Start(0))?;
 
-        /*
-         * Create the metadata db
-         */
-        path.set_extension("db");
-        let metadb = Connection::open(&path)?;
-        assert!(metadb.is_autocommit());
-        metadb.pragma_update(None, "journal_mode", &"WAL")?;
-        metadb.pragma_update(None, "synchronous", &"FULL")?;
+        let mut seed = dir.as_ref().to_path_buf();
+        seed.push("seed");
+        seed.set_extension("db");
 
-        /*
-         * Create tables and insert base data
-         */
-        metadb.execute(
-            "CREATE TABLE metadata (
-                name TEXT PRIMARY KEY,
-                value INTEGER NOT NULL
-            )",
-            [],
-        )?;
+        let metadb = if Path::new(&seed).exists() {
+            path.set_extension("db");
+            std::fs::copy(&seed, &path)?;
 
-        let meta = ExtentMeta::default();
+            path.set_extension("db-shm");
+            seed.set_extension("db-shm");
+            if Path::new(&seed).exists() {
+                std::fs::copy(&seed, &path)?;
+            }
 
-        metadb.execute(
-            "INSERT INTO metadata
-            (name, value) VALUES (?1, ?2)",
-            params!["ext_version", meta.ext_version],
-        )?;
-        metadb.execute(
-            "INSERT INTO metadata
-            (name, value) VALUES (?1, ?2)",
-            params!["gen_number", meta.gen_number],
-        )?;
-        metadb.execute(
-            "INSERT INTO metadata (name, value) VALUES (?1, ?2)",
-            params!["flush_number", meta.flush_number],
-        )?;
-        metadb.execute(
-            "INSERT INTO metadata (name, value) VALUES (?1, ?2)",
-            params!["dirty", meta.dirty],
-        )?;
+            path.set_extension("db-wal");
+            seed.set_extension("db-wal");
+            if Path::new(&seed).exists() {
+                std::fs::copy(&seed, &path)?;
+            }
 
-        metadb.execute(
-            "CREATE TABLE encryption_context (
-                counter INTEGER,
-                block INTEGER,
-                nonce BLOB NOT NULL,
-                tag BLOB NOT NULL,
-                PRIMARY KEY (block, counter)
-            )",
-            [],
-        )?;
+            path.set_extension("db");
+            open_sqlite_connection(&path)?
+        } else {
+            /*
+             * Create the metadata db
+             */
+            path.set_extension("db");
+            let metadb = open_sqlite_connection(&path)?;
 
-        metadb.execute(
-            "CREATE TABLE integrity_hashes (
-                counter INTEGER,
-                block INTEGER,
-                hash BLOB NOT NULL,
-                PRIMARY KEY (block, counter)
-            )",
-            [],
-        )?;
+            /*
+             * Create tables and insert base data
+             */
+            metadb.execute(
+                "CREATE TABLE metadata (
+                    name TEXT PRIMARY KEY,
+                    value INTEGER NOT NULL
+                )",
+                [],
+            )?;
+
+            let meta = ExtentMeta::default();
+
+            metadb.execute(
+                "INSERT INTO metadata
+                (name, value) VALUES (?1, ?2)",
+                params!["ext_version", meta.ext_version],
+            )?;
+            metadb.execute(
+                "INSERT INTO metadata
+                (name, value) VALUES (?1, ?2)",
+                params!["gen_number", meta.gen_number],
+            )?;
+            metadb.execute(
+                "INSERT INTO metadata (name, value) VALUES (?1, ?2)",
+                params!["flush_number", meta.flush_number],
+            )?;
+            metadb.execute(
+                "INSERT INTO metadata (name, value) VALUES (?1, ?2)",
+                params!["dirty", meta.dirty],
+            )?;
+
+            metadb.execute(
+                "CREATE TABLE encryption_context (
+                    counter INTEGER,
+                    block INTEGER,
+                    nonce BLOB NOT NULL,
+                    tag BLOB NOT NULL,
+                    PRIMARY KEY (block, counter)
+                )",
+                [],
+            )?;
+
+            metadb.execute(
+                "CREATE TABLE integrity_hashes (
+                    counter INTEGER,
+                    block INTEGER,
+                    hash BLOB NOT NULL,
+                    PRIMARY KEY (block, counter)
+                )",
+                [],
+            )?;
+
+            // write out
+            metadb.close().map_err(|e| std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("metadb.close() failed! {}", e.1.to_string()),
+            ))?;
+
+            // Save it as DB seed
+            std::fs::copy(&path, &seed)?;
+
+            path.set_extension("db-shm");
+            seed.set_extension("db-shm");
+            if Path::new(&path).exists() {
+                std::fs::copy(&path, &seed)?;
+            }
+
+            path.set_extension("db-wal");
+            seed.set_extension("db-wal");
+            if Path::new(&path).exists() {
+                std::fs::copy(&path, &seed)?;
+            }
+
+            path.set_extension("db");
+            open_sqlite_connection(&path)?
+        };
 
         /*
          * Complete the construction of our new extent
@@ -1132,7 +1185,7 @@ impl Region {
         let next_eid = self.extents.len() as u32;
 
         let these_extents = (next_eid..self.def.extent_count())
-            .into_par_iter()
+            .into_iter()
             .map(|eid| {
                 if create {
                     Extent::create(&self.dir, &self.def, eid)

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -800,10 +800,12 @@ impl Extent {
             )?;
 
             // write out
-            metadb.close().map_err(|e| std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("metadb.close() failed! {}", e.1.to_string()),
-            ))?;
+            metadb.close().map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("metadb.close() failed! {}", e.1),
+                )
+            })?;
 
             // Save it as DB seed
             std::fs::copy(&path, &seed)?;

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -683,6 +683,7 @@ impl Extent {
     /**
      * Create an extent at the location requested.
      * Start off with the default meta data.
+     * Note that this function is not safe to run concurrently.
      */
     fn create<P: AsRef<Path>>(
         // Extent
@@ -721,6 +722,9 @@ impl Extent {
         seed.push("seed");
         seed.set_extension("db");
 
+        // Instead of creating the sqlite db for every extent, create it only
+        // once, and copy from a seed db when creating other extents. This
+        // minimizes Region create time.
         let metadb = if Path::new(&seed).exists() {
             path.set_extension("db");
             std::fs::copy(&seed, &path)?;

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -721,33 +721,19 @@ impl Extent {
         let mut seed = dir.as_ref().to_path_buf();
         seed.push("seed");
         seed.set_extension("db");
+        path.set_extension("db");
 
         // Instead of creating the sqlite db for every extent, create it only
         // once, and copy from a seed db when creating other extents. This
         // minimizes Region create time.
         let metadb = if Path::new(&seed).exists() {
-            path.set_extension("db");
             std::fs::copy(&seed, &path)?;
 
-            path.set_extension("db-shm");
-            seed.set_extension("db-shm");
-            if Path::new(&seed).exists() {
-                std::fs::copy(&seed, &path)?;
-            }
-
-            path.set_extension("db-wal");
-            seed.set_extension("db-wal");
-            if Path::new(&seed).exists() {
-                std::fs::copy(&seed, &path)?;
-            }
-
-            path.set_extension("db");
             open_sqlite_connection(&path)?
         } else {
             /*
              * Create the metadata db
              */
-            path.set_extension("db");
             let metadb = open_sqlite_connection(&path)?;
 
             /*
@@ -814,19 +800,6 @@ impl Extent {
             // Save it as DB seed
             std::fs::copy(&path, &seed)?;
 
-            path.set_extension("db-shm");
-            seed.set_extension("db-shm");
-            if Path::new(&path).exists() {
-                std::fs::copy(&path, &seed)?;
-            }
-
-            path.set_extension("db-wal");
-            seed.set_extension("db-wal");
-            if Path::new(&path).exists() {
-                std::fs::copy(&path, &seed)?;
-            }
-
-            path.set_extension("db");
             open_sqlite_connection(&path)?
         };
 


### PR DESCRIPTION
Remove rayon into_par_iter and instead create only one sqlite db. Copy
that seed db into the region base directory, and it those seed files
exist copy them into new extents during creation.

Note that the pragma_update commands are not durable, and must be called
every time the sqlite connection is opened.

Note as well that this seed.db will have to be updated when our on-disk
format changes.