### PR TITLE
Lookup snapshot dataset from path

### DIFF
--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -621,9 +621,15 @@ impl DataFile {
 
                     let path = path.to_str().unwrap().to_string();
 
-                    let mut chars = path.chars();
-                    chars.next();
-                    chars.as_str().to_string()
+                    // Get dataset name from path
+                    let output = std::process::Command::new("zfs")
+                        .args(["list", "-pH", "-o", "name", &path])
+                        .output()?;
+
+                    let output = String::from_utf8_lossy(&output.stdout);
+
+                    // remove '\n' from end
+                    output.trim_end().to_string()
                 };
 
                 let snapshot_name = format!("{}@{}", dataset_name, dir_name);


### PR DESCRIPTION
This was fixed in the Downstairs but not the agent - lookup the ZFS
dataset from the path, don't assume that the mountpoint has anything to
do with dataset name.