### PR TITLE
Remove vestigial num_blocks field from protocol

### DIFF
--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -540,7 +540,6 @@ fn show_extent(
                 &[ReadRequest {
                     eid: cmp_extent as u64,
                     offset: Block::new_with_ddef(block, &region.def()),
-                    num_blocks: 1,
                 }],
                 0,
             )?;
@@ -665,7 +664,6 @@ fn show_extent_block(
             &[ReadRequest {
                 eid: cmp_extent as u64,
                 offset: Block::new_with_ddef(block_in_extent, &region.def()),
-                num_blocks: 1,
             }],
             0,
         )?;

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -101,7 +101,6 @@ pub fn downstairs_export<P: AsRef<Path> + std::fmt::Debug>(
                             block_offset,
                             &region.def(),
                         ),
-                        num_blocks: 1,
                     }],
                     0,
                 )?;
@@ -2399,7 +2398,6 @@ mod test {
                         requests: vec![ReadRequest {
                             eid: 1,
                             offset: Block::new_512(1),
-                            num_blocks: 1,
                         }],
                     }
                 },
@@ -2567,7 +2565,6 @@ mod test {
             requests: vec![ReadRequest {
                 eid: 0,
                 offset: Block::new_512(1),
-                num_blocks: 1,
             }],
         };
         ds.add_work(upstairs_connection, 1000, rio).await?;
@@ -2578,7 +2575,6 @@ mod test {
             requests: vec![ReadRequest {
                 eid: 1,
                 offset: Block::new_512(1),
-                num_blocks: 1,
             }],
         };
         ds.add_work(upstairs_connection, 1001, rio).await?;
@@ -3434,7 +3430,6 @@ mod test {
                     &[crucible_protocol::ReadRequest {
                         eid: eid.into(),
                         offset: Block::new_512(offset),
-                        num_blocks: 1,
                     }],
                     0,
                 )?;
@@ -3745,7 +3740,6 @@ mod test {
             requests: vec![ReadRequest {
                 eid: 0,
                 offset: Block::new_512(1),
-                num_blocks: 1,
             }],
         };
         ds.add_work(upstairs_connection_1, 1000, read_1.clone())
@@ -3756,7 +3750,6 @@ mod test {
             requests: vec![ReadRequest {
                 eid: 1,
                 offset: Block::new_512(2),
-                num_blocks: 2,
             }],
         };
         ds.add_work(upstairs_connection_2, 1000, read_2.clone())
@@ -3831,7 +3824,6 @@ mod test {
             requests: vec![ReadRequest {
                 eid: 0,
                 offset: Block::new_512(1),
-                num_blocks: 1,
             }],
         };
         ds.add_work(upstairs_connection_1, 1000, rio).await?;
@@ -3918,7 +3910,6 @@ mod test {
             requests: vec![ReadRequest {
                 eid: 0,
                 offset: Block::new_512(1),
-                num_blocks: 1,
             }],
         };
         ds.add_work(upstairs_connection_1, 1000, rio).await?;
@@ -4004,7 +3995,6 @@ mod test {
             requests: vec![ReadRequest {
                 eid: 0,
                 offset: Block::new_512(1),
-                num_blocks: 1,
             }],
         };
         ds.add_work(upstairs_connection_1, 1000, rio).await?;

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -3033,11 +3033,7 @@ mod test {
             let offset: Block =
                 Block::new_512((i as u64) % ddef.extent_size().value);
 
-            requests.push(crucible_protocol::ReadRequest {
-                eid,
-                offset,
-                num_blocks: 1,
-            });
+            requests.push(crucible_protocol::ReadRequest { eid, offset });
         }
 
         let responses = region.region_read(&requests, 0)?;
