### PR TITLE
dsc gets a shutdown endpoint

### DIFF
--- a/dsc/src/control.rs
+++ b/dsc/src/control.rs
@@ -173,7 +173,7 @@ async fn dsc_get_state(
  * Stop the downstairs at the given client_id
  */
 #[endpoint {
-    method = GET,
+    method = POST,
     path = "/stop/cid/{cid}",
 }]
 async fn dsc_stop(
@@ -215,7 +215,7 @@ async fn dsc_stop_all(
  * Stop a random downstairs
  */
 #[endpoint {
-    method = GET,
+    method = POST,
     path = "/stop/rand",
 }]
 async fn dsc_stop_rand(
@@ -232,7 +232,7 @@ async fn dsc_stop_rand(
  * Start the downstairs at the given client_id
  */
 #[endpoint {
-    method = GET,
+    method = POST,
     path = "/start/cid/{cid}",
 }]
 async fn dsc_start(
@@ -258,7 +258,7 @@ async fn dsc_start(
  * Start all the downstairs
  */
 #[endpoint {
-    method = GET,
+    method = POST,
     path = "/start/all",
 }]
 async fn dsc_start_all(
@@ -275,7 +275,7 @@ async fn dsc_start_all(
  * Disable automatic restart on the given client_id
  */
 #[endpoint {
-    method = GET,
+    method = POST,
     path = "/disablerestart/cid/{cid}",
 }]
 async fn dsc_disable_restart(
@@ -301,7 +301,7 @@ async fn dsc_disable_restart(
  * Disable automatic restart on all downstairs
  */
 #[endpoint {
-    method = GET,
+    method = POST,
     path = "/disablerestart/all",
 }]
 async fn dsc_disable_restart_all(
@@ -318,7 +318,7 @@ async fn dsc_disable_restart_all(
  * Enable automatic restart on the given client_id
  */
 #[endpoint {
-    method = GET,
+    method = POST,
     path = "/enablerestart/cid/{cid}",
 }]
 async fn dsc_enable_restart(
@@ -344,7 +344,7 @@ async fn dsc_enable_restart(
  * Enable automatic restart on all downstairs
  */
 #[endpoint {
-    method = GET,
+    method = POST,
     path = "/enablerestart/all",
 }]
 async fn dsc_enable_restart_all(

--- a/dsc/src/control.rs
+++ b/dsc/src/control.rs
@@ -198,7 +198,7 @@ async fn dsc_stop(
  * Stop all downstairs
  */
 #[endpoint {
-    method = GET,
+    method = POST,
     path = "/stop/all",
 }]
 async fn dsc_stop_all(

--- a/dsc/src/control.rs
+++ b/dsc/src/control.rs
@@ -361,7 +361,7 @@ async fn dsc_enable_restart_all(
  * Stop all downstairs, then stop ourselves.
  */
 #[endpoint {
-    method = GET,
+    method = POST,
     path = "/shutdown",
 }]
 async fn dsc_shutdown(

--- a/dsc/src/control.rs
+++ b/dsc/src/control.rs
@@ -29,6 +29,7 @@ pub(crate) fn build_api() -> ApiDescription<DownstairsControl> {
     api.register(dsc_disable_restart_all).unwrap();
     api.register(dsc_enable_restart).unwrap();
     api.register(dsc_enable_restart_all).unwrap();
+    api.register(dsc_shutdown).unwrap();
 
     api
 }
@@ -353,6 +354,23 @@ async fn dsc_enable_restart_all(
 
     let mut dsc_work = api_context.dsci.work.lock().unwrap();
     dsc_work.add_cmd(DscCmd::EnableRestartAll);
+    Ok(HttpResponseUpdatedNoContent())
+}
+
+/**
+ * Stop all downstairs, then stop ourselves.
+ */
+#[endpoint {
+    method = GET,
+    path = "/shutdown",
+}]
+async fn dsc_shutdown(
+    rqctx: Arc<RequestContext<DownstairsControl>>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let api_context = rqctx.context();
+
+    let mut dsc_work = api_context.dsci.work.lock().unwrap();
+    dsc_work.add_cmd(DscCmd::Shutdown);
     Ok(HttpResponseUpdatedNoContent())
 }
 

