### PR TITLE
Scrubber 2.5: write_unwritten at the volume layer

### DIFF
--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -113,7 +113,8 @@ mod test {
     // function should help to make this easier.
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-    async fn integration_test_downstairs() -> Result<()> {
+    async fn integration_test_region() -> Result<()> {
+        // Test a simple single layer volume with a read, write, read
         const BLOCK_SIZE: usize = 512;
 
         let opts = three_downstairs(54001, 54002, 54003, false).unwrap();
@@ -168,10 +169,21 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn integration_test_two_layers() -> Result<()> {
-        const BLOCK_SIZE: usize = 512;
-
         let opts = three_downstairs(54004, 54005, 54006, false).unwrap();
+        integration_test_two_layers_common(opts, false).await
+    }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn integration_test_two_layers_write_unwritten() -> Result<()> {
+        let opts = three_downstairs(54007, 54008, 54009, false).unwrap();
+        integration_test_two_layers_common(opts, true).await
+    }
+
+    async fn integration_test_two_layers_common(
+        opts: CrucibleOpts,
+        is_write_unwritten: bool,
+    ) -> Result<()> {
+        const BLOCK_SIZE: usize = 512;
         // Create in memory block io full of 11
         let in_memory_data = Arc::new(InMemoryBlockIO::new(
             Uuid::new_v4(),
@@ -208,12 +220,21 @@ mod test {
         assert_eq!(vec![11; BLOCK_SIZE * 10], *buffer.as_vec());
 
         // Write data in
-        volume
-            .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![55; BLOCK_SIZE * 10]),
-            )?
-            .block_wait()?;
+        if is_write_unwritten {
+            volume
+                .write_unwritten(
+                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                    Bytes::from(vec![55; BLOCK_SIZE * 10]),
+                )?
+                .block_wait()?;
+        } else {
+            volume
+                .write(
+                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                    Bytes::from(vec![55; BLOCK_SIZE * 10]),
+                )?
+                .block_wait()?;
+        }
 
         // Verify parent wasn't written to
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -238,7 +259,7 @@ mod test {
     async fn integration_test_three_layers() -> Result<()> {
         const BLOCK_SIZE: usize = 512;
 
-        let opts = three_downstairs(54007, 54008, 54009, false).unwrap();
+        let opts = three_downstairs(54010, 54011, 54012, false).unwrap();
 
         // Create in memory block io full of 11
         let in_memory_data = Arc::new(InMemoryBlockIO::new(
@@ -327,7 +348,7 @@ mod test {
     async fn integration_test_url() -> Result<()> {
         const BLOCK_SIZE: usize = 512;
 
-        let opts = three_downstairs(54010, 54011, 54012, false).unwrap();
+        let opts = three_downstairs(54013, 54014, 54015, false).unwrap();
 
         let server = Server::run();
         server.expect(
@@ -409,10 +430,11 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-    async fn integration_test_read_only() -> Result<()> {
+    async fn integration_test_just_read() -> Result<()> {
+        // Just do a read of a new volume.
         const BLOCK_SIZE: usize = 512;
 
-        let opts = three_downstairs(54013, 54014, 54015, true).unwrap();
+        let opts = three_downstairs(54016, 54017, 54018, true).unwrap();
 
         let vcr: VolumeConstructionRequest =
             VolumeConstructionRequest::Volume {
@@ -451,13 +473,528 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn integration_test_volume_write_unwritten_1() -> Result<()> {
+        // Test a simple single layer volume, verify write_unwritten
+        // works as expected.
+        // Volume with a subvolume:
+        // |----------|
+        //
+        // Write A:
+        // |AAAAAAAAAA|
+        // Write unwritten B:
+        // |BBBBBBBBBB|
+        //
+        // Should result in:
+        // |AAAAAAAAAA|
+        const BLOCK_SIZE: usize = 512;
+
+        let opts = three_downstairs(54019, 54020, 54021, false).unwrap();
+
+        let vcr: VolumeConstructionRequest =
+            VolumeConstructionRequest::Volume {
+                id: Uuid::new_v4(),
+                block_size: BLOCK_SIZE as u64,
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    opts,
+                    gen: 0,
+                }],
+                read_only_parent: None,
+            };
+
+        // XXX Crucible uses std::sync::mpsc::Receiver, not
+        // tokio::sync::mpsc::Receiver, so use tokio::task::block_in_place here.
+        // Remove that when Crucible changes over to the tokio mpsc.
+        let volume = Arc::new(tokio::task::block_in_place(|| {
+            Volume::construct(vcr, None)
+        })?);
+
+        volume.activate(0)?;
+
+        // Write data in
+        volume
+            .write(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![0x55; BLOCK_SIZE * 10]),
+            )?
+            .block_wait()?;
+
+        // Read volume, verify contents
+        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())?
+            .block_wait()?;
+
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec());
+
+        // Write_unwritten data in, should not change anything
+        volume
+            .write_unwritten(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![0x22; BLOCK_SIZE * 10]),
+            )?
+            .block_wait()?;
+
+        // Read volume, verify original contents
+        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())?
+            .block_wait()?;
+
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec());
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn integration_test_volume_write_unwritten_2() -> Result<()> {
+        // Test a simple single layer volume, verify a first write_unwritten
+        // won't be altered by a 2nd write_unwritten.
+        // Volume with a subvolume:
+        // |----------|
+        //
+        // Write unwritten A:
+        // |AAAAAAAAAA|
+        // Write unwritten B:
+        // |BBBBBBBBBB|
+        //
+        // Should result in:
+        // |AAAAAAAAAA|
+        const BLOCK_SIZE: usize = 512;
+        let opts = three_downstairs(54022, 54023, 54024, false).unwrap();
+
+        let vcr: VolumeConstructionRequest =
+            VolumeConstructionRequest::Volume {
+                id: Uuid::new_v4(),
+                block_size: BLOCK_SIZE as u64,
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    opts,
+                    gen: 0,
+                }],
+                read_only_parent: None,
+            };
+
+        // XXX Crucible uses std::sync::mpsc::Receiver, not
+        // tokio::sync::mpsc::Receiver, so use tokio::task::block_in_place here.
+        // Remove that when Crucible changes over to the tokio mpsc.
+        let volume = Arc::new(tokio::task::block_in_place(|| {
+            Volume::construct(vcr, None)
+        })?);
+
+        volume.activate(0)?;
+
+        // Write data in
+        volume
+            .write_unwritten(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![0x55; BLOCK_SIZE * 10]),
+            )?
+            .block_wait()?;
+
+        // Read parent, verify contents
+        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())?
+            .block_wait()?;
+
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec());
+
+        // A second Write_unwritten data, should not change anything
+        volume
+            .write_unwritten(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![0x22; BLOCK_SIZE * 10]),
+            )?
+            .block_wait()?;
+
+        // Read volume, verify original contents
+        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())?
+            .block_wait()?;
+
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec());
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn integration_test_volume_write_unwritten_sparse() -> Result<()> {
+        // Test a simple single layer volume
+        // Perform a smaller write, then a larger write_unwritten and
+        // verify the smaller write is not over-written.
+        // Volume with a subvolume:
+        // |----------|
+        //
+        // Write A:
+        // |A---------|
+        // Write unwritten B:
+        // |BBBBBBBBBB|
+        //
+        // Should result in:
+        // |ABBBBBBBBBB|
+        const BLOCK_SIZE: usize = 512;
+
+        let opts = three_downstairs(54025, 54026, 54027, false).unwrap();
+
+        let vcr: VolumeConstructionRequest =
+            VolumeConstructionRequest::Volume {
+                id: Uuid::new_v4(),
+                block_size: BLOCK_SIZE as u64,
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    opts,
+                    gen: 0,
+                }],
+                read_only_parent: None,
+            };
+
+        // XXX Crucible uses std::sync::mpsc::Receiver, not
+        // tokio::sync::mpsc::Receiver, so use tokio::task::block_in_place here.
+        // Remove that when Crucible changes over to the tokio mpsc.
+        let volume = Arc::new(tokio::task::block_in_place(|| {
+            Volume::construct(vcr, None)
+        })?);
+
+        volume.activate(0)?;
+
+        // Write data at block 0
+        volume
+            .write(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![0x33; BLOCK_SIZE]),
+            )?
+            .block_wait()?;
+
+        // A second Write_unwritten that overlaps the original write.
+        volume
+            .write_unwritten(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![0x55; BLOCK_SIZE * 10]),
+            )?
+            .block_wait()?;
+
+        // Read and verify
+        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())?
+            .block_wait()?;
+
+        // Get the data into a vec we can take slices of.
+        let dl = buffer.as_vec().to_vec();
+
+        // Verify data in the first block is from the first write
+        assert_eq!(vec![0x33_u8; BLOCK_SIZE], dl[0..BLOCK_SIZE]);
+
+        // Verify the remaining blocks have the write_unwritten data
+        assert_eq!(
+            vec![0x55_u8; BLOCK_SIZE * 9],
+            dl[BLOCK_SIZE..BLOCK_SIZE * 10]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn integration_test_volume_write_unwritten_subvols() -> Result<()> {
+        // Test a single layer volume with two subvolumes,
+        // verify a first write_unwritten that crosses the subvols
+        // works as expected.
+        //
+        // Volume with two subvolumes:
+        // |----------||----------|
+        //
+        // Write unwritten:
+        // |AAAAAAAAAA||AAAAAAAAAA|
+        //
+        // Should result in:
+        // |AAAAAAAAAA||AAAAAAAAAA|
+        const BLOCK_SIZE: usize = 512;
+
+        let mut sv = Vec::new();
+        let opts = three_downstairs(54028, 54029, 54030, false).unwrap();
+        sv.push(VolumeConstructionRequest::Region {
+            block_size: BLOCK_SIZE as u64,
+            opts,
+            gen: 0,
+        });
+        let opts = three_downstairs(54031, 54032, 54033, false).unwrap();
+        sv.push(VolumeConstructionRequest::Region {
+            block_size: BLOCK_SIZE as u64,
+            opts,
+            gen: 0,
+        });
+
+        let vcr: VolumeConstructionRequest =
+            VolumeConstructionRequest::Volume {
+                id: Uuid::new_v4(),
+                block_size: BLOCK_SIZE as u64,
+                sub_volumes: sv,
+                read_only_parent: None,
+            };
+
+        // XXX Crucible uses std::sync::mpsc::Receiver, not
+        // tokio::sync::mpsc::Receiver, so use tokio::task::block_in_place here.
+        // Remove that when Crucible changes over to the tokio mpsc.
+        let volume = Arc::new(tokio::task::block_in_place(|| {
+            Volume::construct(vcr, None)
+        })?);
+
+        volume.activate(0)?;
+        let full_volume_size = BLOCK_SIZE * 20;
+        // Write data in
+        volume
+            .write_unwritten(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![0x55; full_volume_size]),
+            )?
+            .block_wait()?;
+
+        // Read parent, verify contents
+        let buffer = Buffer::new(full_volume_size);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())?
+            .block_wait()?;
+
+        assert_eq!(vec![0x55_u8; full_volume_size], *buffer.as_vec());
+
+        // A second Write_unwritten data, should not change anything
+        volume
+            .write_unwritten(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![0x22; full_volume_size]),
+            )?
+            .block_wait()?;
+
+        // Read volume, verify original contents
+        let buffer = Buffer::new(full_volume_size);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())?
+            .block_wait()?;
+
+        assert_eq!(vec![0x55_u8; full_volume_size], *buffer.as_vec());
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn integration_test_volume_write_unwritten_subvols_sparse(
+    ) -> Result<()> {
+        // Test a single layer volume with two subvolumes,
+        // verify a first write_unwritten that crosses the subvols
+        // works as expected.
+        //
+        // Two subvolumes:
+        // |----------||----------|
+        // Write unwritten A:
+        // |---------A||A---------|
+        // Write unwritten B:
+        // |BBBBBBBBBB||BBBBBBBBBB|
+        //
+        // Should result in:
+        // |BBBBBBBBBA||ABBBBBBBBB|
+        const BLOCK_SIZE: usize = 512;
+
+        let mut sv = Vec::new();
+        let opts = three_downstairs(54034, 54035, 54036, false).unwrap();
+        sv.push(VolumeConstructionRequest::Region {
+            block_size: BLOCK_SIZE as u64,
+            opts,
+            gen: 0,
+        });
+        let opts = three_downstairs(54037, 54038, 54039, false).unwrap();
+        sv.push(VolumeConstructionRequest::Region {
+            block_size: BLOCK_SIZE as u64,
+            opts,
+            gen: 0,
+        });
+
+        let vcr: VolumeConstructionRequest =
+            VolumeConstructionRequest::Volume {
+                id: Uuid::new_v4(),
+                block_size: BLOCK_SIZE as u64,
+                sub_volumes: sv,
+                read_only_parent: None,
+            };
+
+        // XXX Crucible uses std::sync::mpsc::Receiver, not
+        // tokio::sync::mpsc::Receiver, so use tokio::task::block_in_place here.
+        // Remove that when Crucible changes over to the tokio mpsc.
+        let volume = Arc::new(tokio::task::block_in_place(|| {
+            Volume::construct(vcr, None)
+        })?);
+
+        volume.activate(0)?;
+        let full_volume_size = BLOCK_SIZE * 20;
+
+        // Write data to last block of first vol, and first block of
+        // second vol.
+        volume
+            .write_unwritten(
+                Block::new(9, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![0x55; BLOCK_SIZE * 2]),
+            )?
+            .block_wait()?;
+
+        // Read parent, verify contents
+        let buffer = Buffer::new(BLOCK_SIZE * 2);
+        volume
+            .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), buffer.clone())?
+            .block_wait()?;
+
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 2], *buffer.as_vec());
+
+        // A second Write_unwritten data, should not change the previous
+        // write_unwritten, but should change the remaining blocks that
+        // were not written yet.
+        volume
+            .write_unwritten(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![0x22; full_volume_size]),
+            )?
+            .block_wait()?;
+
+        // Read full volume, verify first write_unwritten still valid, but the
+        // other blocks of the 2nd write_unwritten are updated.
+        let buffer = Buffer::new(full_volume_size);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())?
+            .block_wait()?;
+
+        // Get the data into a vec we can take slices of.
+        let dl = buffer.as_vec().to_vec();
+
+        // Verify data in blocks 0-9 is the second write_unwritten
+        assert_eq!(vec![0x22_u8; BLOCK_SIZE * 9], dl[0..(BLOCK_SIZE * 9)]);
+
+        // Verify data in blocks 10-11 is the first write_unwritten
+        assert_eq!(
+            vec![0x55_u8; BLOCK_SIZE * 2],
+            dl[(BLOCK_SIZE * 9)..(BLOCK_SIZE * 11)]
+        );
+
+        // Verify the remaining blocks have the second write_unwritten data
+        assert_eq!(
+            vec![0x22_u8; BLOCK_SIZE * 9],
+            dl[(BLOCK_SIZE * 11)..full_volume_size]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn integration_test_volume_write_unwritten_subvols_3() -> Result<()> {
+        // Test a single layer volume with two subvolumes,
+        // A first write_unwritten that crosses the subvols
+        // A 2nd write unwritten.
+        // A 3rd regular write
+        //
+        // Two subvolumes:
+        // |----------||----------|
+        // Write unwritten A:
+        // |---------A||A---------|
+        // Write unwritten B:
+        // |BBBBBBBBBB||----------|
+        // Write C:
+        // |-------CCC||CCCCCCCCCC|
+        //
+        // Should result in:
+        // |BBBBBBBCCC||CCCCCCCCCC|
+        const BLOCK_SIZE: usize = 512;
+
+        let mut sv = Vec::new();
+        let opts = three_downstairs(54040, 54041, 54042, false).unwrap();
+        sv.push(VolumeConstructionRequest::Region {
+            block_size: BLOCK_SIZE as u64,
+            opts,
+            gen: 0,
+        });
+        let opts = three_downstairs(54043, 54044, 54045, false).unwrap();
+        sv.push(VolumeConstructionRequest::Region {
+            block_size: BLOCK_SIZE as u64,
+            opts,
+            gen: 0,
+        });
+
+        let vcr: VolumeConstructionRequest =
+            VolumeConstructionRequest::Volume {
+                id: Uuid::new_v4(),
+                block_size: BLOCK_SIZE as u64,
+                sub_volumes: sv,
+                read_only_parent: None,
+            };
+
+        // XXX Crucible uses std::sync::mpsc::Receiver, not
+        // tokio::sync::mpsc::Receiver, so use tokio::task::block_in_place here.
+        // Remove that when Crucible changes over to the tokio mpsc.
+        let volume = Arc::new(tokio::task::block_in_place(|| {
+            Volume::construct(vcr, None)
+        })?);
+
+        volume.activate(0)?;
+        let full_volume_size = BLOCK_SIZE * 20;
+
+        // Write data to last block of first vol, and first block of
+        // second vol.
+        volume
+            .write_unwritten(
+                Block::new(9, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![0x55; BLOCK_SIZE * 2]),
+            )?
+            .block_wait()?;
+
+        // A second Write_unwritten data, should not change the previous
+        // write_unwritten, but should change the remaining blocks that
+        // were not written yet.
+        volume
+            .write_unwritten(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![0x22; BLOCK_SIZE * 10]),
+            )?
+            .block_wait()?;
+
+        // A write
+        volume
+            .write(
+                Block::new(7, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![0x11; BLOCK_SIZE * 13]),
+            )?
+            .block_wait()?;
+
+        // Read full volume
+        let buffer = Buffer::new(full_volume_size);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())?
+            .block_wait()?;
+
+        // Get the data into a vec we can take slices of.
+        let dl = buffer.as_vec().to_vec();
+
+        // Verify data in blocks 0-7 is the second write_unwritten
+        assert_eq!(vec![0x22_u8; BLOCK_SIZE * 7], dl[0..(BLOCK_SIZE * 7)]);
+
+        // Verify data in blocks 8-19 is the third write
+        assert_eq!(
+            vec![0x11_u8; BLOCK_SIZE * 13],
+            dl[(BLOCK_SIZE * 7)..full_volume_size]
+        );
+
+        Ok(())
+    }
+
+    // The following tests work at the "guest" layer.  The volume
+    // layers above (in general) will eventually call a BlockIO trait
+    // on a guest layer.  Port numbers from this point below should
+    // start at 55001 and go up from there.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn integration_test_guest_downstairs() -> Result<()> {
         // Test using the guest layer to verify a new region is
         // what we expect, and a write and read work as expected
         const BLOCK_SIZE: usize = 512;
 
         // Spin off three downstairs, build our Crucible struct.
