### PR TITLE
Make perf header a function

### DIFF
--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -644,6 +644,7 @@ async fn process_cli_command(
                 )))
                 .await
             } else {
+                perf_header();
                 match perf_workload(
                     guest,
                     ri,

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -743,21 +743,7 @@ fn main() -> Result<()> {
             }
 
             // The header for all perf tests
-            println!(
-                "{:>8} {:7} {:5} {:4} {:>7} {:>7} {:>7} \
-                {:>7} {:>8} {:>5} {:>5}",
-                "TEST",
-                "SECONDS",
-                "COUNT",
-                "DPTH",
-                "IOPS",
-                "MEAN",
-                "P95",
-                "P99",
-                "MAX",
-                "ES",
-                "EC",
-            );
+            perf_header();
             runtime.block_on(perf_workload(
                 &guest,
                 &mut region_info,
@@ -1375,6 +1361,26 @@ async fn dirty_workload(
         wa.block_wait()?;
     }
     Ok(())
+}
+
+/*
+ * Print the perf header.
+ */
+pub fn perf_header() {
+    println!(
+        "{:>8} {:7} {:5} {:4} {:>7} {:>7} {:>7} {:>7} {:>8} {:>5} {:>5}",
+        "TEST",
+        "SECONDS",
+        "COUNT",
+        "DPTH",
+        "IOPS",
+        "MEAN",
+        "P95",
+        "P99",
+        "MAX",
+        "ES",
+        "EC",
+    );
 }
 
 /*


### PR DESCRIPTION
Update cli perf command to print the perf header.

This commit was done from a VM running on propolis/omicron