### PR TITLE
Grow the abilities of the dsc program.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,7 +539,7 @@ dependencies = [
  "toml",
  "tracing",
  "usdt",
- "uuid",
+ "uuid 1.0.0",
  "version_check",
 ]
 
@@ -566,7 +566,7 @@ dependencies = [
  "structopt",
  "subprocess",
  "tokio",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -610,7 +610,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.0",
  "toml",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -627,7 +627,7 @@ dependencies = [
  "tokio-rustls",
  "toml",
  "twox-hash",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -692,7 +692,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "uuid",
+ "uuid 1.0.0",
  "version_check",
 ]
 
@@ -726,7 +726,7 @@ dependencies = [
  "httptest",
  "tempfile",
  "tokio",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -770,7 +770,7 @@ dependencies = [
  "crucible-common",
  "serde",
  "tokio-util 0.7.0",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -959,7 +959,7 @@ dependencies = [
  "tokio-rustls",
  "toml",
  "usdt",
- "uuid",
+ "uuid 1.0.0",
  "version_check",
 ]
 
@@ -983,8 +983,18 @@ dependencies = [
  "byte-unit",
  "clap 3.1.16",
  "csv",
+ "dropshot",
+ "expectorate",
+ "openapi-lint",
+ "openapiv3",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "schemars",
+ "serde",
+ "serde_json",
  "statistical",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -1829,7 +1839,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -1996,7 +2006,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-postgres",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -2165,7 +2175,7 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -2196,7 +2206,7 @@ dependencies = [
  "slog-dtrace",
  "thiserror",
  "tokio",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -2409,7 +2419,7 @@ dependencies = [
  "chrono",
  "fallible-iterator",
  "postgres-protocol",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -2965,7 +2975,8 @@ dependencies = [
  "schemars_derive",
  "serde",
  "serde_json",
- "uuid",
+ "uuid 0.8.2",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -3344,7 +3355,7 @@ dependencies = [
  "slog",
  "thiserror",
  "tokio",
- "uuid",
+ "uuid 1.0.0",
 ]
 
 [[package]]
@@ -4113,6 +4124,12 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"

--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -9,7 +9,17 @@ anyhow = "1"
 byte-unit = "4.0.14"
 clap = { version = "3.1.16", features = ["derive", "env"] }
 csv = "1.1.6"
+dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
+rand = "0.8.5"
+rand_chacha = "0.3.1"
+schemars = { version = "0.8.8", features = [ "uuid" ] }
+serde = { version = "1", features = ["derive"] }
 statistical = "1.0.0"
+tokio = { version = "1.18.1", features = ["full"] }
 
 [dev-dependencies]
+expectorate = "1.0.5"
+openapiv3 = "1.0.1"
+openapi-lint = { git = "https://github.com/oxidecomputer/openapi-lint" }
 tempfile = "3"
+serde_json = "1"

--- a/dsc/src/control.rs
+++ b/dsc/src/control.rs
@@ -1,0 +1,384 @@
+// Copyright 2022 Oxide Computer Company
+use dropshot::endpoint;
+use dropshot::ApiDescription;
+use dropshot::ConfigDropshot;
+use dropshot::ConfigLogging;
+use dropshot::ConfigLoggingLevel;
+use dropshot::HttpError;
+use dropshot::HttpServerStarter;
+use dropshot::Path;
+use dropshot::RequestContext;
+use dropshot::{HttpResponseOk, HttpResponseUpdatedNoContent};
+use schemars::JsonSchema;
+use serde::Deserialize;
+//use serde::Serialize;
+use std::sync::Arc;
+
+use super::*;
+
+pub(crate) fn build_api() -> ApiDescription<DownstairsControl> {
+    let mut api = ApiDescription::new();
+    api.register(dsc_get_state).unwrap();
+    api.register(dsc_get_pid).unwrap();
+    api.register(dsc_stop).unwrap();
+    api.register(dsc_stop_all).unwrap();
+    api.register(dsc_stop_rand).unwrap();
+    api.register(dsc_start).unwrap();
+    api.register(dsc_start_all).unwrap();
+    api.register(dsc_disable_restart).unwrap();
+    api.register(dsc_disable_restart_all).unwrap();
+    api.register(dsc_enable_restart).unwrap();
+    api.register(dsc_enable_restart_all).unwrap();
+
+    api
+}
+
+/**
+ * Start up a dropshot server. This offers a way to control which downstairs
+ * are running and determine their state.
+ */
+pub async fn begin(dsci: Arc<DscInfo>, addr: SocketAddr) -> Result<(), String> {
+    // Setup dropshot
+    let config_dropshot = ConfigDropshot {
+        bind_address: addr,
+        request_body_max_bytes: 1024,
+        tls: None,
+    };
+    println!("start access at:{:?}", addr);
+
+    let config_logging = ConfigLogging::StderrTerminal {
+        level: ConfigLoggingLevel::Info,
+    };
+    let log = config_logging
+        .to_logger("example-basic")
+        .map_err(|error| format!("failed to create logger: {}", error))?;
+
+    // Build a description of the API.
+    let api = build_api();
+
+    // The functions that implement our API endpoints will share this
+    // context.
+    let api_context = DownstairsControl::new(&dsci);
+
+    /*
+     * Set up the server.
+     */
+    let server =
+        HttpServerStarter::new(&config_dropshot, api, api_context, &log)
+            .map_err(|error| format!("failed to create server: {}", error))?
+            .start();
+
+    println!("Control access at:{:?}", addr);
+    /*
+     * Wait for the server to stop.  Note that there's not any code to shut
+     * down this server, so we should never get past this point.
+     */
+    server.await
+}
+
+/**
+ * The state shared by handler functions
+ */
+pub struct DownstairsControl {
+    /**
+     * The dsc struct that holds info on what the dsc is doing.
+     */
+    dsci: Arc<DscInfo>,
+}
+
+impl DownstairsControl {
+    /**
+     * Return a new DownstairsControl.
+     */
+    pub fn new(dsci: &Arc<DscInfo>) -> DownstairsControl {
+        DownstairsControl { dsci: dsci.clone() }
+    }
+}
+
+#[derive(Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Cid {
+    cid: usize,
+}
+
+fn cid_bad(dsci: &DscInfo, cid: usize) -> bool {
+    let rs = dsci.rs.lock().unwrap();
+    rs.ds_state.len() <= cid
+}
+
+/**
+ * Fetch the reported pid for the requested client_id
+ */
+#[endpoint {
+    method = GET,
+    path = "/pid/cid/{cid}",
+}]
+async fn dsc_get_pid(
+    rqctx: Arc<RequestContext<DownstairsControl>>,
+    path: Path<Cid>,
+) -> Result<HttpResponseOk<Option<u32>>, HttpError> {
+    let path = path.into_inner();
+    let cid = path.cid;
+    let api_context = rqctx.context();
+
+    if cid_bad(&api_context.dsci, cid) {
+        return Err(HttpError::for_bad_request(
+            Some(String::from("BadInput")),
+            format!("Invalid client id: {}", cid),
+        ));
+    }
+    let ds_pid = api_context.dsci.get_ds_pid(cid).map_err(|e| {
+        HttpError::for_bad_request(
+            None,
+            format!("failed to state for downstairs {}: {:#}", 0, e),
+        )
+    })?;
+
+    Ok(HttpResponseOk(ds_pid))
+}
+
+/**
+ * Fetch the current state for the requested client_id
+ */
+#[endpoint {
+    method = GET,
+    path = "/state/cid/{cid}",
+}]
+async fn dsc_get_state(
+    rqctx: Arc<RequestContext<DownstairsControl>>,
+    path: Path<Cid>,
+) -> Result<HttpResponseOk<DownstairsState>, HttpError> {
+    let path = path.into_inner();
+    let cid = path.cid;
+    let api_context = rqctx.context();
+
+    if cid_bad(&api_context.dsci, cid) {
+        return Err(HttpError::for_bad_request(
+            None,
+            format!("Invalid client id: {}", cid),
+        ));
+    }
+    let ds_state = api_context.dsci.get_ds_state(cid).map_err(|e| {
+        HttpError::for_bad_request(
+            None,
+            format!("failed to state for downstairs {}: {:#}", 0, e),
+        )
+    })?;
+
+    Ok(HttpResponseOk(ds_state))
+}
+
+/**
+ * Stop the downstairs at the given client_id
+ */
+#[endpoint {
+    method = GET,
+    path = "/stop/cid/{cid}",
+}]
+async fn dsc_stop(
+    rqctx: Arc<RequestContext<DownstairsControl>>,
+    path: Path<Cid>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let path = path.into_inner();
+    let cid = path.cid;
+    let api_context = rqctx.context();
+
+    if cid_bad(&api_context.dsci, cid) {
+        return Err(HttpError::for_bad_request(
+            None,
+            format!("Invalid client id: {}", cid),
+        ));
+    }
+    let mut dsc_work = api_context.dsci.work.lock().unwrap();
+    dsc_work.add_cmd(DscCmd::Stop(cid));
+    Ok(HttpResponseUpdatedNoContent())
+}
+/**
+ * Stop all downstairs
+ */
+#[endpoint {
+    method = GET,
+    path = "/stop/all",
+}]
+async fn dsc_stop_all(
+    rqctx: Arc<RequestContext<DownstairsControl>>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let api_context = rqctx.context();
+
+    let mut dsc_work = api_context.dsci.work.lock().unwrap();
+    dsc_work.add_cmd(DscCmd::StopAll);
+    Ok(HttpResponseUpdatedNoContent())
+}
+
+/**
+ * Stop a random downstairs
+ */
+#[endpoint {
+    method = GET,
+    path = "/stop/rand",
+}]
+async fn dsc_stop_rand(
+    rqctx: Arc<RequestContext<DownstairsControl>>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let api_context = rqctx.context();
+
+    let mut dsc_work = api_context.dsci.work.lock().unwrap();
+    dsc_work.add_cmd(DscCmd::StopRand);
+    Ok(HttpResponseUpdatedNoContent())
+}
+
+/**
+ * Start the downstairs at the given client_id
+ */
+#[endpoint {
+    method = GET,
+    path = "/start/cid/{cid}",
+}]
+async fn dsc_start(
+    rqctx: Arc<RequestContext<DownstairsControl>>,
+    path: Path<Cid>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let path = path.into_inner();
+    let cid = path.cid;
+    let api_context = rqctx.context();
+
+    if cid_bad(&api_context.dsci, cid) {
+        return Err(HttpError::for_bad_request(
+            None,
+            format!("Invalid client id: {}", cid),
+        ));
+    }
+    let mut dsc_work = api_context.dsci.work.lock().unwrap();
+    dsc_work.add_cmd(DscCmd::Start(cid));
+    Ok(HttpResponseUpdatedNoContent())
+}
+
+/**
+ * Start all the downstairs
+ */
+#[endpoint {
+    method = GET,
+    path = "/start/all",
+}]
+async fn dsc_start_all(
+    rqctx: Arc<RequestContext<DownstairsControl>>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let api_context = rqctx.context();
+
+    let mut dsc_work = api_context.dsci.work.lock().unwrap();
+    dsc_work.add_cmd(DscCmd::StartAll);
+    Ok(HttpResponseUpdatedNoContent())
+}
+
+/**
+ * Disable automatic restart on the given client_id
+ */
+#[endpoint {
+    method = GET,
+    path = "/disablerestart/cid/{cid}",
+}]
+async fn dsc_disable_restart(
+    rqctx: Arc<RequestContext<DownstairsControl>>,
+    path: Path<Cid>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let path = path.into_inner();
+    let cid = path.cid;
+    let api_context = rqctx.context();
+
+    if cid_bad(&api_context.dsci, cid) {
+        return Err(HttpError::for_bad_request(
+            None,
+            format!("Invalid client id: {}", cid),
+        ));
+    }
+    let mut dsc_work = api_context.dsci.work.lock().unwrap();
+    dsc_work.add_cmd(DscCmd::DisableRestart(cid));
+    Ok(HttpResponseUpdatedNoContent())
+}
+
+/**
+ * Disable automatic restart on all downstairs
+ */
+#[endpoint {
+    method = GET,
+    path = "/disablerestart/all",
+}]
+async fn dsc_disable_restart_all(
+    rqctx: Arc<RequestContext<DownstairsControl>>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let api_context = rqctx.context();
+
+    let mut dsc_work = api_context.dsci.work.lock().unwrap();
+    dsc_work.add_cmd(DscCmd::DisableRestartAll);
+    Ok(HttpResponseUpdatedNoContent())
+}
+
+/**
+ * Enable automatic restart on the given client_id
+ */
+#[endpoint {
+    method = GET,
+    path = "/enablerestart/cid/{cid}",
+}]
+async fn dsc_enable_restart(
+    rqctx: Arc<RequestContext<DownstairsControl>>,
+    path: Path<Cid>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let path = path.into_inner();
+    let cid = path.cid;
+    let api_context = rqctx.context();
+
+    if cid_bad(&api_context.dsci, cid) {
+        return Err(HttpError::for_bad_request(
+            None,
+            format!("Invalid client id: {}", cid),
+        ));
+    }
+    let mut dsc_work = api_context.dsci.work.lock().unwrap();
+    dsc_work.add_cmd(DscCmd::EnableRestart(cid));
+    Ok(HttpResponseUpdatedNoContent())
+}
+
+/**
+ * Enable automatic restart on all downstairs
+ */
+#[endpoint {
+    method = GET,
+    path = "/enablerestart/all",
+}]
+async fn dsc_enable_restart_all(
+    rqctx: Arc<RequestContext<DownstairsControl>>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let api_context = rqctx.context();
+
+    let mut dsc_work = api_context.dsci.work.lock().unwrap();
+    dsc_work.add_cmd(DscCmd::EnableRestartAll);
+    Ok(HttpResponseUpdatedNoContent())
+}
+
+#[cfg(test)]
+mod test {
+    use openapiv3::OpenAPI;
+
+    use super::build_api;
+
+    #[test]
+    fn test_dsc_openapi() {
+        let api = build_api();
+        let mut raw = Vec::new();
+        api.openapi("DownStairs Control", "0.0.0")
+            .write(&mut raw)
+            .unwrap();
+        let actual = String::from_utf8(raw).unwrap();
+
+        // Make sure the result parses as a valid OpenAPI spec.
+        let spec = serde_json::from_str::<OpenAPI>(&actual)
+            .expect("output was not valid OpenAPI");
+
+        // Check for lint errors.
+        let errors = openapi_lint::validate(&spec);
+        assert!(errors.is_empty(), "{}", errors.join("\n\n"));
+
+        expectorate::assert_contents("../openapi/dsc-control.json", &actual);
+    }
+}

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -11,3 +11,6 @@ Described in this file is the control API for Crucible Upstairs.
 
 ## downstairs-repair.json
 This file describes the API for repairing between Crucible Downstairs.
