### PR TITLE
Enable panic when hash mismatch (or failure)

### DIFF
--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -255,8 +255,7 @@ async fn cmd_to_msg(
             fw.send(CliMessage::IsActive).await?;
         }
         CliCommand::Show => {
-            println!("No support for {:?}", cmd);
-            return Ok(());
+            fw.send(CliMessage::ShowWork).await?;
         }
         CliCommand::Wait => {
             println!("No support for {:?}", cmd);
@@ -560,10 +559,13 @@ async fn process_cli_command(
                 }
             }
         }
-        CliMessage::Flush => match guest.flush(None) {
-            Ok(_) => fw.send(CliMessage::DoneOk).await,
-            Err(e) => fw.send(CliMessage::Error(e)).await,
-        },
+        CliMessage::Flush => {
+            println!("Flush");
+            match guest.flush(None) {
+                Ok(_) => fw.send(CliMessage::DoneOk).await,
+                Err(e) => fw.send(CliMessage::Error(e)).await,
+            }
+        }
         CliMessage::IsActive => match guest.query_is_active() {
             Ok(a) => fw.send(CliMessage::ActiveIs(a)).await,
             Err(e) => fw.send(CliMessage::Error(e)).await,
@@ -633,6 +635,10 @@ async fn process_cli_command(
                 fw.send(CliMessage::ReadResponse(offset, res)).await
             }
         }