--- a/openapi/dsc-control.json
+++ b/openapi/dsc-control.json
@@ -141,7 +141,7 @@
       }
     },
     "/shutdown": {
-      "get": {
+      "post": {
         "summary": "Stop all downstairs, then stop ourselves.",
         "operationId": "dsc_shutdown",
         "responses": {
@@ -242,7 +242,7 @@
       }
     },
     "/stop/all": {
-      "get": {
+      "post": {
         "summary": "Stop all downstairs",
         "operationId": "dsc_stop_all",
         "responses": {

--- a/openapi/dsc-control.json
+++ b/openapi/dsc-control.json
@@ -6,7 +6,7 @@
   },
   "paths": {
     "/disablerestart/all": {
-      "get": {
+      "post": {
         "summary": "Disable automatic restart on all downstairs",
         "operationId": "dsc_disable_restart_all",
         "responses": {
@@ -23,7 +23,7 @@
       }
     },
     "/disablerestart/cid/{cid}": {
-      "get": {
+      "post": {
         "summary": "Disable automatic restart on the given client_id",
         "operationId": "dsc_disable_restart",
         "parameters": [
@@ -53,7 +53,7 @@
       }
     },
     "/enablerestart/all": {
-      "get": {
+      "post": {
         "summary": "Enable automatic restart on all downstairs",
         "operationId": "dsc_enable_restart_all",
         "responses": {
@@ -70,7 +70,7 @@
       }
     },
     "/enablerestart/cid/{cid}": {
-      "get": {
+      "post": {
         "summary": "Enable automatic restart on the given client_id",
         "operationId": "dsc_enable_restart",
         "parameters": [
@@ -158,7 +158,7 @@
       }
     },
     "/start/all": {
-      "get": {
+      "post": {
         "summary": "Start all the downstairs",
         "operationId": "dsc_start_all",
         "responses": {
@@ -175,7 +175,7 @@
       }
     },
     "/start/cid/{cid}": {
-      "get": {
+      "post": {
         "summary": "Start the downstairs at the given client_id",
         "operationId": "dsc_start",
         "parameters": [
@@ -259,7 +259,7 @@
       }
     },
     "/stop/cid/{cid}": {
-      "get": {
+      "post": {
         "summary": "Stop the downstairs at the given client_id",
         "operationId": "dsc_stop",
         "parameters": [
@@ -289,7 +289,7 @@
       }
     },
     "/stop/rand": {
-      "get": {
+      "post": {
         "summary": "Stop a random downstairs",
         "operationId": "dsc_stop_rand",
         "responses": {

--- a/openapi/dsc-control.json
+++ b/openapi/dsc-control.json
@@ -140,6 +140,23 @@
         }
       }
     },
+    "/shutdown": {
+      "get": {
+        "summary": "Stop all downstairs, then stop ourselves.",
+        "operationId": "dsc_shutdown",
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/start/all": {
       "get": {
         "summary": "Start all the downstairs",

--- a/tools/test_dsc.sh
+++ b/tools/test_dsc.sh
@@ -99,7 +99,8 @@ curl_flags="-o /dev/null -s "
 dsc_url="http://127.0.0.1:9998/"
 
 echo "Test start/all"
-hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"start/all)
+hc=$(curl ${curl_flags} -X POST -H "Content-Type: application/json" -w "%{http_code}\n" "${dsc_url}"start/all)
+echo hc is:  "$hc"
 if [[ "$hc" -ne 204 ]]; then
     echo "Failed to start all" | tee -a "$fail_log"
     (( res += 1 ))
@@ -129,7 +130,7 @@ for cid in {0..2}; do
 
 	# Next, stop the downstairs.  It should restart with a new pid.
     echo "Stop client id $cid"
-    hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"stop/cid/"$cid")
+    hc=$(curl ${curl_flags} -X POST -H "Content-Type: application/json" -w "%{http_code}\n" "${dsc_url}"stop/cid/"$cid")
     if [[ "$hc" -ne 204 ]]; then
         echo "Failed to stop cid:$cid http:$hc" | tee -a "$fail_log"
         (( res += 1 ))
@@ -160,7 +161,7 @@ done
 
 sleep 2
 echo "Test disable/all"
-hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"disablerestart/all)
+hc=$(curl ${curl_flags} -X POST -H "Content-Type: application/json" -w "%{http_code}\n" "${dsc_url}"disablerestart/all)
 if [[ "$hc" -ne 204 ]]; then
     echo "Failed to disable restart all" | tee -a "$fail_log"
     (( res += 1 ))
@@ -199,7 +200,7 @@ for cid in {0..2}; do
 done
 
 echo "Start up ds 1"
-hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"start/cid/1)
+hc=$(curl ${curl_flags} -X POST -H "Content-Type: application/json" -w "%{http_code}\n" "${dsc_url}"start/cid/1)
 if [[ "$hc" -ne 204 ]]; then
     echo "Failed to start cid:1 after stop/all" | tee -a "$fail_log"
     (( res += 1 ))
@@ -230,7 +231,7 @@ while :; do
 done
 
 echo "Stop ds 1, should not restart"
-hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"stop/cid/1)
+hc=$(curl ${curl_flags} -X POST -H "Content-Type: application/json" -w "%{http_code}\n" "${dsc_url}"stop/cid/1)
 if [[ "$hc" -ne 204 ]]; then
     echo "Failed to stop cid:1 after stop/all then start" | tee -a "$fail_log"
     (( res += 1 ))
@@ -253,7 +254,7 @@ echo "Test invalid cid for pid"
 hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"pid/cid/3)
 if [[ "$hc" -ne 400 ]]; then
     echo ""
-    echo Failed to fail pid request with bad cid >> "$fail_log"
+    echo Failed to fail pid request with bad cid: "$hc" >> "$fail_log"
     (( res += 1 ))
 fi
 
@@ -261,23 +262,23 @@ echo "Test invalid cid for state"
 hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"state/cid/3)
 if [[ "$hc" -ne 400 ]]; then
     echo ""
-    echo Failed to fail state request with bad cid >> "$fail_log"
+    echo Failed to fail state request with bad cid: "$hc" >> "$fail_log"
     (( res += 1 ))
 fi
 
 echo "Test invalid cid for start"
-hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"start/cid/3)
+hc=$(curl ${curl_flags} -X POST -H "Content-Type: application/json" -w "%{http_code}\n" "${dsc_url}"start/cid/3)
 if [[ "$hc" -ne 400 ]]; then
     echo ""
-    echo Failed to fail start request with bad cid >> "$fail_log"
+    echo Failed to fail start request with bad cid: "$hc" >> "$fail_log"
     (( res += 1 ))
 fi
 
 echo "Test invalid cid for stop"
-hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"stop/cid/3)
+hc=$(curl ${curl_flags} -X POST -H "Content-Type: application/json" -w "%{http_code}\n" "${dsc_url}"stop/cid/3)
 if [[ "$hc" -ne 400 ]]; then
     echo ""
-    echo Failed to fail stop request with bad cid >> "$fail_log"
+    echo Failed to fail stop request with bad cid: "$hc" >> "$fail_log"
     (( res += 1 ))
 fi
 

--- a/tools/test_dsc.sh
+++ b/tools/test_dsc.sh
@@ -167,7 +167,7 @@ if [[ "$hc" -ne 204 ]]; then
 fi
 
 echo "Test stop/all"
-hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"stop/all)
+hc=$(curl ${curl_flags} -w "%{http_code}\n" -X POST -H "Content-Type: application/json" "${dsc_url}"stop/all)
 if [[ "$hc" -ne 204 ]]; then
     echo "Failed to stop all" | tee -a "$fail_log"
     (( res += 1 ))
@@ -283,7 +283,7 @@ fi
 
 # The final test is to clean it all up!
 echo "Test /shutdown endpoint"
-hc=$(curl ${curl_flags} -w "%{http_code}\n" "${dsc_url}"shutdown)
+hc=$(curl ${curl_flags} -w "%{http_code}\n" -X POST -H "Content-Type: application/json" "${dsc_url}"shutdown)
 if [[ "$hc" -ne 204 ]]; then
     echo "Failed to shutdown, got $hc" | tee -a "$fail_log"
     (( res += 1 ))


### PR DESCRIPTION
Added a new endpoint to dsc to allow remote shutdown of all downstairs and then the dsc process itself.  This opens the door to more bash script replacement.

Updated the communication channel between the dsc main task and the sub-tasks for each downstairs to allow more than one outstanding command at a time.

Updated the test_dsc.sh to test (and make use of) the /shutdown endpoint.