### PR TITLE
Correctly modify generation number

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -947,7 +947,7 @@ where
 
                         // Only allowed to promote or demote self
                         let mut upstairs_connection =
-                            upstairs_connection.unwrap();
+                            upstairs_connection.as_mut().unwrap();
                         let matches_self =
                             upstairs_connection.upstairs_id == upstairs_id &&
                             upstairs_connection.session_id == session_id;
@@ -986,7 +986,7 @@ where
                             {
                                 let mut ds = ads.lock().await;
                                 ds.promote_to_active(
-                                    upstairs_connection,
+                                    *upstairs_connection,
                                     another_upstairs_active_tx.clone()
                                 ).await?;
                             }


### PR DESCRIPTION
This commit corrects a bad use of unwrap, where changes were made to a
copy of UpstairsConnection, not the value in the Option.

Fixes #413