+        CliMessage::ShowWork => match guest.show_work() {
+            Ok(_) => fw.send(CliMessage::DoneOk).await,
+            Err(e) => fw.send(CliMessage::Error(e)).await,
+        },
         CliMessage::Write(offset, len) => {
             if ri.write_log.is_empty() {
                 fw.send(CliMessage::Error(CrucibleError::GenericError(

--- a/client/src/protocol.rs
+++ b/client/src/protocol.rs
@@ -41,6 +41,8 @@ pub enum CliMessage {
     RandRead,
     ReadResponse(usize, Result<Vec<u8>, CrucibleError>),
     RandWrite,
+    // Show the work queues
+    ShowWork,
     // Run the Verify test.
     Verify,
     Write(usize, usize),
@@ -253,6 +255,13 @@ mod tests {
     #[test]
     fn rt_read() -> Result<()> {
         let input = CliMessage::Read(32, 22);
+        assert_eq!(input, round_trip(&input)?);
+        Ok(())
+    }
+
+    #[test]
+    fn rt_is_show() -> Result<()> {
+        let input = CliMessage::ShowWork;
         assert_eq!(input, round_trip(&input)?);
         Ok(())
     }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2358,11 +2358,12 @@ impl Downstairs {
             }
 
             if !successful_hash {
-                println!("No match encrypted computed hash");
+                println!("No match for encrypted computed hash");
                 // no hash was correct
                 return Err(CrucibleError::HashMismatch);
             } else if !successful_decryption {
                 // no hash + encryption context combination decrypted this block
+                println!("Decryption failed with correct hash");
                 return Err(CrucibleError::DecryptionError);
             } else {
                 // Ok!
@@ -2531,10 +2532,28 @@ impl Downstairs {
                             // It's possible we get a read error if the
                             // downstairs disconnects.  However XXX, someone
                             // should be told about this error.
-                            println!(
-                                "[{}] {} read error {:?} {:?}",
-                                client_id, ds_id, e, job
-                            );
+                            //
+                            // Some errors, we need to panic on.
+                            match e {
+                                CrucibleError::HashMismatch => {
+                                    panic!(
+                                        "[{}] {} read hash mismatch {:?} {:?}",
+                                        client_id, ds_id, e, job
+                                    );
+                                }
+                                CrucibleError::DecryptionError => {
+                                    panic!(
+                                        "[{}] {} read decryption error {:?} {:?}",
+                                        client_id, ds_id, e, job
+                                    );
+                                }
+                                _ => {
+                                    println!(
+                                        "[{}] {} read error {:?} {:?}",
+                                        client_id, ds_id, e, job
+                                    );
+                                }
+                            }
                         }
                     }
                 }
@@ -2567,7 +2586,9 @@ impl Downstairs {
                     assert!(!read_data.is_empty());
                     if job.read_response_hashes != read_response_hashes {
                         // XXX This error needs to go to Nexus
-                        println!(
+                        // XXX This will become the "force all downstairs
+                        // to stop and refuse to restart" mode.
+                        panic!(
                             "[{}] read hash mismatch on {} {:?} {:?} j:{:?}",
                             client_id,
                             ds_id,
@@ -2611,7 +2632,9 @@ impl Downstairs {
                          */
                         if job.read_response_hashes != read_response_hashes {
                             // XXX This error needs to go to Nexus
-                            println!(
+                            // XXX This will become the "force all downstairs
+                            // to stop and refuse to restart" mode.
+                            panic!(
                                 "[{}] read hash mismatch on {} {:?} {:?} j:{:?}",
                                 client_id,
                                 ds_id,

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2360,10 +2360,7 @@ impl Downstairs {
 
             if !successful_hash {
                 println!("No match for encrypted computed hash");
-                for (i, ctx) in response
-                    .encryption_contexts
-                    .iter()
-                    .enumerate()
+                for (i, ctx) in response.encryption_contexts.iter().enumerate()
                 {
                     let computed_hash = integrity_hash(&[
                         &ctx.nonce[..],
@@ -2463,10 +2460,7 @@ impl Downstairs {
                     // The downstairs sent us this error
                     println!(
                         "[{}] DS Reports error {:?} on job {}, {:?} EC",
-                        client_id,
-                        responses,
-                        ds_id,
-                        job,
+                        client_id, responses, ds_id, job,
                     );
                     // bad responses
                     responses
@@ -2493,10 +2487,7 @@ impl Downstairs {
                     // The downstairs sent us this error
                     println!(
                         "[{}] DS Reports error {:?} on job {}, {:?}",
-                        client_id,
-                        responses,
-                        ds_id,
-                        job,
+                        client_id, responses, ds_id, job,
                     );
                     // bad responses
                     responses
@@ -2506,10 +2497,7 @@ impl Downstairs {
         let newstate = if let Err(ref e) = read_data {
             println!(
                 "[{}] Reports error {:?} on job {}, {:?}",
-                client_id,
-                e,
-                ds_id,
-                job,
+                client_id, e, ds_id, job,
             );
             IOState::Error(e.clone())
         } else {


### PR DESCRIPTION
### Panic when a read hash does not match between downstairs

When a read response comes back from a downstairs, we store
the hash that is returned.  When another downstairs returns
the same read request, we compare the hashes to make sure
that all downstairs are returning the same values.  A failure
of this check is now cause for panic, where before it was just
printing a message.

This is part one of what we want to do if the upstairs finds
data from a read is not what it expects.  Eventually there
will be more action taken.

However, during replay, there are situations where it's possible
to have a read return a different hash (and data) between the 
downstairs.  When we are replaying, we take all jobs since the 
last flush and replay them in order. This situation could result
in the contents of a read being different on a replaying
downstairs vs. the non-replaying downstairs if a write of the 
same block came after the read.

Add a new field to the DownstairsIO struct to indicate when
an IO is a Replay IO and we can ignore a read hash mismatch
from other downstairs.

### Other tidbits with this change

Updated show_all_work to display the replay field of the 
DownstairsIO struct.

Connect up the cli show command to show the work queues.

Some new tests around making sure we panic on hash mismatch
except when under replay.
A few tests were refactored and renamed to better reflect what 
they are now testing.  Some tests were removed that were not
testing what they claimed to be testing.

test_reconnect.sh improvements:  Change the test to do an
initial fill, then run the generic test during the loop.