@@ -3117,11 +3113,7 @@ mod test {
 
         // Now read back that block, make sure it is updated.
         let responses = region.region_read(
-            &[crucible_protocol::ReadRequest {
-                eid,
-                offset,
-                num_blocks: 1,
-            }],
+            &[crucible_protocol::ReadRequest { eid, offset }],
             0,
         )?;
 
@@ -3182,11 +3174,7 @@ mod test {
 
         // Now read back that block, make sure it has the first write
         let responses = region.region_read(
-            &[crucible_protocol::ReadRequest {
-                eid,
-                offset,
-                num_blocks: 1,
-            }],
+            &[crucible_protocol::ReadRequest { eid, offset }],
             2,
         )?;
 
@@ -3272,11 +3260,7 @@ mod test {
 
         // Read back our block, make sure it has the first write data
         let responses = region.region_read(
-            &[crucible_protocol::ReadRequest {
-                eid,
-                offset,
-                num_blocks: 1,
-            }],
+            &[crucible_protocol::ReadRequest { eid, offset }],
             2,
         )?;
 
@@ -3354,11 +3338,7 @@ mod test {
             let offset: Block =
                 Block::new_512((i as u64) % ddef.extent_size().value);
 
-            requests.push(crucible_protocol::ReadRequest {
-                eid,
-                offset,
-                num_blocks: 1,
-            });
+            requests.push(crucible_protocol::ReadRequest { eid, offset });
         }
 
         let responses = region.region_read(&requests, 0)?;
@@ -3469,11 +3449,7 @@ mod test {
             let offset: Block =
                 Block::new_512((i as u64) % ddef.extent_size().value);
 
-            requests.push(crucible_protocol::ReadRequest {
-                eid,
-                offset,
-                num_blocks: 1,
-            });
+            requests.push(crucible_protocol::ReadRequest { eid, offset });
         }
 
         let responses = region.region_read(&requests, 0)?;
@@ -3585,11 +3561,7 @@ mod test {
             let offset: Block =
                 Block::new_512((i as u64) % ddef.extent_size().value);
 
-            requests.push(crucible_protocol::ReadRequest {
-                eid,
-                offset,
-                num_blocks: 1,
-            });
+            requests.push(crucible_protocol::ReadRequest { eid, offset });
         }
 
         let responses = region.region_read(&requests, 0)?;
@@ -3694,11 +3666,7 @@ mod test {
                 Block::new_512((i as u64) % ddef.extent_size().value);
 
             println!("Read eid: {}, {} offset: {:?}", eid, i, offset);
-            requests.push(crucible_protocol::ReadRequest {
-                eid,
-                offset,
-                num_blocks: 1,
-            });
+            requests.push(crucible_protocol::ReadRequest { eid, offset });
         }
 
         let responses = region.region_read(&requests, 0)?;
@@ -3805,11 +3773,7 @@ mod test {
             let offset: Block =
                 Block::new_512((i as u64) % ddef.extent_size().value);
 
-            requests.push(crucible_protocol::ReadRequest {
-                eid,
-                offset,
-                num_blocks: 1,
-            });
+            requests.push(crucible_protocol::ReadRequest { eid, offset });
         }
 
         let responses = region.region_read(&requests, 0)?;
@@ -3873,7 +3837,6 @@ mod test {
             &[crucible_protocol::ReadRequest {
                 eid: 0,
                 offset: Block::new_512(0),
-                num_blocks: 1,
             }],
             0,
         )?;

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -43,7 +43,6 @@ pub struct Write {
 pub struct ReadRequest {
     pub eid: u64,
     pub offset: Block,
-    pub num_blocks: u64,
 }
 
 // Note: if you change this, you may have to add to the dump commands that show
@@ -52,7 +51,6 @@ pub struct ReadRequest {
 pub struct ReadResponse {
     pub eid: u64,
     pub offset: Block,
-    pub num_blocks: u64,
 
     pub data: bytes::BytesMut,
     pub encryption_contexts: Vec<EncryptionContext>,
@@ -73,14 +71,13 @@ impl ReadResponse {
          * Also, we (I) need to figure out how to read data into an
          * uninitialized buffer. Until then, we have this workaround.
          */
-        let sz = request.num_blocks as usize * bs;
+        let sz = bs;
         let mut data = BytesMut::with_capacity(sz);
         data.resize(sz, 1);
 
         ReadResponse {
             eid: request.eid,
             offset: request.offset,
-            num_blocks: request.num_blocks,
             data,
             encryption_contexts: vec![],
             hashes: vec![],
@@ -94,7 +91,6 @@ impl ReadResponse {
         ReadResponse {
             eid: request.eid,
             offset: request.offset,
-            num_blocks: request.num_blocks,
             data: BytesMut::from(data),
             encryption_contexts: vec![],
             hashes: vec![crucible_common::integrity_hash(&[data])],

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -4244,11 +4244,7 @@ impl Upstairs {
         let mut requests: Vec<ReadRequest> = Vec::with_capacity(nwo.len());
 
         for (eid, bo) in nwo {
-            requests.push(ReadRequest {
-                eid,
-                offset: bo,
-                num_blocks: 1,
-            });
+            requests.push(ReadRequest { eid, offset: bo });
         }
 
         sub.insert(next_id, 0); // XXX does this value matter?
@@ -7614,12 +7610,7 @@ fn show_all_work(up: &Arc<Upstairs>) -> WQCounts {
                     requests,
                 } => {
                     let job_type = "Read".to_string();
-                    let mut num_blocks = 0;
-
-                    for request in requests {
-                        num_blocks += request.num_blocks as usize;
-                    }
-
+                    let num_blocks = requests.len();
                     (job_type, num_blocks)
                 }
                 IOop::Write {

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -649,7 +649,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
 
@@ -733,7 +732,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
 
@@ -813,7 +811,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
 
@@ -888,7 +885,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
 
@@ -954,7 +950,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
 
         let next_id = {
@@ -1033,7 +1028,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(id, vec![], 10, vec![request.clone()]);
 
@@ -1083,7 +1077,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(id, vec![], 10, vec![request.clone()]);
 
@@ -1131,7 +1124,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(id, vec![], 10, vec![request.clone()]);
 
@@ -1185,7 +1177,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(id, vec![], 10, vec![request.clone()]);
 
@@ -1239,7 +1230,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(id, vec![], 10, vec![request.clone()]);
 
@@ -1284,7 +1274,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(id, vec![], 10, vec![request.clone()]);
 
@@ -1328,7 +1317,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(id, vec![], 10, vec![request.clone()]);
 
@@ -1454,7 +1442,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
 
@@ -1505,7 +1492,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
 
@@ -1581,7 +1567,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
 
@@ -1661,7 +1646,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
 
@@ -2373,7 +2357,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
         ds.enqueue(op);
@@ -2430,7 +2413,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
         ds.enqueue(op);
@@ -2525,7 +2507,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
         ds.enqueue(op);
@@ -2629,7 +2610,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
         ds.enqueue(op);
@@ -2728,7 +2708,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
         let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
         ds.enqueue(op);
@@ -4187,7 +4166,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
 
         let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
@@ -4223,12 +4201,11 @@ mod test {
 
         // compute integrity hash after alteration above! It should still
         // validate
-        let hash = crucible_common::integrity_hash(&[&nonce, &tag, &data]);
+        let hash = integrity_hash(&[&nonce, &tag, &data]);
 
         let response = Ok(vec![ReadResponse {
             eid: request.eid,
             offset: request.offset,
-            num_blocks: request.num_blocks,
 
             data: BytesMut::from(&data[..]),
             encryption_contexts: vec![crucible_protocol::EncryptionContext {
@@ -4263,7 +4240,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
 
         let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
@@ -4279,7 +4255,6 @@ mod test {
         let response = Ok(vec![ReadResponse {
             eid: request.eid,
             offset: request.offset,
-            num_blocks: request.num_blocks,
 
             data: BytesMut::from(&data[..]),
             encryption_contexts: vec![],
@@ -4311,7 +4286,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
 
         let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
@@ -4341,7 +4315,6 @@ mod test {
         let response = Ok(vec![ReadResponse {
             eid: request.eid,
             offset: request.offset,
-            num_blocks: request.num_blocks,
 
             data: BytesMut::from(&data[..]),
             encryption_contexts: vec![crucible_protocol::EncryptionContext {
@@ -4886,7 +4859,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
 
         let next_id = {
@@ -5050,7 +5022,6 @@ mod test {
         let request = ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-            num_blocks: 2,
         };
 
         let next_id = {


### PR DESCRIPTION
ReadRequest and ReadResponse had a num_blocks field that was at one point used, but isn't anymore. Now, one request is one block, and its associated response bundles up all the hash and encryption metadata associated with that block. This commit removes that field.

This field was not actually used in more than a few places in the code, so most of the affected lines of code are in tests. A lot of them were using `num_blocks = 2`, but none of those tests were actually testing behavior that was impacted by the `num_blocks` field, and a couple of them were otherwise acting as if they had requested 1 block of data, so this shouldn't impact the veracity of the tests.