### PR TITLE
Add a perf test to buildomat

### DIFF
--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -30,7 +30,7 @@ for t in crucible-downstairs crucible-client crucible-hammer dsc; do
 done
 
 mkdir -p /work/scripts
-for s in tools/test_up.sh tools/test_ds.sh; do
+for s in tools/test_perf.sh; do
 	cp "$s" /work/scripts/
 done
 

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#:
+#: name = "test-perf"
+#: variety = "basic"
+#: target = "helios"
+#: output_rules = [
+#:	"/tmp/perfout.csv",
+#:  "./*.csv",
+#: ]
+#: skip_clone = true
+#:
+#: [dependencies.rbuild]
+#: job = "rbuild"
+
+input="/input/rbuild/work"
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+echo "input rbins dir contains:"
+ls -ltr "$input"/rbins || true
+echo "input scripts dir contains:"
+ls -ltr "$input"/scripts || true
+
+banner unpack
+mkdir -p /var/tmp/bins
+for t in "$input/rbins/"*.gz; do
+	b=$(basename "$t")
+	b=${b%.gz}
+	gunzip < "$t" > "/var/tmp/bins/$b"
+	chmod +x "/var/tmp/bins/$b"
+done
+
+export BINDIR=/var/tmp/bins
+
+banner perf
+pfexec plimit -n 9123456 $$
+
+ptime -m bash "$input/scripts/test_perf.sh"

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -4,8 +4,8 @@
 #: variety = "basic"
 #: target = "helios"
 #: output_rules = [
-#:	"/tmp/perfout.csv",
-#:  "./*.csv",
+#:  "/tmp/perf*.csv",
+#:  "/tmp/perfout.txt",
 #: ]
 #: skip_clone = true
 #:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,6 +990,7 @@ dependencies = [
  "clap 3.1.16",
  "csv",
  "statistical",
+ "tempfile",
 ]
 
 [[package]]

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -686,14 +686,16 @@ fn main() -> Result<()> {
                 "ES",
                 "EC",
             );
