### PR TITLE
in_memory write_unwritten, new test, dtrace cleanup

### DIFF
--- a/tools/dtrace/perf-downstairs-three.d
+++ b/tools/dtrace/perf-downstairs-three.d
@@ -97,14 +97,14 @@ crucible_downstairs*:::submit-read-done
 }
 
 /*
- * Now the same, but for readfill
+ * Now the same, but for write unwritten
  */
-crucible_downstairs*:::submit-readfill-start
+crucible_downstairs*:::submit-writeunwritten-start
 {
     wstart[pid,arg0] = timestamp;
 }
 
-crucible_downstairs*:::os-readfill-start
+crucible_downstairs*:::os-writeunwritten-start
 /wstart[pid,arg0]/
 {
     @wtimeone[pid,"read submit-OS"] = quantize(timestamp - wstart[pid,arg0]);
@@ -112,7 +112,7 @@ crucible_downstairs*:::os-readfill-start
     wsubstart[pid,arg0] = timestamp;
 }
 
-crucible_downstairs*:::os-readfill-done
+crucible_downstairs*:::os-writeunwritten-done
 /wsubstart[pid,arg0]/
 {
     @wtimetwo[pid,"read OS"] = quantize(timestamp - wsubstart[pid,arg0]);
@@ -120,7 +120,7 @@ crucible_downstairs*:::os-readfill-done
     wfinal[pid,arg0] = timestamp;
 }
 
-crucible_downstairs*:::submit-readfill-done
+crucible_downstairs*:::submit-writeunwritten-done
 /wfinal[pid,arg0]/
 {
     @wtimethree[pid,"read OS-done"] = quantize(timestamp - wfinal[pid,arg0]);

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -1099,15 +1099,15 @@ mod test {
         )?
         .block_wait()?;
 
-        // Write unwritten should not change the block we just wrote:
-        // Write unwritten twos to the second block
+        // Write unwritten twos to the second block.
+        // This should not change the block.
         disk.write_unwritten(
             Block::new(1, BLOCK_SIZE.trailing_zeros()),
             Bytes::from(vec![2; 512]),
         )?
         .block_wait()?;
 
-        // Read and verify
+        // Read and verify the data is from the first write
         let buffer = Buffer::new(4096);
         disk.read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())?
             .block_wait()?;
@@ -1134,14 +1134,14 @@ mod test {
         expected.extend(vec![0; 4096 - 1024]);
         assert_eq!(*buffer.as_vec(), expected);
 
-        // Write sevens to third and fourth block
+        // Write sevens to third and fourth blocks
         disk.write(
             Block::new(2, BLOCK_SIZE.trailing_zeros()),
             Bytes::from(vec![7; 1024]),
         )?
         .block_wait()?;
 
-        // Write_unwritten eights to fifth and six block
+        // Write_unwritten eights to fifth and six blocks
         disk.write_unwritten(
             Block::new(4, BLOCK_SIZE.trailing_zeros()),
             Bytes::from(vec![8; 1024]),

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -1099,6 +1099,14 @@ mod test {
         )?
         .block_wait()?;
 
+        // Write unwritten should not change the block we just wrote:
+        // Write unwritten twos to the second block
+        disk.write_unwritten(
+            Block::new(1, BLOCK_SIZE.trailing_zeros()),
+            Bytes::from(vec![2; 512]),
+        )?
+        .block_wait()?;
+
         // Read and verify
         let buffer = Buffer::new(4096);
         disk.read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())?
@@ -1133,6 +1141,13 @@ mod test {
         )?
         .block_wait()?;
 
+        // Write_unwritten eights to fifth and six block
+        disk.write_unwritten(
+            Block::new(4, BLOCK_SIZE.trailing_zeros()),
+            Bytes::from(vec![8; 1024]),
+        )?
+        .block_wait()?;
+
         // Read and verify
         let buffer = Buffer::new(4096);
         disk.read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())?
@@ -1141,7 +1156,8 @@ mod test {
         let mut expected = vec![2; 512];
         expected.extend(vec![1; 512]);
         expected.extend(vec![7; 1024]);
-        expected.extend(vec![0; 4096 - 2048]);
+        expected.extend(vec![8; 1024]);
+        expected.extend(vec![0; 1024]);
         assert_eq!(*buffer.as_vec(), expected);
 
         Ok(())


### PR DESCRIPTION
Added support for write_unwritten command to in_memory BlockIO
Included a simple test for it as well.

Fixed the names of some dtrace probes.

Added a test to make sure the scrubber does nothing if there are
no read only parent volumes.