### PR TITLE
Repair only what is needed, and other misc updates

### DIFF
--- a/.github/buildomat/jobs/build.sh
+++ b/.github/buildomat/jobs/build.sh
@@ -27,7 +27,7 @@ for t in crucible-downstairs crucible-client crucible-hammer dsc; do
 done
 
 mkdir -p /work/scripts
-for s in tools/create-generic-ds.sh tools/test_repair.sh tools/test_up.sh tools/test_ds.sh; do
+for s in tools/test_repair.sh tools/test_up.sh tools/test_ds.sh; do
 	cp "$s" /work/scripts/
 done
 

--- a/.github/buildomat/jobs/build.sh
+++ b/.github/buildomat/jobs/build.sh
@@ -27,7 +27,7 @@ for t in crucible-downstairs crucible-client crucible-hammer dsc; do
 done
 
 mkdir -p /work/scripts
-for s in tools/test_repair.sh tools/test_up.sh tools/test_ds.sh; do
+for s in tools/create-generic-ds.sh tools/test_repair.sh tools/test_up.sh tools/test_ds.sh; do
 	cp "$s" /work/scripts/
 done
 

--- a/.github/buildomat/jobs/build.sh
+++ b/.github/buildomat/jobs/build.sh
@@ -27,7 +27,7 @@ for t in crucible-downstairs crucible-client crucible-hammer dsc; do
 done
 
 mkdir -p /work/scripts
-for s in tools/test_up.sh tools/test_ds.sh; do
+for s in tools/test_repair.sh tools/test_up.sh tools/test_ds.sh; do
 	cp "$s" /work/scripts/
 done
 

--- a/.github/buildomat/jobs/test-repair.sh
+++ b/.github/buildomat/jobs/test-repair.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #:
-#: name = "test-up-repair"
+#: name = "test-repair"
 #: variety = "basic"
 #: target = "helios"
 #: output_rules = [
@@ -35,7 +35,6 @@ for t in "$input/bins/"*.gz; do
 done
 
 export BINDIR=/var/tmp/bins
-export SCRIPTDIR="$input"/scripts
 
 banner repair
 ptime -m bash "$input/scripts/test_repair.sh"

--- a/.github/buildomat/jobs/test-repair.sh
+++ b/.github/buildomat/jobs/test-repair.sh
@@ -19,6 +19,8 @@ set -o xtrace
 
 echo "input bins dir contains:"
 ls -ltr "$input"/bins || true
+echo "input script dir contains:"
+ls -ltr "$input"/scripts || true
 
 banner unpack
 mkdir -p /var/tmp/bins
@@ -30,6 +32,7 @@ for t in "$input/bins/"*.gz; do
 done
 
 export BINDIR=/var/tmp/bins
+export SCRIPTDIR="$input"/scripts
 
 banner repair
 ptime -m bash "$input/scripts/test_repair.sh"

--- a/.github/buildomat/jobs/test-repair.sh
+++ b/.github/buildomat/jobs/test-repair.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#:
+#: name = "test-up-repair"
+#: variety = "basic"
+#: target = "helios"
+#: output_rules = [
+#:	"/tmp/*.txt",
+#: ]
+#: skip_clone = true
+#:
+#: [dependencies.build]
+#: job = "build"
+
+input="/input/build/work"
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+echo "input bins dir contains:"
+ls -ltr "$input"/bins || true
+
+banner unpack
+mkdir -p /var/tmp/bins
+for t in "$input/bins/"*.gz; do
+	b=$(basename "$t")
+	b=${b%.gz}
+	gunzip < "$t" > "/var/tmp/bins/$b"
+	chmod +x "/var/tmp/bins/$b"
+done
+
+export BINDIR=/var/tmp/bins
+
+banner repair
+ptime -m bash "$input/scripts/test_repair.sh"
+
+# Save the output files?

--- a/.github/buildomat/jobs/test-repair.sh
+++ b/.github/buildomat/jobs/test-repair.sh
@@ -37,6 +37,6 @@ done
 export BINDIR=/var/tmp/bins
 
 banner repair
