### PR TITLE
Enforce read-only Upstairs and Downstairs

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -466,6 +466,7 @@ fn main() -> Result<()> {
         key_pem: opt.key_pem,
         root_cert_pem: opt.root_cert_pem,
         control: opt.control,
+        read_only: false,
     };
 
     /*

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -845,14 +845,39 @@ where
                         upstairs_id,
                         session_id,
                         gen,
+                        read_only,
+                        encrypted,
                     }) => {
                         if negotiated != 0 {
                             bail!("Received connect out of order {}",
                                 negotiated);
                         }
+
                         if version != 1 {
                             bail!("expected version 1, got {}", version);
                         }
+
+                        // Reject an Upstairs connection if there is a mismatch
+                        // of expectation
+                        {
+                            let ds = ads.lock().await;
+                            if ds.read_only != read_only {
+                                let mut fw = fw.lock().await;
+                                fw.send(Message::ReadOnlyMismatch {
+                                    expected: ds.read_only,
+                                }).await?;
+                                continue;
+                            }
+
+                            if ds.encrypted != encrypted {
+                                let mut fw = fw.lock().await;
+                                fw.send(Message::EncryptedMismatch {
+                                    expected: ds.encrypted,
+                                }).await?;
+                                continue;
+                            }
+                        }
+
                         negotiated = 1;
                         upstairs_connection = Some(UpstairsConnection {
                             upstairs_id,
@@ -1085,11 +1110,11 @@ where
     tokio::pin!(pf_task);
     loop {
         tokio::select! {
-            _ = &mut dw_task => {
-                bail!("do_work_task task has ended");
+            e = &mut dw_task => {
+                bail!("do_work_task task has ended: {:?}", e);
             }
-            _ = &mut pf_task => {
-                bail!("pf task ended");
+            e = &mut pf_task => {
+                bail!("pf task ended: {:?}", e);
             }
             /*
              * If we have set "lossy", then we need to check every now and
@@ -1213,10 +1238,18 @@ pub struct Downstairs {
     active_upstairs:
         Option<(UpstairsConnection, Arc<Sender<UpstairsConnection>>)>,
     dss: DsStatOuter,
+    read_only: bool,
+    encrypted: bool,
 }
 
 impl Downstairs {
-    fn new(region: Region, lossy: bool, return_errors: bool) -> Self {
+    fn new(
+        region: Region,
+        lossy: bool,
+        return_errors: bool,
+        read_only: bool,
+        encrypted: bool,
+    ) -> Self {
         let dss = DsStatOuter {
             ds_stat_wrap: Arc::new(Mutex::new(DsCountStat::new(
                 region.def().uuid(),
@@ -1229,6 +1262,8 @@ impl Downstairs {
             return_errors,
             active_upstairs: None,
             dss,
+            read_only,
+            encrypted,
         }
     }
 
@@ -1300,6 +1335,21 @@ impl Downstairs {
         ds_id: u64,
         work: IOop,
     ) -> Result<()> {
+        // The Upstairs will send Flushes periodically, even in read only mode
+        // we have to accept them. But read-only should never accept writes!
+        if self.read_only
+            && matches!(
+                work,
+                IOop::Write {
+                    dependencies: _,
+                    writes: _
+                }
+            )
+        {
+            eprintln!("read-only but received work {:?}", work);
+            bail!(CrucibleError::ModifyingReadOnlyRegion);
+        }
+
         let dsw = DownstairsWork {
             upstairs_uuid,
             ds_id,
@@ -1902,10 +1952,14 @@ pub fn build_downstairs_for_region(
         region.def().extent_count(),
     );
 
+    let encrypted = region.encrypted();
+
     Ok(Arc::new(Mutex::new(Downstairs::new(
         region,
         lossy,
         return_errors,
+        read_only,
+        encrypted,
     ))))
 }
 

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -89,6 +89,7 @@ fn main() -> Result<()> {
         key_pem: opt.key_pem,
         root_cert_pem: opt.root_cert_pem,
         control: opt.control,
+        read_only: false,
     };
     let mut generation_number = opt.gen;
 

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -101,6 +101,7 @@ mod test {
             key_pem: None,
             root_cert_pem: None,
             control: None,
+            read_only,
         };
         Ok(co)
     }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -513,12 +513,17 @@ mod test {
         guest.activate(0)?;
 
         // Expect an error attempting to write.
-        let write_result = guest.write(
-            Block::new(0, BLOCK_SIZE.trailing_zeros()),
-            Bytes::from(vec![0x55; BLOCK_SIZE * 10]),
-        )?.block_wait();
+        let write_result = guest
+            .write(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![0x55; BLOCK_SIZE * 10]),
+            )?
+            .block_wait();
         assert!(write_result.is_err());
-        assert!(matches!(write_result.err().unwrap(), CrucibleError::ModifyingReadOnlyRegion));
+        assert!(matches!(
+            write_result.err().unwrap(),
+            CrucibleError::ModifyingReadOnlyRegion
+        ));
 
         Ok(())
     }

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -80,6 +80,7 @@ fn main() -> Result<()> {
         key_pem: opt.key_pem,
         root_cert_pem: opt.root_cert_pem,
         control: None,
+        read_only: false,
     };
 
     /*

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -120,9 +120,19 @@ pub enum Message {
         upstairs_id: Uuid,
         session_id: Uuid,
         gen: u64,
+        read_only: bool,
+        encrypted: bool,
     },
     YesItsMe {
         version: u32,
+    },
+
+    // Reasons to reject the initial negotiation
+    ReadOnlyMismatch {
+        expected: bool,
+    },
+    EncryptedMismatch {
+        expected: bool,
     },
 
     /**
@@ -561,6 +571,8 @@ mod tests {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
             gen: 123,
+            read_only: false,
+            encrypted: true,
         };
         assert_eq!(input, round_trip(&input)?);
         Ok(())
@@ -626,6 +638,8 @@ mod tests {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
             gen: 23849183,
+            read_only: true,
+            encrypted: false,
         };
         let mut buffer = BytesMut::new();
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -192,6 +192,7 @@ pub struct CrucibleOpts {
     pub key_pem: Option<String>,
     pub root_cert_pem: Option<String>,
     pub control: Option<SocketAddr>,
+    pub read_only: bool,
 }
 
 impl CrucibleOpts {
@@ -354,7 +355,6 @@ async fn io_send<WT>(
     u: &Arc<Upstairs>,
     fw: &mut FramedWrite<WT, CrucibleEncoder>,
     client_id: u8,
-    lossy: bool,
 ) -> Result<bool>
 where
     WT: tokio::io::AsyncWrite
@@ -403,7 +403,7 @@ where
          * Walk the list of work to do, update its status as in progress
          * and send the details to our downstairs.
          */