-            runtime.block_on(perf_workload(
-                &guest,
-                &mut region_info,
-                &mut opt_wtr,
-                ops,
-                io_depth,
-                io_size,
-            ))?;
+            for _ in 0..2 {
+                runtime.block_on(perf_workload(
+                    &guest,
+                    &mut region_info,
+                    &mut opt_wtr,
+                    ops,
+                    io_depth,
+                    io_size,
+                ))?;
+            }
             if opt.quit {
                 return Ok(());
             }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -659,7 +659,7 @@ fn main() -> Result<()> {
                     .unwrap();
                 wtr.serialize((
                     "type",
-                    "total_time",
+                    "total_time_ns",
                     "io_depth",
                     "io_size",
                     "count",
@@ -1317,12 +1317,12 @@ pub fn perf_csv(
         .map(|x| (x.as_secs() as u64 * 100000000) + x.subsec_nanos() as u64)
         .collect::<Vec<u64>>();
 
-    let time_in_sec =
+    let time_in_nsec =
         duration.as_secs() as u64 * 100000000 + duration.subsec_nanos() as u64;
 
     wtr.serialize(Record {
         label: msg.to_string(),
-        total_time: time_in_sec,
+        total_time: time_in_nsec,
         io_depth,
         io_size,
         count,

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -182,7 +182,7 @@ fn get_region_info(guest: &Arc<Guest>) -> Result<RegionInfo, CrucibleError> {
     let total_blocks = (total_size / block_size) as usize;
 
     /*
-     * Limit the max IO size (in blocks) to be 1M or the size
+     * Limit the max IO size (in blocks) to be 1MiB or the size
      * of the volume, whichever is smaller
      */
     const MAX_IO_BYTES: usize = 1024 * 1024;
@@ -192,8 +192,9 @@ fn get_region_info(guest: &Arc<Guest>) -> Result<RegionInfo, CrucibleError> {
     }
 
     println!(
-        "Region: es:{:?}  bs:{}  ts:{}  tb:{}  max_io:{} or {}",
+        "Region: es:{} ec:{} bs:{}  ts:{}  tb:{}  max_io:{} or {}",
         extent_size.value,
+        total_blocks as u64 / extent_size.value,
         block_size,
         total_size,
         total_blocks,
@@ -653,13 +654,39 @@ fn main() -> Result<()> {
             let mut wtr;
             if let Some(perf_out) = perf_out {
                 wtr = WriterBuilder::new()
-                    .has_headers(false)
+                    .flexible(true)
                     .from_path(perf_out)
                     .unwrap();
+                wtr.serialize((
+                    "type",
+                    "total_time",
+                    "io_depth",
+                    "io_size",
+                    "count",
+                    "es",
+                    "ec",
+                    "times",
+                ))?;
                 opt_wtr = Some(&mut wtr);
             }
 
-            for _ in 0..5 {
+            // The header for all perf tests
+            println!(
+                "{:>8} {:7} {:5} {:4} {:>7} {:>7} {:>7} \
+                {:>7} {:>8} {:>5} {:>5}",
+                "TEST",
+                "SECONDS",
+                "COUNT",
+                "DPTH",
+                "IOPS",
+                "MEAN",
+                "STDV",
+                "MIN",
+                "MAX",
+                "ES",
+                "EC",
+            );
+            for _ in 0..8 {
                 runtime.block_on(perf_workload(
                     &guest,
                     &mut region_info,
@@ -1272,13 +1299,17 @@ async fn dirty_workload(
  * Take the Vec of Durations for IOs and write it out in CSV format using
  * the provided CSV Writer.
  */
+#[allow(clippy::too_many_arguments)]
 pub fn perf_csv(
     wtr: &mut csv::Writer<File>,
     msg: &str,
     count: usize,
     io_depth: usize,
     io_size: usize,
+    duration: Duration,
     iotimes: Vec<Duration>,
+    es: u64,
+    ec: u64,
 ) {
     // Convert all Durations to u64 nanoseconds.
     let times = iotimes
@@ -1286,11 +1317,17 @@ pub fn perf_csv(
         .map(|x| (x.as_secs() as u64 * 100000000) + x.subsec_nanos() as u64)
         .collect::<Vec<u64>>();
 
+    let time_in_sec =
+        duration.as_secs() as u64 * 100000000 + duration.subsec_nanos() as u64;
+
     wtr.serialize(Record {
         label: msg.to_string(),
+        total_time: time_in_sec,
         io_depth,
         io_size,
         count,
+        es,
+        ec,
         time: times,
     })
     .unwrap();
@@ -1306,6 +1343,8 @@ fn perf_summary(
     io_depth: usize,
     times: Vec<Duration>,
     total_time: Duration,
+    es: u64,
+    ec: u64,
 ) {
     // Convert all the Durations into floats.
     let mut times = times
@@ -1319,11 +1358,8 @@ fn perf_summary(
     // the average IOPs
     let time_f =
         total_time.as_secs() as f32 + (total_time.subsec_nanos() as f32 / 1e9);
-
     println!(
-        "{}:{:.2}sec {} {} IOPs:{:.2} \
-        mean:{:.5} stdv:{:.5} \
-        min:{:.5} max:{:.5}",
+        "{:>8} {:>7.2} {:5} {:4} {:>7.2} {:.5} {:.5} {:.5} {:8.5} {:>5} {:>5}",
         msg,
         time_f,
         count,
@@ -1333,15 +1369,20 @@ fn perf_summary(
         statistical::standard_deviation(&times, None),
         times.first().unwrap(),
         times.last().unwrap(),
+        es,
+        ec,
     );
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Record {
     label: String,
+    total_time: u64,
     io_depth: usize,
     io_size: usize,
     count: usize,
+    es: u64,
+    ec: u64,
     time: Vec<u64>,
 }
 /**
@@ -1377,10 +1418,9 @@ async fn perf_workload(
         .map(|_| Buffer::new(io_size as usize))
         .collect();
 
-    println!(
-        "Performance test io_size:({}){} io_depth:{} total ops:{}",
-        blocks_per_io, io_size, io_depth, count,
-    );
+    let es = ri.extent_size.value;
+    let ec = ri.total_blocks as u64 / es;
+
     // To make a random block offset modulus, we take the total
     // block number and subtract the IO size in blocks.
     let offset_mod =
@@ -1393,7 +1433,6 @@ async fn perf_workload(
         let mut write_waiters = Vec::with_capacity(io_depth);
         for write_buffer in write_buffers.iter().take(io_depth) {
             let offset: u64 = rng.gen::<u64>() % offset_mod;
-            // println!("Write at: {}", offset);
 
             let waiter = guest.write_to_byte_offset(
                 offset * ri.block_size,
@@ -1410,9 +1449,19 @@ async fn perf_workload(
     let big_end = big_start.elapsed();
 
     guest.flush(None)?;
-    perf_summary("rwrites", count, io_depth, wtime.clone(), big_end);
+    perf_summary("rwrites", count, io_depth, wtime.clone(), big_end, es, ec);
     if let Some(wtr) = wtr {
-        perf_csv(wtr, "rwrite", count, io_depth, blocks_per_io, wtime.clone());
+        perf_csv(
+            wtr,
+            "rwrite",
+            count,
+            io_depth,
+            blocks_per_io,
+            big_end,
+            wtime.clone(),
+            es,
+            ec,
+        );
     }
 
     // Before we start reads, make sure the work queues are empty.
@@ -1445,10 +1494,20 @@ async fn perf_workload(
     }
     let big_end = big_start.elapsed();
 
-    perf_summary(" rreads", count, io_depth, rtime.clone(), big_end);
+    perf_summary("rreads", count, io_depth, rtime.clone(), big_end, es, ec);
 
     if let Some(wtr) = wtr {
-        perf_csv(wtr, "rread", count, io_depth, blocks_per_io, rtime.clone());
+        perf_csv(
+            wtr,
+            "rread",
+            count,
+            io_depth,
+            blocks_per_io,
+            big_end,
+            rtime.clone(),
+            es,
+            ec,
+        );
     }
 
     guest.flush(None)?;

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -686,16 +686,14 @@ fn main() -> Result<()> {
                 "ES",
                 "EC",
             );
-            for _ in 0..5 {
-                runtime.block_on(perf_workload(
-                    &guest,
-                    &mut region_info,
-                    &mut opt_wtr,
-                    ops,
-                    io_depth,
-                    io_size,
-                ))?;
-            }
+            runtime.block_on(perf_workload(
+                &guest,
+                &mut region_info,
+                &mut opt_wtr,
+                ops,
+                io_depth,
+                io_size,
+            ))?;
             if opt.quit {
                 return Ok(());
             }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -686,7 +686,7 @@ fn main() -> Result<()> {
                 "ES",
                 "EC",
             );
-            for _ in 0..8 {
+            for _ in 0..5 {
                 runtime.block_on(perf_workload(
                     &guest,
                     &mut region_info,

--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -10,3 +10,6 @@ byte-unit = "4.0.14"
 clap = { version = "3.1.16", features = ["derive", "env"] }
 csv = "1.1.6"
 statistical = "1.0.0"
+
+[dev-dependencies]
+tempfile = "3"

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -4,6 +4,8 @@ use std::fs;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::{mpsc, Arc};
+use std::thread;
 use std::time::Instant;
 
 use anyhow::{bail, Context, Result};
@@ -54,7 +56,16 @@ enum Commands {
         csv_out: Option<PathBuf>,
     },
     /// Create and start downstairs regions
-    Start,
+    Start {
+        #[clap(long, default_value = "4096")]
+        block_size: u32,
+
+        #[clap(long, default_value = "100")]
+        extent_size: u64,
+
+        #[clap(long, default_value = "15")]
+        extent_count: u64,
+    },
 }
 
 /// Information about a single downstairs.
@@ -68,16 +79,32 @@ struct DownstairsInfo {
 }
 
 impl DownstairsInfo {
-    fn start(self) -> Result<Child> {
+    fn new(
+        ds_bin: String,
+        region_dir: String,
+        port: u32,
+        _create_output: String,
+        output_file: PathBuf,
+    ) -> DownstairsInfo {
+        DownstairsInfo {
+            ds_bin,
+            region_dir,
+            port,
+            _create_output,
+            output_file,
+        }
+    }
+
+    fn start(&self) -> Result<Child> {
         println!("Make output file at {:?}", self.output_file);
-        let outputs = File::create(self.output_file)
+        let outputs = File::create(&self.output_file)
             .context("Failed to create test file")?;
         let errors = outputs.try_clone()?;
 
         let port_value = format!("{}", self.port);
 
-        let region_dir = self.region_dir;
-        let cmd = Command::new(self.ds_bin)
+        let region_dir = self.region_dir.clone();
+        let cmd = Command::new(self.ds_bin.clone())
             .args(&["run", "-p", &port_value, "-d", &region_dir])
             .stdout(Stdio::from(outputs))
             .stderr(Stdio::from(errors))
@@ -85,12 +112,11 @@ impl DownstairsInfo {
             .context("Failed trying to run downstairs")?;
 
         println!(
-            "Downstaris {} port {} PID:{:?}",
+            "Downstairs {} port {} PID:{:?}",
             region_dir,
             self.port,
             cmd.id()
         );
-
         Ok(cmd)
     }
 }
@@ -98,7 +124,7 @@ impl DownstairsInfo {
 // Describing the downstairs that together make a region.
 #[derive(Debug)]
 struct RegionSet {
-    ds: Vec<DownstairsInfo>,
+    ds: Vec<Arc<DownstairsInfo>>,
     ds_bin: String,
     region_dir: String,
 }
@@ -108,7 +134,6 @@ struct RegionSet {
 struct TestInfo {
     output_dir: PathBuf,
     rs: RegionSet,
-    cmd: Vec<Child>,
 }
 
 impl TestInfo {
@@ -136,11 +161,7 @@ impl TestInfo {
             ds_bin: downstairs_bin,
             region_dir: region_dir.into_os_string().into_string().unwrap(),
         };
-        Ok(TestInfo {
-            output_dir,
-            rs,
-            cmd: Vec::new(),
-        })
+        Ok(TestInfo { output_dir, rs })
     }
 
     /**
@@ -148,7 +169,6 @@ impl TestInfo {
      * the provided extent size and count.
      *
      * TODO: Add encryption option
-     * TODO: Take command line args for region info.
      */
     fn create_ds_region(
         &mut self,
@@ -169,7 +189,7 @@ impl TestInfo {
         let extent_size = format!("{}", extent_size);
         let extent_count = format!("{}", extent_count);
         let block_size = format!("{}", block_size);
-        let uuid = format!("12345678-{0}-{0}-{0}-00000000{0}", port);
+        let uuid = format!("12345678-0000-0000-0000-{:012}", port);
         let start = Instant::now();
         let output = Command::new(self.rs.ds_bin.clone())
             .args(&[
@@ -217,14 +237,14 @@ impl TestInfo {
             t
         };
 
-        let dsi = DownstairsInfo {
-            ds_bin: self.rs.ds_bin.clone(),
-            region_dir: new_region_dir,
+        let dsi = DownstairsInfo::new(
+            self.rs.ds_bin.clone(),
+            new_region_dir,
             port,
-            _create_output: String::from_utf8(output.stdout).unwrap(),
-            output_file: output_path,
-        };
-        self.rs.ds.push(dsi);
+            String::from_utf8(output.stdout).unwrap(),
+            output_path,
+        );
+        self.rs.ds.push(Arc::new(dsi));
         Ok(time_f)
     }
 
@@ -248,46 +268,137 @@ impl TestInfo {
         Ok(())
     }
 
-    // Start all downstairs.
-    fn start_all_downstairs(&mut self) -> Result<()> {
+    /**
+     * Start all downstairs.
+     * Walk the list of downstairs in our region set and spawn
+     * a thread that will then start a downstairs and watch it.
+     *
+     * TODO: There is more coming here, this currently never returns
+     * unless there is an error.  Eventually this will become the
+     * controller of the three downstairs and will be able to stop/start
+     * them as so desired.
+     */
+    fn start_all_downstairs(&mut self) {
+        let (tx, rx) = mpsc::channel::<MonitorInfo>();
+        let mut handles = vec![];
+
         for ds in self.rs.ds.iter() {
-            let cmd = ds.clone().start().unwrap();
-            println!("started ds: {:?}", cmd);
-            self.cmd.push(cmd);
+            println!("start ds: {:?}", ds.port);
+            let txc = tx.clone();
+            let dsc = ds.clone();
+            let handle = thread::spawn(move || {
+                ds_start_monitor(txc, dsc);
+            });
+            handles.push(handle);
         }
-        Ok(())
+        drop(tx);
+        loop {
+            let res = rx.recv();
+            match res {
+                Ok(mi) => {
+                    println!("[{}] reports {:?}", mi.port, mi.status);
+                }
+                Err(e) => {
+                    println!("Receive thread stops with error {:?}", e);
+                    break;
+                }
+            }
+        }
+
+        println!("recv channel is done");
     }
 }
 
-fn create_and_run(ti: &mut TestInfo) -> Result<()> {
-    let _ = ti.create_ds_region(3810, 10, 20, 4096, false).unwrap();
-    let _ = ti.create_ds_region(3820, 10, 20, 4096, false).unwrap();
-    let _ = ti.create_ds_region(3830, 10, 20, 4096, false).unwrap();
+/*
+ * This is used to communicate between the main thread and a thread that
+ * is responsible for starting and monitoring a downstairs process.
+ */
+#[derive(Debug)]
+struct MonitorInfo {
+    port: u32,
+    status: DownstairsStatus,
+}
 
-    println!("All regions created, now start all downstairs");
-    ti.start_all_downstairs().unwrap();
+// Status of a downstairs.
+#[derive(Debug)]
+enum DownstairsStatus {
+    Starting,
+    Running,
+    Exit,
+    Error,
+}
 
-    println!("ti: {:?}", ti);
+/*
+ * Start up a downstairs. Monitor that downstairs and send a message to the
+ * channel if the downstairs exits.
+ *
+ * TODO: This is really just the first stage of much more work here.
+ * Right now all this does is start a downstairs then watch for what
+ * happens, sending a message to another thread when things change. This
+ * will become smarter in the future and will restart on failure and or
+ * possibly also listen for commands from another thread.
+ */
+fn ds_start_monitor(tx: mpsc::Sender<MonitorInfo>, ds: Arc<DownstairsInfo>) {
+    println!("starting downstairs at port {}", ds.port);
+    let _ = tx.send(MonitorInfo {
+        port: ds.port,
+        status: DownstairsStatus::Starting,
+    });
 
-    // Spawn a thread to watch each downstairs??
-    // No, ZZZ spawn a thread to first create, then wait on a downstairs.
-    // The PID should be updated somewhere another task can find it.
-    // Setup a mpsc channel and a head controller thread that knows if a
-    // thread dies unexpected, and can also restart threads (downstairs)
-    // if so desired.
-    //
-    // Messages to tell each monitor thread what to do?
-    for ads in ti.cmd.iter_mut() {
-        match ads.try_wait() {
-            Ok(Some(status)) => println!("exited with: {}", status),
-            Ok(None) => {
-                println!("status not ready yet, lets really wait");
-                let res = ads.wait();
-                println!("result: {:?}", res);
-            }
-            Err(e) => println!("error attempting to wait: {}", e),
+    let mut cmd = ds.start().unwrap();
+    let _ = tx.send(MonitorInfo {
+        port: ds.port,
+        status: DownstairsStatus::Running,
+    });
+
+    match cmd.wait() {
+        Ok(status) => {
+            println!("[{}] exited with: {}", ds.port, status);
+            let _ = tx.send(MonitorInfo {
+                port: ds.port,
+                status: DownstairsStatus::Exit,
+            });
+        }
+        Err(e) => {
+            println!("[{}] wait error {} from downstairs", ds.port, e);
+            let _ = tx.send(MonitorInfo {
+                port: ds.port,
+                status: DownstairsStatus::Error,
+            });
         }
     }
+    println!("[{}] thread all done", ds.port);
+}
+
+/*
+ * Create a default region set.  Attach it to our test info struct
+ */
+fn create_region_set(
+    ti: &mut TestInfo,
+    extent_size: u64,
+    extent_count: u64,
+    block_size: u32,
+    port_base: u32,
+) -> Result<()> {
+    // How far apart the ports are for a default region set.
+    // Note that this value is sprinkled all over the tests scripts,
+    // so when you change it here, go forth and search.
+    const DEFAULT_PORT_STEP: u32 = 10;
+    let mut port = port_base;
+
+    for _ in 0..3 {
+        let _ = ti
+            .create_ds_region(
+                port,
+                extent_size,
+                extent_count,
+                block_size,
+                false,
+            )
+            .unwrap();
+        port += DEFAULT_PORT_STEP;
+    }
+    println!("Region set was created");
     Ok(())
 }
 
@@ -300,7 +411,7 @@ fn loop_create_test(
     ti: &mut TestInfo,
     extent_size: u64,
     extent_count: u64,
-    block_size: u64,
+    block_size: u32,
 ) -> Result<()> {
     let mut times = Vec::new();
     for _ in 0..5 {
@@ -308,7 +419,7 @@ fn loop_create_test(
             3810,
             extent_size,
             extent_count,
-            block_size as u32,
+            block_size,
             true,
         )?;
         times.push(ct);
@@ -338,8 +449,8 @@ fn loop_create_test(
 /*
  * Return a formatted string of the region size in SI units.
  */
-fn region_si(es: u64, ec: u64, bs: u64) -> String {
-    let sz = Byte::from_bytes((bs * es * ec).into());
+fn region_si(es: u64, ec: u64, bs: u32) -> String {
+    let sz = Byte::from_bytes((bs as u64 * es * ec).into());
     let bu = sz.get_appropriate_unit(true);
     format!("{:>11}", bu.to_string())
 }
@@ -347,8 +458,8 @@ fn region_si(es: u64, ec: u64, bs: u64) -> String {
 /*
  * Return a formatted string of the extent file size in SI units
  */
-fn efile_si(es: u64, bs: u64) -> String {
-    let sz = Byte::from_bytes((bs * es).into());
+fn efile_si(es: u64, bs: u32) -> String {
+    let sz = Byte::from_bytes((bs as u64 * es).into());
     let bu = sz.get_appropriate_unit(true);
     format!("{:>11}", bu.to_string())
 }
@@ -361,16 +472,11 @@ fn single_create_test(
     ti: &mut TestInfo,
     extent_size: u64,
     extent_count: u64,
-    block_size: u64,
+    block_size: u32,
     csv: &mut Option<&mut csv::Writer<File>>,
 ) -> Result<()> {
-    let ct = ti.create_ds_region(
-        3810,
-        extent_size,
-        extent_count,
-        block_size as u32,
-        true,
-    )?;
+    let ct =
+        ti.create_ds_region(3810, extent_size, extent_count, block_size, true)?;
 
     let size = region_si(extent_size, extent_count, block_size);
     let extent_file_size = efile_si(extent_size, block_size);
@@ -384,8 +490,8 @@ fn single_create_test(
     if let Some(csv) = csv {
         csv.serialize((
             ct,
-            block_size * extent_size * extent_count,
-            block_size * extent_size,
+            block_size as u64 * extent_size * extent_count,
+            block_size as u64 * extent_size,
             extent_size,
             extent_count,
             block_size,
@@ -407,7 +513,7 @@ fn region_create_test(
     long: bool,
     csv_out: Option<PathBuf>,
 ) -> Result<()> {
-    let block_size = 4096;
+    let block_size: u32 = 4096;
 
     // The total region size we want for the test.  The total region
     // divided by the extent_size will give us the number of extents
@@ -463,7 +569,7 @@ fn region_create_test(
         for es in extent_size.iter() {
             // With power of 2 region sizes, the rs/es should always yield
             // a correct ec.
-            let ec = (rs / block_size) / es;
+            let ec = (rs / (block_size as u64)) / es;
             if long {
                 loop_create_test(ti, *es, ec, block_size)?;
             } else {
@@ -495,6 +601,7 @@ fn main() -> Result<()> {
             bail!("Remove region {:?} before running", args.region_dir);
         }
     }
+
     if !Path::new(&args.ds_bin).exists() {
         bail!("Can't find downstairs binary at {:?}", args.ds_bin);
     }
@@ -506,8 +613,19 @@ fn main() -> Result<()> {
         Commands::RegionPerf { long, csv_out } => {
             region_create_test(&mut ti, long, csv_out)?;
         }
-        Commands::Start => {
-            create_and_run(&mut ti)?;
+        Commands::Start {
+            block_size,
+            extent_size,
+            extent_count,
+        } => {
+            create_region_set(
+                &mut ti,
+                extent_size,
+                extent_count,
+                block_size,
+                8810,
+            )?;
+            ti.start_all_downstairs();
         }
     }
     Ok(())

--- a/tools/test_perf.sh
+++ b/tools/test_perf.sh
@@ -30,7 +30,7 @@ function perf_round() {
     args="-t 127.0.0.1:8810 -t 127.0.0.1:8820 -t 127.0.0.1:8830 -c 4000 -q"
 
     echo Create region with ES:"$es" EC:"$ec"
-    "$dsc" start --cleanup --extent-size  "$es" --extent-count "$ec" &
+    "$dsc" start --ds-bin "$downstairs" --cleanup --extent-size  "$es" --extent-count "$ec" &
     dsc_pid=$!
     sleep 5
     pfiles $dsc_pid > /dev/null
@@ -58,9 +58,10 @@ fi
 
 cc="$BINDIR/crucible-client"
 dsc="$BINDIR/dsc"
+downstairs="$BINDIR/crucible-downstairs"
 outfile="/tmp/perfout.txt"
 
-for bin in $dsc $cc; do
+for bin in $dsc $cc $downstairs; do
     if [[ ! -f "$bin" ]]; then
         echo "Can't find crucible binary at $bin" >&2
         exit 1

--- a/tools/test_perf.sh
+++ b/tools/test_perf.sh
@@ -35,8 +35,8 @@ function perf_round() {
     sleep 5
     pfiles $dsc_pid > /dev/null
     echo "IOPs for es=$es ec=$ec" >> "$outfile"
-    echo "$cc" perf $args --perf-out perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
-    "$cc" perf $args --perf-out perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
+    echo "$cc" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
+    "$cc" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
     echo "" >> "$outfile"
     echo Perf test completed, stop all downstairs
     pkill -f -U "$(id -u)" downstairs

--- a/tools/test_perf.sh
+++ b/tools/test_perf.sh
@@ -27,7 +27,7 @@ function perf_round() {
     es=$1
     ec=$2
     # Args for crucible-client.  Using the default IP:port for dsc
-    args="-t 127.0.0.1:8810 -t 127.0.0.1:8820 -t 127.0.0.1:8830 -c 4000 -q"
+    args="-t 127.0.0.1:8810 -t 127.0.0.1:8820 -t 127.0.0.1:8830 -c 16000 -q"
 
     echo Create region with ES:"$es" EC:"$ec"
     "$dsc" start --ds-bin "$downstairs" --cleanup --extent-size  "$es" --extent-count "$ec" &
@@ -82,6 +82,8 @@ perf_round 32768  800
 echo ""
 grep TEST $outfile | head -1
 grep rwrites $outfile
+echo ""
+grep TEST $outfile | head -1
 grep rreads $outfile
 
 echo "Perf test finished on $(date)" | tee -a "$outfile"

--- a/tools/test_perf.sh
+++ b/tools/test_perf.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Perf test shell script.
+
+set -o errexit
+set -o pipefail
+
+# Control-C to cleanup.
+trap ctrl_c INT
+function ctrl_c() {
+    echo "Stopping at your request"
+    pkill -f -U "$(id -u)" downstairs
+    if [[ -n "$dsc_pid" ]]; then
+        kill "$dsc_pid"
+    fi
+    exit 1
+}
+
+# Create a region with the given extent_size ($1) and extent_count ($2)
+# Once created, run the client perf test on that region, recording the
+# output to a csv file.
+function perf_round() {
+    if [[ $# -ne 2 ]]; then
+        echo "Missing EC and ES for perf_round()"
+        exit -1
+    fi
+    es=$1
+    ec=$2
+    # Args for crucible-client.  Using the default IP:port for dsc
+    args="-t 127.0.0.1:8810 -t 127.0.0.1:8820 -t 127.0.0.1:8830 -c 4000 -q"
+
+    echo Create region with ES:"$es" EC:"$ec"
+    "$dsc" start --cleanup --extent-size  "$es" --extent-count "$ec" &
+    dsc_pid=$!
+    sleep 5
+    pfiles $dsc_pid > /dev/null
+    echo "IOPs for es=$es ec=$ec" >> "$outfile"
+    echo "$cc" perf $args --perf-out perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
+    "$cc" perf $args --perf-out perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
+    echo "" >> "$outfile"
+    echo Perf test completed, stop all downstairs
+    pkill -f -U "$(id -u)" downstairs
+    kill $dsc_pid
+    wait $dsc_pid || true
+}
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+BINDIR=${BINDIR:-$ROOT/target/release}
+
+echo "$ROOT"
+cd "$ROOT"
+
+if pgrep -fl -U "$(id -u)" downstairs; then
+    echo "Downstairs already running"
+    echo Run: pkill -f -U "$(id -u)" downstairs
+    exit 1
+fi
+
+cc="$BINDIR/crucible-client"
+dsc="$BINDIR/dsc"
+outfile="/tmp/perfout.txt"
+
+for bin in $dsc $cc; do
+    if [[ ! -f "$bin" ]]; then
+        echo "Can't find crucible binary at $bin" >&2
+        exit 1
+    fi
+done
+
+echo "Perf test begins at $(date)" > "$outfile"
+
+#            ES   EC
+perf_round  4096 6400
+perf_round  8192 3200
+perf_round 16384 1600
+perf_round 32768  800
+
+# Print out a nice summary of all the perf results.  This depends
+# on the header and client perf output matching specific strings.
+# A hack, yes, sorry. We are in bash hell here.
+echo ""
+grep TEST $outfile | head -1
+grep rwrites $outfile
+grep rreads $outfile
+
+echo "Perf test finished on $(date)" | tee -a "$outfile"

--- a/tools/test_perf.sh
+++ b/tools/test_perf.sh
@@ -21,8 +21,8 @@ function ctrl_c() {
 # output to a csv file.
 function perf_round() {
     if [[ $# -ne 2 ]]; then
-        echo "Missing EC and ES for perf_round()"
-        exit -1
+        echo "Missing EC and ES for perf_round()" >&2
+        exit 1
     fi
     es=$1
     ec=$2
@@ -40,7 +40,7 @@ function perf_round() {
     echo "" >> "$outfile"
     echo Perf test completed, stop all downstairs
     pkill -f -U "$(id -u)" downstairs
-    kill $dsc_pid
+    kill $dsc_pid || true
     wait $dsc_pid || true
 }
 
@@ -51,8 +51,8 @@ echo "$ROOT"
 cd "$ROOT"
 
 if pgrep -fl -U "$(id -u)" downstairs; then
-    echo "Downstairs already running"
-    echo Run: pkill -f -U "$(id -u)" downstairs
+    echo "Downstairs already running" >&2
+    echo Run: pkill -f -U "$(id -u)" downstairs >&2
     exit 1
 fi
 


### PR DESCRIPTION
This adds the `crucible-client perf` test to buildomat.

Improved the display output for the perf test, 80 columns, more info, etc.
Added a header column to the generated CSV file.

New test `test_perf.sh` that loops over four different extent size and
extent count values (for the same 100Gib volume size)

Added some tests to the dsc binary.  There should be more here, but
it makes sense to better flush out how dsc will evolve before adding
too much more.
Updated dsc to take block_size, extent_size, extent_count as options
to the create_and_start test.
dsc auto generated UUID is based on the port number, but allows for
port numbers > 4 digits now.  Refactored the functions a bit in dsc to
better reflect what I want this to do, which I'm also still determining.

Perf test output looks like this (ignoring the upstairs log messages):
```                               
    TEST SECONDS COUNT DPTH    IOPS    MEAN    STDV     MIN      MAX    ES    EC
 rwrites  168.79 40000    1  236.98 0.00422 0.07472 0.00112  8.25378 32768   800
  rreads   56.54 40000    1  707.46 0.00141 0.00118 0.00012  0.01906 32768   800
 rwrites  118.69 40000    1  337.01 0.00297 0.00759 0.00105  0.85717 32768   800
  rreads   58.30 40000    1  686.08 0.00146 0.00118 0.00012  0.02447 32768   800
  ```

Still trying to decide how many loops the test should do itself.  That will
probably become another option to pass to the test.