### PR TITLE
Remove std::sync::Mutex downstairs

### DIFF
--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -18,7 +18,7 @@ struct ExtInfo {
  *
  * If you don't want color, then set nc to true.
  */
-pub fn dump_region(
+pub async fn dump_region(
     region_dir: Vec<PathBuf>,
     mut cmp_extent: Option<u32>,
     block: Option<u64>,
@@ -89,7 +89,7 @@ pub fn dump_region(
                     continue;
                 }
             }
-            let inner = e.inner();
+            let inner = e.inner().await;
 
             /*
              * Create the ExtentMeta struct for this directory's extent
@@ -145,7 +145,8 @@ pub fn dump_region(
                 only_show_differences,
                 nc,
                 log,
-            );
+            )
+            .await;
         }
 
         show_extent(
@@ -156,7 +157,8 @@ pub fn dump_region(
             only_show_differences,
             nc,
             log,
-        )?;
+        )
+        .await?;
 
         return Ok(());
     };
@@ -440,7 +442,7 @@ fn return_status_letters<'a, T, U: std::cmp::PartialEq>(
  * Show the metadata and a block by block diff of a single extent
  * We need at least two directories to compare, and no more than three.
  */
-fn show_extent(
+async fn show_extent(
     region_dir: Vec<PathBuf>,
     ei_hm: &HashMap<u32, ExtentMeta>,
     cmp_extent: u32,
@@ -534,13 +536,15 @@ fn show_extent(
             let region =
                 Region::open(dir, Default::default(), false, true, &log)?;
 
-            let mut responses = region.region_read(
-                &[ReadRequest {
-                    eid: cmp_extent as u64,
-                    offset: Block::new_with_ddef(block, &region.def()),
-                }],
-                0,
-            )?;
+            let mut responses = region
+                .region_read(
+                    &[ReadRequest {
+                        eid: cmp_extent as u64,
+                        offset: Block::new_with_ddef(block, &region.def()),
+                    }],
+                    0,
+                )
+                .await?;
             let response = responses.pop().unwrap();
 
             dvec.insert(index, response);
@@ -614,7 +618,7 @@ fn is_all_same<T: PartialEq>(slice: &[T]) -> bool {
 /*
  * Show detailed comparison of different region's blocks
  */
-fn show_extent_block(
+async fn show_extent_block(
     region_dir: Vec<PathBuf>,
     cmp_extent: u32,
     block: u64,
@@ -646,13 +650,18 @@ fn show_extent_block(
         // Open Region read only
         let region = Region::open(dir, Default::default(), false, true, &log)?;
 
-        let mut responses = region.region_read(
-            &[ReadRequest {
-                eid: cmp_extent as u64,
-                offset: Block::new_with_ddef(block_in_extent, &region.def()),
-            }],
-            0,
-        )?;
+        let mut responses = region
+            .region_read(
+                &[ReadRequest {
+                    eid: cmp_extent as u64,
+                    offset: Block::new_with_ddef(
+                        block_in_extent,
+                        &region.def(),
+                    ),
+                }],
+                0,
+            )
+            .await?;
         let response = responses.pop().unwrap();
 
         dvec.insert(index, response);

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -599,12 +599,16 @@ where
                     flush_number,
                     gen_number
                 );
-                match d.region.region_flush_extent(
-                    *extent_id,
-                    *flush_number,
-                    *gen_number,
-                    *repair_id,
-                ).await {
+                match d
+                    .region
+                    .region_flush_extent(
+                        *extent_id,
+                        *flush_number,
+                        *gen_number,
+                        *repair_id,
+                    )
+                    .await
+                {
                     Ok(()) => Message::RepairAckId {
                         repair_id: *repair_id,
                     },

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -261,7 +261,8 @@ async fn main() -> Result<()> {
                 only_show_differences,
                 no_color,
                 log,
-            ).await?;
+            )
+            .await?;
             Ok(())
         }
         Args::Export {

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -227,12 +227,12 @@ async fn main() -> Result<()> {
             )?;
 
             if let Some(ref ip) = import_path {
-                downstairs_import(&mut region, ip).unwrap();
+                downstairs_import(&mut region, ip).await.unwrap();
                 /*
                  * The region we just created should now have a flush so the
                  * new data and inital flush number is written to disk.
                  */
-                region.region_flush(1, 0, &None, 0)?;
+                region.region_flush(1, 0, &None, 0).await?;
             }
 
             info!(log, "UUID: {:?}", region.def().uuid());
@@ -261,7 +261,7 @@ async fn main() -> Result<()> {
                 only_show_differences,
                 no_color,
                 log,
-            )?;
+            ).await?;
             Ok(())
         }
         Args::Export {
@@ -279,7 +279,7 @@ async fn main() -> Result<()> {
                 &log,
             )?;
 
-            downstairs_export(&mut region, export_path, skip, count).unwrap();
+            downstairs_export(&mut region, export_path, skip, count).await?;
             Ok(())
         }
         Args::Run {

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1792,7 +1792,9 @@ impl Region {
         for eid in batched_writes.keys() {
             let extent = &self.extents[*eid];
             let writes = batched_writes.get(eid).unwrap();
-            extent.write(job_id, &writes[..], only_write_unwritten).await?;
+            extent
+                .write(job_id, &writes[..], only_write_unwritten)
+                .await?;
         }
         if only_write_unwritten {
             cdt::os__writeunwritten__done!(|| job_id);
@@ -1830,7 +1832,9 @@ impl Region {
                     batched_reads.push(request);
                 } else {
                     let extent = &self.extents[_eid as usize];
-                    extent.read(job_id, &batched_reads[..], &mut responses).await?;
+                    extent
+                        .read(job_id, &batched_reads[..], &mut responses)
+                        .await?;
 
                     eid = Some(request.eid);
                     batched_reads.clear();
@@ -1845,7 +1849,9 @@ impl Region {
 
         if let Some(_eid) = eid {
             let extent = &self.extents[_eid as usize];
-            extent.read(job_id, &batched_reads[..], &mut responses).await?;
+            extent
+                .read(job_id, &batched_reads[..], &mut responses)
+                .await?;
         }
         cdt::os__read__done!(|| job_id);
 
@@ -1873,7 +1879,9 @@ impl Region {
         );
 
         let extent = &self.extents[eid];
-        extent.flush_block(flush_number, gen_number, 0, &self.log).await?;
+        extent
+            .flush_block(flush_number, gen_number, 0, &self.log)
+            .await?;
 
         Ok(())
     }
@@ -1901,7 +1909,9 @@ impl Region {
         cdt::os__flush__start!(|| job_id);
         for eid in 0..self.def.extent_count() {
             let extent = &self.extents[eid as usize];
-            extent.flush_block(flush_number, gen_number, job_id, &self.log).await?;
+            extent
+                .flush_block(flush_number, gen_number, job_id, &self.log)
+                .await?;
         }
         cdt::os__flush__done!(|| job_id);
 

--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -336,7 +336,7 @@ mod test {
         region.extend(3)?;
 
         let ext_one = &mut region.extents[1];
-        ext_one.close()?;
+        ext_one.close().await?;
 
         // Determine the directory and name for expected extent files.
         let extent_dir = extent_dir(&dir, 1);


### PR DESCRIPTION
Don't use std::sync::Mutex downstairs either, use tokio::sync::Mutex. This meant making the downstairs also use async in a lot more places. This was also mostly a rote process of adding `async` before bunch of functions and adding `.await` to the call sites.