### PR TITLE
Implement missing "snapshot" integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,6 +739,7 @@ dependencies = [
  "futures",
  "futures-core",
  "httptest",
+ "lazy_static",
  "rand 0.8.5",
  "tempfile",
  "tokio",

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -1590,7 +1590,7 @@ async fn perf_workload(
         }
         let big_end = big_start.elapsed();
 
-        guest.flush(None)?;
+        guest.flush(None)?.block_wait()?;
         perf_summary(
             "rwrites",
             count,
@@ -1662,7 +1662,8 @@ async fn perf_workload(
             );
         }
 
-        guest.flush(None)?;
+        guest.flush(None)?.block_wait()?;
+
         // Before we finish, make sure the work queues are empty.
         loop {
             let wc = guest.query_work_queue()?;

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -19,3 +19,4 @@ rand = "0.8.5"
 tempfile = "3.3.0"
 tokio = { version = "1.21.0", features = ["full"] }
 uuid = { version = "1.0.0", features = [ "serde", "v4" ] }
+lazy_static = "1.4.0"

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -1888,15 +1888,6 @@ mod test {
 
         volume.deactivate()?.block_wait()?;
 
-        let mut active_check_counter = 0;
-        while volume.query_is_active()? {
-            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-            active_check_counter += 1;
-            if active_check_counter > 10 {
-                panic!("took too long to deactivate!");
-            }
-        }
-
         drop(volume);
 
         test_downstairs_set.reboot_read_only()?;

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -12,10 +12,10 @@ mod test {
     use crucible_downstairs::*;
     use futures::lock::Mutex;
     use httptest::{matchers::*, responders::*, Expectation, Server};
+    use lazy_static::lazy_static;
     use rand::Rng;
     use tempfile::*;
     use uuid::*;
-    use lazy_static::lazy_static;
 
     use std::collections::HashSet;
 
@@ -99,7 +99,7 @@ mod test {
             )?;
 
             let adownstairs = self.downstairs.clone();
-            let address = self.address.clone();
+            let address = self.address;
             let port = self.port;
 
             self.join_handle = tokio::spawn(async move {
@@ -139,19 +139,22 @@ mod test {
                 port1,
                 true,
                 read_only,
-            ).await?;
+            )
+            .await?;
             let downstairs2 = TestDownstairs::new(
                 "127.0.0.1".parse()?,
                 port2,
                 true,
                 read_only,
-            ).await?;
+            )
+            .await?;
             let downstairs3 = TestDownstairs::new(
                 "127.0.0.1".parse()?,
                 port3,
                 true,
                 read_only,
-            ).await?;
+            )
+            .await?;
 
             // Generate random data for our key
             let key_bytes = rand::thread_rng().gen::<[u8; 32]>();
@@ -1957,7 +1960,8 @@ mod test {
 
         // create a new volume, layering a new set of downstairs on top of the
         // read-only one we just (re)booted
-        let top_layer_tds = TestDownstairsSet::new(54085, 54086, 54087, false).await?;
+        let top_layer_tds =
+            TestDownstairsSet::new(54085, 54086, 54087, false).await?;
         let top_layer_opts = top_layer_tds.opts();
         let bottom_layer_opts = test_downstairs_set.opts();
 

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -208,7 +208,7 @@ fn main() -> Result<()> {
     }
 
     // One last flush
-    guest.flush(None)?;
+    guest.flush(None)?.block_wait()?;
 
     println!("Done ok, waiting on show_work");
 

--- a/upstairs/src/block_io.rs
+++ b/upstairs/src/block_io.rs
@@ -40,6 +40,10 @@ impl BlockIO for FileBlockIO {
         Ok(())
     }
 
+    fn deactivate(&self) -> Result<BlockReqWaiter, CrucibleError> {
+        BlockReqWaiter::immediate()
+    }
+
     fn query_is_active(&self) -> Result<bool, CrucibleError> {
         Ok(true)
     }
@@ -177,6 +181,10 @@ impl ReqwestBlockIO {
 impl BlockIO for ReqwestBlockIO {
     fn activate(&self, _gen: u64) -> Result<(), CrucibleError> {
         Ok(())
+    }
+
+    fn deactivate(&self) -> Result<BlockReqWaiter, CrucibleError> {
+        BlockReqWaiter::immediate()
     }
 
     fn query_is_active(&self) -> Result<bool, CrucibleError> {

--- a/upstairs/src/in_memory.rs
+++ b/upstairs/src/in_memory.rs
@@ -25,6 +25,10 @@ impl BlockIO for InMemoryBlockIO {
         Ok(())
     }
 
+    fn deactivate(&self) -> Result<BlockReqWaiter, CrucibleError> {
+        BlockReqWaiter::immediate()
+    }
+
     fn query_is_active(&self) -> Result<bool, CrucibleError> {
         Ok(true)
     }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -6156,6 +6156,7 @@ impl BlockReq {
  * When BlockOps are sent to a guest, the calling function receives a
  * waiter that it can block on.
  */
+#[must_use]
 pub struct BlockReqWaiter {
     recv: std_mpsc::Receiver<Result<(), CrucibleError>>,
 }

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -371,11 +371,11 @@ impl BlockIO for Volume {
 
     fn deactivate(&self) -> Result<BlockReqWaiter, CrucibleError> {
         for sub_volume in &self.sub_volumes {
-            sub_volume.deactivate()?;
+            sub_volume.deactivate()?.block_wait()?;
         }
 
         if let Some(ref read_only_parent) = &self.read_only_parent {
-            read_only_parent.deactivate()?;
+            read_only_parent.deactivate()?.block_wait()?;
         }
 
         BlockReqWaiter::immediate()


### PR DESCRIPTION
There were two tests in upstairs/src/volume.rs that remained unimplemented due to requiring a running set of downstairs:

        construct_snapshot_backed_vol
        construct_read_only_iso_volume

We have a way to write integration tests now, so this commit implements a test for a "snapshot" backed volume. It does not perform a snapshot but simply boots a downstairs in read-only mode and uses that as a read-only parent.

In order to implement this, I wanted to write some data into a set of downstairs, then boot new downstairs read-only but pointing at the same on-disk files. The integration test framework couldn't support this without adding `fn deactivate` to the BlockIO trait - the original read-write downstairs have to be deactivated (and have their tasks stopped) in order for the read-only downstairs to boot ok.

Closes https://github.com/oxidecomputer/crucible/issues/298