-ptime -m bash "$input/scripts/test_repair.sh"
+ptime -m bash "$input/scripts/test_repair.sh" "-N"
 
 # Save the output files?

--- a/.github/buildomat/jobs/test-repair.sh
+++ b/.github/buildomat/jobs/test-repair.sh
@@ -21,6 +21,9 @@ echo "input bins dir contains:"
 ls -ltr "$input"/bins || true
 echo "input script dir contains:"
 ls -ltr "$input"/scripts || true
+pfexec chmod +x "$input"/scripts/* || true
+echo " chmod input script dir contains:"
+ls -ltr "$input"/scripts || true
 
 banner unpack
 mkdir -p /var/tmp/bins

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1810,7 +1810,7 @@ async fn repair_workload(
             let offset =
                 Block::new(block_index as u64, ri.block_size.trailing_zeros());
 
-            if one_write == false || op <= 4 {
+            if !one_write || op <= 4 {
                 // Write
                 one_write = true;
                 // Update the write count for all blocks we plan to write to.

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -93,6 +93,10 @@ enum Args {
          */
         #[structopt(short, long)]
         only_show_differences: bool,
+
+        /// No color output
+        #[structopt(long)]
+        no_color: bool,
     },
     Export {
         /*
@@ -214,11 +218,12 @@ async fn main() -> Result<()> {
             extent,
             block,
             only_show_differences,
+            no_color,
         } => {
             if data.is_empty() {
                 bail!("Need at least one data directory to dump");
             }
-            dump_region(data, extent, block, only_show_differences)?;
+            dump_region(data, extent, block, only_show_differences, no_color)?;
             Ok(())
         }
         Args::Export {

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -2598,7 +2598,7 @@ mod test {
         /*
          * Dump the region
          */
-        dump_region(dvec, None, None, false)?;
+        dump_region(dvec, None, None, false, false)?;
 
         Ok(())
     }
@@ -2630,7 +2630,7 @@ mod test {
         /*
          * Dump the region
          */
-        dump_region(dvec, None, None, false)?;
+        dump_region(dvec, None, None, false, false)?;
 
         Ok(())
     }
@@ -2663,7 +2663,7 @@ mod test {
         /*
          * Dump the region
          */
-        dump_region(dvec, Some(2), None, false)?;
+        dump_region(dvec, Some(2), None, false, false)?;
 
         Ok(())
     }

--- a/tools/create-generic-ds.sh
+++ b/tools/create-generic-ds.sh
@@ -3,8 +3,14 @@
 # A hack of downstairs create tool
 
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
-
 cd "$ROOT" || (echo failed to cd "$ROOT"; exit 1)
