### PR TITLE
Return JoinHandles when spawning our services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,6 @@ dependencies = [
  "futures",
  "futures-core",
  "httptest",
- "lazy_static",
  "rand 0.8.5",
  "tempfile",
  "tokio",

--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -489,7 +489,8 @@ async fn main() -> Result<()> {
     // TODO: volumes?
     let guest = Arc::new(Guest::new());
 
-    tokio::spawn(up_main(crucible_opts, opt.gen, guest.clone(), None));
+    let _join_handle =
+        up_main(crucible_opts, opt.gen, guest.clone(), None).await?;
     eprintln!("Crucible runtime is spawned");
 
     // IO time

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -517,7 +517,8 @@ async fn main() -> Result<()> {
         pr = None;
     }
 
-    tokio::spawn(up_main(crucible_opts, opt.gen, guest.clone(), pr));
+    let _join_handle =
+        up_main(crucible_opts, opt.gen, guest.clone(), pr).await?;
     println!("Crucible runtime is spawned");
 
     if let Workload::CliServer { listen, port } = opt.workload {

--- a/downstairs/src/admin.rs
+++ b/downstairs/src/admin.rs
@@ -20,6 +20,7 @@ pub struct RunDownstairsForRegionParams {
     oximeter: Option<SocketAddr>,
     lossy: bool,
     port: u16,
+    rport: u16,
     return_errors: bool,
     cert_pem: Option<String>,
     key_pem: Option<String>,
@@ -67,20 +68,20 @@ pub async fn run_downstairs_for_region(
     )
     .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
 
-    let dd = d.clone();
-    tokio::spawn(async move {
-        // XXX result eaten here!
-        let _ = start_downstairs(
-            dd,
-            run_params.address,
-            run_params.oximeter,
-            run_params.port,
-            run_params.cert_pem,
-            run_params.key_pem,
-            run_params.root_cert_pem,
-        )
-        .await;
-    });
+    let _join_handle = start_downstairs(
+        d.clone(),
+        run_params.address,
+        run_params.oximeter,
+        run_params.port,
+        run_params.rport,
+        run_params.cert_pem,
+        run_params.key_pem,
+        run_params.root_cert_pem,
+    )
+    .await
+    .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
+
+    // past here, the downstairs has started successfully
 
     downstairs.insert(uuid, d);
 

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -783,6 +783,10 @@ where
         + std::marker::Send
         + 'static,
 {
+    // In this function, repair address should exist, and shouldn't change. Grab
+    // it here.
+    let repair_addr = ads.lock().await.repair_address.unwrap();
+
     let mut negotiated = 0;
     let mut upstairs_connection: Option<UpstairsConnection> = None;
 
@@ -946,7 +950,7 @@ where
                             upstairs_connection.unwrap());
 
                         let mut fw = fw.lock().await;
-                        fw.send(Message::YesItsMe { version: 1, repair_addr: ads.lock().await.repair_address.unwrap() }).await?;
+                        fw.send(Message::YesItsMe { version: 1, repair_addr }).await?;
                     }
                     Some(Message::PromoteToActive {
                         upstairs_id,

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -946,7 +946,7 @@ where
                             upstairs_connection.unwrap());
 
                         let mut fw = fw.lock().await;
-                        fw.send(Message::YesItsMe { version: 1 }).await?;
+                        fw.send(Message::YesItsMe { version: 1, repair_addr: ads.lock().await.repair_address.unwrap() }).await?;
                     }
                     Some(Message::PromoteToActive {
                         upstairs_id,
@@ -1311,6 +1311,8 @@ pub struct Downstairs {
     dss: DsStatOuter,
     read_only: bool,
     encrypted: bool,
+    pub address: Option<SocketAddr>,
+    pub repair_address: Option<SocketAddr>,
 }
 
 impl Downstairs {
@@ -1334,6 +1336,8 @@ impl Downstairs {
             dss,
             read_only,
             encrypted,
+            address: None,
+            repair_address: None,
         }
     }
 
@@ -2246,15 +2250,21 @@ pub fn build_downstairs_for_region(
     ))))
 }
 
+/// Returns Ok if everything spawned ok, Err otherwise
+///
+/// Return Ok(main task join handle) if all the necessary tasks spawned
+/// successfully, and Err otherwise.
+#[allow(clippy::too_many_arguments)]
 pub async fn start_downstairs(
     d: Arc<Mutex<Downstairs>>,
     address: IpAddr,
     oximeter: Option<SocketAddr>,
     port: u16,
+    rport: u16,
     cert_pem: Option<String>,
     key_pem: Option<String>,
     root_cert_pem: Option<String>,
-) -> Result<()> {
+) -> Result<tokio::task::JoinHandle<Result<()>>> {
     if let Some(oximeter) = oximeter {
         let dssw = d.lock().await;
         let dss = dssw.dss.clone();
@@ -2277,29 +2287,38 @@ pub async fn start_downstairs(
         });
     }
 
-    // Start the repair server on the same address at port + REPAIR_PORT_OFFSET
-    let rport = port + REPAIR_PORT_OFFSET;
-    let repair_address = match address {
-        IpAddr::V4(ipv4) => SocketAddr::new(std::net::IpAddr::V4(ipv4), rport),
-        IpAddr::V6(ipv6) => SocketAddr::new(std::net::IpAddr::V6(ipv6), rport),
-    };
-    let dss = d.clone();
-    tokio::spawn(async move {
-        let s = repair::repair_main(&dss, repair_address).await;
-        println!("Got {:?} from repair main", s);
-    });
-
     let listen_on = match address {
         IpAddr::V4(ipv4) => SocketAddr::new(std::net::IpAddr::V4(ipv4), port),
         IpAddr::V6(ipv6) => SocketAddr::new(std::net::IpAddr::V6(ipv6), port),
     };
 
-    /*
-     * Establish a listen server on the port.
-     */
-    println!("Using address: {:?}", listen_on);
+    // Establish a listen server on the port.
     let listener = TcpListener::bind(&listen_on).await?;
+    let local_addr = listener.local_addr()?;
 
+    {
+        let mut ds = d.lock().await;
+        ds.address = Some(local_addr);
+        println!("Using address: {:?}", local_addr);
+    }
+
+    let repair_address = match address {
+        IpAddr::V4(ipv4) => SocketAddr::new(std::net::IpAddr::V4(ipv4), rport),
+        IpAddr::V6(ipv6) => SocketAddr::new(std::net::IpAddr::V6(ipv6), rport),
+    };
+
+    if let Err(e) = repair::repair_main(&d, repair_address).await {
+        // TODO tear down other things if repair server can't be started?
+        bail!("got {:?} from repair main", e);
+    }
+
+    {
+        let mut ds = d.lock().await;
+        ds.repair_address = Some(repair_address);
+        println!("Using repair address: {:?}", repair_address);
+    }
+
+    // Optionally require SSL connections
     let ssl_acceptor = if let Some(cert_pem_path) = cert_pem {
         let key_pem_path = key_pem.unwrap();
         let root_cert_pem_path = root_cert_pem.unwrap();
@@ -2321,49 +2340,58 @@ pub async fn start_downstairs(
         None
     };
 
-    /*
-     * We now loop listening for a connection from the Upstairs.
-     * When we get one, we then spawn the proc() function to handle
-     * it and wait for another connection. Downstairs can handle
-     * multiple Upstairs connecting but only one active one.
-     */
-    println!("listening on {}", listen_on);
-    loop {
-        let (sock, raddr) = listener.accept().await?;
+    let join_handle = tokio::spawn(async move {
+        /*
+         * We now loop listening for a connection from the Upstairs.
+         * When we get one, we then spawn the proc() function to handle
+         * it and wait for another connection. Downstairs can handle
+         * multiple Upstairs connecting but only one active one.
+         */
+        println!("listening on {}", listen_on);
+        loop {
+            let (sock, raddr) = listener.accept().await?;
 
-        let stream: WrappedStream = if let Some(ssl_acceptor) = &ssl_acceptor {
-            let ssl_acceptor = ssl_acceptor.clone();
-            WrappedStream::Https(match ssl_acceptor.accept(sock).await {
-                Ok(v) => v,
-                Err(e) => {
-                    println!("rejecting connection from {:?}: {:?}", raddr, e,);
-                    continue;
-                }
-            })
-        } else {
-            WrappedStream::Http(sock)
-        };
-
-        println!("accepted connection from {:?}", raddr);
-        {
-            /*
-             * Add one to the counter every time we have a connection
-             * from an upstairs
-             */
-            let mut ds = d.lock().await;
-            ds.dss.add_connection().await;
-        }
-
-        let mut dd = d.clone();
-
-        tokio::spawn(async move {
-            if let Err(e) = proc_stream(&mut dd, stream).await {
-                println!("ERROR: connection({}): {:?}", raddr, e);
+            let stream: WrappedStream = if let Some(ssl_acceptor) =
+                &ssl_acceptor
+            {
+                let ssl_acceptor = ssl_acceptor.clone();
+                WrappedStream::Https(match ssl_acceptor.accept(sock).await {
+                    Ok(v) => v,
+                    Err(e) => {
+                        println!(
+                            "rejecting connection from {:?}: {:?}",
+                            raddr, e,
+                        );
+                        continue;
+                    }
+                })
             } else {
-                println!("OK: connection({}): all done", raddr);
+                WrappedStream::Http(sock)
+            };
+
+            println!("accepted connection from {:?}", raddr);
+            {
+                /*
+                 * Add one to the counter every time we have a connection
+                 * from an upstairs
+                 */
+                let mut ds = d.lock().await;
+                ds.dss.add_connection().await;
             }
-        });
-    }
+
+            let mut dd = d.clone();
+
+            tokio::spawn(async move {
+                if let Err(e) = proc_stream(&mut dd, stream).await {
+                    println!("ERROR: connection({}): {:?}", raddr, e);
+                } else {
+                    println!("OK: connection({}): all done", raddr);
+                }
+            });
+        }
+    });
+
+    Ok(join_handle)
 }
 
 #[cfg(test)]

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -308,16 +308,20 @@ async fn main() -> Result<()> {
                 read_only,
             )?;
 
-            start_downstairs(
+            let downstairs_join_handle = start_downstairs(
                 d,
                 address,
                 oximeter,
                 port,
+                // TODO accept as an argument?
+                port + crucible_common::REPAIR_PORT_OFFSET,
                 cert_pem,
                 key_pem,
                 root_cert_pem,
             )
-            .await
+            .await?;
+
+            downstairs_join_handle.await?
         }
         Args::RepairAPI => repair::write_openapi(&mut std::io::stdout()),
         Args::Serve {

--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -40,6 +40,7 @@ fn build_api() -> ApiDescription<FileServerContext> {
     api
 }
 
+/// Returns Ok if everything launched ok, Err otherwise
 pub async fn repair_main(
     ds: &Arc<Mutex<Downstairs>>,
     addr: SocketAddr,
@@ -87,11 +88,16 @@ pub async fn repair_main(
         .map_err(|error| format!("failed to create server: {}", error))?
         .start();
 
-    /*
-     * Wait for the server to stop.  Note that there's not any code to shut
-     * down this server, so we should never get past this point.
-     */
-    server.await
+    tokio::spawn(async move {
+        /*
+         * Wait for the server to stop.  Note that there's not any code to
+         * shut down this server, so we should never get past this
+         * point.
+         */
+        server.await
+    });
+
+    Ok(())
 }
 
 #[derive(Deserialize, JsonSchema)]

--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -40,7 +40,7 @@ fn build_api() -> ApiDescription<FileServerContext> {
     api
 }
 
-/// Returns Ok if everything launched ok, Err otherwise
+/// Returns Ok(listen address) if everything launched ok, Err otherwise
 pub async fn repair_main(
     ds: &Arc<Mutex<Downstairs>>,
     addr: SocketAddr,

--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -44,7 +44,7 @@ fn build_api() -> ApiDescription<FileServerContext> {
 pub async fn repair_main(
     ds: &Arc<Mutex<Downstairs>>,
     addr: SocketAddr,
-) -> Result<(), String> {
+) -> Result<SocketAddr, String> {
     /*
      * We must specify a configuration with a bind address.
      */
@@ -87,6 +87,7 @@ pub async fn repair_main(
     let server = HttpServerStarter::new(&config_dropshot, api, context, &log)
         .map_err(|error| format!("failed to create server: {}", error))?
         .start();
+    let local_addr = server.local_addr();
 
     tokio::spawn(async move {
         /*
@@ -97,7 +98,7 @@ pub async fn repair_main(
         server.await
     });
 
-    Ok(())
+    Ok(local_addr)
 }
 
 #[derive(Deserialize, JsonSchema)]

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -133,12 +133,13 @@ async fn main() -> Result<()> {
          */
         let guest = Arc::new(Guest::new());
 
-        tokio::spawn(up_main(
+        let _join_handle = up_main(
             crucible_opts.clone(),
-            opt.gen,
+            opt.gen, // XXX increase gen per upstairs
             guest.clone(),
             None,
-        )); // XXX increase gen per upstairs
+        )
+        .await?;
         println!("Crucible runtime is spawned");
 
         cpfs.push(crucible::CruciblePseudoFile::from(guest)?);

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -19,4 +19,3 @@ rand = "0.8.5"
 tempfile = "3.3.0"
 tokio = { version = "1.21.0", features = ["full"] }
 uuid = { version = "1.0.0", features = [ "serde", "v4" ] }
-lazy_static = "1.4.0"

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -104,7 +104,8 @@ async fn main() -> Result<()> {
     }
 
     let guest = Arc::new(guest);
-    tokio::spawn(up_main(crucible_opts, opt.gen, guest.clone(), None));
+    let _join_handle =
+        up_main(crucible_opts, opt.gen, guest.clone(), None).await?;
     println!("Crucible runtime is spawned");
 
     guest.activate(opt.gen).await?;

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -93,7 +93,8 @@ async fn main() -> Result<()> {
      */
     let guest = Arc::new(Guest::new());
 
-    tokio::spawn(up_main(crucible_opts, opt.gen, guest.clone(), None));
+    let _join_handle =
+        up_main(crucible_opts, opt.gen, guest.clone(), None).await?;
     println!("Crucible runtime is spawned");
 
     // NBD server

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -121,6 +121,7 @@ pub enum Message {
     },
     YesItsMe {
         version: u32,
+        repair_addr: SocketAddr,
     },
 
     // Reasons to reject the initial negotiation
@@ -589,7 +590,10 @@ mod tests {
 
     #[test]
     fn rt_yes_its_me() -> Result<()> {
-        let input = Message::YesItsMe { version: 20000 };
+        let input = Message::YesItsMe {
+            version: 20000,
+            repair_addr: "127.0.0.1:123".parse().unwrap(),
+        };
         assert_eq!(input, round_trip(&input)?);
         Ok(())
     }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -3778,14 +3778,6 @@ impl Upstairs {
          */
         #[cfg(not(test))]
         assert_eq!(opt.target.len(), 3);
-        /*
-         * The repair port is the downstairs target port + 4000
-         * XXX How do we advertise/enforce this?
-         */
-        #[cfg(not(test))]
-        for addr in opt.target.iter() {
-            assert!(addr.port() < u16::MAX - 4000);
-        }
 
         // create an encryption context if a key is supplied.
         let encryption_context = opt.key_bytes().map(|key| {

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -896,7 +896,7 @@ where
 
                         negotiated = 1;
 
-                        up.ds_repair_address(
+                        up.ds_set_repair_address(
                             up_coms.client_id, repair_addr,
                         ).await;
 
@@ -5563,7 +5563,7 @@ impl Upstairs {
         Ok(notify_guest)
     }
 
-    async fn ds_repair_address(&self, client_id: u8, addr: SocketAddr) {
+    async fn ds_set_repair_address(&self, client_id: u8, addr: SocketAddr) {
         let mut ds = self.downstairs.lock().await;
         ds.ds_repair.insert(client_id, addr);
     }

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -1007,8 +1007,7 @@ mod up_test {
     #[tokio::test]
     async fn work_read_hash_mismatch_third() {
         // Test that a hash mismatch on the third response will trigger a panic.
-        let target = vec![];
-        let mut ds = Downstairs::new(target, csl());
+        let mut ds = Downstairs::new(csl());
 
         let id = ds.next_id();
 
@@ -3778,8 +3777,7 @@ mod up_test {
     #[test]
     fn bad_hash_on_encrypted_read_panic() {
         // Verify that a decryption failure on a read will panic.
-        let target = vec![];
-        let mut ds = Downstairs::new(target, csl());
+        let mut ds = Downstairs::new(csl());
         let next_id = ds.next_id();
 
         let request = ReadRequest {

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -134,10 +134,8 @@ impl Volume {
 
         // Spawn crucible tasks
         let guest_clone = guest.clone();
-        tokio::spawn(async move {
-            // XXX result eaten here!
-            let _ = up_main(opts, gen, guest_clone, producer_registry).await;
-        });
+        let _join_handle =
+            up_main(opts, gen, guest_clone, producer_registry).await?;
 
         guest.activate(gen).await?;
 


### PR DESCRIPTION
Previous to this commit, the integration tests would "randomly" hang. This was due to our port selection for downstairs being "fixed" in the integration test (with required collision detection), but but the Upstairs gets a random port when it opens its connection to the downstairs. The hang occurs when the Upstairs is randomly assigned a port that one of the integration tests is going to use to spawn the downstairs.

Say there are two integration tests. Test A uses ports X, X+1, and X+2 for the downstairs, and test B uses X+3, X+4, X+5. The hang occurs when:

- Test A runs and spawns three downstairs successfully at X, X+1, and X+2.

- Test A spawns an upstairs, which is assigned port X+4, to talk to X, X+1, and X+2.

- Test B tries to spawn three downstairs, but can only spawn X+3 and X+5 because X+4 is taken.

- Test B spawns an upstairs, which is assigned some random port, to talk to X+3, X+4, and X+5.

When Test B's upstairs tries to activate, it will send the HereIAm message to the three targets defined in the Crucible opts. Test B sends HereIAm to X+3, X+4, and X+5, where X+4 in this case is another Upstairs, leading to the very confusing error message:

> ERRO 127.0.0.1:55016: proc: [0] unexpected command HereIAm { ... }
> received in state New

Notice in this case the Upstairs' port is 55016, the same as one of the integration tests (before this commit). Activation cannot occur without three downstairs, and the test hangs.

The fix is to not set the downstair's ports and instead grab whatever is available. By passing 0 into start_downstairs, the operating system will choose a port from the ephemeral range. This necessitated storing the SocketAddr the downstairs is listening on in the Downstairs struct for later querying.

I've tested this for 24h and it ran without hanging. But, there is some additional refactoring that this commit introduces to make this scenario less likely in the future.

When calling up_main or start_downstairs, return a JoinHandle that consumers can await on instead of never returning anything. This can be used to signal that the creation of the Upstairs or Downstairs was successful, and if that is not returned then that is an error that can be dealt with accordingly. This would have prevented our integration tasks from hanging: `start_downstairs` would have returned an Err instead of Ok(JoinHandle) because it wouldn't have been able to listen on the port. Notably, if Ok(JoinHandle) was returned, then the address field in Downstairs will be Some.

One additional complication here: having the operating system choose from the ephemeral range means that it may choose a port that is too high to add REPAIR_PORT_OFFSET to in order to choose a repair port.

So this commit **also** changes how repair ports work: start_downstairs now accepts an rport argument. If it's set to non-zero, then use that port for the repair server address. If it's zero, then pick an open port for the repair server. This necessitated the downstairs sending the upstairs what port it chose for the repair server, which caused a bit of a jumble around of things BUT means that the only place where REPAIR_PORT_OFFSET is used now is when running the downstairs from the command line.