+
+### dsc-control.json
+The API for controlling the dsc (DownStairs Control) test program.

--- a/openapi/dsc-control.json
+++ b/openapi/dsc-control.json
@@ -1,0 +1,339 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "DownStairs Control",
+    "version": "0.0.0"
+  },
+  "paths": {
+    "/disablerestart/all": {
+      "get": {
+        "summary": "Disable automatic restart on all downstairs",
+        "operationId": "dsc_disable_restart_all",
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/disablerestart/cid/{cid}": {
+      "get": {
+        "summary": "Disable automatic restart on the given client_id",
+        "operationId": "dsc_disable_restart",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cid",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/enablerestart/all": {
+      "get": {
+        "summary": "Enable automatic restart on all downstairs",
+        "operationId": "dsc_enable_restart_all",
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/enablerestart/cid/{cid}": {
+      "get": {
+        "summary": "Enable automatic restart on the given client_id",
+        "operationId": "dsc_enable_restart",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cid",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/pid/cid/{cid}": {
+      "get": {
+        "summary": "Fetch the reported pid for the requested client_id",
+        "operationId": "dsc_get_pid",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cid",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "nullable": true,
+                  "title": "Nullable_uint32",
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/start/all": {
+      "get": {
+        "summary": "Start all the downstairs",
+        "operationId": "dsc_start_all",
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/start/cid/{cid}": {
+      "get": {
+        "summary": "Start the downstairs at the given client_id",
+        "operationId": "dsc_start",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cid",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/state/cid/{cid}": {
+      "get": {
+        "summary": "Fetch the current state for the requested client_id",
+        "operationId": "dsc_get_state",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cid",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownstairsState"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/stop/all": {
+      "get": {
+        "summary": "Stop all downstairs",
+        "operationId": "dsc_stop_all",
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/stop/cid/{cid}": {
+      "get": {
+        "summary": "Stop the downstairs at the given client_id",
+        "operationId": "dsc_stop",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cid",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/stop/rand": {
+      "get": {
+        "summary": "Stop a random downstairs",
+        "operationId": "dsc_stop_rand",
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "Error": {
+        "description": "Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "DownstairsState": {
+        "description": "State of a downstairs.",
+        "type": "string",
+        "enum": [
+          "Stopped",
+          "Stopping",
+          "Starting",
+          "Running",
+          "Exit",
+          "Error"
+        ]
+      },
+      "Error": {
+        "description": "Error information from a response.",
+        "type": "object",
+        "properties": {
+          "error_code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "request_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message",
+          "request_id"
+        ]
+      }
+    }
+  }
+}

--- a/tools/test_dsc.sh
+++ b/tools/test_dsc.sh
@@ -1,0 +1,305 @@
+#!/bin/bash
+#
+# Test dsc
+# This walks through the list of dsc dropshot endpoints and makes sure
+# we return the proper things in the proper situations.
+#
+# This, as in all things bash, should not live to a ripe old age, but
+# instead, be replaced by a proper test using the API endpoints that
+# I still have to write.
+
+set -o pipefail
+SECONDS=0
+
+trap ctrl_c INT
+function ctrl_c() {
+    echo "Stopping at your request"
+    cleanup
+    exit 1
+}
+
+function cleanup() {
+    if [[ -n $dsc_pid ]]; then
+		kill "$dsc_pid" 2> /dev/null || true
+        sleep 1
+		kill -9 "$dsc_pid" 2> /dev/null || true
+	fi
+}
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+BINDIR=${BINDIR:-$ROOT/target/debug}
+
+echo "$ROOT"
+cd "$ROOT" || exit 1
+
+if pgrep -fl crucible-downstairs; then
+    echo 'Downstairs already running?' >&2
+    exit 1
+fi
+
+downstairs="$BINDIR/crucible-downstairs"
+dsc="$BINDIR/dsc"
+for bin in $downstairs $dsc; do
+    if [[ ! -f "$bin" ]]; then
+        echo "Can't find crucible binary at $bin" >&2
+        exit 1
+    fi
+done
+
+os_name=$(uname)
+if [[ "$os_name" == 'Darwin' ]]; then
+    # stupid macos needs this to avoid popup hell.
+    codesign -s - -f "$dsc"
+    codesign -s - -f "$downstairs"
+fi
+
+testdir="/var/tmp/test_dsc"
+if [[ -d ${testdir} ]]; then
+    rm -rf ${testdir}
+fi
+
+# Store log files we want to keep in /tmp/*.txt as this is what
+# buildomat will look for and archive
+
+log_prefix="/tmp/test_dsc"
+fail_log="${log_prefix}_fail.txt"
+rm -f "$fail_log"
+res=0
+
+outfile="/tmp/test_dsc.txt"
+echo "" > $outfile
+
+echo "$dsc" create --ds-bin "$downstairs" --extent-count 5 \
+    --extent-size 5 --output-dir "$testdir" \
+    --region-dir "$testdir" | tee "$outfile"
+
+${dsc} create --ds-bin "$downstairs" --extent-count 5 \
+    --extent-size 5 --output-dir "$testdir" \
+    --region-dir "$testdir" | tee -a "$outfile"
+
+
+echo "Running dsc:"
+echo "${dsc}" start --ds-bin "$downstairs" \
+    --output-dir "$testdir" \
+    --region-dir "$testdir" | tee -a "$outfile"
+
+${dsc} start --ds-bin "$downstairs" \
+    --output-dir "$testdir" \
+    --region-dir "$testdir" >> "$outfile" 2>&1 &
+dsc_pid=$!
+
+echo "dsc running at: $dsc_pid  log at $outfile"
+sleep 3
+
+# Some common flags for all to use.  If we need to break out the port or
+# build specific URLs for endpoints, then we can do that here, but I'm
+# not doing that work till we need it., and like stated above, this should
+# all go away with a proper API client test.
+curl_flags="-o /dev/null -s "
+dsc_url="http://127.0.0.1:9998/"
+
+echo "Test start/all"
+hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"start/all)
+if [[ "$hc" -ne 204 ]]; then
+    echo "Failed to start all" | tee -a "$fail_log"
+    (( res += 1 ))
+fi
+
+# Loop through all the valid client IDs and verify that each
+# one will restart automatically after stopping it.  This tests
+# both the stop, the auto start, and returning the PID
+for cid in {0..2}; do
+    # This is used to compare our PID value to make sure it is a digit
+    isdigit='^[0-9]+$'
+
+	# First, get the PID for our client ID, make sure it is valid
+    echo "Get first pid for client $cid"
+    pid_a=$(curl -s "${dsc_url}"pid/cid/"$cid")
+    echo "curl for cid $cid returns $?, pid is $pid_a"
+    if [[ -z $pid_a ]]; then
+        echo "Failed to get pid for cid $cid" | tee -a "$fail_log"
+        (( res += 1 ))
+        continue
+    fi
+	if ! [[ $pid_a =~ $isdigit ]] ; then
+		echo "Pid for $cid not a number: $pid_a" | tee -a "$fail_log"
+        (( res += 1 ))
+       continue
+	fi
+
+	# Next, stop the downstairs.  It should restart with a new pid.
+    echo "Stop client id $cid"
+    hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"stop/cid/"$cid")
+    if [[ "$hc" -ne 204 ]]; then
+        echo "Failed to stop cid:$cid http:$hc" | tee -a "$fail_log"
+        (( res += 1 ))
+        continue
+    fi
+
+	# Give the restart code time to restart.
+    sleep 2
+    echo "Get 2nd pid for client $cid"
+    pid_b=$(curl -s "${dsc_url}"pid/cid/"$cid")
+    if [[ -z $pid_b ]]; then
+        echo "Failed to get 2nd pid for cid:$cid" | tee -a "$fail_log"
+        (( res += 1 ))
+        continue
+    fi
+	if ! [[ $pid_b =~ $isdigit ]] ; then
+		echo "2nd pid for $cid not a number: $pid_b" | tee -a "$fail_log"
+        (( res += 1 ))
+        continue
+    fi
+
+    echo "Verify pids are different after restart"
+    if [[ "$pid_a" -eq "$pid_b" ]]; then
+        echo "Failed: no new pid on restart test cid:$cid" | tee -a "$fail_log"
+        (( res += 1 ))
+    fi
+done
+
+sleep 2
+echo "Test disable/all"
+hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"disablerestart/all)
+if [[ "$hc" -ne 204 ]]; then
+    echo "Failed to disable restart all" | tee -a "$fail_log"
+    (( res += 1 ))
+fi
+
+echo "Test stop/all"
+hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"stop/all)
+if [[ "$hc" -ne 204 ]]; then
+    echo "Failed to stop all" | tee -a "$fail_log"
+    (( res += 1 ))
+fi
+
+# After disabling restart, then stopping all, none of the
+# downstairs should restart.
+sleep 4
+echo "Verify all ds are stopped"
+for cid in {0..2}; do
+    retry=1
+    # Loop until we find exit, or have exhausted our retry count
+	while :; do
+		state=$(curl -s "${dsc_url}"state/cid/0 | tr -d \")
+		if [[ "$state" == "Exit" ]]; then
+			echo "cid $cid in $state after $retry attempt(s)"
+			break;
+		fi
+		echo "cid $cid Failed to stop: $state, retry" | tee -a "$fail_log"
+		if [[ "$retry" -ge 10 ]]; then
+			echo "cid $cid Failed to stop: $state, abort" | tee -a "$fail_log"
+			(( res += 1 ))
+			exit 1
+			break;
+		fi
+		(( retry += 1 ))
+		sleep 3
+	done
+done
+
+echo "Start up ds 1"
+hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"start/cid/1)
+if [[ "$hc" -ne 204 ]]; then
+    echo "Failed to start cid:1 after stop/all" | tee -a "$fail_log"
+    (( res += 1 ))
+fi
+
+# It can take a few seconds for dsc to notice that things are
+# down, then maybe a few more to resume after that.  This retry
+# loop should be more than enough to cover any normal issues, but
+# not so long that if things are broken, the tests will take forever.
+sleep 2
+echo "Verify ds 1 is now running"
+retry=1
+while :; do
+	state=$(curl -s "${dsc_url}"state/cid/1 | tr -d \")
+	if [[ "$state" == "Running" ]]; then
+		echo "cid 1 restart: $state after $retry attempt(s)"
+		break;
+    fi
+	echo "cid 1 Failed to restart: $state RETRY:$retry" | tee -a "$fail_log"
+	if [[ "$retry" -ge 10 ]]; then
+		echo "cid 1 Failed to restart: $state" | tee -a "$fail_log"
+		(( res += 1 ))
+		exit 1
+		break
+	fi
+    (( retry += 1 ))
+    sleep 3
+done
+
+echo "Stop ds 1, should not restart"
+hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"stop/cid/1)
+if [[ "$hc" -ne 204 ]]; then
+    echo "Failed to stop cid:1 after stop/all then start" | tee -a "$fail_log"
+    (( res += 1 ))
+fi
+
+sleep 2
+state=$(curl -s "${dsc_url}"state/cid/1 | tr -d \")
+if [[ "$state" != "Exit" ]]; then
+    echo "cid 1 Failed to stop after stop/all then start, retry" | tee -a "$fail_log"
+	sleep 4
+	state=$(curl -s "${dsc_url}"state/cid/1 | tr -d \")
+	if [[ "$state" != "Exit" ]]; then
+		echo "cid 1 Failed to stop after stop/all then start" | tee -a "$fail_log"
+		(( res += 1 ))
+	fi
+fi
+
+# Tests using an invalid CID.
+echo "Test invalid cid for pid"
+hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"pid/cid/3)
+if [[ "$hc" -ne 400 ]]; then
+    echo ""
+    echo Failed to fail pid request with bad cid >> "$fail_log"
+    (( res += 1 ))
+fi
+
+echo "Test invalid cid for state"
+hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"state/cid/3)
+if [[ "$hc" -ne 400 ]]; then
+    echo ""
+    echo Failed to fail state request with bad cid >> "$fail_log"
+    (( res += 1 ))
+fi
+
+echo "Test invalid cid for start"
+hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"start/cid/3)
+if [[ "$hc" -ne 400 ]]; then
+    echo ""
+    echo Failed to fail start request with bad cid >> "$fail_log"
+    (( res += 1 ))
+fi
+
+echo "Test invalid cid for stop"
+hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"stop/cid/3)
+if [[ "$hc" -ne 400 ]]; then
+    echo ""
+    echo Failed to fail stop request with bad cid >> "$fail_log"
+    (( res += 1 ))
+fi
+
+# Tests are done
+echo ""
+echo "Tests done, cleanup $dsc_pid"
+kill $dsc_pid
+sleep 1
+kill -9 $dsc_pid 2> /dev/null
+echo "Wait on pid $dsc_pid"
+wait $dsc_pid
+if [[ $res != 0 ]]; then
+    echo "$res Tests have failed"
+    cat "$fail_log"
+else
+    echo "All Tests have passed"
+fi
+
+echo ""
+echo ""
+echo "All done"
+duration=$SECONDS
+printf "%d:%02d Test duration\n" $((duration / 60)) $((duration % 60))
+
+exit "$res"

--- a/tools/test_perf.sh
+++ b/tools/test_perf.sh
@@ -30,7 +30,7 @@ function perf_round() {
     args="-t 127.0.0.1:8810 -t 127.0.0.1:8820 -t 127.0.0.1:8830 -c 16000 -q"
 
     echo Create region with ES:"$es" EC:"$ec"
-    "$dsc" start --ds-bin "$downstairs" --cleanup --extent-size  "$es" --extent-count "$ec" &
+    "$dsc" start --create --ds-bin "$downstairs" --cleanup --extent-size  "$es" --extent-count "$ec" &
     dsc_pid=$!
     sleep 5
     pfiles $dsc_pid > /dev/null


### PR DESCRIPTION
This is another gradual update of the `dsc` program that will hopefully
someday, replace all the bash scripts.  There is more work here, but honestly I felt like
this set of changes was already too big to handle and I wish I had submitted it earlier.
There are a few more features I want to implement before we have complete coverage
with what the bash scripts do now, so I'll probably have little more churn in the exact
set of dropshot endpoints we export.

dsc now supports just creating a region then exiting.  This is almost enough to replace
the `tools/create-generic-ds.sh` script, but we still need encryption.

A dropshot server has been added to dsc, and now the "start" command
will start up three downstairs and a dropshot server.  This dropshot
server will take commands from outside and apply them to one or all
of the downstairs processes.  A bunch of internal plumbing was added
to support this including a work queue and several channels to
communicate between the tasks.

Here is the block comment from the main task:

```
/// This task is the "main task" for the dsc server.  It is responsible for
/// the initial startup of all the downstairs, then to respond to commands
/// from the dropshot server (via a channel and work queue) and submit
/// those commands to the downstairs.
///
/// The dropshot server should already be running when this function
/// is called.
///
///                                       +-------------+
///  Http or API requests from outside -> |  Dropshot   |   Async
///                                       |   server    |   task
///                                       +-------------+
///                                              |
///                                           notify_*
///                                           channel
///                  +-------------+             |
///                  |  DSC main   | <-----------+          Async
///                  |    task     |                        task
///                  +---+--+--+---+
///                      |  |  |
///                     action_*x
///                      channels
///                      |  |  |
///        +-------------+  |  +-------------+
///        |                |                |
/// +------+------+  +------+------+  +------+------+
/// |  Client 0   |  |  Client 1   |  |  Client 2   |       Async
/// |             |  |             |  |             |       task
/// |------|------|  |------|------|  |------|------|
/// | Downstairs  |  | Downstairs  |  | Downstairs  |       Spawned
/// |             |  |             |  |             |       process
/// +-------------+  +-------------+  +-------------+
///
/// Each client task spawns a process for their downstairs
/// and watches that process as well as the action channel
/// for changes requested by the main task.
///
/// When a command is received from the dropshot server, it puts that
/// command on a queue, then notifies the main task that new work has
/// arrived.  When the main task receives a notification, it walks
/// the queue and performs all jobs it finds.
```
Cleaned up the names of some things, now that I know better what I'm
trying to do.

Added tools/test_dsc.sh to test the dropshot endpoints, but I believe
this will be short lived as coming next will be a real API user as
well as a test using the API and not curl.