### PR TITLE
Downstairs dump space and region error fix

### DIFF
--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -622,10 +622,15 @@ impl Extent {
             match OpenOptions::new().read(true).write(!read_only).open(&path) {
                 Err(e) => {
                     println!(
-                        "Error: {} No extent#{} file found for {:?}",
-                        e, number, path
+                        "Error: Open of {:?} for extent#{} returned: {}",
+                        path, number, e,
                     );
-                    bail!("Error: {} No extent file found for {:?}", e, path);
+                    bail!(
+                        "Open of {:?} for extent#{} returned: {}",
+                        path,
+                        number,
+                        e,
+                    );
                 }
                 Ok(f) => {
                     let cur_size = f.metadata().unwrap().len();
@@ -647,14 +652,14 @@ impl Extent {
         let metadb = match open_sqlite_connection(&path) {
             Err(e) => {
                 println!(
-                    "Error: {} No extent#{} db file found for {:?}",
-                    e, number, path
+                    "Error: Open of db file {:?} for extent#{} returned: {}",
+                    path, number, e
                 );
                 bail!(
-                    "Error: {} No extent#{} db file found for {:?}",
-                    e,
+                    "Open of db file {:?} for extent#{} returned: {}",
+                    path,
                     number,
-                    path
+                    e,
                 );
             }
             Ok(m) => m,


### PR DESCRIPTION
Updated downstairs dump command to do a better job of displaying
generation numbers and flush numbers in matching columns.

Updated some misleading error messages when opening an extent
or extent database file fails.

Dump when one extent has a shorter generation number:
```
final:dsdrop$ cdump.sh
cargo run -p crucible-downstairs -- dump -d var/8810 -d var/8820 -d var/8830
    Blocking waiting for file lock on build directory
   Compiling crucible-downstairs v0.0.1 (/Users/alan/Oxide/ws/dsdrop/downstairs)
    Finished dev [unoptimized + debuginfo] target(s) in 8.35s
     Running `target/debug/crucible-downstairs dump -d var/8810 -d var/8820 -d var/8830`
EXT  BLOCKS   GEN0   GEN1   GEN2     FL0    FL1    FL2  D0 D1 D2
  0 000-008  10001  10001  10001   10440  10440  10440   T  T  T
  1 009-017  10001  10001  10001   10440  10440  10440   F  F  F
  2 018-026  10001  10001  10001   10440  10440  10440   F  F  F
  3 027-035  10000  10000  10000   10439  10439  10439   F  F  F
  4 036-044  10000  10000  10000   10439  10439  10439   T  T  T
  5 045-053  10000  10000  10000   10437  10437  10437   T  T  T
  6 054-062  10001  10001  10001   10440  10440  10440   F  F  F
  7 063-071  10001  10001  10001   10440  10440  10440   F  F  F
  8 072-080   9999   9999   9999   10435  10435  10435   T  T  T
  9 081-089  10001  10001  10001   10440  10440  10440   F  F  F
Max gen: 10001,  Max flush: 10440
```
Dump when  one column of generation numbers is larger than the others:
```
final:dsdrop$ cargo run -p crucible-downstairs -- dump -d ../crucible/var/8810 -d ../crucible/var/8820 -d ../stock/var/8830
    Finished dev [unoptimized + debuginfo] target(s) in 0.29s
     Running `target/debug/crucible-downstairs dump -d ../crucible/var/8810 -d ../crucible/var/8820 -d ../stock/var/8830`
EXT    BLOCKS GEN0 GEN1 GEN2    FL0   FL1   FL2  D0 D1 D2
  0 0000-0099   21   21   25    760   760  1263   F  F  F
  1 0100-0199   21   21   25    760   760  1268   F  F  T
  2 0200-0299   21   21   25    760   760  1257   F  F  F
  3 0300-0399   21   21   25    760   760  1264   F  F  T
  4 0400-0499   21   21   25    760   760  1268   F  F  T
  5 0500-0599   21   21   25    760   760  1265   F  F  T
  6 0600-0699   21   21   25    760   760  1258   F  F  F
  7 0700-0799   21   21   25    760   760  1265   F  F  F
  8 0800-0899   21   21   25    760   760  1259   F  F  F
  9 0900-0999   21   21   25    760   760  1267   F  F  F
 10 1000-1099   21   21   25    760   760  1259   F  F  F
 11 1100-1199   21   21   25    760   760  1268   F  F  T
 12 1200-1299   21   21   25    760   760  1263   F  F  T
 13 1300-1399   21   21   25    760   760  1267   F  F  F
 14 1400-1499   21   21   25    760   760  1257   F  F  F
 15 1500-1599   20   20   25    686   686  1263   F  F  F
 16 1600-1699   20   20   25    686   686  1261   F  F  F
 17 1700-1799   20   20   25    686   686  1263   F  F  F
 18 1800-1899   20   20   25    686   686  1252   F  F  T
 19 1900-1999   20   20   25    686   686  1261   F  F  F
Max gen: 25,  Max flush: 1268
Error: Difference in extent metadata found!
```