-        let opts = three_downstairs(54016, 54017, 54018, false).unwrap();
+        let opts = three_downstairs(55016, 55017, 55018, false).unwrap();
 
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
@@ -501,7 +1038,7 @@ mod test {
         const BLOCK_SIZE: usize = 512;
 
         // Spin up three read-only downstairs
-        let opts = three_downstairs(54019, 54020, 54021, true).unwrap();
+        let opts = three_downstairs(55019, 55020, 55021, true).unwrap();
 
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
@@ -537,7 +1074,7 @@ mod test {
         const BLOCK_SIZE: usize = 512;
 
         // Spin off three downstairs, build our Crucible struct.
-        let opts = three_downstairs(54022, 54023, 54024, false).unwrap();
+        let opts = three_downstairs(55022, 55023, 55024, false).unwrap();
 
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
@@ -611,7 +1148,7 @@ mod test {
         const BLOCK_SIZE: usize = 512;
 
         // Spin off three downstairs, build our Crucible struct.
-        let opts = three_downstairs(54025, 54026, 54027, false).unwrap();
+        let opts = three_downstairs(55025, 55026, 55027, false).unwrap();
 
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
@@ -670,7 +1207,7 @@ mod test {
         const BLOCK_SIZE: usize = 512;
 
         // Spin off three downstairs, build our Crucible struct.
-        let opts = three_downstairs(54028, 54029, 54030, false).unwrap();
+        let opts = three_downstairs(55028, 55029, 55030, false).unwrap();
 
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
@@ -730,7 +1267,7 @@ mod test {
         const BLOCK_SIZE: usize = 512;
 
         // Spin off three downstairs, build our Crucible struct.
-        let opts = three_downstairs(54031, 54032, 54033, false).unwrap();
+        let opts = three_downstairs(55031, 55032, 55033, false).unwrap();
 
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
@@ -788,7 +1325,7 @@ mod test {
         const BLOCK_SIZE: usize = 512;
 
         // Spin off three downstairs, build our Crucible struct.
-        let opts = three_downstairs(54034, 54035, 54036, false).unwrap();
+        let opts = three_downstairs(55034, 55035, 55036, false).unwrap();
 
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
@@ -846,7 +1383,7 @@ mod test {
         const BLOCK_SIZE: usize = 512;
 
         // Spin off three downstairs, build our Crucible struct.
-        let opts = three_downstairs(54037, 54038, 54039, false).unwrap();
+        let opts = three_downstairs(55037, 55038, 55039, false).unwrap();
 
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();


### PR DESCRIPTION
This adds support for write_unwritten at the volume layer and
a bunch of tests to make sure it works.  Abstracted the previous
write method to support both regular write and now write_unwritten.

https://github.com/oxidecomputer/crucible/issues/404