### PR TITLE
Upgrade to clap 3.2 and fix deprecation warnings.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.16"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52d4f8e4a1419219935762e32913b4430f37cb0c0200ad17a89ee18c0188a9f"
+checksum = "a836566fa5f52f7ddf909a8a2f9029b9f78ca584cd95cf7e87f8073110f4c5c9"
 dependencies = [
  "atty",
  "bitflags",
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "986fd75d1dfd2c34eb8c9275ae38ad87ea9478c9b79e87f1801f7d866dfb1e37"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
 dependencies = [
  "os_str_bytes",
 ]
@@ -500,7 +500,7 @@ dependencies = [
 name = "crucadm"
 version = "0.1.0"
 dependencies = [
- "clap 3.1.16",
+ "clap 3.2.1",
  "crucible",
  "crucible-control-client",
  "tokio",
@@ -551,7 +551,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 3.1.16",
+ "clap 3.2.1",
  "crucible-common",
  "crucible-smf",
  "dropshot",
@@ -592,7 +592,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "bytes",
- "clap 3.1.16",
+ "clap 3.2.1",
  "crossterm",
  "crucible",
  "crucible-common",
@@ -652,7 +652,7 @@ dependencies = [
  "bincode",
  "bytes",
  "chrono",
- "clap 3.1.16",
+ "clap 3.2.1",
  "crucible",
  "crucible-common",
  "crucible-protocol",
@@ -704,7 +704,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "clap 3.1.16",
+ "clap 3.2.1",
  "crucible",
  "crucible-common",
  "opentelemetry",
@@ -737,7 +737,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "clap 3.1.16",
+ "clap 3.2.1",
  "crucible",
  "crucible-common",
  "crucible-protocol",
@@ -968,7 +968,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "byte-unit",
- "clap 3.1.16",
+ "clap 3.2.1",
  "csv",
  "dropshot",
  "expectorate",
@@ -1700,7 +1700,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "bytes",
- "clap 3.1.16",
+ "clap 3.2.1",
  "crucible",
  "crucible-common",
  "rand 0.8.5",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1"
 chrono = { version = "0.4", features = [ "serde" ] }
-clap = { version = "3.1", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main" }
 futures = "0.3.21"
 http = "0.2.8"

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -24,27 +24,27 @@ use model::State;
 #[clap(name = PROG, about = "Crucible zone management agent")]
 enum Args {
     OpenApi {
-        #[clap(short = 'o', parse(try_from_str))]
+        #[clap(short = 'o', action)]
         output: PathBuf,
     },
     Run {
         // zfs dataset to be used by the crucible agent
-        #[clap(long, parse(try_from_str))]
+        #[clap(long, action)]
         dataset: PathBuf,
 
-        #[clap(short = 'l', parse(try_from_str))]
+        #[clap(short = 'l', action)]
         listen: SocketAddr,
 
-        #[clap(short = 'D', parse(try_from_str))]
+        #[clap(short = 'D', action)]
         downstairs_program: PathBuf,
 
-        #[clap(short = 'P', parse(try_from_str))]
+        #[clap(short = 'P', action)]
         lowport: u16,
 
-        #[clap(short = 'p', parse(try_from_str))]
+        #[clap(short = 'p', action)]
         downstairs_prefix: String,
 
-        #[clap(short = 's', parse(try_from_str))]
+        #[clap(short = 's', action)]
         snapshot_prefix: String,
     },
 }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 anyhow = "1"
 bincode = "1.3.3"
 bytes = "1"
-clap = { version = "3.1.16", features = ["derive", "env"] }
+clap = { version = "3.2", features = ["derive", "env"] }
 crossterm = { version = "0.23.2" }
 crucible = { path = "../upstairs" }
 crucible-common = { path = "../common" }

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -33,7 +33,7 @@ enum CliCommand {
     /// until all the downstairs answer
     Activate {
         /// Specify this generation number to use when requesting activation.
-        #[clap(long, short, default_value = "1")]
+        #[clap(long, short, default_value = "1", action)]
         gen: u64,
     },
     /// Commit the current write_log data to the minimum expected counts.
@@ -43,7 +43,7 @@ enum CliCommand {
     /// Report the expected read count for an offset.
     Expected {
         /// The desired offset to see the expected value for.
-        #[clap(long, short)]
+        #[clap(long, short, action)]
         offset: usize,
     },
     /// Export the current write count to the verify out file
@@ -55,7 +55,7 @@ enum CliCommand {
     /// Run Generic workload
     Generic {
         /// Number of IOs to execute
-        #[clap(long, short, default_value = "5000")]
+        #[clap(long, short, default_value = "5000", action)]
         count: usize,
     },
     /// Request region information
@@ -65,19 +65,19 @@ enum CliCommand {
     /// Run the client perf test
     Perf {
         /// Number of IOs to execute for each test phase
-        #[clap(long, short, default_value = "5000")]
+        #[clap(long, short, default_value = "5000", action)]
         count: usize,
         /// Size in blocks of each IO
-        #[clap(long, default_value = "1")]
+        #[clap(long, default_value = "1", action)]
         io_size: usize,
         /// Number of outstanding IOs at the same time
-        #[clap(long, default_value = "1")]
+        #[clap(long, default_value = "1", action)]
         io_depth: usize,
         /// Number of read test loops to do.
-        #[clap(long, default_value = "2")]
+        #[clap(long, default_value = "2", action)]
         read_loops: usize,
         /// Number of write test loops to do.
-        #[clap(long, default_value = "2")]
+        #[clap(long, default_value = "2", action)]
         write_loops: usize,
     },
     /// Quit the CLI
@@ -85,10 +85,10 @@ enum CliCommand {
     /// Read from a given block offset
     Read {
         /// The desired offset in blocks to read from.
-        #[clap(long, short)]
+        #[clap(long, short, action)]
         offset: usize,
         /// The number of blocks to read.
-        #[clap(long, short, default_value = "1")]
+        #[clap(long, short, default_value = "1", action)]
         len: usize,
     },
     /// Issue a random read
@@ -104,10 +104,10 @@ enum CliCommand {
     /// Write to a given block offset
     Write {
         /// The desired offset in blocks to write to.
-        #[clap(short)]
+        #[clap(short, action)]
         offset: usize,
         /// The number of blocks to write.
-        #[clap(long, short, default_value = "1")]
+        #[clap(long, short, default_value = "1", action)]
         len: usize,
     },
     /// Get the upstairs UUID

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -35,16 +35,16 @@ enum Workload {
     /// Starts a CLI client
     Cli {
         /// Address to connect to
-        #[clap(long, short, default_value = "0.0.0.0:5050")]
+        #[clap(long, short, default_value = "0.0.0.0:5050", action)]
         attach: SocketAddr,
     },
     /// Start a server and listen on the given address and port
     CliServer {
         /// Address to listen on
-        #[clap(long, short, default_value = "0.0.0.0")]
+        #[clap(long, short, default_value = "0.0.0.0", action)]
         listen: IpAddr,
         /// Port to listen on
-        #[clap(long, short, default_value = "5050")]
+        #[clap(long, short, default_value = "5050", action)]
         port: u16,
     },
     Deactivate,
@@ -58,19 +58,19 @@ enum Workload {
     /// Run the perf test, random writes, then random reads
     Perf {
         /// Size in blocks of each IO
-        #[clap(long, default_value = "1")]
+        #[clap(long, default_value = "1", action)]
         io_size: usize,
         /// Number of outstanding IOs at the same time.
-        #[clap(long, default_value = "1")]
+        #[clap(long, default_value = "1", action)]
         io_depth: usize,
         /// Output file for IO times
-        #[clap(long, global = true, parse(from_os_str), name = "PERF")]
+        #[clap(long, global = true, name = "PERF", action)]
         perf_out: Option<PathBuf>,
         /// Number of read test loops to do.
-        #[clap(long, default_value = "2")]
+        #[clap(long, default_value = "2", action)]
         read_loops: usize,
         /// Number of write test loops to do.
-        #[clap(long, default_value = "2")]
+        #[clap(long, default_value = "2", action)]
         write_loops: usize,
     },
     Rand,
@@ -85,10 +85,16 @@ enum Workload {
 pub struct Opt {
     ///  For tests that support it, pass this count value for the number
     ///  of loops the test should do.
-    #[clap(short, long, global = true, default_value = "0")]
+    #[clap(short, long, global = true, default_value = "0", action)]
     count: usize,
 
-    #[clap(short, long, global = true, default_value = "127.0.0.1:9000")]
+    #[clap(
+        short,
+        long,
+        global = true,
+        default_value = "127.0.0.1:9000",
+        action
+    )]
     target: Vec<SocketAddr>,
 
     #[clap(subcommand)]
@@ -100,67 +106,67 @@ pub struct Opt {
     ///  used in production.  Passing args like this to the upstairs
     ///  may not be the best way to test, but until we have something
     ///  better... XXX
-    #[clap(long, global = true)]
+    #[clap(long, global = true, action)]
     lossy: bool,
 
     ///  quit after all crucible work queues are empty.
-    #[clap(short, global = true, long)]
+    #[clap(short, global = true, long, action)]
     quit: bool,
 
-    #[clap(short, global = true, long)]
+    #[clap(short, global = true, long, action)]
     key: Option<String>,
 
-    #[clap(short, global = true, long, default_value = "0")]
+    #[clap(short, global = true, long, default_value = "0", action)]
     gen: u64,
 
     /// For the verify test, if this option is included we will allow
     /// the write log range of data to pass the verify_volume check.
-    #[clap(long, global = true)]
+    #[clap(long, global = true, action)]
     range: bool,
 
     /// Retry for activate, as long as it takes.  If we pass this arg, the
     /// test will retry the initial activate command as long as it takes.
-    #[clap(long, global = true)]
+    #[clap(long, global = true, action)]
     retry_activate: bool,
 
     /// In addition to any tests, verify the volume on startup.
     /// This only has value if verify_in is also set.
-    #[clap(long, global = true)]
+    #[clap(long, global = true, action)]
     verify: bool,
 
     /// For tests that support it, load the expected write count from
     /// the provided file.  The addition of a --verify option will also
     /// have the test verify what it imports from the file is valid.
-    #[clap(long, global = true, parse(from_os_str), name = "INFILE")]
+    #[clap(long, global = true, name = "INFILE", action)]
     verify_in: Option<PathBuf>,
 
     ///  For tests that support it, save the write count into the
     ///  provided file.
-    #[clap(long, global = true, parse(from_os_str), name = "FILE")]
+    #[clap(long, global = true, name = "FILE", action)]
     verify_out: Option<PathBuf>,
 
     // TLS options
-    #[clap(long)]
+    #[clap(long, action)]
     cert_pem: Option<String>,
-    #[clap(long)]
+    #[clap(long, action)]
     key_pem: Option<String>,
-    #[clap(long)]
+    #[clap(long, action)]
     root_cert_pem: Option<String>,
 
     /// IP:Port for the upstairs control http server
-    #[clap(long, global = true)]
+    #[clap(long, global = true, action)]
     control: Option<SocketAddr>,
 
     /// How long to wait before the auto flush check fires
-    #[clap(long, global = true)]
+    #[clap(long, global = true, action)]
     flush_timeout: Option<u32>,
 
     /// IP:Port for the Oximeter register address, which is Nexus.
-    #[clap(long, global = true, default_value = "127.0.0.1:12221")]
+    #[clap(long, global = true, default_value = "127.0.0.1:12221", action)]
     metric_register: SocketAddr,
 
     /// IP:Port for the Oximeter listen address
-    #[clap(long, global = true, default_value = "127.0.0.1:55443")]
+    #[clap(long, global = true, default_value = "127.0.0.1:55443", action)]
     metric_collect: SocketAddr,
 }
 

--- a/crucadm/Cargo.toml
+++ b/crucadm/Cargo.toml
@@ -5,7 +5,7 @@ license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]
-clap = { version = "3.1.16", features = ["derive", "env"] }
+clap = { version = "3.2", features = ["derive", "env"] }
 crucible = { path = "../upstairs" }
 crucible-control-client = { path = "../control-client" }
 tokio = { version = "1.19.2", features = ["full"] }

--- a/crucadm/src/main.rs
+++ b/crucadm/src/main.rs
@@ -7,7 +7,7 @@ use crucible_control_client::Client;
 #[clap(about, long_about = None)]
 struct Args {
     /// URL location of the Crucible control server
-    #[clap(short, long, default_value = "http://127.0.0.1:9999")]
+    #[clap(short, long, default_value = "http://127.0.0.1:9999", action)]
     control: String,
 }
 

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1"
 bincode = "1.3"
 bytes = "1"
 chrono = { version = "0.4.19", features = [ "serde" ] }
-clap = { version = "3.1", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }
 crucible = { path = "../upstairs" }
 crucible-common = { path = "../common" }
 crucible-protocol = { path = "../protocol" }

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -60,7 +60,12 @@ enum Args {
         #[clap(short, long, name = "UUID", action)]
         uuid: Uuid,
 
-        #[clap(long, default_value = "false", action)]
+        #[clap(
+            long,
+            default_value = "false",
+            default_missing_value = "true",
+            action(clap::ArgAction::Set)
+        )]
         encrypted: bool,
     },
     /*

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 use crucible_downstairs::admin::*;
 use crucible_downstairs::*;
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 enum Mode {
     Ro,
     Rw,
@@ -42,25 +42,25 @@ impl std::str::FromStr for Mode {
 #[clap(about = "disk-side storage component")]
 enum Args {
     Create {
-        #[clap(long, default_value = "512")]
+        #[clap(long, default_value = "512", action)]
         block_size: u64,
 
-        #[clap(short, long, parse(from_os_str), name = "DIRECTORY")]
+        #[clap(short, long, name = "DIRECTORY", action)]
         data: PathBuf,
 
-        #[clap(long, default_value = "100")]
+        #[clap(long, default_value = "100", action)]
         extent_size: u64,
 
-        #[clap(long, default_value = "15")]
+        #[clap(long, default_value = "15", action)]
         extent_count: u64,
 
-        #[clap(short, long, parse(from_os_str), name = "FILE")]
+        #[clap(short, long, name = "FILE", action)]
         import_path: Option<PathBuf>,
 
-        #[clap(short, long, name = "UUID", parse(try_from_str))]
+        #[clap(short, long, name = "UUID", action)]
         uuid: Uuid,
 
-        #[clap(long, parse(try_from_str), default_value = "false")]
+        #[clap(long, default_value = "false", action)]
         encrypted: bool,
     },
     /*
@@ -74,59 +74,65 @@ enum Args {
         /*
          * Directories containing a region.
          */
-        #[clap(short, long, parse(from_os_str), name = "DIRECTORY")]
+        #[clap(short, long, name = "DIRECTORY", action)]
         data: Vec<PathBuf>,
 
         /*
          * Just dump this extent number
          */
-        #[clap(short, long)]
+        #[clap(short, long, action)]
         extent: Option<u32>,
 
         /*
          * Detailed view for a block
          */
-        #[clap(short, long)]
+        #[clap(short, long, action)]
         block: Option<u64>,
 
         /*
          * Only show differences
          */
-        #[clap(short, long)]
+        #[clap(short, long, action)]
         only_show_differences: bool,
 
         /// No color output
-        #[clap(long)]
+        #[clap(long, action)]
         no_color: bool,
     },
     Export {
         /*
          * Number of blocks to export.
          */
-        #[clap(long, default_value = "0", name = "COUNT")]
+        #[clap(long, default_value = "0", name = "COUNT", action)]
         count: u64,
 
-        #[clap(short, long, parse(from_os_str), name = "DIRECTORY")]
+        #[clap(short, long, name = "DIRECTORY", action)]
         data: PathBuf,
 
-        #[clap(short, long, parse(from_os_str), name = "OUT_FILE")]
+        #[clap(short, long, name = "OUT_FILE", action)]
         export_path: PathBuf,
 
-        #[clap(short, long, default_value = "0", name = "SKIP")]
+        #[clap(short, long, default_value = "0", name = "SKIP", action)]
         skip: u64,
     },
     Run {
         /// Address the downstairs will listen for the upstairs on.
-        #[clap(short, long, default_value = "0.0.0.0", name = "ADDRESS")]
+        #[clap(
+            short,
+            long,
+            default_value = "0.0.0.0",
+            name = "ADDRESS",
+            action
+        )]
         address: IpAddr,
 
         /// Directory where the region is located.
-        #[clap(short, long, parse(from_os_str), name = "DIRECTORY")]
+        #[clap(short, long, name = "DIRECTORY", action)]
         data: PathBuf,
 
         /// Test option, makes the search for new work sleep and sometimes
         /// skip doing work.
-        #[clap(long)]
+        #[clap(long, action)]
         lossy: bool,
 
         /*
@@ -134,37 +140,37 @@ enum Args {
          * oximeter server, the downstairs will publish stats.
          */
         /// Use this address:port to send stats to an Oximeter server.
-        #[clap(long, name = "OXIMETER_ADDRESS:PORT")]
+        #[clap(long, name = "OXIMETER_ADDRESS:PORT", action)]
         oximeter: Option<SocketAddr>,
 
         /// Listen on this port for the upstairs to connect to us.
-        #[clap(short, long, default_value = "9000")]
+        #[clap(short, long, default_value = "9000", action)]
         port: u16,
 
-        #[clap(long)]
+        #[clap(long, action)]
         return_errors: bool,
 
-        #[clap(short, long)]
+        #[clap(short, long, action)]
         trace_endpoint: Option<String>,
 
         // TLS options
-        #[clap(long)]
+        #[clap(long, action)]
         cert_pem: Option<String>,
-        #[clap(long)]
+        #[clap(long, action)]
         key_pem: Option<String>,
-        #[clap(long)]
+        #[clap(long, action)]
         root_cert_pem: Option<String>,
 
-        #[clap(long, default_value = "rw")]
+        #[clap(long, default_value = "rw", action)]
         mode: Mode,
     },
     RepairAPI,
     Serve {
-        #[clap(short, long)]
+        #[clap(short, long, action)]
         trace_endpoint: Option<String>,
 
         // Dropshot server details
-        #[clap(long, default_value = "127.0.0.1:4567")]
+        #[clap(long, default_value = "127.0.0.1:4567", action)]
         bind_addr: SocketAddr,
     },
 }

--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1"
 byte-unit = "4.0.14"
-clap = { version = "3.1.16", features = ["derive", "env"] }
+clap = { version = "3.2", features = ["derive", "env"] }
 csv = "1.1.6"
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 rand = "0.8.5"

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -38,7 +38,7 @@ const DEFAULT_PORT_STEP: u32 = 10;
 #[clap(about = "A downstairs controller", long_about = None)]
 struct Cli {
     /// Delete all existing test and region directories
-    #[clap(long, global = true)]
+    #[clap(long, global = true, action)]
     cleanup: bool,
 
     #[clap(subcommand)]
@@ -48,16 +48,17 @@ struct Cli {
     #[clap(
         long,
         global = true,
-        default_value = "target/release/crucible-downstairs"
+        default_value = "target/release/crucible-downstairs",
+        action
     )]
     ds_bin: String,
 
     /// default output directory
-    #[clap(long, global = true, default_value = "/tmp/dsc")]
+    #[clap(long, global = true, default_value = "/tmp/dsc", action)]
     output_dir: PathBuf,
 
     /// default region directory
-    #[clap(long, global = true, default_value = "/var/tmp/dsc/region")]
+    #[clap(long, global = true, default_value = "/var/tmp/dsc/region", action)]
     region_dir: PathBuf,
 }
 
@@ -66,26 +67,26 @@ enum Commands {
     /// Create a downstairs region then exit.
     Create {
         /// The block size for the region
-        #[clap(long, default_value = "4096")]
+        #[clap(long, default_value = "4096", action)]
         block_size: u32,
 
         /// The extent size for the region
-        #[clap(long, default_value = "100")]
+        #[clap(long, default_value = "100", action)]
         extent_size: u64,
 
         /// The extent count for the region
-        #[clap(long, default_value = "15")]
+        #[clap(long, default_value = "15", action)]
         extent_count: u64,
     },
     /// Test creation of downstairs regions
     RegionPerf {
         /// Run a longer test, do 10 loops for each region size combo
         /// and report mean min max and stddev.
-        #[clap(long)]
+        #[clap(long, action)]
         long: bool,
         /// If supplied, also write create performance numbers in .csv
         /// format to the provided file name.
-        #[clap(long, parse(from_os_str), name = "CSV")]
+        #[clap(long, name = "CSV", action)]
         csv_out: Option<PathBuf>,
     },
     /// Start a downstairs region set
@@ -94,23 +95,23 @@ enum Commands {
     Start {
         /// Delete any existing region and create a new one using the
         /// default or provided block-size, extent-size, and extent-count.
-        #[clap(long)]
+        #[clap(long, action)]
         create: bool,
 
         /// If creating, the block size for the region
-        #[clap(long, default_value = "4096")]
+        #[clap(long, default_value = "4096", action)]
         block_size: u32,
 
         /// If creating, the extent size for the region
-        #[clap(long, default_value = "100")]
+        #[clap(long, default_value = "100", action)]
         extent_size: u64,
 
         /// If creating, the extent count for the region
-        #[clap(long, default_value = "15")]
+        #[clap(long, default_value = "15", action)]
         extent_count: u64,
 
         /// The IP/Port where the control server will listen
-        #[clap(long, default_value = "127.0.0.1:9998")]
+        #[clap(long, default_value = "127.0.0.1:9998", action)]
         control: SocketAddr,
     },
 }

--- a/hammer/Cargo.toml
+++ b/hammer/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1"
 bytes = "1"
-clap = { version = "3.1", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }
 crucible = { path = "../upstairs" }
 crucible-common = { path = "../common" }
 rand = "0.8.5"

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -23,40 +23,40 @@ fn do_vecs_match<T: PartialEq>(a: &[T], b: &[T]) -> bool {
 #[derive(Debug, Parser)]
 #[clap(about = "volume-side storage component")]
 pub struct Opt {
-    #[clap(short, long, default_value = "127.0.0.1:9000")]
+    #[clap(short, long, default_value = "127.0.0.1:9000", action)]
     target: Vec<SocketAddr>,
 
     /*
      * Verify that writes don't extend before or after the actual location.
      */
-    #[clap(short, long)]
+    #[clap(short, long, action)]
     verify_isolation: bool,
 
-    #[clap(long)]
+    #[clap(long, action)]
     tracing_endpoint: Option<String>,
 
-    #[clap(short, long)]
+    #[clap(short, long, action)]
     key: Option<String>,
 
-    #[clap(short, long, default_value = "0")]
+    #[clap(short, long, default_value = "0", action)]
     gen: u64,
 
     /*
      * Number of upstairs to sequentially activate and handoff to
      */
-    #[clap(short, long, default_value = "5")]
+    #[clap(short, long, default_value = "5", action)]
     num_upstairs: usize,
 
     // TLS options
-    #[clap(long)]
+    #[clap(long, action)]
     cert_pem: Option<String>,
-    #[clap(long)]
+    #[clap(long, action)]
     key_pem: Option<String>,
-    #[clap(long)]
+    #[clap(long, action)]
     root_cert_pem: Option<String>,
 
     // Start upstairs control http server
-    #[clap(long)]
+    #[clap(long, action)]
     control: Option<SocketAddr>,
 }
 

--- a/measure_iops/Cargo.toml
+++ b/measure_iops/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1"
 bytes = "1"
-clap = { version = "3.1", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }
 crucible = { path = "../upstairs" }
 crucible-common = { path = "../common" }
 rand = "0.8.5"

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -15,38 +15,38 @@ use crucible::*;
 #[clap(about = "measure iops!")]
 pub struct Opt {
     // Upstairs options
-    #[clap(short, long, default_value = "127.0.0.1:9000")]
+    #[clap(short, long, default_value = "127.0.0.1:9000", action)]
     target: Vec<SocketAddr>,
 
-    #[clap(short, long)]
+    #[clap(short, long, action)]
     key: Option<String>,
 
-    #[clap(short, long, default_value = "0")]
+    #[clap(short, long, default_value = "0", action)]
     gen: u64,
 
-    #[clap(long)]
+    #[clap(long, action)]
     cert_pem: Option<String>,
 
-    #[clap(long)]
+    #[clap(long, action)]
     key_pem: Option<String>,
 
-    #[clap(long)]
+    #[clap(long, action)]
     root_cert_pem: Option<String>,
 
     // Tool options
-    #[clap(long, default_value = "100")]
+    #[clap(long, default_value = "100", action)]
     samples: usize,
 
-    #[clap(long)]
+    #[clap(long, action)]
     iop_limit: Option<usize>,
 
-    #[clap(long)]
+    #[clap(long, action)]
     io_size_in_bytes: Option<usize>,
 
-    #[clap(long)]
+    #[clap(long, action)]
     io_depth: Option<usize>,
 
-    #[clap(long)]
+    #[clap(long, action)]
     bw_limit_in_bytes: Option<usize>,
 }
 

--- a/nbd_server/Cargo.toml
+++ b/nbd_server/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1"
 bytes = "1"
-clap = { version = "3.1", features = ["derive"] }
+clap = { version = "3.2", features = ["derive"] }
 crucible = { path = "../upstairs" }
 crucible-common = { path = "../common" }
 crucible-protocol = { path = "../protocol" }

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -33,25 +33,25 @@ fn handle_nbd_client<T: crucible::BlockIO>(
 #[derive(Debug, Parser)]
 #[clap(about = "volume-side storage component")]
 pub struct Opt {
-    #[clap(short, long, default_value = "127.0.0.1:9000")]
+    #[clap(short, long, default_value = "127.0.0.1:9000", action)]
     target: Vec<SocketAddr>,
 
-    #[clap(short, long)]
+    #[clap(short, long, action)]
     key: Option<String>,
 
-    #[clap(short, long, default_value = "0")]
+    #[clap(short, long, default_value = "0", action)]
     gen: u64,
 
     // TLS options
-    #[clap(long)]
+    #[clap(long, action)]
     cert_pem: Option<String>,
-    #[clap(long)]
+    #[clap(long, action)]
     key_pem: Option<String>,
-    #[clap(long)]
+    #[clap(long, action)]
     root_cert_pem: Option<String>,
 
     // Start upstairs control http server
-    #[clap(long)]
+    #[clap(long, action)]
     control: Option<SocketAddr>,
 }
 


### PR DESCRIPTION


Turns out clap 3.2 came out today and with it a bunch of deprecations.