-        if lossy && random() && random() {
+        if u.lossy && random() && random() {
             continue;
         }
 
@@ -478,7 +478,6 @@ async fn proc_stream(
     stream: WrappedStream,
     connected: &mut bool,
     up_coms: &mut UpComs,
-    lossy: bool,
 ) -> Result<()> {
     match stream {
         WrappedStream::Http(sock) => {
@@ -487,7 +486,7 @@ async fn proc_stream(
             let fr = FramedRead::new(read, CrucibleDecoder::new());
             let fw = FramedWrite::new(write, CrucibleEncoder::new());
 
-            proc(target, up, fr, fw, connected, up_coms, lossy).await
+            proc(target, up, fr, fw, connected, up_coms).await
         }
         WrappedStream::Https(stream) => {
             let (read, write) = tokio::io::split(stream);
@@ -495,7 +494,7 @@ async fn proc_stream(
             let fr = FramedRead::new(read, CrucibleDecoder::new());
             let fw = FramedWrite::new(write, CrucibleEncoder::new());
 
-            proc(target, up, fr, fw, connected, up_coms, lossy).await
+            proc(target, up, fr, fw, connected, up_coms).await
         }
     }
 }
@@ -515,7 +514,6 @@ async fn proc<RT, WT>(
     mut fw: FramedWrite<WT, CrucibleEncoder>,
     connected: &mut bool,
     up_coms: &mut UpComs,
-    lossy: bool,
 ) -> Result<()>
 where
     RT: tokio::io::AsyncRead + std::marker::Unpin + std::marker::Send,
@@ -568,6 +566,8 @@ where
         upstairs_id: up.uuid,
         session_id: up.session_id,
         gen: up.get_generation(),
+        read_only: up.read_only,
+        encrypted: up.encrypted(),
     };
     fw.send(m).await?;
 
@@ -712,6 +712,22 @@ where
                         return Ok(())
                     }
                     Some(Message::Imok) => {}
+                    Some(Message::ReadOnlyMismatch { expected }) => {
+                        // Upstairs will never be able to connect, bail
+                        bail!(
+                            "downstairs read_only is {}, ours is {}!",
+                            expected,
+                            up.read_only,
+                        );
+                    }
+                    Some(Message::EncryptedMismatch { expected }) => {
+                        // Upstairs will never be able to connect, bail
+                        bail!(
+                            "downstairs encrypted is {}, ours is {}!",
+                            expected,
+                            up.encrypted(),
+                        );
+                    }
                     Some(Message::YesItsMe { version }) => {
                         if negotiated != 0 {
                             bail!("Got version already!");
@@ -1100,7 +1116,7 @@ where
      * for a downstairs connection.
      */
     assert_eq!(negotiated, 5);
-    cmd_loop(up, fr, fw, up_coms, lossy).await
+    cmd_loop(up, fr, fw, up_coms).await
 }
 
 /*
@@ -1130,7 +1146,6 @@ async fn cmd_loop<RT, WT>(
     mut fr: FramedRead<RT, crucible_protocol::CrucibleDecoder>,
     mut fw: FramedWrite<WT, crucible_protocol::CrucibleEncoder>,
     up_coms: &mut UpComs,
-    lossy: bool,
 ) -> Result<()>
 where
     RT: tokio::io::AsyncRead + std::marker::Unpin + std::marker::Send,
@@ -1147,7 +1162,7 @@ where
      */
     let mut more_work = up.ds_is_replay(up_coms.client_id);
     if !more_work {
-        do_reconcile_work(up, &mut fr, &mut fw, up_coms, lossy).await?;
+        do_reconcile_work(up, &mut fr, &mut fw, up_coms).await?;
     }
 
     /*
@@ -1317,7 +1332,7 @@ where
                  * check.
                  */
                 let more =
-                    io_send(up, &mut fw, up_coms.client_id, lossy).await?;
+                    io_send(up, &mut fw, up_coms.client_id).await?;
 
                 if more && !more_work {
                     println!("[{}] flow control start ", up_coms.client_id);
@@ -1332,9 +1347,7 @@ where
                     up_coms.client_id
                 );
 
-                let more = io_send(
-                                up, &mut fw, up_coms.client_id, lossy
-                            ).await?;
+                let more = io_send(up, &mut fw, up_coms.client_id).await?;
 
                 if more {
                     more_work = true;
@@ -1361,14 +1374,14 @@ where
                  */
                 fw.send(Message::Ruok).await?;
 
-                if lossy {
+                if up.lossy {
                     /*
                      * When lossy is set, we don't always send work to a
                      * downstairs when we should. This means we need to,
                      * every now and then, signal the downstairs task to
                      * check and see if we skipped some work earlier.
                      */
-                    io_send(up, &mut fw, up_coms.client_id, lossy).await?;
+                    io_send(up, &mut fw, up_coms.client_id).await?;
                 }
 
                 /*
@@ -1411,7 +1424,6 @@ async fn do_reconcile_work<RT, WT>(
     fr: &mut FramedRead<RT, crucible_protocol::CrucibleDecoder>,
     fw: &mut FramedWrite<WT, crucible_protocol::CrucibleEncoder>,
     up_coms: &mut UpComs,
-    _lossy: bool,
 ) -> Result<()>
 where
     RT: tokio::io::AsyncRead + std::marker::Unpin + std::marker::Send,
@@ -1794,7 +1806,6 @@ async fn looper(
     >,
     up: &Arc<Upstairs>,
     mut up_coms: UpComs,
-    lossy: bool,
 ) {
     let mut firstgo = true;
     let mut connected = false;
@@ -1880,8 +1891,7 @@ async fn looper(
          * Once we have a connected downstairs, the proc task takes over and
          * handles negotiation and work processing.
          */
-        match proc_stream(&target, up, tcp, &mut connected, &mut up_coms, lossy)
-            .await
+        match proc_stream(&target, up, tcp, &mut connected, &mut up_coms).await
         {
             Ok(()) => {
                 // XXX figure out what to do here
@@ -3437,6 +3447,16 @@ pub struct Upstairs {
      * Upstairs stats.
      */
     stats: UpStatOuter,
+
+    /*
+     * Does this Upstairs throw random errors?
+     */
+    lossy: bool,
+
+    /*
+     * Operate in read-only mode
+     */
+    read_only: bool,
 }
 
 impl Upstairs {
@@ -3451,6 +3471,7 @@ impl Upstairs {
             key_pem: None,
             root_cert_pem: None,
             control: None,
+            read_only: false,
         };
         Self::new(
             &opts,
@@ -3515,7 +3536,13 @@ impl Upstairs {
             encryption_context,
             need_flush: Mutex::new(false),
             stats,
+            lossy: opt.lossy,
+            read_only: opt.read_only,
         })
+    }
+
+    pub fn encrypted(&self) -> bool {
+        self.encryption_context.is_some()
     }
 
     /**
@@ -3965,6 +3992,10 @@ impl Upstairs {
     ) -> Result<(), CrucibleError> {
         if !self.guest_io_ready() {
             crucible_bail!(UpstairsInactive);
+        }
+
+        if self.read_only {
+            crucible_bail!(ModifyingReadOnlyRegion);
         }
 
         /*
@@ -7140,8 +7171,6 @@ pub async fn up_main(
         }
     }
 
-    let lossy = opt.lossy;
-
     /*
      * Build the Upstairs struct that we use to share data between
      * the different async tasks
@@ -7237,7 +7266,7 @@ pub async fn up_main(
             };
             let tls_context = tls_context.clone();
             tokio::spawn(async move {
-                looper(t0, tls_context, &up, up_coms, lossy).await;
+                looper(t0, tls_context, &up, up_coms).await;
             });
             client_id += 1;
 


### PR DESCRIPTION
Move the `lossy` flag into the Upstairs, and add a `read_only` flag.
Make sure that an Upstairs in read-only mode cannot submit writes.

Supporting configuring Downstairs in read-only mode, which opens Extents
in read-only mode. Return errors if an Upstairs tries to modify on-disk
state.

Negotiation now sends read-only and encryption expectation, and the
Downstairs will reject connections where there is a mismatch.