### PR TITLE
Creating a running snapshot should be idempotent

### DIFF
--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -303,11 +303,14 @@ impl DataFile {
             inner.running_snapshots.get_mut(&request.id).unwrap();
 
         if running_snapshots.get(&request.name).is_none() {
-            bail!(
-                "not running for region {} snapshot {}",
+            info!(
+                self.log,
+                "not running for region {} snapshot {}, returning Ok",
                 request.id.0,
                 request.name
             );
+
+            return Ok(());
         }
 
         info!(

--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -241,13 +241,13 @@ impl DataFile {
         /*
          * Look for an existing running snapshot.
          */
-        if inner
+        if let Some(r) = inner
             .running_snapshots
             .entry(request.id.clone())
             .or_insert_with(BTreeMap::default)
-            .contains_key(&request.name)
+            .get(&request.name)
         {
-            bail!("already running snapshot {} {}", request.id.0, request.name);
+            return Ok(r.clone());
         }
 
         /*

--- a/agent/src/model.rs
+++ b/agent/src/model.rs
@@ -142,6 +142,21 @@ impl CreateRegion {
                 "encrypted {} instead of requested {}",
                 self.encrypted, r.encrypted
             ))
+        } else if self.cert_pem != r.cert_pem {
+            Some(format!(
+                "cert_pem {:?} instead of requested {:?}",
+                self.cert_pem, r.cert_pem
+            ))
+        } else if self.key_pem != r.key_pem {
+            Some(format!(
+                "key_pem {:?} instead of requested {:?}",
+                self.key_pem, r.key_pem
+            ))
+        } else if self.root_pem != r.root_pem {
+            Some(format!(
+                "root_pem {:?} instead of requested {:?}",
+                self.root_pem, r.root_pem
+            ))
         } else {
             None
         }


### PR DESCRIPTION
Also, comparison of running downstairs request should check X509
information too (even though we don't current use it).

Closes #380