+export BINDIR=${BINDIR:-$ROOT/target/debug}
+
+cds="$BINDIR/crucible-downstairs"
+if [[ ! -f "$cds" ]]; then
+    echo "Can't find crucible binary at $cds" >&2
+    exit 1
+fi
 
 usage () {
     echo "Usage: $0 [de] [-b #] [-c #] [-s #]" >&2
@@ -59,15 +65,6 @@ if [[ $delete -eq 1 ]]; then
 else
     if [[ -d var/8810 ]] || [[ -d var/8820 ]] || [[ -d var/8830 ]]; then
         echo " var/88.. directories are already present"
-        exit 1
-    fi
-fi
-
-cds="./target/release/crucible-downstairs"
-if [[ ! -f ${cds} ]]; then
-    cds="./target/debug/crucible-downstairs"
-    if [[ ! -f ${cds} ]]; then
-        echo "Can't find crucible binary at $cds"
         exit 1
     fi
 fi

--- a/tools/create-generic-ds.sh
+++ b/tools/create-generic-ds.sh
@@ -3,14 +3,8 @@
 # A hack of downstairs create tool
 
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
-cd "$ROOT" || (echo failed to cd "$ROOT"; exit 1)
-export BINDIR=${BINDIR:-$ROOT/target/debug}
 
-cds="$BINDIR/crucible-downstairs"
-if [[ ! -f "$cds" ]]; then
-    echo "Can't find crucible binary at $cds" >&2
-    exit 1
-fi
+cd "$ROOT" || (echo failed to cd "$ROOT"; exit 1)
 
 usage () {
     echo "Usage: $0 [de] [-b #] [-c #] [-s #]" >&2
@@ -65,6 +59,15 @@ if [[ $delete -eq 1 ]]; then
 else
     if [[ -d var/8810 ]] || [[ -d var/8820 ]] || [[ -d var/8830 ]]; then
         echo " var/88.. directories are already present"
+        exit 1
+    fi
+fi
+
+cds="./target/release/crucible-downstairs"
+if [[ ! -f ${cds} ]]; then
+    cds="./target/debug/crucible-downstairs"
+    if [[ ! -f ${cds} ]]; then
+        echo "Can't find crucible binary at $cds"
         exit 1
     fi
 fi

--- a/tools/test_repair.sh
+++ b/tools/test_repair.sh
@@ -15,10 +15,13 @@ function ctrl_c() {
 }
 
 function cleanup() {
-    kill "$ds0_pid" 2> /dev/null
-    kill "$ds1_pid" 2> /dev/null
-    kill "$ds2_pid" 2> /dev/null
+    kill "$ds0_pid" 2> /dev/null || true
+    kill "$ds1_pid" 2> /dev/null || true
+    kill "$ds2_pid" 2> /dev/null || true
 }
+
+set -o errexit
+set -o pipefail
 
 SECONDS=0
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
@@ -26,7 +29,7 @@ BINDIR=${BINDIR:-$ROOT/target/debug}
 
 cds="$BINDIR/crucible-downstairs"
 cc="$BINDIR/crucible-client"
-for bin in $cds $cc $ch; do
+for bin in $cds $cc; do
     if [[ ! -f "$bin" ]]; then
         echo "Can't find crucible binary at $bin" >&2
         exit 1
@@ -77,17 +80,17 @@ for (( i = 0; i < 10; i += 1 )); do
     # stop a downstairs and restart with lossy
     if [[ $choice -eq 0 ]]; then
         kill "$ds0_pid"
-        wait "$ds0_pid"
+        wait "$ds0_pid" || true
         ${cds} run -d var/8810 -p 8810 --lossy &> "$ds_log_prefix"8810.txt &
         ds0_pid=$!
     elif [[ $choice -eq 1 ]]; then
         kill "$ds1_pid"
-        wait "$ds1_pid"
+        wait "$ds1_pid" || true
         ${cds} run -d var/8820 -p 8820 --lossy &> "$ds_log_prefix"8820.txt &
         ds1_pid=$!
     else
         kill "$ds2_pid"
-        wait "$ds2_pid"
+        wait "$ds2_pid" || true
         ${cds} run -d var/8830 -p 8830 --lossy &> "$ds_log_prefix"8830.txt &
         ds2_pid=$!
     fi
@@ -103,18 +106,20 @@ for (( i = 0; i < 10; i += 1 )); do
     # Stop --lossy downstairs so it can't complete all its IOs
     if [[ $choice -eq 0 ]]; then
         kill "$ds0_pid"
-        wait "$ds0_pid"
+        wait "$ds0_pid" || true
     elif [[ $choice -eq 1 ]]; then
         kill "$ds1_pid"
-        wait "$ds1_pid"
+        wait "$ds1_pid" || true
     else
         kill "$ds2_pid"
-        wait "$ds2_pid"
+        wait "$ds2_pid" || true
     fi
 
     # Did we get any mismatches?
+    # We || true because dump will return non-zero when it finds
+    # a mismatch
     echo "Current downstairs dump:"
-    ${cds} dump -d var/8810 -d var/8820 -d var/8830
+    ${cds} dump -d var/8810 -d var/8820 -d var/8830 || true
     echo "On loop $i"
 
     echo ""

--- a/tools/test_repair.sh
+++ b/tools/test_repair.sh
@@ -25,7 +25,7 @@ set -o pipefail
 
 SECONDS=0
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
-BINDIR=${BINDIR:-$ROOT/target/debug}
+export BINDIR=${BINDIR:-$ROOT/target/debug}
 
 cds="$BINDIR/crucible-downstairs"
 cc="$BINDIR/crucible-client"
@@ -72,7 +72,7 @@ then
 fi
 
 # Start loop
-for (( i = 0; i < 2; i += 1 )); do
+for (( i = 0; i < 10; i += 1 )); do
 
     choice=$((RANDOM % 3))
     echo ""

--- a/tools/test_repair.sh
+++ b/tools/test_repair.sh
@@ -36,7 +36,9 @@ for bin in $cds $cc; do
     fi
 done
 
-if ! ./tools/create-generic-ds.sh -d -c 30 -s 20; then
+SCRIPTDIR=${SCRIPTDIR:-$ROOT/tools}
+create_ds="$SCRIPTDIR/create-generic-ds.sh"
+if ! $create_ds -d -c 30 -s 20; then
     echo "Failed to create new region"
     exit 1
 fi
@@ -70,7 +72,7 @@ then
 fi
 
 # Start loop
-for (( i = 0; i < 10; i += 1 )); do
+for (( i = 0; i < 2; i += 1 )); do
 
     choice=$((RANDOM % 3))
     echo ""

--- a/tools/test_repair.sh
+++ b/tools/test_repair.sh
@@ -42,6 +42,10 @@ if [[ -d ${testdir} ]]; then
     rm -rf ${testdir}
 fi
 
+verify_file=/tmp/repair_test_verify.data
+test_log=/tmp/verify_out.txt
+ds_log_prefix=/tmp/test_repair_ds
+
 # This is temporary hack until dsc is able to do this
 uuidprefix="12345678-1234-1234-1234-00000000"
 port_base=8810
@@ -49,12 +53,12 @@ args=()
 for (( i = 0; i < 3; i++ )); do
     (( port_step = i * 10 )) || true
     (( port = port_base + port_step )) || true
-	echo $port
+    echo $port
     dir="${testdir}/$port"
     uuid="${uuidprefix}${port}"
     args+=( -t "127.0.0.1:$port" )
-	echo "$cds" create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10
-	${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10
+    echo "$cds" create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10
+    ${cds} create -u "$uuid" -d "$dir" --extent-count 5 --extent-size 10
 done
 
 # Start all three downstairs
@@ -71,10 +75,6 @@ if [[ "$os_name" == 'Darwin' ]]; then
     codesign -s - -f "$cds"
     codesign -s - -f "$cc"
 fi
-
-verify_file=/tmp/repair_test_verify.data
-test_log=/tmp/verify_out.txt
-ds_log_prefix=/tmp/test_repair_ds
 
 target_args="-t 127.0.0.1:8810 -t 127.0.0.1:8820 -t 127.0.0.1:8830"
 # Do initial volume population.

--- a/tools/test_repair.sh
+++ b/tools/test_repair.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # A test to break, then Repair a downstairs region that is out of sync with
 # the other regions. We pick a downstairs at random and restart it with
@@ -20,14 +20,18 @@ function cleanup() {
     kill "$ds2_pid" 2> /dev/null
 }
 
-cargo build || echo "Failed to build"
+SECONDS=0
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+BINDIR=${BINDIR:-$ROOT/target/debug}
 
-cds="./target/debug/crucible-downstairs"
-cc="./target/debug/crucible-client"
-if [[ ! -f ${cds} ]] || [[ ! -f ${cc} ]]; then
-    echo "Can't find crucible binaries at $cds or $cc"
-    exit 1
-fi
+cds="$BINDIR/crucible-downstairs"
+cc="$BINDIR/crucible-client"
+for bin in $cds $cc $ch; do
+    if [[ ! -f "$bin" ]]; then
+        echo "Can't find crucible binary at $bin" >&2
+        exit 1
+    fi
+done
 
 if ! ./tools/create-generic-ds.sh -d -c 30 -s 20; then
     echo "Failed to create new region"
@@ -35,11 +39,11 @@ if ! ./tools/create-generic-ds.sh -d -c 30 -s 20; then
 fi
 
 # Start all three downstairs
-${cds} run -d var/8810 -p 8810 &> /tmp/ds8810 &
+${cds} run -d var/8810 -p 8810 &> "$ds_log_prefix"8810.txt &
 ds0_pid=$!
-${cds} run -d var/8820 -p 8820 &> /tmp/ds8820 &
+${cds} run -d var/8820 -p 8820 &> "$ds_log_prefix"8820.txt &
 ds1_pid=$!
-${cds} run -d var/8830 -p 8830 &> /tmp/ds8830 &
+${cds} run -d var/8830 -p 8830 &> "$ds_log_prefix"8830.txt &
 ds2_pid=$!
 
 os_name=$(uname)
@@ -50,19 +54,20 @@ if [[ "$os_name" == 'Darwin' ]]; then
 fi
 
 verify_file=/tmp/repair_test_verify.data
-test_log=/tmp/verify_out
+test_log=/tmp/verify_out.txt
+ds_log_prefix=/tmp/test_repair_ds
 
 target_args="-t 127.0.0.1:8810 -t 127.0.0.1:8820 -t 127.0.0.1:8830"
 # Do initial volume population.
 if ! ${cc} fill ${target_args} --verify-out "$verify_file" -q
 then
-    echo "Exit on initial fill"
+    echo "ERROR: Exit on initial fill"
     cleanup
     exit 1
 fi
 
 # Start loop
-for (( i = 0; i < 900; i += 1 )); do
+for (( i = 0; i < 10; i += 1 )); do
 
     choice=$((RANDOM % 3))
     echo ""
@@ -73,17 +78,17 @@ for (( i = 0; i < 900; i += 1 )); do
     if [[ $choice -eq 0 ]]; then
         kill "$ds0_pid"
         wait "$ds0_pid"
-        ${cds} run -d var/8810 -p 8810 --lossy &> /tmp/ds8810 &
+        ${cds} run -d var/8810 -p 8810 --lossy &> "$ds_log_prefix"8810.txt &
         ds0_pid=$!
     elif [[ $choice -eq 1 ]]; then
         kill "$ds1_pid"
         wait "$ds1_pid"
-        ${cds} run -d var/8820 -p 8820 --lossy &> /tmp/ds8820 &
+        ${cds} run -d var/8820 -p 8820 --lossy &> "$ds_log_prefix"8820.txt &
         ds1_pid=$!
     else
         kill "$ds2_pid"
         wait "$ds2_pid"
-        ${cds} run -d var/8830 -p 8830 --lossy &> /tmp/ds8830 &
+        ${cds} run -d var/8830 -p 8830 --lossy &> "$ds_log_prefix"8830.txt &
         ds2_pid=$!
     fi
 
@@ -106,24 +111,22 @@ for (( i = 0; i < 900; i += 1 )); do
         kill "$ds2_pid"
         wait "$ds2_pid"
     fi
-    sleep 2
 
     # Did we get any mismatches?
     echo "Current downstairs dump:"
     ${cds} dump -d var/8810 -d var/8820 -d var/8830
     echo "On loop $i"
 
-    sleep 2
     echo ""
     # Start downstairs without lossy
     if [[ $choice -eq 0 ]]; then
-        ${cds} run -d var/8810 -p 8810 &> /tmp/ds8810 &
+        ${cds} run -d var/8810 -p 8810 &> "$ds_log_prefix"8810.txt &
         ds0_pid=$!
     elif [[ $choice -eq 1 ]]; then
-        ${cds} run -d var/8820 -p 8820 &> /tmp/ds8820 &
+        ${cds} run -d var/8820 -p 8820 &> "$ds_log_prefix"8820.txt &
         ds1_pid=$!
     else
-        ${cds} run -d var/8830 -p 8830 &> /tmp/ds8830 &
+        ${cds} run -d var/8830 -p 8830 &> "$ds_log_prefix"8830.txt &
         ds2_pid=$!
     fi
 
@@ -137,20 +140,12 @@ for (( i = 0; i < 900; i += 1 )); do
         exit 1
     fi
 
-    # XXX This check is here because we don't yet have a way of getting
-    # error status from the upstairs to indicate this has happened.
-	if grep "read hash mismatch" "$test_log"; then
-        echo "Found Mismatch"
-        echo "" >> "$test_log".new
-        echo "loop $i, choice: $choice" >> "$test_log".new
-        echo $(date) >> "$test_log".new
-        cat "$test_log" >> "$test_log".new
-    fi
-
     echo "Loop: $i  Downstairs dump after verify (and repair):"
     ${cds} dump -d var/8810 -d var/8820 -d var/8830
 
 done
 
-echo "Tests all done at $(date)"
+duration=$SECONDS
+printf "%d:%02d Test duration\n" $((duration / 60)) $((duration % 60))
+echo "Test completed"
 cleanup


### PR DESCRIPTION
Fixed the issue where the repair process would repair extents that don't need to be repaired.
https://github.com/oxidecomputer/crucible/issues/275
That was actually just a few line fix.  

However, once I fixed it, that then pushed me to polish up the repair test so I could run it in 
buildomat.  A little work there getting the right things added to build scripts, a few false
starts and, eventually, I hacked the right things together.

And, once I started that, I discovered that the pretty colors the downstairs dump command
prints were not translating well to the buildomat logs.  So, then I had to change
the dump command to have a no color option.

So, 8 files with 202 additions and 85 deletions later we have this PR.

Here is the original colored output:
```
329 | 2022-05-16T23:55:32.031Z | Current downstairs dump:
330 | 2022-05-16T23:55:32.038Z | EXT  BLOCKS GEN0 GEN1 GEN2  FL0 FL1 FL2  D0 D1 D2
331 | 2022-05-16T23:55:32.044Z | 0 000-009 [32m   1 [32m   1 [32m   1[0m  [32m  1 [32m  1 [32m  1[0m   [32mF  [31mT  [31mT[0m
332 | 2022-05-16T23:55:32.049Z | 1 010-019 [31m   1 [32m   2 [32m   2[0m  [31m  1 [32m  2 [32m  2[0m   [31mT  [31mT  [31mT[0m
333 | 2022-05-16T23:55:32.056Z | 2 020-029 [31m   1 [32m   2 [32m   2[0m  [31m  1 [32m  3 [32m  3[0m   [31mT  [31mT  [31mT[0m
334 | 2022-05-16T23:55:32.062Z | 3 030-039 [31m   1 [32m   2 [32m   2[0m  [31m  1 [32m  3 [32m  3[0m   [32mF  [31mT  [31mT[0m
335 | 2022-05-16T23:55:32.068Z | 4 040-049 [31m   1 [32m   2 [32m   2[0m  [31m  1 [32m  3 [32m  3[0m   [32mF  [31mT  [31mT[0m
336 | 2022-05-16T23:55:32.074Z | Max gen: 2,  Max flush: 3
```

And, here is dump without color, much more readable:
```
335 | 2022-05-17T04:55:54.451Z | EXT  BLOCKS GEN0 GEN1 GEN2  FL0 FL1 FL2  D0 D1 D2 DIFF
336 | 2022-05-17T04:55:54.457Z | 0 000-019    1    1    1    1   1   1   F  F  F
337 | 2022-05-17T04:55:54.463Z | 1 020-039    2    1    2    4   1   4   F  F  F <---
338 | 2022-05-17T04:55:54.468Z | 2 040-059    2    1    2    4   1   4   T  F  T <---
339 | 2022-05-17T04:55:54.474Z | 3 060-079    2    1    2    3   1   3   F  F  F <---
340 | 2022-05-17T04:55:54.479Z | 4 080-099    1    1    1    1   1   1   F  F  F
341 | 2022-05-17T04:55:54.485Z | 5 100-119    1    1    1    1   1   1   F  F  F
342 | 2022-05-17T04:55:54.491Z | 6 120-139    2    1    2    4   1   4   F  F  F <---
343 | 2022-05-17T04:55:54.497Z | 7 140-159    2    1    2    4   1   4   F  F  F <---
344 | 2022-05-17T04:55:54.503Z | 8 160-179    1    1    1    1   1   1   F  F  F
345 | 2022-05-17T04:55:54.509Z | 9 180-199    1    1    1    1   1   1   F  F  F
```

I put back the `DIFF` column with arrows that @jmpesp had there before to 
draw attention to the diffs when color option is not chosen.

And, fixed a clippy lint.