### PR TITLE
Multiple activations to read-only downstairs

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -466,6 +466,7 @@ fn main() -> Result<()> {
         key_pem: opt.key_pem,
         root_cert_pem: opt.root_cert_pem,
         control: opt.control,
+        read_only: false,
     };
 
     /*

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -104,6 +104,9 @@ pub enum CrucibleError {
 
     #[error("Repair stream error {0}")]
     RepairStreamError(String),
+
+    #[error("Read-only mismatch")]
+    ReadOnlyMismatch,
 }
 
 impl From<std::io::Error> for CrucibleError {

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1138,7 +1138,15 @@ impl Downstairs {
     ) -> Result<()> {
         // The Upstairs will send Flushes periodically, even in read only mode
         // we have to accept them.
-        if self.read_only && matches!(work, IOop::Write { dependencies: _, writes: _ }) {
+        if self.read_only
+            && matches!(
+                work,
+                IOop::Write {
+                    dependencies: _,
+                    writes: _
+                }
+            )
+        {
             eprintln!("read-only but received work {:?}", work);
             bail!(CrucibleError::ReadOnlyMismatch);
         }

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1078,7 +1078,9 @@ impl Downstairs {
      * # Read-only mode
      *
      * In read-only mode, multiple Upstairs with different UUIDs can connect
-     * to the same downstairs and
+     * read-only to the same downstairs and they will not be forcibly
+     * disconnected. In this case, multiple Work structs will be created, and
+     * `work_lock` is still the way to access the appropriate Work struct.
      */
     async fn work_lock(
         &self,

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -89,6 +89,7 @@ fn main() -> Result<()> {
         key_pem: opt.key_pem,
         root_cert_pem: opt.root_cert_pem,
         control: opt.control,
+        read_only: false,
     };
     let mut generation_number = opt.gen;
 

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -80,6 +80,7 @@ fn main() -> Result<()> {
         key_pem: opt.key_pem,
         root_cert_pem: opt.root_cert_pem,
         control: None,
+        read_only: false,
     };
 
     /*

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -118,13 +118,15 @@ pub enum Message {
     HereIAm(u32, Uuid),
     YesItsMe(u32),
 
+    ReadOnlyMismatch(bool),
+
     /*
-     * Forcefully tell this downstairs to promote us (an Upstairs) to
-     * active.
+     * If read only is false, forcefully tell this downstairs to promote us
+     * (an Upstairs) to active. Kick out the old Upstairs.
      *
-     * Kick out the old Upstairs.
+     * If read only is true, multiple upstairs can connect ok.
      */
-    PromoteToActive(Uuid),
+    PromoteToActive(Uuid, bool),
     YouAreNowActive(Uuid),
     YouAreNoLongerActive(Uuid), // UUID of new active Upstairs
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -5097,27 +5097,6 @@ impl IOop {
             } => dependencies,
         }
     }
-
-    pub fn read_only(&self) -> bool {
-        match &self {
-            IOop::Write {
-                dependencies: _,
-                writes: _,
-            } => false,
-
-            IOop::Flush {
-                dependencies: _,
-                flush_number: _,
-                gen_number: _,
-                snapshot_details: _,
-            } => false,
-
-            IOop::Read {
-                dependencies: _,
-                requests: _,
-            } => true,
-        }
-    }
 }
 
 /*


### PR DESCRIPTION
In order to support snapshots, add support for a downstairs booted in
read-only mode to accept multiple read-only activations. This type of
activation only supports reads, and will create one Work struct for each
Upstairs that connects to it. Note that in order for this to not mix job
ids, *each Upstairs must have a different UUID when connecting*. This is
Nexus' responsibility.