### PR TITLE
More features for dsc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,7 @@ dependencies = [
  "clap 3.2.1",
  "csv",
  "dropshot",
+ "dsc-client",
  "expectorate",
  "openapi-lint",
  "openapiv3",

--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ $ cargo run -q -p crucible-downstairs -- run -p 3830 -d var/3830
 ```
 
 Once all three are started, you can connect to them by using the crucible
-client program that will start the upstairs side of crucible for you, run
-a write/flush/read, then exit.
+crutest program that will start the upstairs side of crucible for you and
+can run a variety of tests on it.
+
+Here is an example running crutest with the "one" test option.  This will
+connect to the three downstairs and do one write/read/flush then exit.
 
 ```
-$ cargo run -q -p crucible -- -t 127.0.0.1:3830 -t 127.0.0.1:3820 -t 127.0.0.1:3810
+$ cargo run -q -p crutest -- one -t 127.0.0.1:3830 -t 127.0.0.1:3820 -t 127.0.0.1:3810 -q
 raw options: Opt { target: [127.0.0.1:3830, 127.0.0.1:3820, 127.0.0.1:3810] }
 runtime is spawned
 DTrace probes registered ok

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -26,6 +26,8 @@ pub struct CliAction {
 pub enum DscCommand {
     /// Connect to the default DSC server (http://127.0.0.1:9998)
     Connect,
+    /// Disable random stopping of downstairs
+    DisableRandomStop,
     /// Disable auto restart on the given downstairs client ID
     DisableRestart {
         #[clap(long, short, action)]
@@ -38,8 +40,22 @@ pub enum DscCommand {
         #[clap(long, short, action)]
         cid: u32,
     },
+    /// Enable random stopping of downstairs
+    EnableRandomStop,
+    /// Set the minimum random stop time (in seconds)
+    EnableRandomMin {
+        #[clap(long, short, action)]
+        min: u64,
+    },
+    /// Set the maximum random stop time (in seconds)
+    EnableRandomMax {
+        #[clap(long, short, action)]
+        max: u64,
+    },
     /// Enable auto restart on all downstairs
     EnableRestartAll,
+    /// Shutdown all downstairs, then shutdown dsc itself.
+    Shutdown,
     /// Start the downstairs at the given client ID
     Start {
         #[clap(long, short, action)]
@@ -341,6 +357,10 @@ async fn handle_dsc(
             DscCommand::Connect => {
                 println!("Already connected");
             }
+            DscCommand::DisableRandomStop => {
+                let res = dsc_client.dsc_disable_random_stop().await;
+                println!("Got res: {:?}", res);
+            }
             DscCommand::DisableRestart { cid } => {
                 let res = dsc_client.dsc_disable_restart(cid).await;
                 println!("Got res: {:?}", res);
@@ -349,12 +369,28 @@ async fn handle_dsc(
                 let res = dsc_client.dsc_disable_restart_all().await;
                 println!("Got res: {:?}", res);
             }
+            DscCommand::EnableRandomStop => {
+                let res = dsc_client.dsc_enable_random_stop().await;
+                println!("Got res: {:?}", res);
+            }
+            DscCommand::EnableRandomMin { min } => {
+                let res = dsc_client.dsc_enable_random_min(min).await;
+                println!("Got res: {:?}", res);
+            }
+            DscCommand::EnableRandomMax { max } => {
+                let res = dsc_client.dsc_enable_random_max(max).await;
+                println!("Got res: {:?}", res);
+            }
             DscCommand::EnableRestart { cid } => {
                 let res = dsc_client.dsc_enable_restart(cid).await;
                 println!("Got res: {:?}", res);
             }
             DscCommand::EnableRestartAll => {
                 let res = dsc_client.dsc_enable_restart_all().await;
+                println!("Got res: {:?}", res);
+            }
+            DscCommand::Shutdown => {
+                let res = dsc_client.dsc_shutdown().await;
                 println!("Got res: {:?}", res);
             }
             DscCommand::Start { cid } => {
@@ -378,7 +414,7 @@ async fn handle_dsc(
                 println!("Got res: {:?}", res);
             }
             DscCommand::State { cid } => {
-                let res = dsc_client.dsc_get_state(cid).await;
+                let res = dsc_client.dsc_get_ds_state(cid).await;
                 println!("Got res: {:?}", res);
             }
         }

--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "1"
 byte-unit = "4.0.14"
 clap = { version = "3.2", features = ["derive", "env"] }
 csv = "1.1.6"
+dsc-client = { path = "../dsc-client" }
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 rand = "0.8.5"
 rand_chacha = "0.3.1"

--- a/dsc/src/client.rs
+++ b/dsc/src/client.rs
@@ -1,0 +1,125 @@
+// Copyright 2022 Oxide Computer Company
+
+use clap::Parser;
+use dsc_client::Client;
+
+use anyhow::Result;
+
+#[derive(Debug, Parser, PartialEq)]
+pub enum ClientCommand {
+    /// Disable random stopping of downstairs
+    DisableRandomStop,
+    /// Disable auto restart on the given downstairs client ID
+    DisableRestart {
+        #[clap(long, short, action)]
+        cid: u32,
+    },
+    /// Disable auto restart on all downstairs
+    DisableRestartAll,
+    /// Disable restart on the given client ID
+    EnableRestart {
+        #[clap(long, short, action)]
+        cid: u32,
+    },
+    /// Enable random stopping of downstairs
+    EnableRandomStop,
+    /// Set the minimum random stop time (in seconds)
+    EnableRandomMin {
+        #[clap(long, short, action)]
+        min: u64,
+    },
+    /// Set the maximum random stop time (in seconds)
+    EnableRandomMax {
+        #[clap(long, short, action)]
+        max: u64,
+    },
+    /// Enable auto restart on all downstairs
+    EnableRestartAll,
+    /// Get PID of the given client ID
+    Pid {
+        #[clap(long, short, action)]
+        cid: u32,
+    },
+    /// Shutdown all downstairs, then shutdown dsc itself.
+    Shutdown,
+    /// Start the downstairs at the given client ID
+    Start {
+        #[clap(long, short, action)]
+        cid: u32,
+    },
+    /// Start all downstairs
+    StartAll,
+    /// Get the state of the given client ID
+    State {
+        #[clap(long, short, action)]
+        cid: u32,
+    },
+    /// Stop the downstairs at the given client ID
+    Stop {
+        #[clap(long, short, action)]
+        cid: u32,
+    },
+    /// Stop all the downstairs
+    StopAll,
+    /// Stop a random downstairs
+    StopRand,
+}
+
+// Connect to the DSC and run a command.
+#[tokio::main]
+pub async fn client_main(server: String, cmd: ClientCommand) -> Result<()> {
+    let dsc = Client::new(&server);
+    match cmd {
+        ClientCommand::DisableRandomStop => {
+            let _ = dsc.dsc_disable_random_stop().await.unwrap();
+        }
+        ClientCommand::DisableRestart { cid } => {
+            let _ = dsc.dsc_disable_restart(cid).await.unwrap();
+        }
+        ClientCommand::DisableRestartAll => {
+            let _ = dsc.dsc_disable_restart_all().await.unwrap();
+        }
+        ClientCommand::EnableRandomStop => {
+            let _ = dsc.dsc_enable_random_stop().await.unwrap();
+        }
+        ClientCommand::EnableRandomMin { min } => {
+            let _ = dsc.dsc_enable_random_min(min).await.unwrap();
+        }
+        ClientCommand::EnableRandomMax { max } => {
+            let _ = dsc.dsc_enable_random_max(max).await.unwrap();
+        }
+        ClientCommand::EnableRestart { cid } => {
+            let _ = dsc.dsc_enable_restart(cid).await.unwrap();
+        }
+        ClientCommand::EnableRestartAll => {
+            let _ = dsc.dsc_enable_restart_all().await.unwrap();
+        }
+        ClientCommand::Pid { cid } => {
+            let res = dsc.dsc_get_pid(cid).await.unwrap();
+            println!("{:?}", res);
+        }
+        ClientCommand::Shutdown => {
+            let _ = dsc.dsc_shutdown().await.unwrap();
+        }
+        ClientCommand::State { cid } => {
+            let res = dsc.dsc_get_ds_state(cid).await.unwrap();
+            println!("{:?}", res);
+        }
+        ClientCommand::Start { cid } => {
+            let _ = dsc.dsc_start(cid).await.unwrap();
+        }
+        ClientCommand::StartAll => {
+            let _ = dsc.dsc_start_all().await.unwrap();
+        }
+        ClientCommand::Stop { cid } => {
+            let _ = dsc.dsc_stop(cid).await.unwrap();
+        }
+        ClientCommand::StopAll => {
+            let _ = dsc.dsc_stop_all().await.unwrap();
+        }
+        ClientCommand::StopRand => {
+            let _ = dsc.dsc_stop_rand().await.unwrap();
+        }
+    }
+    Ok(())
+}

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -1227,7 +1227,7 @@ async fn region_create_test(
 }
 
 // Remove any existing dsc files/regions
-fn cleanup_region(output_dir: PathBuf, region_dir: PathBuf) -> Result<()> {
+fn cleanup(output_dir: PathBuf, region_dir: PathBuf) -> Result<()> {
     if Path::new(&output_dir).exists() {
         println!("Removing existing dsc directory {:?}", output_dir);
         std::fs::remove_dir_all(&output_dir)?;
@@ -1278,7 +1278,7 @@ fn main() -> Result<()> {
             region_dir,
         } => {
             if cleanup {
-                cleanup_region(output_dir.clone(), region_dir.clone())?;
+                crate::cleanup(output_dir.clone(), region_dir.clone())?;
             }
             let dsci =
                 DscInfo::new(ds_bin, output_dir, region_dir, notify_tx, true)?;
@@ -1315,7 +1315,7 @@ fn main() -> Result<()> {
         } => {
             // Delete any existing region if requested
             if cleanup {
-                cleanup_region(output_dir.clone(), region_dir.clone())?;
+                crate::cleanup(output_dir.clone(), region_dir.clone())?;
             } else if create && Path::new(&region_dir).exists() {
                 println!("Removing existing region {:?}", region_dir);
                 std::fs::remove_dir_all(&region_dir)?;
@@ -1352,7 +1352,7 @@ mod test {
     use tempfile::{tempdir, NamedTempFile};
 
     // Create a temporary file.  Close the file but return the path
-    // so it won't delete be deleted.
+    // so it won't be deleted.
     fn temp_file_path() -> (String, tempfile::TempPath) {
         let ds_file = NamedTempFile::new().unwrap();
         let ds_path = ds_file.into_temp_path();

--- a/openapi/dsc-control.json
+++ b/openapi/dsc-control.json
@@ -140,6 +140,100 @@
         }
       }
     },
+    "/randomstop/disable": {
+      "post": {
+        "summary": "Disable the random stopping of a downstairs",
+        "operationId": "dsc_disable_random_stop",
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/randomstop/enable": {
+      "post": {
+        "summary": "Enable stopping a random downstairs every [min-max] seconds",
+        "operationId": "dsc_enable_random_stop",
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/randomstop/max/{max}": {
+      "post": {
+        "summary": "Set the maximum time between random stopping requests",
+        "operationId": "dsc_enable_random_max",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "max",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/randomstop/min/{min}": {
+      "post": {
+        "summary": "Set the minimum time between random stopping requests",
+        "operationId": "dsc_enable_random_min",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "min",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/shutdown": {
       "post": {
         "summary": "Stop all downstairs, then stop ourselves.",
@@ -207,7 +301,7 @@
     "/state/cid/{cid}": {
       "get": {
         "summary": "Fetch the current state for the requested client_id",
-        "operationId": "dsc_get_state",
+        "operationId": "dsc_get_ds_state",
         "parameters": [
           {
             "in": "path",


### PR DESCRIPTION
These changes mean nearly all of the ./tools/downstairs_daemon.sh script
can be replaced by dsc (though that work is not part of this change).

Dsc can now support random restart of one of the downstairs under
its control. The requester can pick a min and max time to fence
the restarts. This required a little refactor of the dsc main loop
to allow for some persistent state.

Updated dsc to support sending a single command to a running dsc
server, basically making it a client of itself. To support this,
further refactoring of dsc was required.

Added the new dsc commands to the crutest cli.

Wrote a small test function to create a temporary file instead of
creating an empty file in the current directory which was not
removed at the end of the tests.

Updated the top level README.md to make it match the current
names of things.

dsc now looks like this:
```
final:crucible$ ./target/release/dsc
dsc
A downstairs controller

USAGE:
    dsc <SUBCOMMAND>

OPTIONS:
    -h, --help    Print help information

SUBCOMMANDS:
    cmd            Send a command to a running dsc server
    create         Create a downstairs region then exit
    help           Print this message or the help of the given subcommand(s)
    region-perf    Test creation of downstairs regions
    start          Start a downstairs region set This requires the region is
                       already created, unless you include the --create option

```

The new `cmd` looks like this:
```
final:crucible$ ./target/release/dsc cmd
dsc-cmd
Send a command to a running dsc server

USAGE:
    dsc cmd [OPTIONS] <SUBCOMMAND>

OPTIONS:
    -h, --help               Print help information
        --server <SERVER>    URL location of the Crucible control server
                             [default: http://127.0.0.1:9998]

SUBCOMMANDS:
    disable-random-stop    Disable random stopping of downstairs
    disable-restart        Disable auto restart on the given downstairs
                               client ID
    disable-restart-all    Disable auto restart on all downstairs
    enable-random-max      Set the maximum random stop time (in seconds)
    enable-random-min      Set the minimum random stop time (in seconds)
    enable-random-stop     Enable random stopping of downstairs
    enable-restart         Disable restart on the given client ID
    enable-restart-all     Enable auto restart on all downstairs
    help                   Print this message or the help of the given
                               subcommand(s)
    pid                    Get PID of the given client ID
    shutdown               Shutdown all downstairs, then shutdown dsc itself
    start                  Start the downstairs at the given client ID
    start-all              Start all downstairs
    state                  Get the state of the given client ID
    stop                   Stop the downstairs at the given client ID
    stop-all               Stop all the downstairs
    stop-rand              Stop a random downstairs
```