### PR TITLE
Repair the test_repair.sh test, handle async

### DIFF
--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -378,8 +378,10 @@ impl WriteLog {
             res = false;
         }
         if update {
-            println!("Update block {} to {} (min:{} max:{} res:{}",
-                index, new_max, min, max, res);
+            println!(
+                "Update block {} to {} (min:{} max:{} res:{}",
+                index, new_max, min, max, res
+            );
             self.count_cur[index] = new_max;
         }
         res
@@ -857,8 +859,10 @@ async fn verify_volume(
 ) -> Result<()> {
     assert_eq!(ri.write_log.len(), ri.total_blocks);
 
-    println!("Read and Verify all blocks (0..{} range:{})",
-        ri.total_blocks, range);
+    println!(
+        "Read and Verify all blocks (0..{} range:{})",
+        ri.total_blocks, range
+    );
 
     let pb = ProgressBar::new(ri.total_blocks as u64);
     pb.set_style(ProgressStyle::default_bar()

--- a/tools/test_repair.sh
+++ b/tools/test_repair.sh
@@ -103,7 +103,7 @@ fi
 (( generation += 1))
 
 # Start loop
-for (( i = 0; i < 200; i += 1 )); do
+for (( i = 0; i < 100; i += 1 )); do
 
     choice=$((RANDOM % 3))
     echo ""

--- a/tools/test_repair.sh
+++ b/tools/test_repair.sh
@@ -92,16 +92,18 @@ fi
 
 target_args="-t 127.0.0.1:8810 -t 127.0.0.1:8820 -t 127.0.0.1:8830"
 
+generation=1
 # Do initial volume population.
-if ! ${ct} fill ${target_args} --verify-out "$verify_file" -q
+if ! ${ct} fill ${target_args} --verify-out "$verify_file" -q -g "$generation"
 then
     echo "ERROR: Exit on initial fill"
     cleanup
     exit 1
 fi
+(( generation += 1))
 
 # Start loop
-for (( i = 0; i < 20; i += 1 )); do
+for (( i = 0; i < 200; i += 1 )); do
 
     choice=$((RANDOM % 3))
     echo ""
@@ -126,12 +128,13 @@ for (( i = 0; i < 20; i += 1 )); do
         ds2_pid=$!
     fi
 
-    if ! ${ct} repair ${target_args} --verify-out "$verify_file" --verify-in "$verify_file" -c 30
+    if ! ${ct} repair ${target_args} --verify-out "$verify_file" --verify-in "$verify_file" -c 30 -g "$generation"
     then
         echo "Exit on repair fail, loop: $i, choice: $choice"
         cleanup
         exit 1
     fi
+    (( generation += 1))
 
     echo ""
     # Stop --lossy downstairs so it can't complete all its IOs
@@ -167,14 +170,15 @@ for (( i = 0; i < 20; i += 1 )); do
     fi
 
     echo "Verifying data now"
-    echo ${ct} verify ${target_args} --verify-out "$verify_file" --verify-in "$verify_file" --range -q > "$test_log"
-    if ! ${ct} verify ${target_args} --verify-out "$verify_file" --verify-in "$verify_file" --range -q >> "$test_log"
+    echo ${ct} verify ${target_args} --verify-out "$verify_file" --verify-in "$verify_file" --range -q -g "$generation" > "$test_log"
+    if ! ${ct} verify ${target_args} --verify-out "$verify_file" --verify-in "$verify_file" --range -q -g "$generation" >> "$test_log" 2>&1
     then
         echo "Exit on verify fail, loop: $i, choice: $choice"
         echo "Check $test_log for details"
         cleanup
         exit 1
     fi
+    (( generation += 1))
 
     echo "Loop: $i  Downstairs dump after verify (and repair):"
     ${cds} dump ${dump_args[@]}


### PR DESCRIPTION
This is a fix for the test_repair.sh test to support the new async guest in the upstairs.

Also, fixed the `-N` option.
Added a bit more detail to messages when a mismatch is encountered.
