### PR TITLE
Compute better job dependencies Upstairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +565,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "base64",
+ "bitvec",
  "bytes",
  "chrono",
  "crucible-client-types",
@@ -562,6 +575,7 @@ dependencies = [
  "expectorate",
  "futures",
  "futures-core",
+ "itertools",
  "omicron-common",
  "openapi-lint",
  "openapiv3",
@@ -1259,6 +1273,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -2676,6 +2696,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3632,6 +3658,12 @@ name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -4615,6 +4647,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -219,7 +219,7 @@ pub fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
         let nblocks = Block::from_bytes(total, &rm);
         let mut pos = Block::from_bytes(0, &rm);
         let mut writes = vec![];
-        for (eid, offset) in extent_from_offset(rm, offset, nblocks) {
+        for (eid, offset) in extent_from_offset(rm, offset, nblocks).tuples() {
             let len = Block::new_with_ddef(1, &region.def());
             let data = &buffer[pos.bytes()..(pos.bytes() + len.bytes())];
             let mut buffer = BytesMut::with_capacity(data.len());

--- a/upstairs/Cargo.toml
+++ b/upstairs/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "1"
 async-trait = "0.1.57"
 async-recursion = "1.0.0"
 base64 = "0.13.0"
+bitvec = "1"
 bytes = "1"
 chrono = { version = "0.4.22", features = [ "serde" ] }
 crucible-common = { path = "../common" }
@@ -25,6 +26,7 @@ crucible-protocol = { path = "../protocol" }
 dropshot = { git = "https://github.com/oxidecomputer/dropshot", branch = "main", features = [ "usdt-probes" ] }
 futures = "0.3"
 futures-core = "0.3"
+itertools = "0.10.4"
 omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }

--- a/upstairs/src/impacted_blocks.rs
+++ b/upstairs/src/impacted_blocks.rs
@@ -55,6 +55,12 @@ impl ImpactedBlocks {
         false
     }
 
+    /// Return a list of impacted extents
+    #[cfg(test)]
+    pub fn extents(&self) -> Vec<&u64> {
+        self.blocks.keys().collect()
+    }
+
     /// Returns (extent id, block) tuples
     pub fn tuples(&self) -> Vec<(u64, Block)> {
         let mut result = Vec::with_capacity(self.len());

--- a/upstairs/src/impacted_blocks.rs
+++ b/upstairs/src/impacted_blocks.rs
@@ -89,18 +89,29 @@ impl ImpactedBlocks {
     }
 }
 
-/// Given an offset and number of blocks, return a list of individually impacted
-/// blocks:
+/// Given an offset and number of blocks, compute a list of individually
+/// impacted blocks:
 ///
-///  |eid0                   |eid1
-///  |───────────────────────────────────────────────│
-///  ┌───────────────────────|───────────────────────┐
-///  │   |   |xxx|xxx|xxx|xxx|xxx|xxx|xxx|   |   |   │
-///  └───────────────────────|───────────────────────┘
-///          |--------------------------|
-///          offset                     offset + len
+///         |eid0                   |eid1
+///         |───────────────────────────────────────────────│
+///         ┌───────────────────────|───────────────────────┐
+///         │   |   |xxx|xxx|xxx|xxx|xxx|xxx|xxx|   |   |   │
+///         └───────────────────────|───────────────────────┘
+/// block#    0   1 | 2   3   4   5   0   1   2 | 3   4   5
+///                 |---------------------------|
+///                 offset                     offset + len
 ///
-/// The example above would return a list of 7 impacted blocks.
+/// The example offset and length above spans 7 blocks over two extents.
+///
+/// Return an ImpactedBlocks object that stores which extents are impacted,
+/// along with the specific blocks in those extents. For the above example, the
+/// hashmap inside ImpactedBlocks would be:
+///
+///  blocks = {
+///    eid0 -> [2, 3, 4, 5],
+///    eid1 -> [0, 1, 2],
+///  }
+///
 pub fn extent_from_offset(
     ddef: RegionDefinition,
     offset: Block,

--- a/upstairs/src/impacted_blocks.rs
+++ b/upstairs/src/impacted_blocks.rs
@@ -92,16 +92,17 @@ impl ImpactedBlocks {
 /// Given an offset and number of blocks, compute a list of individually
 /// impacted blocks:
 ///
-///         |eid0                   |eid1
-///         |───────────────────────────────────────────────│
-///         ┌───────────────────────|───────────────────────┐
-///         │   |   |xxx|xxx|xxx|xxx|xxx|xxx|xxx|   |   |   │
-///         └───────────────────────|───────────────────────┘
-/// block#    0   1 | 2   3   4   5   0   1   2 | 3   4   5
-///                 |---------------------------|
-///                 offset                     offset + len
+///  |eid0                   |eid1
+///  |───────────────────────────────────────────────│
+///  ┌───────────────────────|───────────────────────┐
+///  │   |   |xxx|xxx|xxx|xxx|xxx|xxx|xxx|   |   |   │
+///  └───────────────────────|───────────────────────┘
+///    0   1 | 2   3   4   5   0   1   2 | 3   4   5
+///          |---------------------------|
+///          offset                     offset + len
 ///
-/// The example offset and length above spans 7 blocks over two extents.
+/// The example offset and length above spans 7 blocks over two extents (where
+/// the numbers at the bottom of the diagram are block numbers).
 ///
 /// Return an ImpactedBlocks object that stores which extents are impacted,
 /// along with the specific blocks in those extents. For the above example, the
@@ -111,7 +112,6 @@ impl ImpactedBlocks {
 ///    eid0 -> [2, 3, 4, 5],
 ///    eid1 -> [0, 1, 2],
 ///  }
-///
 pub fn extent_from_offset(
     ddef: RegionDefinition,
     offset: Block,

--- a/upstairs/src/impacted_blocks.rs
+++ b/upstairs/src/impacted_blocks.rs
@@ -121,8 +121,7 @@ pub fn extent_from_offset(
         /*
          * XXX We only support a single region (downstairs). When we grow to
          * support a LBA size that is larger than a single region, then we
-         * will need to write more code. But - that code may live
-         * upstairs?
+         * will need to write more code.
          */
         let eid: u64 = o / ddef.extent_size().value;
         assert!((eid as u32) < ddef.extent_count());

--- a/upstairs/src/impacted_blocks.rs
+++ b/upstairs/src/impacted_blocks.rs
@@ -1,0 +1,275 @@
+// Copyright 2022 Oxide Computer Company
+
+use super::*;
+
+use bitvec::prelude::*;
+use itertools::Itertools;
+use std::ops::BitAnd;
+
+/// Store a list of impacted blocks for later job dependency calculation
+#[derive(Debug, Default, PartialEq)]
+pub struct ImpactedBlocks {
+    ddef: RegionDefinition,
+
+    // extent id -> list of block offsets
+    blocks: HashMap<u64, BitVec>,
+}
+
+impl ImpactedBlocks {
+    pub fn new(ddef: RegionDefinition) -> Self {
+        ImpactedBlocks {
+            ddef,
+            blocks: HashMap::default(),
+        }
+    }
+
+    pub fn blocks_in_extent(&self) -> usize {
+        self.ddef.extent_size().value as usize
+    }
+
+    pub fn add(&mut self, extent_id: u64, block: Block) {
+        let blocks_in_extent = self.blocks_in_extent();
+        let bv = self.blocks.entry(extent_id).or_insert_with(|| {
+            let mut bv = BitVec::with_capacity(blocks_in_extent);
+            bv.resize(blocks_in_extent, false);
+            bv
+        });
+
+        bv.set(block.value as usize, true);
+    }
+
+    /// Return true if this list of impacted blocks overlaps with another.
+    pub fn conflicts(&self, other: &ImpactedBlocks) -> bool {
+        for shared_key in self
+            .blocks
+            .keys()
+            .filter(|key| other.blocks.contains_key(key))
+        {
+            // TODO any way to avoid this clone?
+            let bv = self.blocks[shared_key].clone();
+            if bv.bitand(&other.blocks[shared_key]).any() {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Returns (extent id, block) tuples
+    pub fn tuples(&self) -> Vec<(u64, Block)> {
+        let mut result = Vec::with_capacity(self.len());
+
+        let sorted_keys = self.blocks.keys().sorted();
+        for eid in sorted_keys {
+            let block_offsets =
+                self.blocks[eid].iter_ones().collect::<Vec<usize>>();
+            for i in block_offsets.iter().sorted() {
+                result
+                    .push((*eid, Block::new_with_ddef(*i as u64, &self.ddef)));
+            }
+        }
+
+        result
+    }
+
+    /// Returns the number of impacted blocks
+    pub fn len(&self) -> usize {
+        let mut len = 0;
+
+        for bv in self.blocks.values() {
+            len += bv.iter_ones().count();
+        }
+
+        len
+    }
+
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Given an offset and number of blocks, return a list of individually impacted
+/// blocks:
+///
+///  |eid0                   |eid1
+///  |───────────────────────────────────────────────│
+///  ┌───────────────────────|───────────────────────┐
+///  │   |   |xxx|xxx|xxx|xxx|xxx|xxx|xxx|   |   |   │
+///  └───────────────────────|───────────────────────┘
+///          |--------------------------|
+///          offset                     offset + len
+///
+/// The example above would return a list of 7 impacted blocks.
+pub fn extent_from_offset(
+    ddef: RegionDefinition,
+    offset: Block,
+    num_blocks: Block,
+) -> ImpactedBlocks {
+    assert!(num_blocks.value > 0);
+    assert!(
+        (offset.value + num_blocks.value)
+            <= (ddef.extent_size().value * ddef.extent_count() as u64)
+    );
+    assert_eq!(offset.block_size_in_bytes() as u64, ddef.block_size());
+
+    let mut result = ImpactedBlocks::new(ddef);
+    let mut o: u64 = offset.value;
+    let mut blocks_left: u64 = num_blocks.value;
+
+    while blocks_left > 0 {
+        /*
+         * XXX We only support a single region (downstairs). When we grow to
+         * support a LBA size that is larger than a single region, then we
+         * will need to write more code. But - that code may live
+         * upstairs?
+         */
+        let eid: u64 = o / ddef.extent_size().value;
+        assert!((eid as u32) < ddef.extent_count());
+
+        let extent_offset: u64 = o % ddef.extent_size().value;
+        let sz: u64 = 1; // one block at a time
+
+        result.add(eid, Block::new_with_ddef(extent_offset, &ddef));
+
+        match blocks_left.checked_sub(sz) {
+            Some(v) => {
+                blocks_left = v;
+            }
+            None => {
+                break;
+            }
+        }
+
+        o += sz;
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn extent_tuple(eid: u64, offset: u64) -> (u64, Block) {
+        (eid, Block::new_512(offset))
+    }
+
+    #[test]
+    fn test_extent_from_offset() {
+        let mut ddef = RegionDefinition::default();
+        ddef.set_block_size(512);
+        ddef.set_extent_size(Block::new_512(2));
+        ddef.set_extent_count(10);
+
+        // Test block size, less than extent size
+        assert_eq!(
+            extent_from_offset(ddef, Block::new_512(0), Block::new_512(1))
+                .tuples(),
+            vec![extent_tuple(0, 0)],
+        );
+
+        // Test greater than block size, less than extent size
+        assert_eq!(
+            extent_from_offset(ddef, Block::new_512(0), Block::new_512(2))
+                .tuples(),
+            vec![extent_tuple(0, 0), extent_tuple(0, 1),],
+        );
+
+        // Test greater than extent size
+        assert_eq!(
+            extent_from_offset(ddef, Block::new_512(0), Block::new_512(4))
+                .tuples(),
+            vec![
+                extent_tuple(0, 0),
+                extent_tuple(0, 1),
+                extent_tuple(1, 0),
+                extent_tuple(1, 1),
+            ],
+        );
+
+        // Test offsets
+        assert_eq!(
+            extent_from_offset(ddef, Block::new_512(1), Block::new_512(4))
+                .tuples(),
+            vec![
+                extent_tuple(0, 1),
+                extent_tuple(1, 0),
+                extent_tuple(1, 1),
+                extent_tuple(2, 0),
+            ],
+        );
+
+        assert_eq!(
+            extent_from_offset(ddef, Block::new_512(2), Block::new_512(4))
+                .tuples(),
+            vec![
+                extent_tuple(1, 0),
+                extent_tuple(1, 1),
+                extent_tuple(2, 0),
+                extent_tuple(2, 1),
+            ],
+        );
+
+        assert_eq!(
+            extent_from_offset(ddef, Block::new_512(2), Block::new_512(16))
+                .tuples(),
+            vec![
+                extent_tuple(1, 0),
+                extent_tuple(1, 1),
+                extent_tuple(2, 0),
+                extent_tuple(2, 1),
+                extent_tuple(3, 0),
+                extent_tuple(3, 1),
+                extent_tuple(4, 0),
+                extent_tuple(4, 1),
+                extent_tuple(5, 0),
+                extent_tuple(5, 1),
+                extent_tuple(6, 0),
+                extent_tuple(6, 1),
+                extent_tuple(7, 0),
+                extent_tuple(7, 1),
+                extent_tuple(8, 0),
+                extent_tuple(8, 1),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_extent_from_offset_single_block_only() {
+        let mut ddef = RegionDefinition::default();
+        ddef.set_block_size(512);
+        ddef.set_extent_size(Block::new_512(2));
+        ddef.set_extent_count(10);
+
+        assert_eq!(
+            extent_from_offset(
+                ddef,
+                Block::new_512(2), // offset
+                Block::new_512(1), // num_blocks
+            )
+            .tuples(),
+            vec![extent_tuple(1, 0),]
+        );
+
+        assert_eq!(
+            extent_from_offset(
+                ddef,
+                Block::new_512(2), // offset
+                Block::new_512(2), // num_blocks
+            )
+            .tuples(),
+            vec![extent_tuple(1, 0), extent_tuple(1, 1),]
+        );
+
+        assert_eq!(
+            extent_from_offset(
+                ddef,
+                Block::new_512(2), // offset
+                Block::new_512(3), // num_blocks
+            )
+            .tuples(),
+            vec![extent_tuple(1, 0), extent_tuple(1, 1), extent_tuple(2, 0),]
+        );
+    }
+}

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -4254,14 +4254,16 @@ impl Upstairs {
         cdt::gw__flush__start!(|| (gw_id));
 
         /*
-         * To build the dependency list for this flush, iterate from the end of
-         * the downstairs work active list in reverse order and check each job
-         * in that list to see if this new flush must depend on it.
+         * To build the dependency list for this flush, iterate from the end
+         * of the downstairs work active list in reverse order and
+         * check each job in that list to see if this new flush must
+         * depend on it.
          *
          * We can safely ignore everything before the last flush, because the
-         * last flush will depend on jobs before it. But this flush must depend
-         * on the last flush - flush and gen numbers downstairs need to be
-         * sequential and the same for each downstairs.
+         * last flush will depend on jobs before it. But this flush must
+         * depend on the last flush - flush and gen numbers
+         * downstairs need to be sequential and the same for each
+         * downstairs.
          *
          * This flush does not have to depend on reads as they do not impact
          * downstairs state, but must depend on every write since the last
@@ -4400,9 +4402,10 @@ impl Upstairs {
         let mut cur_offset: usize = 0;
 
         /*
-         * To build the dependency list for this write, iterate from the end of
-         * the downstairs work active list in reverse order and check each job
-         * in that list to see if this new write must depend on it.
+         * To build the dependency list for this write, iterate from the end
+         * of the downstairs work active list in reverse order and
+         * check each job in that list to see if this new write must
+         * depend on it.
          *
          * Construct a list of dependencies for this write based on the
          * following rules:
@@ -4411,9 +4414,10 @@ impl Upstairs {
          * - writes have to depend on the last flush completing
          * - any overlap of impacted blocks requires a dependency
          *
-         * TODO: any overlap of impacted blocks will create a dependency. take
-         * this an example (this shows three writes, all to the same block,
-         * along with the dependency list for each write):
+         * TODO: any overlap of impacted blocks will create a dependency.
+         * take this an example (this shows three writes, all to the
+         * same block, along with the dependency list for each
+         * write):
          *
          *       block
          * op# | 0 1 2 | deps
@@ -4596,16 +4600,18 @@ impl Upstairs {
         let next_id = downstairs.next_id();
 
         /*
-         * To build the dependency list for this read, iterate from the end of
-         * the downstairs work active list in reverse order and check each job
-         * in that list to see if this new read must depend on it.
+         * To build the dependency list for this read, iterate from the end
+         * of the downstairs work active list in reverse order and
+         * check each job in that list to see if this new read must
+         * depend on it.
          *
          * Construct a list of dependencies for this read based on the
          * following rules:
          *
          * - reads do not depend on flushes, only writes (because flushes do
          *   not modify data!)
-         * - any write with an overlap of impacted blocks requires a dependency
+         * - any write with an overlap of impacted blocks requires a
+         *   dependency
          */
         let num_jobs = downstairs.active.keys().len();
         let mut dep: Vec<u64> = Vec::with_capacity(num_jobs);

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -4258,9 +4258,9 @@ impl Upstairs {
          * jobs. Anything we have not submitted back to the guest.
          *
          * We can safely ignore everything before the last flush, because the
-         * last flush will depend on jobs before it. But we must depend on
-         * the previous flush - flush and gen numbers downstairs need
-         * to be sequential and the same for each downstairs.
+         * last flush will depend on jobs before it. But we must depend on the
+         * last flush - flush and gen numbers downstairs need to be sequential
+         * and the same for each downstairs.
          *
          * We can safely ignore reads as they do not impact downstairs state,
          * but flushes must depend on every write since the last flush.

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -4265,7 +4265,8 @@ impl Upstairs {
          * We can safely ignore reads as they do not impact downstairs state,
          * but flushes must depend on every write since the last flush.
          */
-        let mut dep: Vec<u64> = Vec::with_capacity(200); // max in-flight jobs
+        let num_jobs = downstairs.active.keys().len();
+        let mut dep: Vec<u64> = Vec::with_capacity(num_jobs);
 
         for job_id in downstairs
             .active
@@ -4420,7 +4421,8 @@ impl Upstairs {
          * with an existing job, it would be nice if those were removed from
          * this job's dependencies.
          */
-        let mut dep: Vec<u64> = Vec::with_capacity(200); // max in-flight jobs
+        let num_jobs = downstairs.active.keys().len();
+        let mut dep: Vec<u64> = Vec::with_capacity(num_jobs);
 
         // Search backwards in the list of active jobs
         for job_id in downstairs
@@ -4613,7 +4615,8 @@ impl Upstairs {
          * with an existing job, it would be nice if those were removed from
          * this job's dependencies.
          */
-        let mut dep: Vec<u64> = Vec::with_capacity(200); // max in-flight jobs
+        let num_jobs = downstairs.active.keys().len();
+        let mut dep: Vec<u64> = Vec::with_capacity(num_jobs);
 
         // Search backwards in the list of active jobs
         for job_id in downstairs

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -24,6 +24,7 @@ pub use crucible_protocol::*;
 use anyhow::{anyhow, bail, Result};
 pub use bytes::{Bytes, BytesMut};
 use futures::{SinkExt, StreamExt};
+use itertools::Itertools;
 use oximeter::types::ProducerRegistry;
 use rand::prelude::*;
 use ringbuffer::{AllocRingBuffer, RingBufferExt, RingBufferWrite};
@@ -65,6 +66,9 @@ pub use pseudo_file::CruciblePseudoFile;
 
 mod stats;
 pub use stats::*;
+
+mod impacted_blocks;
+pub use impacted_blocks::*;
 
 use async_trait::async_trait;
 
@@ -411,68 +415,6 @@ async fn process_message(
     }
 
     Ok(())
-}
-
-/*
- * Convert a virtual block offset and length into a Vec of tuples:
- *
- *     (Extent number (EID), Block offset)
- *
- * Each tuple represents the "address" of one block downstairs.
- */
-pub fn extent_from_offset(
-    ddef: RegionDefinition,
-    offset: Block,
-    num_blocks: Block,
-) -> Vec<(u64, Block)> {
-    assert!(num_blocks.value > 0);
-    assert!(
-        (offset.value + num_blocks.value)
-            <= (ddef.extent_size().value * ddef.extent_count() as u64)
-    );
-    assert_eq!(offset.block_size_in_bytes() as u64, ddef.block_size());
-
-    /*
-     *
-     *  |eid0                  |eid1
-     *  |────────────────────────────────────────────>│
-     *  ┌──────────────────────|──────────────────────┐
-     *  │                      |                      │
-     *  └──────────────────────|──────────────────────┘
-     *  |offset                                       |offset + len
-     */
-    let mut result = Vec::new();
-    let mut o: u64 = offset.value;
-    let mut blocks_left: u64 = num_blocks.value;
-
-    while blocks_left > 0 {
-        /*
-         * XXX We only support a single region (downstairs). When we grow to
-         * support a LBA size that is larger than a single region, then we
-         * will need to write more code. But - that code may live
-         * upstairs?
-         */
-        let eid: u64 = o / ddef.extent_size().value;
-        assert!((eid as u32) < ddef.extent_count());
-
-        let extent_offset: u64 = o % ddef.extent_size().value;
-        let sz: u64 = 1; // one block at a time
-
-        result.push((eid, Block::new_with_ddef(extent_offset, &ddef)));
-
-        match blocks_left.checked_sub(sz) {
-            Some(v) => {
-                blocks_left = v;
-            }
-            None => {
-                break;
-            }
-        }
-
-        o += sz;
-    }
-
-    result
 }
 
 /*
@@ -3416,27 +3358,32 @@ impl Downstairs {
 
     /**
      * This request is now complete on all peers, but is is ready to retire?
-     * Only when a flush is complete on all three do we check
-     * to see if we can remove the job.  When we remove a job, we
-     * also take all the previous jobs out of the queue as well.
-     * Double check that all previous jobs have finished and panic
-     * if not.
+     * Only when a flush is complete on all three downstairs do we check to
+     * see if we can remove jobs. Double check that all write jobs have
+     * finished and panic if not.
+     *
+     * Note we don't retire jobs until all three downstairs have returned
+     * from the same flush because the Upstairs replays all jobs since
+     * the last flush if a downstairs goes away and then comes back.
+     * This includes reads because they can be in the deps list for
+     * writes and if they aren't included in replay then the write will
+     * never start.
      */
     fn retire_check(&mut self, ds_id: u64) {
-        // Only a completed flush will remove work from the active queue.
         if !self.is_flush(ds_id).unwrap() {
             return;
         }
-        // Sort the job list, and retire all the work that is older than us.
+
+        // Only a completed flush will remove jobs from the active queue -
+        // currently we have to keep everything around for use during replay
         let wc = self.state_count(ds_id).unwrap();
         if (wc.error + wc.skipped + wc.done) == 3 {
             assert!(!self.completed.contains(&ds_id));
             assert_eq!(wc.active, 0);
 
-            /*
-             * Build the list of keys to iterate.  Don't bother to look
-             * at any key ids greater than our ds_id.
-             */
+            // Sort the job list, and retire all the jobs that happened before
+            // and including this flush.
+
             let mut kvec: Vec<u64> = self
                 .active
                 .keys()
@@ -3445,9 +3392,29 @@ impl Downstairs {
                 .collect::<Vec<u64>>();
 
             kvec.sort_unstable();
+
             for id in kvec.iter() {
+                // Remove everything before this flush
                 assert!(*id <= ds_id);
+
+                // Assert the job is actually done, then complete it
                 let wc = self.state_count(*id).unwrap();
+                let job = self.active.get(id).unwrap();
+
+                if wc.active > 0 && matches!(job.work, IOop::Read { .. }) {
+                    // Flushes do not depend on reads, so there's a special case
+                    // where all writes that a flush depends on have completed,
+                    // and we're retiring that flush, but there's still an
+                    // outstanding read result (one that does not overlap with
+                    // any write, or does overlap with a write and depends on
+                    // that write).
+                    //
+                    // Call continue here - some future flush will retire this
+                    // read, and in the case of replay we'll correctly replay it
+                    // and compare the read result and all that good stuff :)
+                    continue;
+                }
+
                 assert_eq!(wc.active, 0);
                 assert_eq!(wc.error + wc.skipped + wc.done, 3);
                 assert!(!self.completed.contains(id));
@@ -4290,12 +4257,38 @@ impl Upstairs {
          * Walk the downstairs work active list, and pull out all the active
          * jobs. Anything we have not submitted back to the guest.
          *
-         * TODO, we can go faster if we:
-         * 1. Ignore everything that was before and including the last flush.
-         * 2. Ignore reads.
+         * We can safely ignore everything before the last flush, because the
+         * last flush will depend on jobs before it. But we must depend on
+         * the previous flush - flush and gen numbers downstairs need
+         * to be sequential and the same for each downstairs.
+         *
+         * We can safely ignore reads as they do not impact downstairs state,
+         * but flushes must depend on every write since the last flush.
          */
-        let mut dep = downstairs.active.keys().cloned().collect::<Vec<u64>>();
-        dep.sort_unstable();
+        let mut dep: Vec<u64> = Vec::with_capacity(200); // max in-flight jobs
+
+        for job_id in downstairs
+            .active
+            .keys()
+            .sorted()
+            .collect::<Vec<&u64>>()
+            .iter()
+            .rev()
+        {
+            let job = &downstairs.active[job_id];
+
+            // Depend on the previous flush, but then bail out
+            if job.work.is_flush() {
+                dep.push(**job_id);
+                break;
+            }
+
+            // Depend on all writes seen
+            if job.work.is_write() {
+                dep.push(**job_id);
+            }
+        }
+
         /*
          * TODO: Walk the list of guest work structs and build the same list
          * and make sure it matches.
@@ -4305,6 +4298,7 @@ impl Upstairs {
          * Build the flush request, and take note of the request ID that
          * will be assigned to this new piece of work.
          */
+        let ddef = self.ddef.lock().await;
         let fl = create_flush(
             next_id,
             dep,
@@ -4312,6 +4306,7 @@ impl Upstairs {
             gw_id,
             self.get_generation().await,
             snapshot_details,
+            ImpactedBlocks::new(*ddef),
         );
 
         let mut sub = HashMap::new();
@@ -4373,7 +4368,7 @@ impl Upstairs {
          * and length may span two extents, and eventually XXX, two regions.
          */
         let ddef = self.ddef.lock().await;
-        let nwo = extent_from_offset(
+        let impacted_blocks = extent_from_offset(
             *ddef,
             offset,
             Block::from_bytes(data.len(), &ddef),
@@ -4401,14 +4396,48 @@ impl Upstairs {
         let next_id = downstairs.next_id();
         let mut cur_offset: usize = 0;
 
-        let mut dep = downstairs.active.keys().cloned().collect::<Vec<u64>>();
-        dep.sort_unstable();
+        /*
+         * Walk the downstairs work active list, and pull out all the active
+         * jobs (anything we have not submitted back to the guest). Construct
+         * a list of dependencies for this write based on the
+         * following rules:
+         *
+         * - ignore everything that happened before the last flush
+         * - writes have to depend on the last flush completing
+         * - any overlap of impacted blocks requires a dependency
+         */
+        let mut dep: Vec<u64> = Vec::with_capacity(200); // max in-flight jobs
+
+        // Search backwards in the list of active jobs
+        for job_id in downstairs
+            .active
+            .keys()
+            .sorted()
+            .collect::<Vec<&u64>>()
+            .iter()
+            .rev()
+        {
+            let job = &downstairs.active[job_id];
+
+            // Depend on the last flush, then break - flushes are a barrier for
+            // all writes.
+            if job.work.is_flush() {
+                dep.push(**job_id);
+                break;
+            }
+
+            // If this job impacts the same blocks as something already active,
+            // create a dependency.
+            if impacted_blocks.conflicts(&job.impacted_blocks) {
+                dep.push(**job_id);
+            }
+        }
 
         let mut writes: Vec<crucible_protocol::Write> =
-            Vec::with_capacity(nwo.len());
+            Vec::with_capacity(impacted_blocks.tuples().len());
 
         /* Lock here, through both jobs submitted */
-        for (eid, bo) in nwo {
+        for (eid, bo) in impacted_blocks.tuples() {
             let byte_len: usize = ddef.block_size() as usize;
 
             let (sub_data, encryption_context, hash) = if let Some(context) =
@@ -4468,6 +4497,7 @@ impl Upstairs {
             gw_id,
             writes,
             is_write_unwritten,
+            impacted_blocks,
         );
 
         sub.insert(next_id, 0); // XXX does value here matter?
@@ -4525,7 +4555,7 @@ impl Upstairs {
          * and length may span many extents, and eventually, TODO, regions.
          */
         let ddef = self.ddef.lock().await;
-        let nwo = extent_from_offset(
+        let impacted_blocks = extent_from_offset(
             *ddef,
             offset,
             Block::from_bytes(data.len(), &ddef),
@@ -4546,21 +4576,57 @@ impl Upstairs {
         let next_id = downstairs.next_id();
 
         /*
-         * Now create a downstairs work job for each (eid, bo, len) returned
-         * from extent_from_offset
+         * Walk the downstairs work active list, and pull out all the active
+         * jobs (anything we have not submitted back to the guest). Construct
+         * a list of dependencies for this read based on the
+         * following rules:
+         *
+         * - reads do not depend on flushes, only writes (because flushes do
+         *   not modify data!)
+         * - any overlap of impacted blocks requires a dependency
          */
-        let mut dep = downstairs.active.keys().cloned().collect::<Vec<u64>>();
-        dep.sort_unstable();
+        let mut dep: Vec<u64> = Vec::with_capacity(200); // max in-flight jobs
 
-        let mut requests: Vec<ReadRequest> = Vec::with_capacity(nwo.len());
+        // Search backwards in the list of active jobs
+        for job_id in downstairs
+            .active
+            .keys()
+            .sorted()
+            .collect::<Vec<&u64>>()
+            .iter()
+            .rev()
+        {
+            let job = &downstairs.active[job_id];
 
-        for (eid, bo) in nwo {
+            // If this is a write and it impacts the same blocks as something
+            // already active, create a dependency.
+            if job.work.is_write()
+                && impacted_blocks.conflicts(&job.impacted_blocks)
+            {
+                dep.push(**job_id);
+            }
+        }
+
+        /*
+         * Now create a downstairs work job for each (eid, bo) returned
+         * from extent_from_offset.
+         */
+        let mut requests: Vec<ReadRequest> =
+            Vec::with_capacity(impacted_blocks.len());
+
+        for (eid, bo) in impacted_blocks.tuples() {
             requests.push(ReadRequest { eid, offset: bo });
         }
 
         sub.insert(next_id, 0); // XXX does this value matter?
 
-        let wr = create_read_eob(next_id, dep.clone(), gw_id, requests);
+        let wr = create_read_eob(
+            next_id,
+            dep.clone(),
+            gw_id,
+            requests,
+            impacted_blocks,
+        );
 
         /*
          * New work created, add to the guest_work HM. New work must be put
@@ -5814,6 +5880,8 @@ struct DownstairsIO {
      */
     data: Option<Vec<ReadResponse>>,
     read_response_hashes: Vec<Option<u64>>,
+
+    impacted_blocks: ImpactedBlocks,
 }
 
 impl DownstairsIO {
@@ -5931,6 +5999,18 @@ impl IOop {
                 writes: _,
             } => dependencies,
         }
+    }
+
+    pub fn is_read(&self) -> bool {
+        matches!(self, IOop::Read { .. })
+    }
+
+    pub fn is_write(&self) -> bool {
+        matches!(self, IOop::Write { .. })
+    }
+
+    pub fn is_flush(&self) -> bool {
+        matches!(self, IOop::Flush { .. })
     }
 }
 
@@ -7730,6 +7810,7 @@ fn create_write_eob(
     gw_id: u64,
     writes: Vec<crucible_protocol::Write>,
     is_write_unwritten: bool,
+    impacted_blocks: ImpactedBlocks,
 ) -> DownstairsIO {
     /*
      * Note to self:  Should the dependency list cover everything since
@@ -7761,6 +7842,7 @@ fn create_write_eob(
         replay: false,
         data: None,
         read_response_hashes: Vec::new(),
+        impacted_blocks,
     }
 }
 
@@ -7774,6 +7856,7 @@ fn create_read_eob(
     dependencies: Vec<u64>,
     gw_id: u64,
     requests: Vec<ReadRequest>,
+    impacted_blocks: ImpactedBlocks,
 ) -> DownstairsIO {
     let aread = IOop::Read {
         dependencies,
@@ -7794,6 +7877,7 @@ fn create_read_eob(
         replay: false,
         data: None,
         read_response_hashes: Vec::new(),
+        impacted_blocks,
     }
 }
 
@@ -7807,6 +7891,7 @@ fn create_flush(
     guest_id: u64,
     gen_number: u64,
     snapshot_details: Option<SnapshotDetails>,
+    impacted_blocks: ImpactedBlocks,
 ) -> DownstairsIO {
     let flush = IOop::Flush {
         dependencies,
@@ -7828,6 +7913,7 @@ fn create_flush(
         replay: false,
         data: None,
         read_response_hashes: Vec::new(),
+        impacted_blocks,
     }
 }
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -4457,7 +4457,6 @@ impl Upstairs {
         let mut writes: Vec<crucible_protocol::Write> =
             Vec::with_capacity(impacted_blocks.tuples().len());
 
-        /* Lock here, through both jobs submitted */
         for (eid, bo) in impacted_blocks.tuples() {
             let byte_len: usize = ddef.block_size() as usize;
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -6035,7 +6035,7 @@ impl IOop {
     }
 
     pub fn is_write(&self) -> bool {
-        matches!(self, IOop::Write { .. })
+        matches!(self, IOop::Write { .. } | IOop::WriteUnwritten { .. })
     }
 
     pub fn is_flush(&self) -> bool {

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -4405,6 +4405,20 @@ impl Upstairs {
          * - ignore everything that happened before the last flush
          * - writes have to depend on the last flush completing
          * - any overlap of impacted blocks requires a dependency
+         *
+         * TODO: scanning backwards, any overlap of impacted blocks will
+         * create a dependency. take this an example:
+         *
+         *       block
+         * op# | 0 1 2 | deps
+         * ----|-------------
+         *   0 | W     |
+         *   1 | W     | 0
+         *   2 | W     | 0,1
+         *
+         * op 2 depends on both op 1 and op 0. if dependencies are transitive
+         * with an existing job, it would be nice if those were removed from
+         * this job's dependencies.
          */
         let mut dep: Vec<u64> = Vec::with_capacity(200); // max in-flight jobs
 
@@ -4584,6 +4598,20 @@ impl Upstairs {
          * - reads do not depend on flushes, only writes (because flushes do
          *   not modify data!)
          * - any overlap of impacted blocks requires a dependency
+         *
+         * TODO: scanning backwards, any overlap of impacted blocks will
+         * create a dependency. take this an example:
+         *
+         *       block
+         * op# | 0 1 2 | deps
+         * ----|-------------
+         *   0 | R     |
+         *   1 | R     | 0
+         *   2 | R     | 0,1
+         *
+         * op 2 depends on both op 1 and op 0. if dependencies are transitive
+         * with an existing job, it would be nice if those were removed from
+         * this job's dependencies.
          */
         let mut dep: Vec<u64> = Vec::with_capacity(200); // max in-flight jobs
 

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -5247,6 +5247,37 @@ mod up_test {
     }
 
     // Job dependency tests
+    //
+    // Each job dependency test will include a chart of the operations and
+    // dependencies that are expected to be created through the submission of
+    // those operations. An example:
+    //
+    //             block
+    //    op# | 0 1 2 3 4 5 | deps
+    //    ----|-------------|-----
+    //      0 | W           |
+    //      1 |   W         |
+    //      2 |     W       |
+    //      3 | FFFFFFFFFFF | 0,1,2
+    //      4 |       W     | 3
+    //      5 |         W   | 3
+    //      6 |           W | 3
+    //
+    // The order of enqueued operations matches the op# column. In the above
+    // example, three writes were submitted, followed by a flush, followed by
+    // three more writes. There is only one operation per row.
+    //
+    // An operation marks what block it acts on in an extent (in the center
+    // column) with the type of operation it is: R is a read, W is a write, and
+    // Wu is a write unwritten. Flushes impact the whole extent and are marked
+    // with F across every block. If an operation covers more than one extent,
+    // it will have multiple columns titled 'block'.
+    //
+    // The deps column shows which operations this operation depends on -
+    // dependencies must run before the operation can run. If the column is
+    // empty, then the operation does not depend on any other operation. In the
+    // above example, operation 3 depends on operations 0, 1, and 2.
+    //
 
     #[tokio::test]
     async fn test_deps_writes_depend_on_overlapping_writes() {

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -5645,7 +5645,7 @@ mod up_test {
         //   0 | W     |
         //   1 |   W   |
         //   2 |     W |
-        //   3 | W W W |
+        //   3 | W W W | 0,1,2
 
         let upstairs = make_upstairs();
         upstairs.set_active().await.unwrap();
@@ -5698,7 +5698,7 @@ mod up_test {
         // op# | 0 1 2 | deps
         // ----|-------|-----
         //   0 | W     |
-        //   1 | R     |
+        //   1 | R     | 0
 
         let upstairs = make_upstairs();
         upstairs.set_active().await.unwrap();

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -5883,7 +5883,12 @@ mod up_test {
     async fn test_deps_flushes_depend_on_flushes() {
         // Test that the following job dependency graph is made:
         //
-        // flush -> flush -> flush
+        //       block
+        // op# | 0 1 2 | deps
+        // ----|-------|-----
+        //   0 | FFFFF |
+        //   1 | FFFFF | 0
+        //   2 | FFFFF | 1
 
         let upstairs = make_upstairs();
         upstairs.set_active().await.unwrap();

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -5909,10 +5909,6 @@ mod up_test {
     async fn test_deps_flushes_depend_on_flushes_and_all_writes() {
         // Test that the following job dependency graph is made:
         //
-        // flush -> write -> flush -> write -> flush
-        //       -> write ->       -> write ->
-        //       ---------->       -> write ->
-        //                         ---------->
         //       block
         // op# | 0 1 2 | deps
         // ----|-------|-----

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -6,9 +6,18 @@ use super::*;
 #[cfg(test)]
 mod up_test {
     use super::*;
+
+    use std::collections::HashSet;
+    use std::iter::FromIterator;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use itertools::Itertools;
     use pseudo_file::IOSpan;
     use ringbuffer::RingBuffer;
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    fn hashset(data: &[u64]) -> HashSet<u64> {
+        HashSet::from_iter(data.iter().cloned())
+    }
 
     // Create a simple logger
     fn csl() -> Logger {
@@ -18,115 +27,6 @@ mod up_test {
 
     fn extent_tuple(eid: u64, offset: u64) -> (u64, Block) {
         (eid, Block::new_512(offset))
-    }
-
-    #[test]
-    fn test_extent_from_offset() {
-        let mut ddef = RegionDefinition::default();
-        ddef.set_block_size(512);
-        ddef.set_extent_size(Block::new_512(2));
-        ddef.set_extent_count(10);
-
-        // Test block size, less than extent size
-        assert_eq!(
-            extent_from_offset(ddef, Block::new_512(0), Block::new_512(1)),
-            vec![extent_tuple(0, 0)],
-        );
-
-        // Test greater than block size, less than extent size
-        assert_eq!(
-            extent_from_offset(ddef, Block::new_512(0), Block::new_512(2)),
-            vec![extent_tuple(0, 0), extent_tuple(0, 1),],
-        );
-
-        // Test greater than extent size
-        assert_eq!(
-            extent_from_offset(ddef, Block::new_512(0), Block::new_512(4)),
-            vec![
-                extent_tuple(0, 0),
-                extent_tuple(0, 1),
-                extent_tuple(1, 0),
-                extent_tuple(1, 1),
-            ],
-        );
-
-        // Test offsets
-        assert_eq!(
-            extent_from_offset(ddef, Block::new_512(1), Block::new_512(4)),
-            vec![
-                extent_tuple(0, 1),
-                extent_tuple(1, 0),
-                extent_tuple(1, 1),
-                extent_tuple(2, 0),
-            ],
-        );
-
-        assert_eq!(
-            extent_from_offset(ddef, Block::new_512(2), Block::new_512(4)),
-            vec![
-                extent_tuple(1, 0),
-                extent_tuple(1, 1),
-                extent_tuple(2, 0),
-                extent_tuple(2, 1),
-            ],
-        );
-
-        assert_eq!(
-            extent_from_offset(ddef, Block::new_512(2), Block::new_512(16)),
-            vec![
-                extent_tuple(1, 0),
-                extent_tuple(1, 1),
-                extent_tuple(2, 0),
-                extent_tuple(2, 1),
-                extent_tuple(3, 0),
-                extent_tuple(3, 1),
-                extent_tuple(4, 0),
-                extent_tuple(4, 1),
-                extent_tuple(5, 0),
-                extent_tuple(5, 1),
-                extent_tuple(6, 0),
-                extent_tuple(6, 1),
-                extent_tuple(7, 0),
-                extent_tuple(7, 1),
-                extent_tuple(8, 0),
-                extent_tuple(8, 1),
-            ],
-        );
-    }
-
-    #[test]
-    fn test_extent_from_offset_single_block_only() {
-        let mut ddef = RegionDefinition::default();
-        ddef.set_block_size(512);
-        ddef.set_extent_size(Block::new_512(2));
-        ddef.set_extent_count(10);
-
-        assert_eq!(
-            extent_from_offset(
-                ddef,
-                Block::new_512(2), // offset
-                Block::new_512(1), // num_blocks
-            ),
-            vec![extent_tuple(1, 0),]
-        );
-
-        assert_eq!(
-            extent_from_offset(
-                ddef,
-                Block::new_512(2), // offset
-                Block::new_512(2), // num_blocks
-            ),
-            vec![extent_tuple(1, 0), extent_tuple(1, 1),]
-        );
-
-        assert_eq!(
-            extent_from_offset(
-                ddef,
-                Block::new_512(2), // offset
-                Block::new_512(3), // num_blocks
-            ),
-            vec![extent_tuple(1, 0), extent_tuple(1, 1), extent_tuple(2, 0),]
-        );
     }
 
     #[test]
@@ -224,7 +124,7 @@ mod up_test {
     ) -> Vec<(u64, Block)> {
         let ddef = up.ddef.lock().await;
         let num_blocks = Block::new_with_ddef(num_blocks, &ddef);
-        extent_from_offset(*ddef, offset, num_blocks)
+        extent_from_offset(*ddef, offset, num_blocks).tuples()
     }
 
     #[tokio::test]
@@ -803,7 +703,15 @@ mod up_test {
 
         let next_id = ds.next_id();
 
-        let op = create_flush(next_id, vec![], 10, 0, 0, None);
+        let op = create_flush(
+            next_id,
+            vec![],
+            10,
+            0,
+            0,
+            None,
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -860,7 +768,15 @@ mod up_test {
 
         let next_id = ds.next_id();
 
-        let op = create_flush(next_id, vec![], 10, 0, 0, None);
+        let op = create_flush(
+            next_id,
+            vec![],
+            10,
+            0,
+            0,
+            None,
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -917,7 +833,15 @@ mod up_test {
 
         let next_id = ds.next_id();
 
-        let op = create_flush(next_id, vec![], 10, 0, 0, None);
+        let op = create_flush(
+            next_id,
+            vec![],
+            10,
+            0,
+            0,
+            None,
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -978,7 +902,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            next_id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -1031,7 +961,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            next_id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -1088,7 +1024,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            next_id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -1148,7 +1090,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(next_id, vec![], 10, vec![request]);
+        let op = create_read_eob(
+            next_id,
+            vec![],
+            10,
+            vec![request],
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -1213,8 +1161,13 @@ mod up_test {
 
             let next_id = ds.next_id();
 
-            let op =
-                create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+            let op = create_read_eob(
+                next_id,
+                vec![],
+                10,
+                vec![request.clone()],
+                ImpactedBlocks::default(),
+            );
 
             ds.enqueue(op);
 
@@ -1279,7 +1232,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -1322,7 +1281,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -1362,7 +1327,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -1406,7 +1377,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -1450,7 +1427,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -1494,7 +1477,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -1531,7 +1520,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -1561,7 +1556,7 @@ mod up_test {
     }
 
     #[tokio::test]
-    async fn work_ransfer_of_read_after_downstairs_write_unwritten_errors() {
+    async fn work_transfer_of_read_after_downstairs_write_unwritten_errors() {
         work_transfer_of_read_after_downstairs_errors(true).await;
     }
 
@@ -1592,6 +1587,7 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
+            ImpactedBlocks::default(),
         );
 
         ds.enqueue(op);
@@ -1642,7 +1638,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            next_id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -1682,7 +1684,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            next_id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -1743,7 +1751,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            next_id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -1808,7 +1822,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            next_id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -1850,14 +1870,22 @@ mod up_test {
         // Ack the job to the guest
         ds.ack(next_id);
 
-        // Nothing left to ACK, but untill the flush we keep the IO data.
+        // Nothing left to ACK, but until the flush we keep the IO data.
         assert_eq!(ds.ackable_work().len(), 0);
         assert_eq!(ds.completed.len(), 0);
 
         // A flush is required to move work to completed
         // Create the flush then send it to all downstairs.
         let next_id = ds.next_id();
-        let op = create_flush(next_id, vec![], 10, 0, 0, None);
+        let op = create_flush(
+            next_id,
+            vec![],
+            10,
+            0,
+            0,
+            None,
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
 
@@ -1946,6 +1974,7 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
+            ImpactedBlocks::default(),
         );
         ds.enqueue(op);
 
@@ -1963,6 +1992,7 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
+            ImpactedBlocks::default(),
         );
         ds.enqueue(op);
 
@@ -1996,7 +2026,15 @@ mod up_test {
 
         // Create the flush, put on the work queue
         let flush_id = ds.next_id();
-        let op = create_flush(flush_id, vec![], 10, 0, 0, None);
+        let op = create_flush(
+            flush_id,
+            vec![],
+            10,
+            0,
+            0,
+            None,
+            ImpactedBlocks::default(),
+        );
         ds.enqueue(op);
 
         // Simulate sending the flush to downstairs 0 and 1
@@ -2105,6 +2143,7 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
+            ImpactedBlocks::default(),
         );
         // Put the write on the queue.
         ds.enqueue(op);
@@ -2152,7 +2191,15 @@ mod up_test {
 
         // Create the flush IO
         let next_id = ds.next_id();
-        let op = create_flush(next_id, vec![], 10, 0, 0, None);
+        let op = create_flush(
+            next_id,
+            vec![],
+            10,
+            0,
+            0,
+            None,
+            ImpactedBlocks::default(),
+        );
         ds.enqueue(op);
 
         // Submit the flush to all three downstairs.
@@ -2237,6 +2284,7 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
+            ImpactedBlocks::default(),
         );
         ds.enqueue(op);
 
@@ -2254,6 +2302,7 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
+            ImpactedBlocks::default(),
         );
         ds.enqueue(op);
 
@@ -2287,7 +2336,15 @@ mod up_test {
 
         // Create and enqueue the flush.
         let flush_id = ds.next_id();
-        let op = create_flush(flush_id, vec![], 10, 0, 0, None);
+        let op = create_flush(
+            flush_id,
+            vec![],
+            10,
+            0,
+            0,
+            None,
+            ImpactedBlocks::default(),
+        );
         ds.enqueue(op);
 
         // Send the flush to two downstairs.
@@ -2374,7 +2431,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            next_id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
         ds.enqueue(op);
 
         // Submit the read to all three downstairs
@@ -2420,7 +2483,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            next_id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
         ds.enqueue(op);
 
         // Submit the read to each downstairs.
@@ -2488,7 +2557,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            next_id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
         ds.enqueue(op);
 
         // Submit the read to each downstairs.
@@ -2571,7 +2646,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            next_id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
         ds.enqueue(op);
 
         // Submit the read to each downstairs.
@@ -2653,7 +2734,13 @@ mod up_test {
             eid: 0,
             offset: Block::new_512(7),
         };
-        let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            next_id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
         ds.enqueue(op);
 
         // Submit the read to each downstairs.
@@ -2748,6 +2835,7 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
+            ImpactedBlocks::default(),
         );
         ds.enqueue(op);
 
@@ -2822,6 +2910,7 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
+            ImpactedBlocks::default(),
         );
         ds.enqueue(op);
 
@@ -2966,6 +3055,7 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
+            ImpactedBlocks::default(),
         );
         ds.enqueue(op);
 
@@ -3149,6 +3239,7 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
+            ImpactedBlocks::default(),
         );
         ds.enqueue(op);
 
@@ -4033,7 +4124,13 @@ mod up_test {
             offset: Block::new_512(7),
         };
 
-        let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            next_id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
 
         let context = Arc::new(EncryptionContext::new(
             vec![
@@ -4108,7 +4205,13 @@ mod up_test {
             offset: Block::new_512(7),
         };
 
-        let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            next_id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
 
         ds.enqueue(op);
         ds.in_progress(next_id, 0);
@@ -4153,7 +4256,13 @@ mod up_test {
             offset: Block::new_512(7),
         };
 
-        let op = create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+        let op = create_read_eob(
+            next_id,
+            vec![],
+            10,
+            vec![request.clone()],
+            ImpactedBlocks::default(),
+        );
 
         let context = Arc::new(EncryptionContext::new(
             vec![
@@ -4597,7 +4706,7 @@ mod up_test {
         // Verify that three bad writes will ACK the IO, and set the
         // downstairs clients to failed.
         // This test also makes sure proper mutex behavior is used in
-        // process_ds_operaion.
+        // process_ds_operation.
         let up = Upstairs::default();
         for cid in 0..3 {
             up.ds_transition(cid, DsState::WaitActive).await;
@@ -4625,6 +4734,7 @@ mod up_test {
                     },
                 }],
                 false,
+                ImpactedBlocks::default(),
             );
 
             ds.enqueue(op);
@@ -4664,7 +4774,7 @@ mod up_test {
             let state = ds.active.get_mut(&next_id).unwrap().ack_status;
             assert_eq!(state, AckStatus::NotAcked);
         }
-        // Three failures, process_ds_operaion should return true now.
+        // Three failures, process_ds_operation should return true now.
         // Process the operation for client 2
         assert!(up.process_ds_operation(next_id, 2, response).await.unwrap());
         assert_eq!(up.ds_state(0).await, DsState::Failed);
@@ -4711,6 +4821,7 @@ mod up_test {
                     },
                 }],
                 false,
+                ImpactedBlocks::default(),
             );
 
             ds.enqueue(op);
@@ -4738,9 +4849,9 @@ mod up_test {
         assert!(!up
             .process_ds_operation(next_id, 1, ok_response.clone())
             .await
-            .unwrap(),);
+            .unwrap());
 
-        // process_ds_operaion should return true after we process this.
+        // process_ds_operation should return true after we process this.
         assert!(up
             .process_ds_operation(next_id, 2, ok_response)
             .await
@@ -4763,8 +4874,13 @@ mod up_test {
             let mut ds = up.downstairs.lock().await;
 
             let next_id = ds.next_id();
-            let op =
-                create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+            let op = create_read_eob(
+                next_id,
+                vec![],
+                10,
+                vec![request.clone()],
+                ImpactedBlocks::default(),
+            );
 
             ds.enqueue(op);
 
@@ -4797,7 +4913,15 @@ mod up_test {
             let mut ds = up.downstairs.lock().await;
 
             let next_id = ds.next_id();
-            let op = create_flush(next_id, vec![], 10, 0, 0, None);
+            let op = create_flush(
+                next_id,
+                vec![],
+                10,
+                0,
+                0,
+                None,
+                ImpactedBlocks::default(),
+            );
             ds.enqueue(op);
 
             // As this DS is failed, it should return none
@@ -4815,7 +4939,7 @@ mod up_test {
             .await
             .unwrap(),);
 
-        // process_ds_operaion should return true after we process this.
+        // process_ds_operation should return true after we process this.
         assert!(up
             .process_ds_operation(next_id, 2, ok_response)
             .await
@@ -4863,6 +4987,7 @@ mod up_test {
                     },
                 }],
                 false,
+                ImpactedBlocks::default(),
             );
 
             ds.enqueue(op);
@@ -4897,7 +5022,7 @@ mod up_test {
         assert_eq!(up.ds_state(2).await, DsState::Active);
 
         let ok_response = Ok(vec![]);
-        // process_ds_operaion should return true after we process this.
+        // process_ds_operation should return true after we process this.
         assert!(up
             .process_ds_operation(next_id, 2, ok_response)
             .await
@@ -4920,8 +5045,13 @@ mod up_test {
 
             let next_id = ds.next_id();
 
-            let op =
-                create_read_eob(next_id, vec![], 10, vec![request.clone()]);
+            let op = create_read_eob(
+                next_id,
+                vec![],
+                10,
+                vec![request.clone()],
+                ImpactedBlocks::default(),
+            );
 
             ds.enqueue(op);
 
@@ -4973,6 +5103,7 @@ mod up_test {
                     },
                 }],
                 false,
+                ImpactedBlocks::default(),
             );
 
             ds.enqueue(op);
@@ -5000,7 +5131,7 @@ mod up_test {
             .await
             .unwrap());
 
-        // process_ds_operaion should return true after we process this.
+        // process_ds_operation should return true after we process this.
         assert!(up
             .process_ds_operation(next_id, 2, ok_response.clone())
             .await
@@ -5035,6 +5166,7 @@ mod up_test {
                     },
                 }],
                 false,
+                ImpactedBlocks::default(),
             );
 
             ds.enqueue(op);
@@ -5055,7 +5187,7 @@ mod up_test {
 
         // We don't process client 1, it had failed
 
-        // process_ds_operaion should return true after we process this.
+        // process_ds_operation should return true after we process this.
         assert!(up
             .process_ds_operation(next_id, 2, ok_response)
             .await
@@ -5069,7 +5201,15 @@ mod up_test {
             let mut ds = up.downstairs.lock().await;
 
             let next_id = ds.next_id();
-            let op = create_flush(next_id, vec![], 10, 0, 0, None);
+            let op = create_flush(
+                next_id,
+                vec![],
+                10,
+                0,
+                0,
+                None,
+                ImpactedBlocks::default(),
+            );
             ds.enqueue(op);
 
             assert!(ds.in_progress(next_id, 0).is_some());
@@ -5087,7 +5227,7 @@ mod up_test {
             .await
             .unwrap());
 
-        // process_ds_operaion should return true after we process client 2.
+        // process_ds_operation should return true after we process client 2.
         assert!(up
             .process_ds_operation(flush_id, 2, ok_response)
             .await
@@ -5104,5 +5244,883 @@ mod up_test {
 
         // The two writes and the flush should be completed.
         assert_eq!(up.downstairs.lock().await.completed.len(), 3);
+    }
+
+    // Job dependency tests
+
+    #[tokio::test]
+    async fn test_deps_writes_depend_on_overlapping_writes() {
+        // Test that the following job dependency graph is made:
+        //
+        // write @ 0 -> write @ 0
+
+        let upstairs = make_upstairs();
+        upstairs.set_active().await.unwrap();
+
+        upstairs
+            .submit_write(
+                Block::new_512(0),
+                Bytes::from(vec![0xff; 512]),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        upstairs
+            .submit_write(
+                Block::new_512(0),
+                Bytes::from(vec![0x00; 512]),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let ds = upstairs.downstairs.lock().await;
+        let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 2);
+
+        assert!(jobs[0].work.deps().is_empty());
+        assert_eq!(jobs[1].work.deps(), &vec![jobs[0].ds_id]);
+    }
+
+    #[tokio::test]
+    async fn test_deps_writes_depend_on_overlapping_writes_chain() {
+        // Test that the following job dependency graph is made:
+        //
+        //           -> write @ 0 ->
+        // write @ 0                 write @ 0
+        //           -------------->
+        //
+        // TODO: it would be nicer if it was just a straight line
+
+        let upstairs = make_upstairs();
+        upstairs.set_active().await.unwrap();
+
+        upstairs
+            .submit_write(
+                Block::new_512(0),
+                Bytes::from(vec![0xff; 512]),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        upstairs
+            .submit_write(
+                Block::new_512(0),
+                Bytes::from(vec![0x00; 512]),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        upstairs
+            .submit_write(
+                Block::new_512(0),
+                Bytes::from(vec![0x55; 512]),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let ds = upstairs.downstairs.lock().await;
+        let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 3);
+
+        assert!(jobs[0].work.deps().is_empty());
+        assert_eq!(jobs[1].work.deps(), &vec![jobs[0].ds_id]);
+        assert_eq!(
+            hashset(jobs[2].work.deps()),
+            hashset(&[jobs[0].ds_id, jobs[1].ds_id]),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deps_writes_depend_on_overlapping_writes_and_flushes() {
+        // Test that the following job dependency graph is made:
+        //
+        // write @ 0 -> flush -> write @ 0
+
+        let upstairs = make_upstairs();
+        upstairs.set_active().await.unwrap();
+
+        upstairs
+            .submit_write(
+                Block::new_512(0),
+                Bytes::from(vec![0xff; 512]),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        upstairs.submit_flush(None, None).await.unwrap();
+
+        upstairs
+            .submit_write(
+                Block::new_512(0),
+                Bytes::from(vec![0x55; 512]),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let ds = upstairs.downstairs.lock().await;
+        let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 3);
+
+        assert!(jobs[0].work.deps().is_empty());
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]);
+        assert_eq!(jobs[2].work.deps(), &[jobs[1].ds_id]);
+    }
+
+    #[tokio::test]
+    async fn test_deps_all_writes_depend_on_flushes() {
+        // Test that the following job dependency graph is made:
+        //
+        // write @ 0 ->       -> write @ 3
+        // write @ 1 -> flush -> write @ 4
+        // write @ 2 ->       -> write @ 5
+
+        let upstairs = make_upstairs();
+        upstairs.set_active().await.unwrap();
+
+        for i in 0..3 {
+            upstairs
+                .submit_write(
+                    Block::new_512(i),
+                    Bytes::from(vec![0xff; 512]),
+                    None,
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+
+        upstairs.submit_flush(None, None).await.unwrap();
+
+        for i in 3..6 {
+            upstairs
+                .submit_write(
+                    Block::new_512(i),
+                    Bytes::from(vec![0xff; 512]),
+                    None,
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+
+        let ds = upstairs.downstairs.lock().await;
+        let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 7);
+
+        assert!(jobs[0].work.deps().is_empty()); // write @ 0
+        assert!(jobs[1].work.deps().is_empty()); // write @ 1
+        assert!(jobs[2].work.deps().is_empty()); // write @ 2
+
+        assert_eq!(
+            hashset(jobs[3].work.deps()), // flush
+            hashset(&[jobs[0].ds_id, jobs[1].ds_id, jobs[2].ds_id]),
+        );
+
+        assert_eq!(jobs[4].work.deps(), &[jobs[3].ds_id]); // write @ 3
+        assert_eq!(jobs[5].work.deps(), &[jobs[3].ds_id]); // write @ 4
+        assert_eq!(jobs[6].work.deps(), &[jobs[3].ds_id]); // write @ 5
+    }
+
+    #[tokio::test]
+    async fn test_deps_little_writes_depend_on_big_write() {
+        // Test that the following job dependency graph is made:
+        //
+        // write @ 0,1,2 -> write @ 0
+        //               -> write @ 1
+        //               -> write @ 2
+
+        let upstairs = make_upstairs();
+        upstairs.set_active().await.unwrap();
+
+        upstairs
+            .submit_write(
+                Block::new_512(0),
+                Bytes::from(vec![0xff; 512 * 3]),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        for i in 0..3 {
+            upstairs
+                .submit_write(
+                    Block::new_512(i),
+                    Bytes::from(vec![0xff; 512]),
+                    None,
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+
+        let ds = upstairs.downstairs.lock().await;
+        let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 4);
+
+        assert!(jobs[0].work.deps().is_empty()); // write @ 0,1,2
+
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // write @ 0
+        assert_eq!(jobs[2].work.deps(), &[jobs[0].ds_id]); // write @ 1
+        assert_eq!(jobs[3].work.deps(), &[jobs[0].ds_id]); // write @ 2
+    }
+
+    #[tokio::test]
+    async fn test_deps_little_writes_depend_on_big_write_chain() {
+        // Test that the following job dependency graph is made:
+        //
+        // write @ 0,1,2 -> write @ 0 -> write @ 0
+        //               -------------->
+        //               -> write @ 1 -> write @ 1
+        //               -------------->
+        //               -> write @ 2 -> write @ 2
+        //               -------------->
+        //
+        // TODO it would be nicer if this was
+        //
+        // write @ 0,1,2 -> write @ 0 -> write @ 0
+        //               -> write @ 1 -> write @ 1
+        //               -> write @ 2 -> write @ 2
+
+        let upstairs = make_upstairs();
+        upstairs.set_active().await.unwrap();
+
+        upstairs
+            .submit_write(
+                Block::new_512(0),
+                Bytes::from(vec![0xff; 512 * 3]),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        for i in 0..3 {
+            upstairs
+                .submit_write(
+                    Block::new_512(i),
+                    Bytes::from(vec![0xff; 512]),
+                    None,
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+
+        for i in 0..3 {
+            upstairs
+                .submit_write(
+                    Block::new_512(i),
+                    Bytes::from(vec![0xff; 512]),
+                    None,
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+
+        let ds = upstairs.downstairs.lock().await;
+        let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 7);
+
+        assert!(jobs[0].work.deps().is_empty()); // write @ 0,1,2
+
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // write @ 0
+        assert_eq!(jobs[2].work.deps(), &[jobs[0].ds_id]); // write @ 1
+        assert_eq!(jobs[3].work.deps(), &[jobs[0].ds_id]); // write @ 2
+
+        assert_eq!(
+            hashset(jobs[4].work.deps()), // second write @ 0
+            hashset(&[jobs[0].ds_id, jobs[1].ds_id]),
+        );
+        assert_eq!(
+            hashset(jobs[5].work.deps()), // second write @ 1
+            hashset(&[jobs[0].ds_id, jobs[2].ds_id]),
+        );
+        assert_eq!(
+            hashset(jobs[6].work.deps()), // second write @ 2
+            hashset(&[jobs[0].ds_id, jobs[3].ds_id]),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deps_big_write_depends_on_little_writes() {
+        // Test that the following job dependency graph is made:
+        //
+        // write @ 0 ->
+        // write @ 1 -> write @ 0,1,2
+        // write @ 2 ->
+
+        let upstairs = make_upstairs();
+        upstairs.set_active().await.unwrap();
+
+        for i in 0..3 {
+            upstairs
+                .submit_write(
+                    Block::new_512(i),
+                    Bytes::from(vec![0xff; 512]),
+                    None,
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+
+        upstairs
+            .submit_write(
+                Block::new_512(0),
+                Bytes::from(vec![0xff; 512 * 3]),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let ds = upstairs.downstairs.lock().await;
+        let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 4);
+
+        assert!(jobs[0].work.deps().is_empty()); // write @ 0
+        assert!(jobs[1].work.deps().is_empty()); // write @ 1
+        assert!(jobs[2].work.deps().is_empty()); // write @ 2
+
+        assert_eq!(
+            hashset(jobs[3].work.deps()), // write @ 0,1,2
+            hashset(&[jobs[0].ds_id, jobs[1].ds_id, jobs[2].ds_id]),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deps_read_depends_on_write() {
+        // Test that the following job dependency graph is made:
+        //
+        // write @ 0 -> read @ 0
+
+        let upstairs = make_upstairs();
+        upstairs.set_active().await.unwrap();
+
+        upstairs
+            .submit_write(
+                Block::new_512(0),
+                Bytes::from(vec![0xff; 512]),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        upstairs
+            .submit_read(Block::new_512(0), Buffer::new(512), None)
+            .await
+            .unwrap();
+
+        let ds = upstairs.downstairs.lock().await;
+        let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 2);
+
+        assert!(jobs[0].work.deps().is_empty()); // write @ 0
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // read @ 0
+    }
+
+    #[tokio::test]
+    async fn test_deps_big_read_depends_on_little_writes() {
+        // Test that the following job dependency graph is made:
+        //
+        // write @ 0 -> read @ 0,1
+        // write @ 1 ->
+        // write @ 2
+
+        let upstairs = make_upstairs();
+        upstairs.set_active().await.unwrap();
+
+        for i in 0..3 {
+            upstairs
+                .submit_write(
+                    Block::new_512(i),
+                    Bytes::from(vec![0xff; 512]),
+                    None,
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+
+        upstairs
+            .submit_read(Block::new_512(0), Buffer::new(512 * 2), None)
+            .await
+            .unwrap();
+
+        let ds = upstairs.downstairs.lock().await;
+        let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 4);
+
+        assert!(jobs[0].work.deps().is_empty()); // write @ 0
+        assert!(jobs[1].work.deps().is_empty()); // write @ 1
+        assert!(jobs[2].work.deps().is_empty()); // write @ 2
+
+        assert_eq!(
+            hashset(jobs[3].work.deps()), // read @ 0,1
+            hashset(&[jobs[0].ds_id, jobs[1].ds_id]),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deps_read_no_depend_on_read() {
+        // Test that the following job dependency graph is made:
+        //
+        // read @ 0
+        // read @ 0
+        //
+        // (aka two reads don't depend on each other)
+
+        let upstairs = make_upstairs();
+        upstairs.set_active().await.unwrap();
+
+        upstairs
+            .submit_read(Block::new_512(0), Buffer::new(512), None)
+            .await
+            .unwrap();
+
+        upstairs
+            .submit_read(Block::new_512(0), Buffer::new(512), None)
+            .await
+            .unwrap();
+
+        let ds = upstairs.downstairs.lock().await;
+        let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 2);
+
+        assert!(jobs[0].work.deps().is_empty()); // read @ 0
+        assert!(jobs[1].work.deps().is_empty()); // read @ 0
+    }
+
+    #[tokio::test]
+    async fn test_deps_multiple_reads_depend_on_write() {
+        // Test that the following job dependency graph is made:
+        //
+        // write @ 0 -> read @ 0
+        //           -> read @ 0
+
+        let upstairs = make_upstairs();
+        upstairs.set_active().await.unwrap();
+
+        upstairs
+            .submit_write(
+                Block::new_512(0),
+                Bytes::from(vec![0xff; 512]),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        upstairs
+            .submit_read(Block::new_512(0), Buffer::new(512), None)
+            .await
+            .unwrap();
+
+        upstairs
+            .submit_read(Block::new_512(0), Buffer::new(512), None)
+            .await
+            .unwrap();
+
+        let ds = upstairs.downstairs.lock().await;
+        let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 3);
+
+        assert!(jobs[0].work.deps().is_empty()); // write @ 0
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // read @ 0
+        assert_eq!(jobs[2].work.deps(), &[jobs[0].ds_id]); // read @ 0
+    }
+
+    #[tokio::test]
+    async fn test_deps_read_does_not_depend_on_flush() {
+        // Test that the following job dependency graph is made:
+        //
+        // write @ 0 ---------> read @ 0
+        //           -> flush
+
+        let upstairs = make_upstairs();
+        upstairs.set_active().await.unwrap();
+
+        upstairs
+            .submit_write(
+                Block::new_512(0),
+                Bytes::from(vec![0xff; 512]),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        upstairs.submit_flush(None, None).await.unwrap();
+
+        upstairs
+            .submit_read(Block::new_512(0), Buffer::new(512 * 2), None)
+            .await
+            .unwrap();
+
+        let ds = upstairs.downstairs.lock().await;
+        let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 3);
+
+        assert!(jobs[0].work.deps().is_empty()); // write @ 0
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // flush
+        assert_eq!(jobs[2].work.deps(), &[jobs[0].ds_id]); // read @ 0
+    }
+
+    #[tokio::test]
+    async fn test_deps_flushes_depend_on_flushes() {
+        // Test that the following job dependency graph is made:
+        //
+        // flush -> flush -> flush
+
+        let upstairs = make_upstairs();
+        upstairs.set_active().await.unwrap();
+
+        upstairs.submit_flush(None, None).await.unwrap();
+
+        upstairs.submit_flush(None, None).await.unwrap();
+
+        upstairs.submit_flush(None, None).await.unwrap();
+
+        let ds = upstairs.downstairs.lock().await;
+        let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 3);
+
+        assert!(jobs[0].work.deps().is_empty());
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]);
+        assert_eq!(jobs[2].work.deps(), &[jobs[1].ds_id]);
+    }
+
+    #[tokio::test]
+    async fn test_deps_flushes_depend_on_flushes_and_all_writes() {
+        // Test that the following job dependency graph is made:
+        //
+        // flush -> write -> flush -> write -> flush
+        //       -> write ->       -> write ->
+        //       ---------->       -> write ->
+        //                         ---------->
+
+        let upstairs = make_upstairs();
+        upstairs.set_active().await.unwrap();
+
+        upstairs.submit_flush(None, None).await.unwrap();
+
+        for i in 0..2 {
+            upstairs
+                .submit_write(
+                    Block::new_512(i),
+                    Bytes::from(vec![0xff; 512]),
+                    None,
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+
+        upstairs.submit_flush(None, None).await.unwrap();
+
+        for i in 0..3 {
+            upstairs
+                .submit_write(
+                    Block::new_512(i),
+                    Bytes::from(vec![0xff; 512]),
+                    None,
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+
+        upstairs.submit_flush(None, None).await.unwrap();
+
+        let ds = upstairs.downstairs.lock().await;
+        let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 8);
+
+        assert!(jobs[0].work.deps().is_empty()); // flush
+
+        assert_eq!(jobs[1].work.deps(), &vec![jobs[0].ds_id]); // write
+        assert_eq!(jobs[2].work.deps(), &vec![jobs[0].ds_id]); // write
+
+        assert_eq!(
+            hashset(jobs[3].work.deps()), // flush
+            hashset(&[jobs[0].ds_id, jobs[1].ds_id, jobs[2].ds_id]),
+        );
+
+        assert_eq!(jobs[4].work.deps(), &[jobs[3].ds_id]);
+        assert_eq!(jobs[5].work.deps(), &[jobs[3].ds_id]);
+        assert_eq!(jobs[6].work.deps(), &[jobs[3].ds_id]);
+
+        assert_eq!(
+            hashset(jobs[7].work.deps()), // flush
+            hashset(&[
+                jobs[3].ds_id,
+                jobs[4].ds_id,
+                jobs[5].ds_id,
+                jobs[6].ds_id
+            ]),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deps_depend_on_acked_work() {
+        // Test that jobs will depend on acked work (important for the case of
+        // replay - the upstairs will replay all work since the last flush if a
+        // downstairs leaves and comes back)
+
+        let upstairs = make_upstairs();
+        upstairs.set_active().await.unwrap();
+
+        // submit a write, complete, then ack it
+
+        upstairs
+            .submit_write(
+                Block::new_512(0),
+                Bytes::from(vec![0xff; 512]),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        {
+            let mut ds = upstairs.downstairs.lock().await;
+            let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+            let jobs: Vec<&DownstairsIO> =
+                keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+            assert_eq!(jobs.len(), 1);
+
+            let ds_id = jobs[0].ds_id;
+
+            for client_id in 0..3 {
+                ds.in_progress(ds_id, client_id);
+                ds.process_ds_completion(
+                    ds_id,
+                    client_id,
+                    Ok(vec![]),
+                    &None,
+                    UpState::Active,
+                )
+                .unwrap();
+            }
+
+            ds.ack(ds_id);
+        }
+
+        // submit an overlapping write
+
+        upstairs
+            .submit_write(
+                Block::new_512(0),
+                Bytes::from(vec![0xff; 512]),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        {
+            let ds = upstairs.downstairs.lock().await;
+            let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+            let jobs: Vec<&DownstairsIO> =
+                keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+
+            // retire_check not run yet, so there's two active jobs
+            assert_eq!(jobs.len(), 2);
+
+            // the second write should still depend on the first write!
+            assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_deps_retire_check() {
+        // Test that retire_check still works for flushes that depend on writes
+        // but not reads, where the read hasn't completed yet
+
+        let upstairs = make_upstairs();
+        upstairs.set_active().await.unwrap();
+
+        upstairs
+            .submit_write(
+                Block::new_512(0),
+                Bytes::from(vec![0xff; 512]),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        upstairs
+            .submit_read(Block::new_512(1), Buffer::new(512), None)
+            .await
+            .unwrap();
+
+        upstairs
+            .submit_write(
+                Block::new_512(2),
+                Bytes::from(vec![0xff; 512]),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+
+        upstairs.submit_flush(None, None).await.unwrap();
+
+        // complete and ack the previous flush and both writes
+
+        let mut ds = upstairs.downstairs.lock().await;
+        let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 4);
+
+        let write_1 = jobs[0].ds_id;
+        let read = jobs[1].ds_id;
+        let write_2 = jobs[2].ds_id;
+        let flush = jobs[3].ds_id;
+
+        for ds_id in &[write_1, write_2] {
+            for client_id in 0..3 {
+                ds.in_progress(*ds_id, client_id);
+                ds.process_ds_completion(
+                    *ds_id,
+                    client_id,
+                    Ok(vec![]),
+                    &None,
+                    UpState::Active,
+                )
+                .unwrap();
+            }
+
+            ds.ack(*ds_id);
+            ds.retire_check(*ds_id);
+        }
+
+        // complete and ack flush
+        for client_id in 0..3 {
+            ds.in_progress(flush, client_id);
+            ds.process_ds_completion(
+                flush,
+                client_id,
+                Ok(vec![]),
+                &None,
+                UpState::Active,
+            )
+            .unwrap();
+        }
+
+        ds.ack(flush);
+
+        // call retire_check on flush (where the read hasn't been acked yet)
+
+        ds.retire_check(flush);
+
+        // only the read should be left (retire_check removes the flush and the
+        // deps of the flush)
+
+        let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 1);
+
+        assert_eq!(jobs[0].ds_id, read);
+        assert!(matches!(jobs[0].work, IOop::Read { .. }));
+
+        // complete and ack the read, then do another flush. this should retire
+        // everything.
+        for client_id in 0..3 {
+            ds.in_progress(read, client_id);
+
+            let request = ReadRequest {
+                eid: 0,
+                offset: Block::new_512(1),
+            };
+
+            ds.process_ds_completion(
+                read,
+                client_id,
+                Ok(vec![ReadResponse::from_request_with_data(&request, &[])]),
+                &None,
+                UpState::Active,
+            )
+            .unwrap();
+        }
+
+        ds.ack(read);
+        ds.retire_check(read);
+
+        drop(ds);
+        upstairs.submit_flush(None, None).await.unwrap();
+
+        let mut ds = upstairs.downstairs.lock().await;
+        let keys: Vec<&u64> = ds.active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 2);
+
+        let flush = jobs[1].ds_id;
+
+        for client_id in 0..3 {
+            ds.in_progress(flush, client_id);
+            ds.process_ds_completion(
+                flush,
+                client_id,
+                Ok(vec![]),
+                &None,
+                UpState::Active,
+            )
+            .unwrap();
+        }
+
+        ds.ack(flush);
+        ds.retire_check(flush);
+
+        assert_eq!(ds.active.keys().count(), 0);
     }
 }


### PR DESCRIPTION
This commit relaxes how dependencies are computed Upstairs:

- for crash safety, flushes must depend on flushes. (setting flush and
  generation number on each downstairs for the region must be
  synchronized by these flushes)

- flushes depend on all writes seen, but will no longer depend on reads

- writes depend on the last flush and all overlapping writes

- reads depend only on overlapping writes

This commit introduces the "ImpactedBlocks" struct to compute if reads
or writes overlap.

Previous to this commit, `retire_check` would retire every job that
occurred between flushes, and this worked because flushes depended on
every job. `retire_check` needs a special case now: if flushes do not
depend on reads, then retire_check can be called on a flush when a read
hasn't completed on all three downstairs yet. `retire_check` now ignores
unfinished reads when retiring everything that came before the flush:

- reads do not impact any downstairs state

- if a downstairs goes away and comes back, reads will be correctly
  replayed, compared to what the other downstairs returned, and (when
  completed on each downstairs) will eventually retired by future flush

- if a write overlaps with it, these unfinished reads will block that
  write. this is expected behaviour: it's important that acked work can
  still be a dependency for new work if it's not complete yet, and
  especially when replay needs to occur.