### PR TITLE
Allow client program to provide upstairs UUID

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -169,6 +169,10 @@ pub struct Opt {
     /// IP:Port for the Oximeter listen address
     #[clap(long, global = true, default_value = "127.0.0.1:55443", action)]
     metric_collect: SocketAddr,
+
+    /// A UUID to use for the upstairs.
+    #[clap(long, global = true, action)]
+    uuid: Option<Uuid>,
 }
 
 pub fn opts() -> Result<Opt> {
@@ -443,8 +447,14 @@ fn main() -> Result<()> {
         bail!("Initial verify requires verify_in file");
     }
 
+    let up_uuid = if opt.uuid.is_some() {
+        opt.uuid.unwrap()
+    } else {
+        Uuid::new_v4()
+    };
+
     let crucible_opts = CrucibleOpts {
-        id: Uuid::new_v4(),
+        id: up_uuid,
         target: opt.target,
         lossy: opt.lossy,
         flush_timeout: opt.flush_timeout,

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -447,11 +447,7 @@ fn main() -> Result<()> {
         bail!("Initial verify requires verify_in file");
     }
 
-    let up_uuid = if opt.uuid.is_some() {
-        opt.uuid.unwrap()
-    } else {
-        Uuid::new_v4()
-    };
+    let up_uuid = opt.uuid.unwrap_or_else(Uuid::new_v4);
 
     let crucible_opts = CrucibleOpts {
         id: up_uuid,


### PR DESCRIPTION
This allows a user to request a uuid for the upstairs instead of having one auto generated each time.