### PR TITLE
remove unnecessary assert in reopen_all_extents

### DIFF
--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1197,8 +1197,6 @@ impl Region {
      * Open any extents that are not.
      */
     pub fn reopen_all_extents(&mut self) -> Result<()> {
-        assert!(!self.read_only);
-
         let mut to_open = Vec::new();
         for (i, extent) in self.extents.iter().enumerate() {
             if extent.inner.is_none() {

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -24,6 +24,7 @@ mod test {
             address: IpAddr,
             port: u16,
             encrypted: bool,
+            read_only: bool,
         ) -> Result<Self> {
             let tempdir = tempdir()?;
 
@@ -40,7 +41,7 @@ mod test {
                 &tempdir.path(),
                 false, /* lossy */
                 false, /* return_errors */
-                false, /* read_only */
+                read_only,
             )?;
 
             let adownstairs = downstairs.clone();
@@ -71,11 +72,11 @@ mod test {
         const BLOCK_SIZE: usize = 512;
 
         let _downstairs1 =
-            TestDownstairs::new("127.0.0.1".parse()?, 54001, true)?;
+            TestDownstairs::new("127.0.0.1".parse()?, 54001, true, false)?;
         let _downstairs2 =
-            TestDownstairs::new("127.0.0.1".parse()?, 54002, true)?;
+            TestDownstairs::new("127.0.0.1".parse()?, 54002, true, false)?;
         let _downstairs3 =
-            TestDownstairs::new("127.0.0.1".parse()?, 54003, true)?;
+            TestDownstairs::new("127.0.0.1".parse()?, 54003, true, false)?;
 
         let vcr: VolumeConstructionRequest =
             VolumeConstructionRequest::Volume {
@@ -148,11 +149,11 @@ mod test {
         const BLOCK_SIZE: usize = 512;
 
         let _downstairs1 =
-            TestDownstairs::new("127.0.0.1".parse()?, 54004, true)?;
+            TestDownstairs::new("127.0.0.1".parse()?, 54004, true, false)?;
         let _downstairs2 =
-            TestDownstairs::new("127.0.0.1".parse()?, 54005, true)?;
+            TestDownstairs::new("127.0.0.1".parse()?, 54005, true, false)?;
         let _downstairs3 =
-            TestDownstairs::new("127.0.0.1".parse()?, 54006, true)?;
+            TestDownstairs::new("127.0.0.1".parse()?, 54006, true, false)?;
 
         // Create in memory block io full of 11
         let in_memory_data = Arc::new(InMemoryBlockIO::new(
@@ -242,11 +243,11 @@ mod test {
         const BLOCK_SIZE: usize = 512;
 
         let _downstairs1 =
-            TestDownstairs::new("127.0.0.1".parse()?, 54007, true)?;
+            TestDownstairs::new("127.0.0.1".parse()?, 54007, true, false)?;
         let _downstairs2 =
-            TestDownstairs::new("127.0.0.1".parse()?, 54008, true)?;
+            TestDownstairs::new("127.0.0.1".parse()?, 54008, true, false)?;
         let _downstairs3 =
-            TestDownstairs::new("127.0.0.1".parse()?, 54009, true)?;
+            TestDownstairs::new("127.0.0.1".parse()?, 54009, true, false)?;
 
         // Create in memory block io full of 11
         let in_memory_data = Arc::new(InMemoryBlockIO::new(
@@ -355,11 +356,11 @@ mod test {
         const BLOCK_SIZE: usize = 512;
 
         let _downstairs1 =
-            TestDownstairs::new("127.0.0.1".parse()?, 54010, true)?;
+            TestDownstairs::new("127.0.0.1".parse()?, 54010, true, false)?;
         let _downstairs2 =
-            TestDownstairs::new("127.0.0.1".parse()?, 54011, true)?;
+            TestDownstairs::new("127.0.0.1".parse()?, 54011, true, false)?;
         let _downstairs3 =
-            TestDownstairs::new("127.0.0.1".parse()?, 54012, true)?;
+            TestDownstairs::new("127.0.0.1".parse()?, 54012, true, false)?;
 
         let server = Server::run();
         server.expect(
@@ -455,6 +456,71 @@ mod test {
         .block_wait()?;
 
         assert_eq!(vec![0x01; BLOCK_SIZE], *buffer.as_vec());
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn integration_test_read_only() -> Result<()> {
+        const BLOCK_SIZE: usize = 512;
+
+        let _downstairs1 =
+            TestDownstairs::new("127.0.0.1".parse()?, 54013, true, true)?;
+        let _downstairs2 =
+            TestDownstairs::new("127.0.0.1".parse()?, 54014, true, true)?;
+        let _downstairs3 =
+            TestDownstairs::new("127.0.0.1".parse()?, 54015, true, true)?;
+
+        let vcr: VolumeConstructionRequest =
+            VolumeConstructionRequest::Volume {
+                id: Uuid::new_v4(),
+                block_size: BLOCK_SIZE as u64,
+                sub_volumes: vec![],
+                read_only_parent: Some(Box::new(
+                    VolumeConstructionRequest::Region {
+                        block_size: BLOCK_SIZE as u64,
+                        opts: CrucibleOpts {
+                            target: vec![
+                                "127.0.0.1:54013".parse()?,
+                                "127.0.0.1:54014".parse()?,
+                                "127.0.0.1:54015".parse()?,
+                            ],
+                            lossy: false,
+                            flush_timeout: None,
+                            key: Some(
+                                "+3AhoL47nkZPwj9XRmoCnOKa66Cfb8Q2gmQ84pVlsbw="
+                                    .to_string(),
+                            ),
+                            cert_pem: None,
+                            key_pem: None,
+                            root_cert_pem: None,
+                            control: None,
+                            metric_collect: None,
+                            metric_register: None,
+                            ..Default::default()
+                        },
+                        gen: 0,
+                    },
+                )),
+            };
+
+        // XXX Crucible uses std::sync::mpsc::Receiver, not
+        // tokio::sync::mpsc::Receiver, so use tokio::task::block_in_place here.
+        // Remove that when Crucible changes over to the tokio mpsc.
+        let volume = tokio::task::block_in_place(|| Volume::construct(vcr))?;
+        volume.activate(0)?;
+
+        // Read one block: should be all 0x00
+        let buffer = Buffer::new(BLOCK_SIZE);
+        tokio::task::block_in_place(|| {
+            volume.read(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                buffer.clone(),
+            )
+        })?
+        .block_wait()?;
+
+        assert_eq!(vec![0x00; BLOCK_SIZE], *buffer.as_vec());
 
         Ok(())
     }


### PR DESCRIPTION
reopen_all_extents asserts !self.read_only but so does reopen_extent,
and the assert in reopen_all_extents is causing a panic when creating a
volume with a read-only parent that points to a read-only downstairs.

add a integration test to ensure that we can construct these volumes.