### PR TITLE
Remember to draw the rest of the owl

### DIFF
--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -1432,4 +1432,68 @@ mod test {
 
         Ok(())
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn integration_test_two_layers_small_common() -> Result<()> {
+        // Test a RO parent that is smaller than the SubVolume.
+        let opts = three_downstairs(54052, 54053, 54054, false).unwrap();
+
+        const BLOCK_SIZE: usize = 512;
+        // Create in_memory block_io
+        let in_memory_data = Arc::new(InMemoryBlockIO::new(
+            Uuid::new_v4(),
+            BLOCK_SIZE as u64,
+            BLOCK_SIZE * 5,
+        ));
+
+        // Fill the in_memory block_io with 1s
+        in_memory_data
+            .write(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![11; BLOCK_SIZE * 5]),
+            )?
+            .block_wait()?;
+
+        // Read back in_memory, verify 1s
+        let buffer = Buffer::new(BLOCK_SIZE * 5);
+        in_memory_data
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())?
+            .block_wait()?;
+
+        assert_eq!(vec![11; BLOCK_SIZE * 5], *buffer.as_vec());
+
+        let mut volume = Volume::new(BLOCK_SIZE as u64);
+        volume.add_subvolume_create_guest(opts, 0, None)?;
+        volume.add_read_only_parent(in_memory_data.clone())?;
+
+        volume.activate(0)?;
+
+        // Verify parent contents in one read
+        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())?
+            .block_wait()?;
+
+        let mut expected = vec![11; BLOCK_SIZE * 5];
+        expected.extend(vec![0x00; BLOCK_SIZE * 5]);
+        assert_eq!(expected, *buffer.as_vec());
+
+        // One big write!
+        volume
+            .write(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![55; BLOCK_SIZE * 10]),
+            )?
+            .block_wait()?;
+
+        // Verify volume contents in one read
+        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())?
+            .block_wait()?;
+
+        assert_eq!(vec![55; BLOCK_SIZE * 10], *buffer.as_vec());
+
+        Ok(())
+    }
 }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -1434,7 +1434,7 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-    async fn integration_test_two_layers_small_common() -> Result<()> {
+    async fn integration_test_two_layers_parent_smaller() -> Result<()> {
         // Test a RO parent that is smaller than the SubVolume.
         let opts = three_downstairs(54052, 54053, 54054, false).unwrap();
 

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -1121,7 +1121,7 @@ mod test {
         read_only_parent_init_value: u8,
     ) -> Result<()> {
         volume.activate(0)?;
-        assert_eq!(volume.block_size()?, 512);
+        assert_eq!(volume.get_block_size()?, 512);
         assert_eq!(block_size, 512);
         assert_eq!(volume.total_size()?, 4096);
 
@@ -1906,7 +1906,7 @@ mod test {
 
     // Test that blocks are correctly returned during read-only parent +
     // subvolume overlap.
-    async fn test_draw_the_owl(
+    async fn test_correct_blocks_returned(
         block_size: usize,
         subvolumes: &[Arc<dyn BlockIO + Send + Sync>],
     ) -> Result<()> {
@@ -1976,7 +1976,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_draw_the_owl_one_subvolume() -> Result<()> {
+    async fn test_correct_blocks_returned_one_subvolume() -> Result<()> {
         const BLOCK_SIZE: usize = 512;
 
         // this layout has one volume that the parent lba range overlaps:
@@ -1989,11 +1989,12 @@ mod test {
             BLOCK_SIZE * 10,
         ));
 
-        test_draw_the_owl(BLOCK_SIZE, &[subvolume]).await
+        test_correct_blocks_returned(BLOCK_SIZE, &[subvolume]).await
     }
 
     #[tokio::test]
-    async fn test_draw_the_owl_multiple_subvolumes_1() -> Result<()> {
+    async fn test_correct_blocks_returned_multiple_subvolumes_1() -> Result<()>
+    {
         const BLOCK_SIZE: usize = 512;
 
         // this layout has two volumes that the parent lba range overlaps:
@@ -2012,11 +2013,13 @@ mod test {
             BLOCK_SIZE * 8,
         ));
 
-        test_draw_the_owl(BLOCK_SIZE, &[subvolume_1, subvolume_2]).await
+        test_correct_blocks_returned(BLOCK_SIZE, &[subvolume_1, subvolume_2])
+            .await
     }
 
     #[tokio::test]
-    async fn test_draw_the_owl_multiple_subvolumes_2() -> Result<()> {
+    async fn test_correct_blocks_returned_multiple_subvolumes_2() -> Result<()>
+    {
         const BLOCK_SIZE: usize = 512;
 
         // this layout has two volumes that the parent lba range overlaps:
@@ -2035,11 +2038,13 @@ mod test {
             BLOCK_SIZE * 5,
         ));
 
-        test_draw_the_owl(BLOCK_SIZE, &[subvolume_1, subvolume_2]).await
+        test_correct_blocks_returned(BLOCK_SIZE, &[subvolume_1, subvolume_2])
+            .await
     }
 
     #[tokio::test]
-    async fn test_draw_the_owl_multiple_subvolumes_3() -> Result<()> {
+    async fn test_correct_blocks_returned_multiple_subvolumes_3() -> Result<()>
+    {
         const BLOCK_SIZE: usize = 512;
 
         // this layout has two volumes that the parent lba range overlaps:
@@ -2058,11 +2063,12 @@ mod test {
             BLOCK_SIZE * 3,
         ));
 
-        test_draw_the_owl(BLOCK_SIZE, &[subvolume_1, subvolume_2]).await
+        test_correct_blocks_returned(BLOCK_SIZE, &[subvolume_1, subvolume_2])
+            .await
     }
 
     #[tokio::test]
-    async fn test_draw_the_owl_three_subvolumes() -> Result<()> {
+    async fn test_correct_blocks_returned_three_subvolumes() -> Result<()> {
         const BLOCK_SIZE: usize = 512;
 
         // this layout has three volumes that the parent lba range overlaps:
@@ -2087,7 +2093,10 @@ mod test {
             BLOCK_SIZE * 4,
         ));
 
-        test_draw_the_owl(BLOCK_SIZE, &[subvolume_1, subvolume_2, subvolume_3])
-            .await
+        test_correct_blocks_returned(
+            BLOCK_SIZE,
+            &[subvolume_1, subvolume_2, subvolume_3],
+        )
+        .await
     }
 }

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -364,10 +364,10 @@ impl BlockIO for Volume {
 
             if let Some(parent_coverage) = parent_coverage {
                 let parent_offset = Block::new(coverage.start, offset.shift);
-                let sz = self.block_size as usize
+                let sub_sz = self.block_size as usize
                     * (parent_coverage.end - parent_coverage.start) as usize;
 
-                let parent_buffer = Buffer::new(sz);
+                let parent_buffer = Buffer::new(sub_sz);
                 let mut waiter = self
                     .read_only_parent
                     .as_ref()
@@ -383,11 +383,12 @@ impl BlockIO for Volume {
                 let parent_data_vec = parent_buffer.as_vec();
 
                 // "ownership" comes back from the downstairs per byte but all
-                // writes occur per block. iterate over blocks here.
+                // writes occur per block. Iterate over the blocks that both the
+                // read-only parent and subvolume cover here.
                 //
-                // A volume "owns" a block if the subvolume "owns" the block,
-                // *not* if the read only parent does.
-                for i in 0..(sz as u64 / self.block_size) {
+                // This layer of the volume "owns" a block if the subvolume
+                // "owns" the block, *not* if the read only parent does.
+                for i in 0..(sub_sz as u64 / self.block_size) {
                     let start_of_block = (i * self.block_size) as usize;
 
                     if sub_owned_vec[start_of_block] {
@@ -399,6 +400,8 @@ impl BlockIO for Volume {
                             data_vec[data_index + inside_block] =
                                 sub_data_vec[inside_block];
 
+                            // this layer of the volume does own this
+                            // block, it was written to the subvolume
                             owned_vec[data_index + inside_block] = true;
                         }
                     } else {
@@ -411,8 +414,33 @@ impl BlockIO for Volume {
                             data_vec[data_index + inside_block] =
                                 parent_data_vec[inside_block];
 
+                            // this layer of the volume doesn't own this
+                            // block, it came from the read only parent. note
+                            // this doesn't depend if the block was owned by
+                            // the read only parent, just that the subvolume
+                            // doesn't own it.
                             owned_vec[data_index + inside_block] = false;
                         }
+                    }
+                }
+
+                // Iterate over all the blocks that only come from the subvolume
+                // here.
+                for i in (sub_sz as u64 / self.block_size)
+                    ..(sz as u64 / self.block_size)
+                {
+                    let start_of_block = (i * self.block_size) as usize;
+                    for block_offset in 0..self.block_size {
+                        let inside_block =
+                            start_of_block + block_offset as usize;
+
+                        data_vec[data_index + inside_block] =
+                            sub_data_vec[inside_block];
+
+                        // this layer of the volume does own this block, it came
+                        // from the subvolume's LBA - the read-only parent
+                        // cannot own this block because it's outside their LBA.
+                        owned_vec[data_index + inside_block] = true;
                     }
                 }
             } else {
@@ -1084,30 +1112,45 @@ mod test {
         Ok(())
     }
 
+    // Accept an initialization value so that we can test when the read only
+    // parent is uninitialized, and is initialized with a value
     async fn test_parent_read_only_region(
         block_size: u64,
         parent: Arc<dyn BlockIO + Send + Sync>,
         mut volume: Volume,
+        read_only_parent_init_value: u8,
     ) -> Result<()> {
+        volume.activate(0)?;
+        assert_eq!(volume.total_size()?, 4096);
+
         // Volume is set up like this:
         //
-        // parent blocks: 0 0 0 0
+        // parent blocks: n n n n
         //    sub volume: 0 0 0 0 0 0 0 0
+        //
+        // where "n" is read_only_parent_init_value (or "-" if the read only
+        // parent was uninitialized).
         //
         // blocks that have not been written to will be marked with "-" and will
         // assumed to be all zeros.
 
-        // The initial read should come back all zeros
+        // The first 2048b of the initial read should come only from the parent
+        // (aka read_only_parent_init_value), and the second 2048b should come
+        // from the subvolume(s) (aka be uninitialized).
         let buffer = Buffer::new(4096);
         volume
             .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())?
             .block_wait()?;
-        assert_eq!(*buffer.as_vec(), vec![0; 4096]);
+
+        let mut expected = vec![read_only_parent_init_value; 512 * 4];
+        expected.extend(vec![0x00; 512 * 4]);
+
+        assert_eq!(*buffer.as_vec(), expected);
 
         // If the parent volume has data, it should be returned. Write ones to
         // the first block of the parent:
         //
-        // parent blocks: 1 - - -
+        // parent blocks: 1 n n n
         //    sub volume: - - - - - - - -
         //
         parent
@@ -1124,14 +1167,15 @@ mod test {
             .block_wait()?;
 
         let mut expected = vec![1; 512];
-        expected.extend(vec![0; 4096 - 512]);
+        expected.extend(vec![read_only_parent_init_value; 512 * 3]);
+        expected.extend(vec![0x00; 512 * 4]); // <- from subvolume, still "-"
 
         assert_eq!(*buffer.as_vec(), expected);
 
         // If the volume is written to and it doesn't overlap, still return the
         // parent data. Write twos to the volume:
         //
-        // parent blocks: 1 - - -
+        // parent blocks: 1 n n n
         //    sub volume: - 2 2 - - - - -
         volume
             .write(
@@ -1151,7 +1195,7 @@ mod test {
                 .block_wait()?;
 
             let mut expected = vec![1; 512];
-            expected.extend(vec![0; 2048 - 512]);
+            expected.extend(vec![read_only_parent_init_value; 2048 - 512]);
 
             assert_eq!(*buffer.as_vec(), expected);
         }
@@ -1163,15 +1207,16 @@ mod test {
             .block_wait()?;
 
         let mut expected = vec![1; 512];
-        expected.extend(vec![2; 1024]);
-        expected.extend(vec![0; 4096 - 1024 - 512]);
+        expected.extend(vec![2; 512 * 2]);
+        expected.extend(vec![read_only_parent_init_value; 512]);
+        expected.extend(vec![0x00; 512 * 4]); // <- from subvolume, still "-"
 
         assert_eq!(*buffer.as_vec(), expected);
 
         // If the volume is written to and it does overlap, return the volume
         // data. Write threes to the volume:
         //
-        // parent blocks: 1 - - -
+        // parent blocks: 1 n n n
         //    sub volume: 3 3 2 - - - - -
         volume
             .write(
@@ -1191,7 +1236,7 @@ mod test {
                 .block_wait()?;
 
             let mut expected = vec![1; 512];
-            expected.extend(vec![0; 2048 - 512]);
+            expected.extend(vec![read_only_parent_init_value; 2048 - 512]);
 
             assert_eq!(*buffer.as_vec(), expected);
         }
@@ -1204,7 +1249,8 @@ mod test {
 
         let mut expected = vec![3; 512 * 2];
         expected.extend(vec![2; 512]);
-        expected.extend(vec![0; 4096 - 512 * 3]);
+        expected.extend(vec![read_only_parent_init_value; 512]);
+        expected.extend(vec![0x00; 512 * 4]); // <- from subvolume, still "-"
 
         assert_eq!(*buffer.as_vec(), expected);
 
@@ -1229,7 +1275,7 @@ mod test {
         let mut expected = vec![3; 512 * 2];
         expected.extend(vec![2; 512]);
         expected.extend(vec![4; 512]);
-        expected.extend(vec![0; 2048]);
+        expected.extend(vec![0x00; 512 * 4]); // <- from subvolume, still "-"
 
         assert_eq!(*buffer.as_vec(), expected);
 
@@ -1245,21 +1291,82 @@ mod test {
 
         let mut expected = vec![3; 512 * 2];
         expected.extend(vec![2; 512]);
-        expected.extend(vec![0; 512]); // <- was previously from parent
-        expected.extend(vec![0; 2048]);
+        expected.extend(vec![0; 512]); // <- was previously from parent, now "-"
+        expected.extend(vec![0x00; 512 * 4]); // <- from subvolume, still "-"
 
         assert_eq!(*buffer.as_vec(), expected);
+
+        // Write to the whole volume. There's no more read-only parent (it was
+        // dropped above)
+        volume
+            .write(
+                Block::new(0, block_size.trailing_zeros()),
+                Bytes::from(vec![9; 4096]),
+            )?
+            .block_wait()?;
+
+        let buffer = Buffer::new(4096);
+        volume
+            .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())?
+            .block_wait()?;
+
+        assert_eq!(*buffer.as_vec(), vec![9; 4096]);
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_parent_read_only_region_one_subvolume() -> Result<()> {
+    async fn test_parent_initialized_read_only_region_one_subvolume(
+    ) -> Result<()> {
         const BLOCK_SIZE: u64 = 512;
 
+        // test initializing the read only parent with all byte values
+        for i in 0x00..0xff {
+            let parent = Arc::new(InMemoryBlockIO::new(
+                Uuid::new_v4(),
+                BLOCK_SIZE,
+                2048,
+            ));
+            let disk = Arc::new(InMemoryBlockIO::new(
+                Uuid::new_v4(),
+                BLOCK_SIZE,
+                4096,
+            ));
+
+            parent
+                .write(
+                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                    Bytes::from(vec![i; 2048]),
+                )?
+                .block_wait()?;
+
+            // this layout has one volume that the parent lba range overlaps:
+            //
+            // volumes: 0 0 0 0 0 0 0 0
+            //  parent: P P P P
+            //
+            // the total volume size is 4096b
+
+            let mut volume = Volume::new(BLOCK_SIZE);
+            volume.add_subvolume(disk)?;
+            volume.add_read_only_parent(parent.clone())?;
+
+            test_parent_read_only_region(BLOCK_SIZE, parent, volume, i).await?;
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_parent_uninitialized_read_only_region_one_subvolume(
+    ) -> Result<()> {
+        const BLOCK_SIZE: u64 = 512;
+
+        // test an uninitialized read only parent
         let parent =
             Arc::new(InMemoryBlockIO::new(Uuid::new_v4(), BLOCK_SIZE, 2048));
-        let disk = InMemoryBlockIO::new(Uuid::new_v4(), BLOCK_SIZE, 4096);
+        let disk =
+            Arc::new(InMemoryBlockIO::new(Uuid::new_v4(), BLOCK_SIZE, 4096));
 
         // this layout has one volume that the parent lba range overlaps:
         //
@@ -1268,39 +1375,75 @@ mod test {
         //
         // the total volume size is 4096b
 
-        let volume = Volume {
-            uuid: Uuid::new_v4(),
-            sub_volumes: vec![SubVolume {
-                lba_range: Range {
-                    start: 0,
-                    end: disk.total_size()? / BLOCK_SIZE as u64,
-                },
-                block_io: Arc::new(disk),
-            }],
-            read_only_parent: Some(SubVolume {
-                lba_range: Range {
-                    start: 0,
-                    end: parent.total_size()? / BLOCK_SIZE as u64,
-                },
-                block_io: parent.clone(),
-            }),
-            block_size: BLOCK_SIZE,
-        };
+        let mut volume = Volume::new(BLOCK_SIZE);
+        volume.add_subvolume(disk)?;
+        volume.add_read_only_parent(parent.clone())?;
 
-        test_parent_read_only_region(BLOCK_SIZE, parent, volume).await?;
+        test_parent_read_only_region(BLOCK_SIZE, parent, volume, 0x00).await?;
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_parent_read_only_region_with_multiple_sub_volumes(
+    async fn test_parent_initialized_read_only_region_with_multiple_sub_volumes_1(
+    ) -> Result<()> {
+        const BLOCK_SIZE: u64 = 512;
+
+        for i in 0x00..0xFF {
+            let parent = Arc::new(InMemoryBlockIO::new(
+                Uuid::new_v4(),
+                BLOCK_SIZE,
+                2048,
+            ));
+
+            parent
+                .write(
+                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                    Bytes::from(vec![i; 2048]),
+                )?
+                .block_wait()?;
+
+            let subdisk1 = Arc::new(InMemoryBlockIO::new(
+                Uuid::new_v4(),
+                BLOCK_SIZE,
+                1024,
+            ));
+            let subdisk2 = Arc::new(InMemoryBlockIO::new(
+                Uuid::new_v4(),
+                BLOCK_SIZE,
+                3072,
+            ));
+
+            // this layout has two volumes that the parent lba range overlaps:
+            //
+            // volumes: 0 0
+            //              1 1 1 1 1 1
+            //  parent: P P P P
+            //
+            // the total volume size is the same as the previous test: 4096b
+
+            let mut volume = Volume::new(BLOCK_SIZE);
+            volume.add_subvolume(subdisk1)?;
+            volume.add_subvolume(subdisk2)?;
+            volume.add_read_only_parent(parent.clone())?;
+
+            test_parent_read_only_region(BLOCK_SIZE, parent, volume, i).await?;
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_parent_uninitialized_read_only_region_with_multiple_sub_volumes_1(
     ) -> Result<()> {
         const BLOCK_SIZE: u64 = 512;
 
         let parent =
             Arc::new(InMemoryBlockIO::new(Uuid::new_v4(), BLOCK_SIZE, 2048));
-        let subdisk1 = InMemoryBlockIO::new(Uuid::new_v4(), BLOCK_SIZE, 1024);
-        let subdisk2 = InMemoryBlockIO::new(Uuid::new_v4(), BLOCK_SIZE, 3072);
+        let subdisk1 =
+            Arc::new(InMemoryBlockIO::new(Uuid::new_v4(), BLOCK_SIZE, 1024));
+        let subdisk2 =
+            Arc::new(InMemoryBlockIO::new(Uuid::new_v4(), BLOCK_SIZE, 3072));
 
         // this layout has two volumes that the parent lba range overlaps:
         //
@@ -1310,35 +1453,92 @@ mod test {
         //
         // the total volume size is the same as the previous test: 4096b
 
-        let volume = Volume {
-            uuid: Uuid::new_v4(),
-            sub_volumes: vec![
-                SubVolume {
-                    lba_range: Range {
-                        start: 0,
-                        end: 1024 / BLOCK_SIZE as u64,
-                    },
-                    block_io: Arc::new(subdisk1),
-                },
-                SubVolume {
-                    lba_range: Range {
-                        start: 1024 / BLOCK_SIZE as u64,
-                        end: 4096 / BLOCK_SIZE as u64,
-                    },
-                    block_io: Arc::new(subdisk2),
-                },
-            ],
-            read_only_parent: Some(SubVolume {
-                lba_range: Range {
-                    start: 0,
-                    end: parent.total_size()? / BLOCK_SIZE as u64,
-                },
-                block_io: parent.clone(),
-            }),
-            block_size: BLOCK_SIZE,
-        };
+        let mut volume = Volume::new(BLOCK_SIZE);
+        volume.add_subvolume(subdisk1)?;
+        volume.add_subvolume(subdisk2)?;
+        volume.add_read_only_parent(parent.clone())?;
 
-        test_parent_read_only_region(BLOCK_SIZE, parent, volume).await?;
+        test_parent_read_only_region(BLOCK_SIZE, parent, volume, 0x00).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_parent_initialized_read_only_region_with_multiple_sub_volumes_2(
+    ) -> Result<()> {
+        const BLOCK_SIZE: u64 = 512;
+
+        for i in 0x00..0xFF {
+            let parent = Arc::new(InMemoryBlockIO::new(
+                Uuid::new_v4(),
+                BLOCK_SIZE,
+                2048,
+            ));
+
+            parent
+                .write(
+                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                    Bytes::from(vec![i; 2048]),
+                )?
+                .block_wait()?;
+
+            let subdisk1 = Arc::new(InMemoryBlockIO::new(
+                Uuid::new_v4(),
+                BLOCK_SIZE,
+                2048,
+            ));
+            let subdisk2 = Arc::new(InMemoryBlockIO::new(
+                Uuid::new_v4(),
+                BLOCK_SIZE,
+                2048,
+            ));
+
+            // this layout has two volumes that the parent lba range overlaps:
+            //
+            // volumes: 0 0 0 0
+            //                  1 1 1 1
+            //  parent: P P P P
+            //
+            // the total volume size is the same as the previous test: 4096b
+
+            let mut volume = Volume::new(BLOCK_SIZE);
+            volume.add_subvolume(subdisk1)?;
+            volume.add_subvolume(subdisk2)?;
+            volume.add_read_only_parent(parent.clone())?;
+
+            test_parent_read_only_region(BLOCK_SIZE, parent, volume, i).await?;
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_parent_uninitialized_read_only_region_with_multiple_sub_volumes_2(
+    ) -> Result<()> {
+        const BLOCK_SIZE: u64 = 512;
+
+        let parent =
+            Arc::new(InMemoryBlockIO::new(Uuid::new_v4(), BLOCK_SIZE, 2048));
+
+        let subdisk1 =
+            Arc::new(InMemoryBlockIO::new(Uuid::new_v4(), BLOCK_SIZE, 2048));
+        let subdisk2 =
+            Arc::new(InMemoryBlockIO::new(Uuid::new_v4(), BLOCK_SIZE, 2048));
+
+        // this layout has two volumes that the parent lba range overlaps:
+        //
+        // volumes: 0 0 0 0
+        //                  1 1 1 1
+        //  parent: P P P P
+        //
+        // the total volume size is the same as the previous test: 4096b
+
+        let mut volume = Volume::new(BLOCK_SIZE);
+        volume.add_subvolume(subdisk1)?;
+        volume.add_subvolume(subdisk2)?;
+        volume.add_read_only_parent(parent.clone())?;
+
+        test_parent_read_only_region(BLOCK_SIZE, parent, volume, 0x00).await?;
 
         Ok(())
     }
@@ -1700,5 +1900,192 @@ mod test {
             .unwrap();
 
         assert_eq!(vec![0x5; BLOCK_SIZE], *buffer.as_vec());
+    }
+
+    // Test that blocks are correctly returned during read-only parent +
+    // subvolume overlap.
+    async fn test_draw_the_owl(
+        block_size: usize,
+        subvolumes: &[Arc<dyn BlockIO + Send + Sync>],
+    ) -> Result<()> {
+        // Create read only parent
+        let parent = Arc::new(InMemoryBlockIO::new(
+            Uuid::new_v4(),
+            block_size as u64,
+            block_size * 5,
+        ));
+
+        // Fill the parent with 1s
+        parent
+            .write(
+                Block::new(0, block_size.trailing_zeros()),
+                Bytes::from(vec![11; block_size * 5]),
+            )?
+            .block_wait()?;
+
+        // Read back parent, verify 1s
+        let buffer = Buffer::new(block_size * 5);
+        parent
+            .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())?
+            .block_wait()?;
+
+        assert_eq!(vec![11; block_size * 5], *buffer.as_vec());
+
+        // Create a volume out of this parent and the argument subvolume parts
+        let mut volume = Volume::new(block_size as u64);
+
+        for subvolume in subvolumes {
+            volume.add_subvolume(subvolume.clone())?;
+        }
+
+        volume.add_read_only_parent(parent.clone())?;
+
+        volume.activate(0)?;
+
+        assert_eq!(volume.total_size()?, block_size as u64 * 10);
+
+        // Verify parent contents in one read
+        let buffer = Buffer::new(block_size * 10);
+        volume
+            .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())?
+            .block_wait()?;
+
+        let mut expected = vec![11; block_size * 5];
+        expected.extend(vec![0x00; block_size * 5]);
+        assert_eq!(expected, *buffer.as_vec());
+
+        // One big write!
+        volume
+            .write(
+                Block::new(0, block_size.trailing_zeros()),
+                Bytes::from(vec![55; block_size * 10]),
+            )?
+            .block_wait()?;
+
+        // Verify volume contents in one read
+        let buffer = Buffer::new(block_size * 10);
+        volume
+            .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())?
+            .block_wait()?;
+
+        assert_eq!(vec![55; block_size * 10], *buffer.as_vec());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_draw_the_owl_one_subvolume() -> Result<()> {
+        const BLOCK_SIZE: usize = 512;
+
+        // this layout has one volume that the parent lba range overlaps:
+        //
+        // volumes: 0 0 0 0 0 0 0 0 0 0
+        //  parent: P P P P P
+        let subvolume = Arc::new(InMemoryBlockIO::new(
+            Uuid::new_v4(),
+            BLOCK_SIZE as u64,
+            BLOCK_SIZE * 10,
+        ));
+
+        test_draw_the_owl(BLOCK_SIZE, &[subvolume]).await
+    }
+
+    #[tokio::test]
+    async fn test_draw_the_owl_multiple_subvolumes_1() -> Result<()> {
+        const BLOCK_SIZE: usize = 512;
+
+        // this layout has two volumes that the parent lba range overlaps:
+        //
+        // volumes: 0 0
+        //              1 1 1 1 1 1 1 1
+        //  parent: P P P P P
+        let subvolume_1 = Arc::new(InMemoryBlockIO::new(
+            Uuid::new_v4(),
+            BLOCK_SIZE as u64,
+            BLOCK_SIZE * 2,
+        ));
+        let subvolume_2 = Arc::new(InMemoryBlockIO::new(
+            Uuid::new_v4(),
+            BLOCK_SIZE as u64,
+            BLOCK_SIZE * 8,
+        ));
+
+        test_draw_the_owl(BLOCK_SIZE, &[subvolume_1, subvolume_2]).await
+    }
+
+    #[tokio::test]
+    async fn test_draw_the_owl_multiple_subvolumes_2() -> Result<()> {
+        const BLOCK_SIZE: usize = 512;
+
+        // this layout has two volumes that the parent lba range overlaps:
+        //
+        // volumes: 0 0 0 0 0
+        //                    1 1 1 1 1
+        //  parent: P P P P P
+        let subvolume_1 = Arc::new(InMemoryBlockIO::new(
+            Uuid::new_v4(),
+            BLOCK_SIZE as u64,
+            BLOCK_SIZE * 5,
+        ));
+        let subvolume_2 = Arc::new(InMemoryBlockIO::new(
+            Uuid::new_v4(),
+            BLOCK_SIZE as u64,
+            BLOCK_SIZE * 5,
+        ));
+
+        test_draw_the_owl(BLOCK_SIZE, &[subvolume_1, subvolume_2]).await
+    }
+
+    #[tokio::test]
+    async fn test_draw_the_owl_multiple_subvolumes_3() -> Result<()> {
+        const BLOCK_SIZE: usize = 512;
+
+        // this layout has two volumes that the parent lba range overlaps:
+        //
+        // volumes: 0 0 0 0 0 0 0
+        //                        1 1 1
+        //  parent: P P P P P
+        let subvolume_1 = Arc::new(InMemoryBlockIO::new(
+            Uuid::new_v4(),
+            BLOCK_SIZE as u64,
+            BLOCK_SIZE * 7,
+        ));
+        let subvolume_2 = Arc::new(InMemoryBlockIO::new(
+            Uuid::new_v4(),
+            BLOCK_SIZE as u64,
+            BLOCK_SIZE * 3,
+        ));
+
+        test_draw_the_owl(BLOCK_SIZE, &[subvolume_1, subvolume_2]).await
+    }
+
+    #[tokio::test]
+    async fn test_draw_the_owl_three_subvolumes() -> Result<()> {
+        const BLOCK_SIZE: usize = 512;
+
+        // this layout has three volumes that the parent lba range overlaps:
+        //
+        // volumes: 0 0 0
+        //                1 1 1
+        //                      2 2 2 2
+        //  parent: P P P P P
+        let subvolume_1 = Arc::new(InMemoryBlockIO::new(
+            Uuid::new_v4(),
+            BLOCK_SIZE as u64,
+            BLOCK_SIZE * 3,
+        ));
+        let subvolume_2 = Arc::new(InMemoryBlockIO::new(
+            Uuid::new_v4(),
+            BLOCK_SIZE as u64,
+            BLOCK_SIZE * 3,
+        ));
+        let subvolume_3 = Arc::new(InMemoryBlockIO::new(
+            Uuid::new_v4(),
+            BLOCK_SIZE as u64,
+            BLOCK_SIZE * 4,
+        ));
+
+        test_draw_the_owl(BLOCK_SIZE, &[subvolume_1, subvolume_2, subvolume_3])
+            .await
     }
 }

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -1121,6 +1121,8 @@ mod test {
         read_only_parent_init_value: u8,
     ) -> Result<()> {
         volume.activate(0)?;
+        assert_eq!(volume.block_size()?, 512);
+        assert_eq!(block_size, 512);
         assert_eq!(volume.total_size()?, 4096);
 
         // Volume is set up like this:


### PR DESCRIPTION
When Volumes have a read-only parent, `Volume::read` will conditionally
send two reads out in cases where the LBA range coverage overlaps: one
to the read-only parent, and one to the appropriate subvolume.

In the case the where the subvolume's coverage extends past the
read-only parent's coverage:

    read-only parent: AAAA
           subvolume: BBBBCCCC

There was a bug where blocks CCCC from the subvolume were not being
written into the buffer that is returned by `Volume::read`! This commit
fixes that, and adds a lot of tests to cover this case.

All credit goes to Alan (@leftwo) for finding this!