### PR TITLE
Make producer_registry an Option, not Arc Mutex

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -514,12 +514,10 @@ fn main() -> Result<()> {
         {
             Err(e) => {
                 println!("Failed to register with Oximeter {:?}", e);
-                pr = Arc::new(tokio::sync::Mutex::new(None));
+                pr = None;
             }
             Ok(server) => {
-                pr = Arc::new(tokio::sync::Mutex::new(Some(
-                    server.registry().clone(),
-                )));
+                pr = Some(server.registry().clone());
                 // Now Spawn the metric endpoint.
                 runtime.spawn(async move {
                     server.serve_forever().await.unwrap();
@@ -527,7 +525,7 @@ fn main() -> Result<()> {
             }
         }
     } else {
-        pr = Arc::new(tokio::sync::Mutex::new(None));
+        pr = None;
     }
     runtime.spawn(up_main(crucible_opts, guest.clone(), pr));
     println!("Crucible runtime is spawned");

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -144,8 +144,7 @@ fn main() -> Result<()> {
          */
         let guest = Arc::new(Guest::new());
 
-        let pr = Arc::new(tokio::sync::Mutex::new(None));
-        runtime.spawn(up_main(crucible_opts.clone(), guest.clone(), pr));
+        runtime.spawn(up_main(crucible_opts.clone(), guest.clone(), None));
         println!("Crucible runtime is spawned");
 
         cpfs.push(crucible::CruciblePseudoFile::from(guest)?);

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -110,9 +110,8 @@ mod test {
         // XXX Crucible uses std::sync::mpsc::Receiver, not
         // tokio::sync::mpsc::Receiver, so use tokio::task::block_in_place here.
         // Remove that when Crucible changes over to the tokio mpsc.
-        let pr = Arc::new(tokio::sync::Mutex::new(None));
         let volume = Arc::new(tokio::task::block_in_place(|| {
-            Volume::construct(vcr, pr)
+            Volume::construct(vcr, None)
         })?);
 
         volume.activate(0)?;
@@ -177,7 +176,6 @@ mod test {
         assert_eq!(vec![11; BLOCK_SIZE * 10], *buffer.as_vec());
 
         let mut volume = Volume::new(BLOCK_SIZE as u64);
-        let pr = Arc::new(tokio::sync::Mutex::new(None));
         volume.add_subvolume_create_guest(
             CrucibleOpts {
                 target: vec![
@@ -197,7 +195,7 @@ mod test {
                 ..Default::default()
             },
             0,
-            pr,
+            None,
         )?;
         volume.add_read_only_parent(in_memory_data.clone())?;
 
@@ -303,9 +301,8 @@ mod test {
         // XXX Crucible uses std::sync::mpsc::Receiver, not
         // tokio::sync::mpsc::Receiver, so use tokio::task::block_in_place here.
         // Remove that when Crucible changes over to the tokio mpsc.
-        let pr = Arc::new(tokio::sync::Mutex::new(None));
         let mut volume =
-            tokio::task::block_in_place(|| Volume::construct(vcr, pr))?;
+            tokio::task::block_in_place(|| Volume::construct(vcr, None))?;
 
         volume.add_read_only_parent({
             let mut volume = Volume::new(BLOCK_SIZE as u64);
@@ -419,9 +416,8 @@ mod test {
         // XXX Crucible uses std::sync::mpsc::Receiver, not
         // tokio::sync::mpsc::Receiver, so use tokio::task::block_in_place here.
         // Remove that when Crucible changes over to the tokio mpsc.
-        let pr = Arc::new(tokio::sync::Mutex::new(None));
         let volume =
-            tokio::task::block_in_place(|| Volume::construct(vcr, pr))?;
+            tokio::task::block_in_place(|| Volume::construct(vcr, None))?;
         volume.activate(0)?;
 
         // Read one block: should be all 0xff
@@ -503,9 +499,8 @@ mod test {
         // XXX Crucible uses std::sync::mpsc::Receiver, not
         // tokio::sync::mpsc::Receiver, so use tokio::task::block_in_place here.
         // Remove that when Crucible changes over to the tokio mpsc.
-        let pr = Arc::new(tokio::sync::Mutex::new(None));
         let volume =
-            tokio::task::block_in_place(|| Volume::construct(vcr, pr))?;
+            tokio::task::block_in_place(|| Volume::construct(vcr, None))?;
         volume.activate(0)?;
 
         // Read one block: should be all 0x00

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -115,9 +115,7 @@ fn main() -> Result<()> {
     }
 
     let guest = Arc::new(guest);
-    let pr = Arc::new(tokio::sync::Mutex::new(None));
-
-    runtime.spawn(up_main(crucible_opts, guest.clone(), pr));
+    runtime.spawn(up_main(crucible_opts, guest.clone(), None));
     println!("Crucible runtime is spawned");
 
     guest.activate(opt.gen)?;

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -99,9 +99,8 @@ fn main() -> Result<()> {
      * the methods provided by guest to interact with Crucible.
      */
     let guest = Arc::new(Guest::new());
-    let pr = Arc::new(tokio::sync::Mutex::new(None));
 
-    runtime.spawn(up_main(crucible_opts, guest.clone(), pr));
+    runtime.spawn(up_main(crucible_opts, guest.clone(), None));
     println!("Crucible runtime is spawned");
 
     // NBD server

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -6834,7 +6834,7 @@ async fn up_listen(
 pub async fn up_main(
     opt: CrucibleOpts,
     guest: Arc<Guest>,
-    producer_registry: Arc<tokio::sync::Mutex<Option<ProducerRegistry>>>,
+    producer_registry: Option<ProducerRegistry>,
 ) -> Result<()> {
     match register_probes() {
         Ok(()) => {
@@ -6881,8 +6881,7 @@ pub async fn up_main(
         up_ds_listen(&upc, ds_done_rx).await;
     });
 
-    let prl = producer_registry.lock().await;
-    if let Some(pr) = &*prl {
+    if let Some(pr) = producer_registry {
         let up_oxc = Arc::clone(&up);
         let ups = up_oxc.stats.clone();
         if let Err(e) = pr.register_producer(ups) {

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -2,7 +2,6 @@
 
 use super::*;
 use oximeter::types::ProducerRegistry;
-use tokio::sync::Mutex;
 
 use std::ops::Range;
 
@@ -109,7 +108,7 @@ impl Volume {
         &mut self,
         opts: CrucibleOpts,
         gen: u64,
-        producer_registry: Arc<tokio::sync::Mutex<Option<ProducerRegistry>>>,
+        producer_registry: Option<ProducerRegistry>,
     ) -> Result<(), CrucibleError> {
         let guest = Arc::new(Guest::new());
 
@@ -172,7 +171,7 @@ impl Volume {
         &mut self,
         opts: CrucibleOpts,
         gen: u64,
-        producer_registry: Arc<tokio::sync::Mutex<Option<ProducerRegistry>>>,
+        producer_registry: Option<ProducerRegistry>,
     ) -> Result<(), CrucibleError> {
         let guest = Arc::new(Guest::new());
 
@@ -678,7 +677,7 @@ pub enum VolumeConstructionRequest {
 impl Volume {
     pub fn construct(
         request: VolumeConstructionRequest,
-        producer_registry: Arc<Mutex<Option<ProducerRegistry>>>,
+        producer_registry: Option<ProducerRegistry>,
     ) -> Result<Volume> {
         match request {
             VolumeConstructionRequest::Volume {
@@ -1643,8 +1642,7 @@ mod test {
                 path: file_path.into_os_string().into_string().unwrap(),
             })),
         };
-        let pr = Arc::new(tokio::sync::Mutex::new(None));
-        let volume = Volume::construct(request, pr).unwrap();
+        let volume = Volume::construct(request, None).unwrap();
 
         let buffer = Buffer::new(BLOCK_SIZE);
         volume


### PR DESCRIPTION
Ok, so I figured out how to address the comment from PR #362
After discussions and hints from @luqmana, I now have a propolis side version
where produce_metric is an `Option` instead of `Arc<Mutex<Option>>`

Having these changes checked back in allows me to point propolis and omicron at a git rev and should
allow for archives to be built.