### PR TITLE
buildomat images should use --all-features

### DIFF
--- a/.github/buildomat/jobs/image.sh
+++ b/.github/buildomat/jobs/image.sh
@@ -27,7 +27,7 @@ cargo --version
 rustc --version
 
 banner build
-ptime -m cargo build --release --verbose
+ptime -m cargo build --release --verbose --all-features
 
 banner image
 ptime -m cargo run --bin crucible-package


### PR DESCRIPTION
zfs_snapshot is not a default downstairs feature, make sure to build
with --all-features.