### PR TITLE
Fixes for propolis snapshot implementation

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -18,7 +18,6 @@ use std::time::Duration;
 
 use crucible::*;
 use crucible_common::{Block, CrucibleError, MAX_BLOCK_SIZE};
-use crucible_protocol::*;
 
 use anyhow::{bail, Result};
 use bytes::BytesMut;

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 use std::time::Duration;
 
 pub use crucible_common::*;
-use crucible_protocol::*;
+pub use crucible_protocol::*;
 
 use anyhow::{anyhow, bail, Result};
 pub use bytes::{Bytes, BytesMut};

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -32,13 +32,17 @@ impl Debug for SubVolume {
 }
 
 impl Volume {
-    pub fn new(block_size: u64) -> Volume {
+    pub fn new_with_id(block_size: u64, uuid: Uuid) -> Volume {
         Self {
-            uuid: Uuid::new_v4(),
+            uuid,
             sub_volumes: vec![],
             read_only_parent: None,
             block_size,
         }
+    }
+
+    pub fn new(block_size: u64) -> Volume {
+        Volume::new_with_id(block_size, Uuid::new_v4())
     }
 
     // Create a simple Volume from a single guest
@@ -640,6 +644,7 @@ impl BlockIO for SubVolume {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum VolumeConstructionRequest {


### PR DESCRIPTION
Make SnapshotDetails public by making crucible_protocol public.

Add Volume::new_with_id because volumes need a non-random ID so that
Nexus knows the volume ID.

Silence the large enum variant warning! it showed up again