### PR TITLE
Crash consistent removal of block contexts

### DIFF
--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -392,9 +392,9 @@ fn color_vec(compare: &[u64]) -> Vec<u8> {
     colors
 }
 
-fn return_status_letters<T, U: std::cmp::PartialEq>(
-    items: &[T],
-    accessor: fn(&T) -> &U,
+fn return_status_letters<'a, T, U: std::cmp::PartialEq>(
+    items: &'a [T],
+    accessor: fn(&'a T) -> U,
     nc: bool,
 ) -> ([String; 3], bool) {
     let mut status_letters = vec![String::new(); 3];
@@ -498,11 +498,7 @@ fn show_extent(
     }
     print!(" ");
     for (index, _) in region_dir.iter().enumerate() {
-        print!(" {0:^2}", format!("E{}", index));
-    }
-    print!(" ");
-    for (index, _) in region_dir.iter().enumerate() {
-        print!(" {0:^2}", format!("H{}", index));
+        print!(" {0:^2}", format!("C{}", index));
     }
     if !only_show_differences {
         print!(" {0:^5}", "DIFF");
@@ -517,9 +513,7 @@ fn show_extent(
     for block in 0..blocks_per_extent {
         let mut data_columns: [String; 3] =
             ["".to_string(), "".to_string(), "".to_string()];
-        let mut encryption_context_columns: [String; 3] =
-            ["".to_string(), "".to_string(), "".to_string()];
-        let mut hash_columns: [String; 3] =
+        let mut block_context_columns: [String; 3] =
             ["".to_string(), "".to_string(), "".to_string()];
 
         /*
@@ -567,26 +561,17 @@ fn show_extent(
             data_columns[dir_index] = status_letters[dir_index].to_string();
         }
 
-        // then, compare encryption_context_columns
-        let (status_letters, ec_different) =
-            return_status_letters(&dvec, |x| &x.encryption_contexts, nc);
+        // then, compare block_context_columns
+        let (status_letters, bc_different) =
+            return_status_letters(&dvec, |x| &x.block_contexts, nc);
 
-        // Print nonce status letters
+        // Print block context status letters
         for dir_index in 0..dir_count {
-            encryption_context_columns[dir_index] =
+            block_context_columns[dir_index] =
                 status_letters[dir_index].to_string();
         }
 
-        // then, compare hashes
-        let (status_letters, hashes_different) =
-            return_status_letters(&dvec, |x| &x.hashes, nc);
-
-        // Print hash status letters
-        for dir_index in 0..dir_count {
-            hash_columns[dir_index] = status_letters[dir_index].to_string();
-        }
-
-        let different = data_different || ec_different || hashes_different;
+        let different = data_different || bc_different;
 
         // Now that we have collected all the results, print them
         let real_block = (blocks_per_extent * cmp_extent as u64) + block;
@@ -597,11 +582,7 @@ fn show_extent(
                 print!("  {}", column);
             }
             print!(" ");
-            for column in encryption_context_columns.iter().take(dir_count) {
-                print!("  {}", column);
-            }
-            print!(" ");
-            for column in hash_columns.iter().take(dir_count) {
+            for column in block_context_columns.iter().take(dir_count) {
                 print!("  {}", column);
             }
 
@@ -700,10 +681,10 @@ fn show_extent_block(
     }
 
     /*
-     * Compare encryption contexts
+     * Compare block contexts
      */
     let (_, different) =
-        return_status_letters(&dvec, |x| &x.encryption_contexts, nc);
+        return_status_letters(&dvec, |x| &x.block_contexts, nc);
 
     if !only_show_differences || different {
         /*
@@ -718,7 +699,7 @@ fn show_extent_block(
 
             max_nonce_depth = std::cmp::max(
                 max_nonce_depth,
-                response.encryption_contexts.len(),
+                response.encryption_contexts().len(),
             );
         }
         if !only_show_differences {
@@ -741,12 +722,17 @@ fn show_extent_block(
             let mut all_same_len = true;
             let mut nonces = Vec::with_capacity(dir_count);
             for response in dvec.iter() {
-                let ctxs = &response.encryption_contexts;
+                let ctxs = response.encryption_contexts();
                 print!(
                     "{:^24} ",
                     if depth < ctxs.len() {
-                        nonces.push(&ctxs[depth].nonce);
-                        hex::encode(&ctxs[depth].nonce)
+                        if let Some(ec) = ctxs[depth] {
+                            nonces.push(&ec.nonce);
+                            hex::encode(&ec.nonce)
+                        } else {
+                            all_same_len = false;
+                            "".to_string()
+                        }
                     } else {
                         all_same_len = false;
                         "".to_string()
@@ -772,7 +758,7 @@ fn show_extent_block(
 
             max_tag_depth = std::cmp::max(
                 max_tag_depth,
-                response.encryption_contexts.len(),
+                response.encryption_contexts().len(),
             );
         }
         if !only_show_differences {
@@ -795,12 +781,17 @@ fn show_extent_block(
             let mut all_same_len = true;
             let mut tags = Vec::with_capacity(dir_count);
             for response in dvec.iter() {
-                let ctxs = &response.encryption_contexts;
+                let ctxs = response.encryption_contexts();
                 print!(
                     "{:^32} ",
                     if depth < ctxs.len() {
-                        tags.push(&ctxs[depth].tag);
-                        hex::encode(&ctxs[depth].tag)
+                        if let Some(ec) = ctxs[depth] {
+                            tags.push(&ec.tag);
+                            hex::encode(&ec.tag)
+                        } else {
+                            all_same_len = false;
+                            "".to_string()
+                        }
                     } else {
                         all_same_len = false;
                         "".to_string()
@@ -818,7 +809,7 @@ fn show_extent_block(
     /*
      * Compare integrity hashes
      */
-    let (_, different) = return_status_letters(&dvec, |x| &x.hashes, nc);
+    let (_, different) = return_status_letters(&dvec, |x| x.hashes(), nc);
 
     if !only_show_differences || different {
         /*
@@ -832,7 +823,7 @@ fn show_extent_block(
             print!("{:^16} ", dir_index);
 
             max_hash_depth =
-                std::cmp::max(max_hash_depth, response.hashes.len());
+                std::cmp::max(max_hash_depth, response.hashes().len());
         }
         if !only_show_differences {
             print!(" {:<5}", "DIFF");
@@ -856,9 +847,9 @@ fn show_extent_block(
             for response in dvec.iter() {
                 print!(
                     "{:^16} ",
-                    if depth < response.hashes.len() {
-                        hashes.push(&response.hashes[depth]);
-                        hex::encode(&response.hashes[depth].to_le_bytes())
+                    if depth < response.hashes().len() {
+                        hashes.push(response.hashes()[depth]);
+                        hex::encode(response.hashes()[depth].to_le_bytes())
                     } else {
                         all_same_len = false;
                         "".to_string()

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -230,8 +230,10 @@ pub fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
                 eid,
                 offset,
                 data: buffer.freeze(),
-                encryption_context: None,
-                hash: integrity_hash(&[data]),
+                block_context: BlockContext {
+                    hash: integrity_hash(&[data]),
+                    encryption_context: None,
+                },
             });
 
             pos.advance(len);
@@ -3437,10 +3439,10 @@ mod test {
                 assert_eq!(responses.len(), 1);
 
                 let response = &responses[0];
-                assert_eq!(response.hashes.len(), 1);
+                assert_eq!(response.hashes().len(), 1);
                 assert_eq!(
                     integrity_hash(&[&response.data[..]]),
-                    response.hashes[0],
+                    response.hashes()[0],
                 );
 
                 read_data.extend_from_slice(&response.data[..]);

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -38,6 +38,15 @@ pub struct Extent {
     inner: Option<Mutex<Inner>>,
 }
 
+/// BlockContext, with the addition of block index and on_disk_hash
+#[derive(Clone)]
+pub struct DownstairsBlockContext {
+    pub block_context: BlockContext,
+
+    pub block: u64,
+    pub on_disk_hash: u64,
+}
+
 #[derive(Debug)]
 pub struct Inner {
     file: File,
@@ -129,61 +138,31 @@ impl Inner {
         Ok(())
     }
 
-    /// For a given block range, return all encryption contexts since the last
-    /// flush. `get_hashes` returns a `Vec<Vec<u64>>` of length equal to
-    /// `count`. Each `Vec<u64>` inside this parent Vec contains all
-    /// contexts for a single block, ordered so the latest context is last.
-    /// If the region is not using encryption, the inner Vecs will all be
-    /// empty, but the outer Vec will still be of length `count`.
-    fn get_encryption_contexts(
+    /// For a given block range, return all context rows since the last flush.
+    /// `get_block_contexts` returns a `Vec<Vec<DownstairsBlockContext>>` of
+    /// length equal to `count`. Each `Vec<DownstairsBlockContext>` inside this
+    /// parent Vec contains all contexts for a single block.
+    fn get_block_contexts(
         &self,
         block: u64,
         count: u64,
-    ) -> Result<Vec<Vec<EncryptionContext>>> {
+    ) -> Result<Vec<Vec<DownstairsBlockContext>>> {
         // NOTE: "ORDER BY RANDOM()" would be a good --lossy addition here
-        let stmt = "SELECT block, nonce, tag FROM encryption_context \
+        let stmt =
+            "SELECT block, hash, nonce, tag, on_disk_hash FROM block_context \
              WHERE block BETWEEN ?1 AND ?2 \
-             ORDER BY counter ASC";
+             ORDER BY ROWID ASC";
         let mut stmt = self.metadb.prepare_cached(stmt)?;
 
         let stmt_iter =
             stmt.query_map(params![block, block + count - 1], |row| {
-                let block: u64 = row.get(0)?;
-                let nonce: Vec<u8> = row.get(1)?;
-                let tag: Vec<u8> = row.get(2)?;
-                Ok((block, nonce, tag))
-            })?;
-
-        let mut results = Vec::with_capacity(count as usize);
-        for _i in 0..count {
-            results.push(Vec::new());
-        }
-
-        for row in stmt_iter {
-            let (row_block, nonce, tag) = row?;
-            results[(row_block - block) as usize]
-                .push(EncryptionContext { nonce, tag });
-        }
-
-        Ok(results)
-    }
-
-    /// For a given block range, return all hashes since the last flush.
-    /// `get_hashes` returns a `Vec<Vec<u64>>` of length equal to `count`. Each
-    /// `Vec<u64>` inside this parent Vec contains all hashes for a single
-    /// block, ordered so the latest hash is last.
-    pub fn get_hashes(&self, block: u64, count: u64) -> Result<Vec<Vec<u64>>> {
-        // NOTE: "ORDER BY RANDOM()" would be a good --lossy addition here
-        let stmt = "SELECT block, hash FROM integrity_hashes \
-             WHERE block BETWEEN ?1 AND ?2 \
-             ORDER BY counter ASC";
-        let mut stmt = self.metadb.prepare_cached(stmt)?;
-
-        let stmt_iter =
-            stmt.query_map(params![block, block + count - 1], |row| {
-                let block: u64 = row.get(0)?;
+                let block_index: u64 = row.get(0)?;
                 let hash: Vec<u8> = row.get(1)?;
-                Ok((block, hash))
+                let nonce: Option<Vec<u8>> = row.get(2)?;
+                let tag: Option<Vec<u8>> = row.get(3)?;
+                let on_disk_hash: Vec<u8> = row.get(4)?;
+
+                Ok((block_index, hash, nonce, tag, on_disk_hash))
             })?;
 
         let mut results = Vec::with_capacity(count as usize);
@@ -192,39 +171,59 @@ impl Inner {
         }
 
         for row in stmt_iter {
-            let (row_block, hash) = row?;
-            assert_eq!(hash.len(), 8);
-            results[(row_block - block) as usize]
-                .push(u64::from_le_bytes(hash[..].try_into()?));
+            let (block_index, hash, nonce, tag, on_disk_hash) = row?;
+
+            let encryption_context = if let Some(nonce) = nonce {
+                tag.map(|tag| EncryptionContext { nonce, tag })
+            } else {
+                None
+            };
+
+            let ctx = DownstairsBlockContext {
+                block_context: BlockContext {
+                    hash: u64::from_le_bytes(hash[..].try_into()?),
+                    encryption_context,
+                },
+                block: block_index,
+                on_disk_hash: u64::from_le_bytes(on_disk_hash[..].try_into()?),
+            };
+
+            results[(ctx.block - block) as usize].push(ctx);
         }
 
         Ok(results)
     }
 
     /*
-     * Given a (block, nonce, tag), append an encryption context row.
-     *
-     * For the params, keep a list of references so that copying is
-     * minimized.
+     * Append a block context row.
      */
-    pub fn tx_set_encryption_context(
+    pub fn tx_set_block_context(
         tx: &rusqlite::Transaction,
-        encryption_context_params: &(u64, &EncryptionContext),
+        block_context: &DownstairsBlockContext,
     ) -> Result<()> {
-        let (block, encryption_context) = encryption_context_params;
-
         let stmt =
-            "INSERT INTO encryption_context (counter, block, nonce, tag) \
-             VALUES ( \
-                 (SELECT IFNULL(MAX(counter), 0) + 1 FROM encryption_context WHERE block=?1), \
-                 ?1, ?2, ?3 \
-             )";
+            "INSERT INTO block_context (block, hash, nonce, tag, on_disk_hash) \
+             VALUES (?1, ?2, ?3, ?4, ?5)";
+
+        let (nonce, tag) = if let Some(encryption_context) =
+            &block_context.block_context.encryption_context
+        {
+            (
+                Some(&encryption_context.nonce),
+                Some(&encryption_context.tag),
+            )
+        } else {
+            (None, None)
+        };
 
         let rows_affected = tx.prepare_cached(stmt)?.execute(params![
-            block,
-            &encryption_context.nonce,
-            &encryption_context.tag
+            block_context.block,
+            block_context.block_context.hash.to_le_bytes(),
+            nonce,
+            tag,
+            block_context.on_disk_hash.to_le_bytes(),
         ])?;
+
         assert_eq!(rows_affected, 1);
 
         Ok(())
@@ -235,14 +234,14 @@ impl Inner {
     }
 
     #[cfg(test)]
-    fn set_encryption_context(
+    fn set_block_contexts(
         &mut self,
-        encryption_context_params: &[(u64, &EncryptionContext)],
+        block_contexts: &[&DownstairsBlockContext],
     ) -> Result<()> {
         let tx = self.metadb.transaction()?;
 
-        for tuple in encryption_context_params {
-            Self::tx_set_encryption_context(&tx, tuple)?;
+        for block_context in block_contexts {
+            Self::tx_set_block_context(&tx, block_context)?;
         }
 
         tx.commit()?;
@@ -251,124 +250,26 @@ impl Inner {
     }
 
     /*
-     * Given a (block, hash), append a hash row.
+     * Get rid of all block context rows except those that match the on-disk
+     * hash that is computed after a flush.
      */
-    pub fn tx_set_hash(
-        tx: &rusqlite::Transaction,
-        hash_params: &(u64, u64),
+    fn truncate_encryption_contexts_and_hashes(
+        &mut self,
+        extent_block_indexes_and_hashes: Vec<(usize, u64)>,
     ) -> Result<()> {
-        let (block, hash) = hash_params;
-
-        let stmt =
-            "INSERT INTO integrity_hashes (counter, block, hash) \
-             VALUES ( \
-                 (SELECT IFNULL(MAX(counter), 0) + 1 FROM integrity_hashes WHERE block=?1), \
-                 ?1, ?2 \
-             )";
-
-        let rows_affected = tx
-            .prepare_cached(stmt)?
-            .execute(params![block, &hash.to_le_bytes()])?;
-        assert_eq!(rows_affected, 1);
-
-        Ok(())
-    }
-
-    #[cfg(test)]
-    pub fn set_hashes(&mut self, hash_params: &[(u64, u64)]) -> Result<()> {
         let tx = self.metadb.transaction()?;
 
-        for tuple in hash_params {
-            Self::tx_set_hash(&tx, tuple)?;
+        let stmt = "DELETE FROM block_context where block == ?1 and on_disk_hash != ?2";
+
+        for (block, on_disk_hash) in extent_block_indexes_and_hashes {
+            let _rows_affected = tx
+                .prepare_cached(stmt)?
+                .execute(params![block, on_disk_hash.to_le_bytes()])?;
         }
 
         tx.commit()?;
 
         Ok(())
-    }
-
-    /*
-     * Get rid of all but most recent encryption context and hash for each
-     * block.
-     */
-    fn truncate_encryption_contexts_and_hashes(&mut self) -> Result<()> {
-        let tx = self.metadb.transaction()?;
-
-        // Clear encryption context
-        let stmt = "DELETE FROM encryption_context WHERE ROWID not in \
-             (select ROWID from \
-                 (select ROWID,block,MAX(counter) \
-                  from encryption_context group by block\
-                 ) \
-             )";
-
-        let _rows_affected = tx.prepare_cached(stmt)?.execute([])?;
-
-        let _rows_affected = tx
-            .prepare_cached("UPDATE encryption_context SET counter = 0")?
-            .execute([])?;
-
-        // Clear integrity hash
-        let stmt = "DELETE FROM integrity_hashes WHERE ROWID not in \
-             (select ROWID from \
-                 (select ROWID,block,MAX(counter) \
-                  from integrity_hashes group by block \
-                 ) \
-             )";
-
-        let _rows_affected = tx.prepare_cached(stmt)?.execute([])?;
-
-        let _rows_affected = tx
-            .prepare_cached("UPDATE integrity_hashes SET counter = 0")?
-            .execute([])?;
-
-        tx.commit()?;
-
-        Ok(())
-    }
-
-    /*
-     * In order to unit test truncate_encryption_contexts_and_hashes, return
-     * blocks and counters.
-     */
-    #[cfg(test)]
-    fn get_blocks_and_counters_for_encryption_context(
-        &mut self,
-    ) -> Result<Vec<(u64, u64)>> {
-        let mut stmt = self
-            .metadb
-            .prepare_cached("SELECT block, counter FROM encryption_context")?;
-
-        let stmt_iter =
-            stmt.query_map(params![], |row| Ok((row.get(0)?, row.get(1)?)))?;
-
-        let mut results = Vec::new();
-
-        for row in stmt_iter {
-            results.push(row?);
-        }
-
-        Ok(results)
-    }
-
-    #[cfg(test)]
-    fn get_blocks_and_counters_for_hashes(
-        &mut self,
-    ) -> Result<Vec<(u64, u64)>> {
-        let mut stmt = self
-            .metadb
-            .prepare_cached("SELECT block, counter FROM integrity_hashes")?;
-
-        let stmt_iter =
-            stmt.query_map(params![], |row| Ok((row.get(0)?, row.get(1)?)))?;
-
-        let mut results = Vec::new();
-
-        for row in stmt_iter {
-            results.push(row?);
-        }
-
-        Ok(results)
     }
 }
 
@@ -803,23 +704,28 @@ impl Extent {
                 params!["dirty", meta.dirty],
             )?;
 
+            // Within an extent, store a context row for each block.
+            //
+            // The Upstairs will send either an integrity hash, or an integrity
+            // hash along with some encryption context (a nonce and tag).
+            //
+            // The Downstairs will have to record multiple context rows for each
+            // block, because while what is committed to sqlite is durable (due
+            // to the write-ahead logging and the fact that we set PRAGMA
+            // SYNCHRONOUS), what is written to the extent file is not durable
+            // until a flush of that file is performed.
+            //
+            // Any of the context rows written between flushes could be valid
+            // until we call flush and remove context rows where the integrity
+            // hash does not match what was actually flushed to disk.
             metadb.execute(
-                "CREATE TABLE encryption_context (
-                    counter INTEGER,
-                    block INTEGER,
-                    nonce BLOB NOT NULL,
-                    tag BLOB NOT NULL,
-                    PRIMARY KEY (block, counter)
-                )",
-                [],
-            )?;
-
-            metadb.execute(
-                "CREATE TABLE integrity_hashes (
-                    counter INTEGER,
+                "CREATE TABLE block_context (
                     block INTEGER,
                     hash BLOB NOT NULL,
-                    PRIMARY KEY (block, counter)
+                    nonce BLOB,
+                    tag BLOB,
+                    on_disk_hash BLOB NOT NULL,
+                    PRIMARY KEY (block, hash, nonce, tag, on_disk_hash)
                 )",
                 [],
             )?;
@@ -966,11 +872,7 @@ impl Extent {
             inner.file.read_exact(&mut read_buffer)?;
 
             // Query the block metadata
-            let enc_ctxts = inner.get_encryption_contexts(
-                first_req.offset.value,
-                n_contiguous_requests as u64,
-            )?;
-            let hashes = inner.get_hashes(
+            let block_contexts = inner.get_block_contexts(
                 first_req.offset.value,
                 n_contiguous_requests as u64,
             )?;
@@ -982,18 +884,17 @@ impl Extent {
             // (equal to n_contiguous_requests) so zipping is fine
             let resp_iter =
                 responses[resp_run_start..][..n_contiguous_requests].iter_mut();
-            let enc_iter = enc_ctxts.into_iter();
-            let hash_iter = hashes.into_iter();
+            let ctx_iter = block_contexts.into_iter();
             let data_iter = read_buffer.chunks_exact(self.block_size as usize);
 
             // We could make this a little cleaner if we pulled in itertools and
             // used multizip from that, but i don't think it's worth it.
-            for (((resp, r_encs), r_hashes), r_data) in
-                resp_iter.zip(enc_iter).zip(hash_iter).zip(data_iter)
+            for ((resp, r_ctx), r_data) in
+                resp_iter.zip(ctx_iter).zip(data_iter)
             {
                 // Shove everything into the response
-                resp.encryption_contexts = r_encs;
-                resp.hashes = r_hashes;
+                resp.block_contexts =
+                    r_ctx.into_iter().map(|x| x.block_context).collect();
 
                 // XXX if resp.data was Bytes instead of BytesMut we could avoid
                 // a copy here and instead assign it to a frozen subslice.
@@ -1123,13 +1024,13 @@ impl Extent {
                 // Query hashes for the write range.
                 // TODO we should consider adding a query that doesnt actually
                 // give us back the data, just checks for its presence.
-                let hashes = inner.get_hashes(
+                let block_contexts = inner.get_block_contexts(
                     first_write.offset.value,
                     n_contiguous_writes as u64,
                 )?;
 
-                for (i, block_hashes) in hashes.iter().enumerate() {
-                    if !block_hashes.is_empty() {
+                for (i, block_contexts) in block_contexts.iter().enumerate() {
+                    if !block_contexts.is_empty() {
                         let _ = writes_to_skip
                             .insert(i as u64 + first_write.offset.value);
                     }
@@ -1154,14 +1055,14 @@ impl Extent {
                 continue;
             }
 
-            if let Some(encryption_context) = &write.encryption_context {
-                Inner::tx_set_encryption_context(
-                    &tx,
-                    &(write.offset.value, encryption_context),
-                )?;
-            }
-
-            Inner::tx_set_hash(&tx, &(write.offset.value, write.hash))?;
+            Inner::tx_set_block_context(
+                &tx,
+                &DownstairsBlockContext {
+                    block_context: write.block_context.clone(),
+                    block: write.offset.value,
+                    on_disk_hash: integrity_hash(&[&write.data[..]]),
+                },
+            )?;
         }
         tx.commit()?;
 
@@ -1251,11 +1152,30 @@ impl Extent {
             );
         }
 
-        /*
-         * Clear old encryption contexts and hashes. In order to be crash
-         * consistent, only perform this after the extent fsync is done.
-         */
-        inner.truncate_encryption_contexts_and_hashes()?;
+        // Clear old block contexts. In order to be crash consistent, only
+        // perform this after the extent fsync is done. Read each block in the
+        // extent and find out the integrity hash. Then, remove all block
+        // context rows where the integrity hash does not match.
+
+        let total_bytes: usize =
+            self.extent_size.value as usize * self.block_size as usize;
+        let mut extent_data: Vec<u8> = vec![0; total_bytes];
+
+        inner.file.seek(SeekFrom::Start(0))?;
+        inner.file.read_exact(&mut extent_data)?;
+
+        let extent_block_indexes_and_hashes = extent_data
+            .chunks(self.block_size as usize)
+            .enumerate()
+            .map(|(i, data)| (i, integrity_hash(&[data])))
+            .collect();
+
+        inner.truncate_encryption_contexts_and_hashes(
+            extent_block_indexes_and_hashes,
+        )?;
+
+        // Reset the file's seek offset to 0, and set the flush number and gen
+        // number
 
         inner.file.seek(SeekFrom::Start(0))?;
 
@@ -1705,18 +1625,19 @@ impl Region {
         writes: &[crucible_protocol::Write],
     ) -> Result<(), CrucibleError> {
         for write in writes {
-            let computed_hash =
-                if let Some(encryption_context) = &write.encryption_context {
-                    integrity_hash(&[
-                        &encryption_context.nonce[..],
-                        &encryption_context.tag[..],
-                        &write.data[..],
-                    ])
-                } else {
-                    integrity_hash(&[&write.data[..]])
-                };
+            let computed_hash = if let Some(encryption_context) =
+                &write.block_context.encryption_context
+            {
+                integrity_hash(&[
+                    &encryption_context.nonce[..],
+                    &encryption_context.tag[..],
+                    &write.data[..],
+                ])
+            } else {
+                integrity_hash(&[&write.data[..]])
+            };
 
-            if computed_hash != write.hash {
+            if computed_hash != write.block_context.hash {
                 println!("Failed write hash validation");
                 crucible_bail!(HashMismatch);
             }
@@ -2889,7 +2810,7 @@ mod test {
     }
 
     #[test]
-    fn encryption_context() -> Result<()> {
+    fn block_context() -> Result<()> {
         let dir = tempdir()?;
         let mut region = Region::create(&dir, new_region_options())?;
         region.extend(1)?;
@@ -2899,75 +2820,150 @@ mod test {
 
         // Encryption context for blocks 0 and 1 should start blank
 
-        assert!(inner.get_encryption_contexts(0, 1)?[0].is_empty());
-        assert!(inner.get_encryption_contexts(1, 1)?[0].is_empty());
+        assert!(inner.get_block_contexts(0, 1)?[0].is_empty());
+        assert!(inner.get_block_contexts(1, 1)?[0].is_empty());
 
         // Set and verify block 0's context
 
-        inner.set_encryption_context(&[(
-            0,
-            &EncryptionContext {
-                nonce: [1, 2, 3].to_vec(),
-                tag: [4, 5, 6, 7].to_vec(),
+        inner.set_block_contexts(&[&DownstairsBlockContext {
+            block_context: BlockContext {
+                encryption_context: Some(EncryptionContext {
+                    nonce: [1, 2, 3].to_vec(),
+                    tag: [4, 5, 6, 7].to_vec(),
+                }),
+                hash: 123,
             },
-        )])?;
+            block: 0,
+            on_disk_hash: 456,
+        }])?;
 
-        let ctxs = inner.get_encryption_contexts(0, 1)?[0].clone();
+        let ctxs = inner.get_block_contexts(0, 1)?[0].clone();
 
         assert_eq!(ctxs.len(), 1);
 
-        assert_eq!(ctxs[0].nonce, vec![1, 2, 3]);
-        assert_eq!(ctxs[0].tag, vec![4, 5, 6, 7]);
+        assert_eq!(
+            ctxs[0]
+                .block_context
+                .encryption_context
+                .as_ref()
+                .unwrap()
+                .nonce,
+            vec![1, 2, 3]
+        );
+        assert_eq!(
+            ctxs[0]
+                .block_context
+                .encryption_context
+                .as_ref()
+                .unwrap()
+                .tag,
+            vec![4, 5, 6, 7]
+        );
+        assert_eq!(ctxs[0].block_context.hash, 123);
+        assert_eq!(ctxs[0].on_disk_hash, 456);
 
         // Block 1 should still be blank
 
-        assert!(inner.get_encryption_contexts(1, 1)?[0].is_empty());
+        assert!(inner.get_block_contexts(1, 1)?[0].is_empty());
 
         // Set and verify a new context for block 0
 
         let blob1 = rand::thread_rng().gen::<[u8; 32]>();
         let blob2 = rand::thread_rng().gen::<[u8; 32]>();
 
-        inner.set_encryption_context(&[(
-            0,
-            &EncryptionContext {
-                nonce: blob1.to_vec(),
-                tag: blob2.to_vec(),
+        inner.set_block_contexts(&[&DownstairsBlockContext {
+            block_context: BlockContext {
+                encryption_context: Some(EncryptionContext {
+                    nonce: blob1.to_vec(),
+                    tag: blob2.to_vec(),
+                }),
+                hash: 1024,
             },
-        )])?;
+            block: 0,
+            on_disk_hash: 65536,
+        }])?;
 
-        let ctxs = inner.get_encryption_contexts(0, 1)?[0].clone();
+        let ctxs = inner.get_block_contexts(0, 1)?[0].clone();
 
         assert_eq!(ctxs.len(), 2);
 
-        assert_eq!(ctxs[0].nonce, vec![1, 2, 3]);
-        assert_eq!(ctxs[0].tag, vec![4, 5, 6, 7]);
+        // First context didn't change
+        assert_eq!(
+            ctxs[0]
+                .block_context
+                .encryption_context
+                .as_ref()
+                .unwrap()
+                .nonce,
+            vec![1, 2, 3]
+        );
+        assert_eq!(
+            ctxs[0]
+                .block_context
+                .encryption_context
+                .as_ref()
+                .unwrap()
+                .tag,
+            vec![4, 5, 6, 7]
+        );
+        assert_eq!(ctxs[0].block_context.hash, 123);
+        assert_eq!(ctxs[0].on_disk_hash, 456);
 
-        assert_eq!(ctxs[1].nonce, blob1);
-        assert_eq!(ctxs[1].tag, blob2);
+        // Second context was appended
+        assert_eq!(
+            ctxs[1]
+                .block_context
+                .encryption_context
+                .as_ref()
+                .unwrap()
+                .nonce,
+            blob1
+        );
+        assert_eq!(
+            ctxs[1]
+                .block_context
+                .encryption_context
+                .as_ref()
+                .unwrap()
+                .tag,
+            blob2
+        );
+        assert_eq!(ctxs[1].block_context.hash, 1024);
+        assert_eq!(ctxs[1].on_disk_hash, 65536);
 
-        // "Flush", so only the latest should remain.
-        inner.truncate_encryption_contexts_and_hashes()?;
+        // "Flush", so only the rows that match should remain.
+        inner.truncate_encryption_contexts_and_hashes(vec![(0, 65536)])?;
 
-        let ctxs = inner.get_encryption_contexts(0, 1)?[0].clone();
+        let ctxs = inner.get_block_contexts(0, 1)?[0].clone();
 
         assert_eq!(ctxs.len(), 1);
 
-        assert_eq!(ctxs[0].nonce, blob1);
-        assert_eq!(ctxs[0].tag, blob2);
-
-        // Assert counters were reset to zero
-        for (_block, counter) in
-            inner.get_blocks_and_counters_for_encryption_context()?
-        {
-            assert_eq!(counter, 0);
-        }
+        assert_eq!(
+            ctxs[0]
+                .block_context
+                .encryption_context
+                .as_ref()
+                .unwrap()
+                .nonce,
+            blob1
+        );
+        assert_eq!(
+            ctxs[0]
+                .block_context
+                .encryption_context
+                .as_ref()
+                .unwrap()
+                .tag,
+            blob2
+        );
+        assert_eq!(ctxs[0].block_context.hash, 1024);
+        assert_eq!(ctxs[0].on_disk_hash, 65536);
 
         Ok(())
     }
 
     #[test]
-    fn multiple_encryption_context() -> Result<()> {
+    fn multiple_context() -> Result<()> {
         let dir = tempdir()?;
         let mut region = Region::create(&dir, new_region_options())?;
         region.extend(1)?;
@@ -2977,131 +2973,186 @@ mod test {
 
         // Encryption context for blocks 0 and 1 should start blank
 
-        assert!(inner.get_encryption_contexts(0, 1)?[0].is_empty());
-        assert!(inner.get_encryption_contexts(1, 1)?[0].is_empty());
+        assert!(inner.get_block_contexts(0, 1)?[0].is_empty());
+        assert!(inner.get_block_contexts(1, 1)?[0].is_empty());
 
-        // Set and verify block 0's and 1's context
+        // Set block 0's and 1's context
 
-        inner.set_encryption_context(&[
-            (
-                0,
-                &EncryptionContext {
-                    nonce: [1, 2, 3].to_vec(),
-                    tag: [4, 5, 6, 7].to_vec(),
+        inner.set_block_contexts(&[
+            &DownstairsBlockContext {
+                block_context: BlockContext {
+                    encryption_context: Some(EncryptionContext {
+                        nonce: [1, 2, 3].to_vec(),
+                        tag: [4, 5, 6, 7].to_vec(),
+                    }),
+                    hash: 123,
                 },
-            ),
-            (
-                1,
-                &EncryptionContext {
-                    nonce: [4, 5, 6].to_vec(),
-                    tag: [8, 9, 0, 1].to_vec(),
+                block: 0,
+                on_disk_hash: 456,
+            },
+            &DownstairsBlockContext {
+                block_context: BlockContext {
+                    encryption_context: Some(EncryptionContext {
+                        nonce: [4, 5, 6].to_vec(),
+                        tag: [8, 9, 0, 1].to_vec(),
+                    }),
+                    hash: 9999,
                 },
-            ),
+                block: 1,
+                on_disk_hash: 1234567890,
+            },
         ])?;
 
-        let ctxs = inner.get_encryption_contexts(0, 1)?[0].clone();
+        // Verify block 0's context
+
+        let ctxs = inner.get_block_contexts(0, 1)?[0].clone();
 
         assert_eq!(ctxs.len(), 1);
 
-        assert_eq!(ctxs[0].nonce, vec![1, 2, 3]);
-        assert_eq!(ctxs[0].tag, vec![4, 5, 6, 7]);
+        assert_eq!(
+            ctxs[0]
+                .block_context
+                .encryption_context
+                .as_ref()
+                .unwrap()
+                .nonce,
+            vec![1, 2, 3]
+        );
+        assert_eq!(
+            ctxs[0]
+                .block_context
+                .encryption_context
+                .as_ref()
+                .unwrap()
+                .tag,
+            vec![4, 5, 6, 7]
+        );
+        assert_eq!(ctxs[0].block_context.hash, 123);
+        assert_eq!(ctxs[0].on_disk_hash, 456);
 
-        let ctxs = inner.get_encryption_contexts(1, 1)?[0].clone();
+        // Verify block 1's context
+
+        let ctxs = inner.get_block_contexts(1, 1)?[0].clone();
 
         assert_eq!(ctxs.len(), 1);
 
-        assert_eq!(ctxs[0].nonce, vec![4, 5, 6]);
-        assert_eq!(ctxs[0].tag, vec![8, 9, 0, 1]);
+        assert_eq!(
+            ctxs[0]
+                .block_context
+                .encryption_context
+                .as_ref()
+                .unwrap()
+                .nonce,
+            vec![4, 5, 6]
+        );
+        assert_eq!(
+            ctxs[0]
+                .block_context
+                .encryption_context
+                .as_ref()
+                .unwrap()
+                .tag,
+            vec![8, 9, 0, 1]
+        );
+        assert_eq!(ctxs[0].block_context.hash, 9999);
+        assert_eq!(ctxs[0].on_disk_hash, 1234567890);
 
-        Ok(())
-    }
+        // Return both block 0's and block 1's context, and verify
 
-    #[test]
-    fn hashes() -> Result<()> {
-        let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options())?;
-        region.extend(1)?;
+        let ctxs = inner.get_block_contexts(0, 2)?;
 
-        let ext = &region.extents[0];
-        let mut inner = ext.inner();
+        assert_eq!(ctxs[0].len(), 1);
+        assert_eq!(
+            ctxs[0][0]
+                .block_context
+                .encryption_context
+                .as_ref()
+                .unwrap()
+                .nonce,
+            vec![1, 2, 3]
+        );
+        assert_eq!(
+            ctxs[0][0]
+                .block_context
+                .encryption_context
+                .as_ref()
+                .unwrap()
+                .tag,
+            vec![4, 5, 6, 7]
+        );
+        assert_eq!(ctxs[0][0].block_context.hash, 123);
+        assert_eq!(ctxs[0][0].on_disk_hash, 456);
 
-        // Hashes for blocks 0 and 1 should start blank
+        assert_eq!(ctxs[1].len(), 1);
+        assert_eq!(
+            ctxs[1][0]
+                .block_context
+                .encryption_context
+                .as_ref()
+                .unwrap()
+                .nonce,
+            vec![4, 5, 6]
+        );
+        assert_eq!(
+            ctxs[1][0]
+                .block_context
+                .encryption_context
+                .as_ref()
+                .unwrap()
+                .tag,
+            vec![8, 9, 0, 1]
+        );
+        assert_eq!(ctxs[1][0].block_context.hash, 9999);
+        assert_eq!(ctxs[1][0].on_disk_hash, 1234567890);
 
-        assert!(inner.get_hashes(0, 1)?[0].is_empty());
-        assert!(inner.get_hashes(1, 1)?[0].is_empty());
+        // Append a whole bunch of block context rows
 
-        // Set and verify block 0's hash
-
-        inner.set_hashes(&[(0, 23874612987634)])?;
-
-        let hashes = inner.get_hashes(0, 1)?[0].clone();
-
-        assert_eq!(hashes.len(), 1);
-
-        assert_eq!(hashes[0], 23874612987634);
-
-        // Block 1 should still be blank
-
-        assert!(inner.get_hashes(1, 1)?[0].is_empty());
-
-        // Set and verify a new hash for block 0
-
-        let blob1 = rand::thread_rng().gen::<u64>();
-
-        inner.set_hashes(&[(0, blob1)])?;
-
-        let hashes = inner.get_hashes(0, 1)?[0].clone();
-
-        assert_eq!(hashes.len(), 2);
-
-        assert_eq!(hashes[0], 23874612987634);
-        assert_eq!(hashes[1], blob1);
-
-        // "Flush", so only the latest should remain.
-        inner.truncate_encryption_contexts_and_hashes()?;
-
-        let hashes = inner.get_hashes(0, 1)?[0].clone();
-
-        assert_eq!(hashes.len(), 1);
-
-        assert_eq!(hashes[0], blob1);
-
-        // Assert counters were reset to zero
-        for (_block, counter) in inner.get_blocks_and_counters_for_hashes()? {
-            assert_eq!(counter, 0);
+        for i in 0..10 {
+            inner.set_block_contexts(&[
+                &DownstairsBlockContext {
+                    block_context: BlockContext {
+                        encryption_context: Some(EncryptionContext {
+                            nonce: rand::thread_rng()
+                                .gen::<[u8; 32]>()
+                                .to_vec(),
+                            tag: rand::thread_rng().gen::<[u8; 32]>().to_vec(),
+                        }),
+                        hash: rand::thread_rng().gen::<u64>(),
+                    },
+                    block: 0,
+                    on_disk_hash: i,
+                },
+                &DownstairsBlockContext {
+                    block_context: BlockContext {
+                        encryption_context: Some(EncryptionContext {
+                            nonce: rand::thread_rng()
+                                .gen::<[u8; 32]>()
+                                .to_vec(),
+                            tag: rand::thread_rng().gen::<[u8; 32]>().to_vec(),
+                        }),
+                        hash: rand::thread_rng().gen::<u64>(),
+                    },
+                    block: 1,
+                    on_disk_hash: i,
+                },
+            ])?;
         }
 
-        Ok(())
-    }
+        let ctxs = inner.get_block_contexts(0, 2)?;
+        assert_eq!(ctxs[0].len(), 11);
+        assert_eq!(ctxs[1].len(), 11);
 
-    #[test]
-    fn multiple_hashes() -> Result<()> {
-        let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options())?;
-        region.extend(1)?;
+        // "Flush", so only the rows that match the on-disk hash should remain.
 
-        let ext = &region.extents[0];
-        let mut inner = ext.inner();
+        inner.truncate_encryption_contexts_and_hashes(vec![(0, 6), (1, 7)])?;
 
-        // Hashes for blocks 0 and 1 should start blank
+        let ctxs = inner.get_block_contexts(0, 2)?;
 
-        assert!(inner.get_hashes(0, 1)?[0].is_empty());
-        assert!(inner.get_hashes(1, 1)?[0].is_empty());
+        assert_eq!(ctxs[0].len(), 1);
+        assert_eq!(ctxs[0][0].on_disk_hash, 6);
 
-        // Set and verify block 0's and 1's context
-
-        inner
-            .set_hashes(&[(0, 0xbd1f97574fa0c3f4), (1, 0xa040b75cd3c96fff)])?;
-
-        let hashes = inner.get_hashes(0, 1)?[0].clone();
-
-        assert_eq!(hashes.len(), 1);
-        assert_eq!(hashes[0], 0xbd1f97574fa0c3f4);
-
-        let hashes = inner.get_hashes(1, 1)?[0].clone();
-
-        assert_eq!(hashes.len(), 1);
-        assert_eq!(hashes[0], 0xa040b75cd3c96fff);
+        assert_eq!(ctxs[1].len(), 1);
+        assert_eq!(ctxs[1][0].on_disk_hash, 7);
 
         Ok(())
     }
@@ -3139,8 +3190,10 @@ mod test {
                 eid,
                 offset,
                 data,
-                encryption_context: None,
-                hash,
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash,
+                },
             });
         }
 
@@ -3198,13 +3251,15 @@ mod test {
                 eid: 0,
                 offset: Block::new_512(0),
                 data: data.freeze(),
-                encryption_context: Some(
-                    crucible_protocol::EncryptionContext {
-                        nonce: vec![1, 2, 3],
-                        tag: vec![4, 5, 6],
-                    },
-                ),
-                hash: 5061083712412462836,
+                block_context: BlockContext {
+                    encryption_context: Some(
+                        crucible_protocol::EncryptionContext {
+                            nonce: vec![1, 2, 3],
+                            tag: vec![4, 5, 6],
+                        },
+                    ),
+                    hash: 5061083712412462836,
+                },
             }];
 
         region.region_write(&writes, 0, false)?;
@@ -3230,13 +3285,15 @@ mod test {
                 eid,
                 offset,
                 data: data.freeze(),
-                encryption_context: Some(
-                    crucible_protocol::EncryptionContext {
-                        nonce: vec![1, 2, 3],
-                        tag: vec![4, 5, 6],
-                    },
-                ),
-                hash: 4798852240582462654, // Hash for all 9's
+                block_context: BlockContext {
+                    encryption_context: Some(
+                        crucible_protocol::EncryptionContext {
+                            nonce: vec![1, 2, 3],
+                            tag: vec![4, 5, 6],
+                        },
+                    ),
+                    hash: 4798852240582462654, // Hash for all 9's
+                },
             }];
 
         region.region_write(&writes, 0, true)?;
@@ -3254,7 +3311,7 @@ mod test {
         )?;
 
         assert_eq!(responses.len(), 1);
-        assert_eq!(responses[0].hashes.len(), 1);
+        assert_eq!(responses[0].hashes().len(), 1);
         assert_eq!(responses[0].data[..], [9u8; 512][..]);
 
         Ok(())
@@ -3279,13 +3336,15 @@ mod test {
                 eid,
                 offset,
                 data: data.freeze(),
-                encryption_context: Some(
-                    crucible_protocol::EncryptionContext {
-                        nonce: vec![1, 2, 3],
-                        tag: vec![4, 5, 6],
-                    },
-                ),
-                hash: 4798852240582462654, // Hash for all 9s
+                block_context: BlockContext {
+                    encryption_context: Some(
+                        crucible_protocol::EncryptionContext {
+                            nonce: vec![1, 2, 3],
+                            tag: vec![4, 5, 6],
+                        },
+                    ),
+                    hash: 4798852240582462654, // Hash for all 9's
+                },
             }];
 
         region.region_write(&writes, 0, false)?;
@@ -3297,13 +3356,15 @@ mod test {
                 eid,
                 offset,
                 data: data.freeze(),
-                encryption_context: Some(
-                    crucible_protocol::EncryptionContext {
-                        nonce: vec![1, 2, 3],
-                        tag: vec![4, 5, 6],
-                    },
-                ),
-                hash: 5061083712412462836, // hash for all 1s
+                block_context: BlockContext {
+                    encryption_context: Some(
+                        crucible_protocol::EncryptionContext {
+                            nonce: vec![1, 2, 3],
+                            tag: vec![4, 5, 6],
+                        },
+                    ),
+                    hash: 5061083712412462836, // hash for all 1s
+                },
             }];
         // Do the write again, but with only_write_unwritten set now.
         region.region_write(&writes, 1, true)?;
@@ -3317,7 +3378,7 @@ mod test {
         // We should still have one response.
         assert_eq!(responses.len(), 1);
         // Hash should be just 1
-        assert_eq!(responses[0].hashes.len(), 1);
+        assert_eq!(responses[0].hashes().len(), 1);
         // Data should match first write
         assert_eq!(responses[0].data[..], [9u8; 512][..]);
 
@@ -3344,13 +3405,15 @@ mod test {
                 eid,
                 offset,
                 data: data.freeze(),
-                encryption_context: Some(
-                    crucible_protocol::EncryptionContext {
-                        nonce: vec![1, 2, 3],
-                        tag: vec![4, 5, 6],
-                    },
-                ),
-                hash: 4798852240582462654, // Hash for all 9s
+                block_context: BlockContext {
+                    encryption_context: Some(
+                        crucible_protocol::EncryptionContext {
+                            nonce: vec![1, 2, 3],
+                            tag: vec![4, 5, 6],
+                        },
+                    ),
+                    hash: 4798852240582462654, // Hash for all 9s
+                },
             }];
 
         region.region_write(&writes, 0, true)?;
@@ -3375,13 +3438,15 @@ mod test {
                 eid,
                 offset,
                 data: data.freeze(),
-                encryption_context: Some(
-                    crucible_protocol::EncryptionContext {
-                        nonce: vec![1, 2, 3],
-                        tag: vec![4, 5, 6],
-                    },
-                ),
-                hash: 5061083712412462836, // hash for all 1s
+                block_context: BlockContext {
+                    encryption_context: Some(
+                        crucible_protocol::EncryptionContext {
+                            nonce: vec![1, 2, 3],
+                            tag: vec![4, 5, 6],
+                        },
+                    ),
+                    hash: 5061083712412462836, // hash for all 1s
+                },
             }];
 
         // Do the write again, but with only_write_unwritten set now.
@@ -3401,7 +3466,7 @@ mod test {
         // We should still have one response.
         assert_eq!(responses.len(), 1);
         // Hash should be just 1
-        assert_eq!(responses[0].hashes.len(), 1);
+        assert_eq!(responses[0].hashes().len(), 1);
         // Data should match first write
         assert_eq!(responses[0].data[..], [9u8; 512][..]);
 
@@ -3443,8 +3508,10 @@ mod test {
                 eid,
                 offset,
                 data,
-                encryption_context: None,
-                hash,
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash,
+                },
             });
         }
 
@@ -3513,13 +3580,15 @@ mod test {
                 eid,
                 offset,
                 data: data.freeze(),
-                encryption_context: Some(
-                    crucible_protocol::EncryptionContext {
-                        nonce: vec![1, 2, 3],
-                        tag: vec![4, 5, 6],
-                    },
-                ),
-                hash: 4798852240582462654, // Hash for all 9s
+                block_context: BlockContext {
+                    encryption_context: Some(
+                        crucible_protocol::EncryptionContext {
+                            nonce: vec![1, 2, 3],
+                            tag: vec![4, 5, 6],
+                        },
+                    ),
+                    hash: 4798852240582462654, // Hash for all 9s
+                },
             }];
 
         // Now write just one block
@@ -3546,8 +3615,10 @@ mod test {
                 eid,
                 offset,
                 data,
-                encryption_context: None,
-                hash,
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash,
+                },
             });
         }
 
@@ -3623,13 +3694,15 @@ mod test {
                 eid,
                 offset,
                 data: data.freeze(),
-                encryption_context: Some(
-                    crucible_protocol::EncryptionContext {
-                        nonce: vec![1, 2, 3],
-                        tag: vec![4, 5, 6],
-                    },
-                ),
-                hash: 4798852240582462654, // Hash for all 9s
+                block_context: BlockContext {
+                    encryption_context: Some(
+                        crucible_protocol::EncryptionContext {
+                            nonce: vec![1, 2, 3],
+                            tag: vec![4, 5, 6],
+                        },
+                    ),
+                    hash: 4798852240582462654, // Hash for all 9s,
+                },
             }];
 
         // Now write just to the second block.
@@ -3656,8 +3729,10 @@ mod test {
                 eid,
                 offset,
                 data,
-                encryption_context: None,
-                hash,
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash,
+                },
             });
         }
 
@@ -3737,13 +3812,15 @@ mod test {
                 eid,
                 offset,
                 data: data.freeze(),
-                encryption_context: Some(
-                    crucible_protocol::EncryptionContext {
-                        nonce: vec![1, 2, 3],
-                        tag: vec![4, 5, 6],
-                    },
-                ),
-                hash: 4798852240582462654, // Hash for all 9s
+                block_context: BlockContext {
+                    encryption_context: Some(
+                        crucible_protocol::EncryptionContext {
+                            nonce: vec![1, 2, 3],
+                            tag: vec![4, 5, 6],
+                        },
+                    ),
+                    hash: 4798852240582462654, // Hash for all 9s
+                },
             }];
 
         // Now write just to the second block.
@@ -3771,8 +3848,10 @@ mod test {
                 eid,
                 offset,
                 data,
-                encryption_context: None,
-                hash,
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash,
+                },
             });
         }
 
@@ -3841,13 +3920,15 @@ mod test {
                     eid,
                     offset,
                     data: data.freeze(),
-                    encryption_context: Some(
-                        crucible_protocol::EncryptionContext {
-                            nonce: vec![1, 2, 3],
-                            tag: vec![4, 5, 6],
-                        },
-                    ),
-                    hash: 4798852240582462654, // Hash for all 9s
+                    block_context: BlockContext {
+                        encryption_context: Some(
+                            crucible_protocol::EncryptionContext {
+                                nonce: vec![1, 2, 3],
+                                tag: vec![4, 5, 6],
+                            },
+                        ),
+                        hash: 4798852240582462654, // Hash for all 9s
+                    },
                 }];
 
             // Now write just one block
@@ -3875,8 +3956,10 @@ mod test {
                 eid,
                 offset,
                 data,
-                encryption_context: None,
-                hash,
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash,
+                },
             });
         }
 
@@ -3931,13 +4014,15 @@ mod test {
                 eid: 0,
                 offset: Block::new_512(0),
                 data: data.freeze(),
-                encryption_context: Some(
-                    crucible_protocol::EncryptionContext {
-                        nonce: vec![1, 2, 3],
-                        tag: vec![4, 5, 6],
-                    },
-                ),
-                hash: 2398419238764,
+                block_context: BlockContext {
+                    encryption_context: Some(
+                        crucible_protocol::EncryptionContext {
+                            nonce: vec![1, 2, 3],
+                            tag: vec![4, 5, 6],
+                        },
+                    ),
+                    hash: 2398419238764,
+                },
             }];
 
         let result = region.region_write(&writes, 0, false);
@@ -3971,7 +4056,7 @@ mod test {
         )?;
 
         assert_eq!(responses.len(), 1);
-        assert_eq!(responses[0].hashes.len(), 0);
+        assert_eq!(responses[0].hashes().len(), 0);
         assert_eq!(responses[0].data[..], [0u8; 512][..]);
 
         Ok(())

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2819,22 +2819,28 @@ impl Downstairs {
         }
     }
 
+    /// Returns:
+    /// - Ok(Some(valid_hash)) where the integrity hash matches
+    /// - Ok(None) where there is no integrity hash in the response and the
+    ///   block is all 0
+    /// - Err otherwise
     fn validate_unencrypted_read_response(
         response: &mut ReadResponse,
         log: &Logger,
     ) -> Result<Option<u64>, CrucibleError> {
         // check integrity hashes - make sure at least one is correct.
-        let mut vh = None;
-        if !response.hashes.is_empty() {
+        let mut valid_hash = None;
+
+        if !response.block_contexts.is_empty() {
             let mut successful_hash = false;
 
             let computed_hash = integrity_hash(&[&response.data[..]]);
 
             // The most recent hash is probably going to be the right one.
-            for hash in response.hashes.iter().rev() {
-                if computed_hash == *hash {
+            for context in response.block_contexts.iter().rev() {
+                if computed_hash == context.hash {
                     successful_hash = true;
-                    vh = Some(*hash);
+                    valid_hash = Some(context.hash);
                     break;
                 }
             }
@@ -2842,8 +2848,8 @@ impl Downstairs {
             if !successful_hash {
                 // No integrity hash was correct for this response
                 error!(log, "No match computed hash:0x{:x}", computed_hash,);
-                for hash in response.hashes.iter().rev() {
-                    error!(log, "No match          hash:0x{:x}", hash);
+                for context in response.block_contexts.iter().rev() {
+                    error!(log, "No match          hash:0x{:x}", context.hash);
                 }
                 error!(log, "Data from hash: {:?}", response.data);
 
@@ -2859,9 +2865,17 @@ impl Downstairs {
             assert!(response.data[..].iter().all(|&x| x == 0));
         }
 
-        Ok(vh)
+        Ok(valid_hash)
     }
 
+    /// Returns:
+    /// - Ok(Some(valid_hash)) for successfully decrypted data
+    /// - Ok(None) if there were no block contexts, or if there were no
+    ///   encryption contexts in any block context, and block was all 0
+    /// - Err otherwise
+    ///
+    /// The return value of this will be stored with the job, and compared
+    /// between each read.
     fn validate_encrypted_read_response(
         response: &mut ReadResponse,
         encryption_context: &Arc<EncryptionContext>,
@@ -2873,107 +2887,121 @@ impl Downstairs {
         // 1) remove encryption context and cause a denial of service, or
         // 2) roll back a block by writing an old data and encryption context
         //
-        // check for response encryption contexts here
-        let mut vh = None;
-        if !response.encryption_contexts.is_empty() {
-            let mut successful_decryption = false;
-            let mut successful_hash = false;
+        // check that this read response contains block contexts that contain
+        // (at least one) encryption context.
 
-            // Attempt decryption with each encryption context, and fail if all
-            // do not work. The most recent encryption context will most likely
-            // be the correct one so start there.
-            let encryption_context_iter =
-                response.encryption_contexts.iter().enumerate().rev();
-
-            // Hashes and encryption contexts are written out at the same time
-            // (in the same transaction) therefore there should be the same
-            // number of them.
-            assert_eq!(
-                response.encryption_contexts.len(),
-                response.hashes.len(),
-            );
-
-            for (i, ctx) in encryption_context_iter {
-                // Validate integrity hash before decryption
-                let computed_hash = integrity_hash(&[
-                    &ctx.nonce[..],
-                    &ctx.tag[..],
-                    &response.data[..],
-                ]);
-
-                if computed_hash == response.hashes[i] {
-                    successful_hash = true;
-                    vh = Some(computed_hash);
-
-                    // Now that the integrity hash was verified, attempt
-                    // decryption.
-                    //
-                    // Note: decrypt_in_place does not overwrite the buffer if
-                    // it fails, otherwise we would need to copy here. There's a
-                    // unit test to validate this behaviour.
-                    let decryption_result = encryption_context
-                        .decrypt_in_place(
-                            &mut response.data[..],
-                            Nonce::from_slice(&ctx.nonce[..]),
-                            Tag::from_slice(&ctx.tag[..]),
-                        );
-
-                    if decryption_result.is_ok() {
-                        successful_decryption = true;
-                        break;
-                    } else {
-                        // Because hashes, nonces, and tags are committed to
-                        // disk every time there is a Crucible write, but data
-                        // is only committed to disk when there's a Crucible
-                        // flush, only one hash + nonce + tag + data combination
-                        // will be correct. Due to the fact that nonces are
-                        // random for each write, even if the Guest wrote the
-                        // same data block 100 times, only one index will be
-                        // valid.
-                        //
-                        // if the computed integrity hash matched but decryption
-                        // failed, bail out here.
-                        break;
-                    }
-                }
-            }
-
-            if !successful_hash {
-                error!(log, "No match for encrypted computed hash");
-                for (i, ctx) in response.encryption_contexts.iter().enumerate()
-                {
-                    let computed_hash = integrity_hash(&[
-                        &ctx.nonce[..],
-                        &ctx.tag[..],
-                        &response.data[..],
-                    ]);
-                    error!(
-                        log,
-                        "Expected: 0x{:x} != Computed: 0x{:x}",
-                        response.hashes[i],
-                        computed_hash
-                    );
-                }
-                // no hash was correct
-                return Err(CrucibleError::HashMismatch);
-            } else if !successful_decryption {
-                // no hash + encryption context combination decrypted this block
-                error!(log, "Decryption failed with correct hash");
-                return Err(CrucibleError::DecryptionError);
-            } else {
-                // Ok!
-            }
-        } else {
-            // No encryption context in the response!
+        if response.block_contexts.is_empty()
+            || response
+                .block_contexts
+                .iter()
+                .all(|ctx| ctx.encryption_context.is_none())
+        {
+            // No block context(s), or no block context contained an encryption
+            // context, in the response!
             //
             // Either this is a read of an unwritten block, or an attacker
             // removed the encryption contexts from the db.
             //
             // XXX if it's not a blank block, we may be under attack?
             assert!(response.data[..].iter().all(|&x| x == 0));
+            return Ok(None);
         }
 
-        Ok(vh)
+        let mut valid_hash = None;
+
+        let mut successful_decryption = false;
+        let mut successful_hash = false;
+
+        // Attempt decryption with each encryption context, and fail if all
+        // do not work. The most recent encryption context will most likely
+        // be the correct one so start there.
+        for ctx in response.block_contexts.iter().rev() {
+            let block_encryption_ctx =
+                if let Some(block_encryption_ctx) = &ctx.encryption_context {
+                    block_encryption_ctx
+                } else {
+                    // this block context is missing an encryption context!
+                    // continue to see if another block context has a valid one.
+                    continue;
+                };
+
+            // Validate integrity hash before decryption
+            let computed_hash = integrity_hash(&[
+                &block_encryption_ctx.nonce[..],
+                &block_encryption_ctx.tag[..],
+                &response.data[..],
+            ]);
+
+            if computed_hash == ctx.hash {
+                successful_hash = true;
+                valid_hash = Some(ctx.hash);
+
+                // Now that the integrity hash was verified, attempt
+                // decryption.
+                //
+                // Note: decrypt_in_place does not overwrite the buffer if
+                // it fails, otherwise we would need to copy here. There's a
+                // unit test to validate this behaviour.
+                let decryption_result = encryption_context.decrypt_in_place(
+                    &mut response.data[..],
+                    Nonce::from_slice(&block_encryption_ctx.nonce[..]),
+                    Tag::from_slice(&block_encryption_ctx.tag[..]),
+                );
+
+                if decryption_result.is_ok() {
+                    successful_decryption = true;
+                    break;
+                } else {
+                    // Because hashes, nonces, and tags are committed to
+                    // disk every time there is a Crucible write, but data
+                    // is only committed to disk when there's a Crucible
+                    // flush, only one hash + nonce + tag + data combination
+                    // will be correct. Due to the fact that nonces are
+                    // random for each write, even if the Guest wrote the
+                    // same data block 100 times, only one index will be
+                    // valid.
+                    //
+                    // if the computed integrity hash matched but decryption
+                    // failed, bail out of loop here.
+                    break;
+                }
+            }
+        }
+
+        if !successful_hash {
+            error!(log, "No match for integrity hash");
+            for ctx in response.block_contexts.iter() {
+                let block_encryption_ctx = if let Some(block_encryption_ctx) =
+                    &ctx.encryption_context
+                {
+                    block_encryption_ctx
+                } else {
+                    error!(log, "missing encryption context!");
+                    continue;
+                };
+
+                let computed_hash = integrity_hash(&[
+                    &block_encryption_ctx.nonce[..],
+                    &block_encryption_ctx.tag[..],
+                    &response.data[..],
+                ]);
+                error!(
+                    log,
+                    "Expected: 0x{:x} != Computed: 0x{:x}",
+                    ctx.hash,
+                    computed_hash
+                );
+            }
+            // no hash was correct
+            Err(CrucibleError::HashMismatch)
+        } else if !successful_decryption {
+            // no hash + encryption context combination decrypted this block
+            error!(log, "Decryption failed with correct hash");
+            Err(CrucibleError::DecryptionError)
+        } else {
+            // Ok!
+            Ok(valid_hash)
+        }
     }
 
     /**
@@ -4421,8 +4449,10 @@ impl Upstairs {
                 eid,
                 offset: bo,
                 data: sub_data,
-                encryption_context,
-                hash,
+                block_context: BlockContext {
+                    hash,
+                    encryption_context,
+                },
             });
 
             cur_offset += byte_len;
@@ -6368,7 +6398,8 @@ impl GtoS {
 
                         for i in &response.data {
                             vec[offset] = *i;
-                            owned_vec[offset] = !response.hashes.is_empty();
+                            owned_vec[offset] =
+                                !response.block_contexts.is_empty();
                             offset += 1;
                         }
                     }

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -1240,8 +1240,10 @@ mod up_test {
                 eid: 0,
                 offset: Block::new_512(7),
                 data: Bytes::from(vec![1]),
-                encryption_context: None,
-                hash: 0,
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash: 0,
+                },
             }],
             is_write_unwritten,
         );
@@ -1592,8 +1594,10 @@ mod up_test {
                 eid: 0,
                 offset: Block::new_512(7),
                 data: Bytes::from(vec![1]),
-                encryption_context: None,
-                hash: 0,
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash: 0,
+                },
             }],
             is_write_unwritten,
         );
@@ -1607,8 +1611,10 @@ mod up_test {
                 eid: 0,
                 offset: Block::new_512(7),
                 data: Bytes::from(vec![1]),
-                encryption_context: None,
-                hash: 0,
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash: 0,
+                },
             }],
             is_write_unwritten,
         );
@@ -1747,8 +1753,10 @@ mod up_test {
                 eid: 0,
                 offset: Block::new_512(7),
                 data: Bytes::from(vec![1]),
-                encryption_context: None,
-                hash: 0,
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash: 0,
+                },
             }],
             is_write_unwritten,
         );
@@ -1877,8 +1885,10 @@ mod up_test {
                 eid: 0,
                 offset: Block::new_512(7),
                 data: Bytes::from(vec![1]),
-                encryption_context: None,
-                hash: 0,
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash: 0,
+                },
             }],
             is_write_unwritten,
         );
@@ -1892,8 +1902,10 @@ mod up_test {
                 eid: 0,
                 offset: Block::new_512(7),
                 data: Bytes::from(vec![1]),
-                encryption_context: None,
-                hash: 0,
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash: 0,
+                },
             }],
             is_write_unwritten,
         );
@@ -2384,8 +2396,10 @@ mod up_test {
                 eid: 0,
                 offset: Block::new_512(7),
                 data: Bytes::from(vec![1]),
-                encryption_context: None,
-                hash: 0,
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash: 0,
+                },
             }],
             is_write_unwritten,
         );
@@ -2456,8 +2470,10 @@ mod up_test {
                 eid: 0,
                 offset: Block::new_512(7),
                 data: Bytes::from(vec![1]),
-                encryption_context: None,
-                hash: 0,
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash: 0,
+                },
             }],
             is_write_unwritten,
         );
@@ -2598,8 +2614,10 @@ mod up_test {
                 eid: 0,
                 offset: Block::new_512(7),
                 data: Bytes::from(vec![1]),
-                encryption_context: None,
-                hash: 0,
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash: 0,
+                },
             }],
             is_write_unwritten,
         );
@@ -2779,8 +2797,10 @@ mod up_test {
                 eid: 0,
                 offset: Block::new_512(7),
                 data: Bytes::from(vec![1]),
-                encryption_context: None,
-                hash: 0,
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash: 0,
+                },
             }],
             is_write_unwritten,
         );
@@ -3707,11 +3727,12 @@ mod up_test {
             offset: request.offset,
 
             data: BytesMut::from(&data[..]),
-            encryption_contexts: vec![crucible_protocol::EncryptionContext {
-                nonce,
-                tag,
+            block_contexts: vec![BlockContext {
+                encryption_context: Some(
+                    crucible_protocol::EncryptionContext { nonce, tag },
+                ),
+                hash,
             }],
-            hashes: vec![hash],
         }]);
 
         let result =
@@ -3756,10 +3777,10 @@ mod up_test {
             offset: request.offset,
 
             data: BytesMut::from(&data[..]),
-            encryption_contexts: vec![],
-            hashes: vec![
-                10000, // junk hash
-            ],
+            block_contexts: vec![BlockContext {
+                encryption_context: None,
+                hash: 10000, // junk hash,
+            }],
         }]);
 
         let result =
@@ -3816,13 +3837,12 @@ mod up_test {
             offset: request.offset,
 
             data: BytesMut::from(&data[..]),
-            encryption_contexts: vec![crucible_protocol::EncryptionContext {
-                nonce,
-                tag,
+            block_contexts: vec![BlockContext {
+                encryption_context: Some(
+                    crucible_protocol::EncryptionContext { nonce, tag },
+                ),
+                hash: 10000, // junk hash,
             }],
-            hashes: vec![
-                10000, // junk hash
-            ],
         }]);
 
         let result =
@@ -4261,8 +4281,10 @@ mod up_test {
                     eid: 0,
                     offset: Block::new_512(7),
                     data: Bytes::from(vec![1]),
-                    encryption_context: None,
-                    hash: 0,
+                    block_context: BlockContext {
+                        encryption_context: None,
+                        hash: 0,
+                    },
                 }],
                 false,
             );
@@ -4345,8 +4367,10 @@ mod up_test {
                     eid: 0,
                     offset: Block::new_512(7),
                     data: Bytes::from(vec![1]),
-                    encryption_context: None,
-                    hash: 0,
+                    block_context: BlockContext {
+                        encryption_context: None,
+                        hash: 0,
+                    },
                 }],
                 false,
             );
@@ -4495,8 +4519,10 @@ mod up_test {
                     eid: 0,
                     offset: Block::new_512(7),
                     data: Bytes::from(vec![1]),
-                    encryption_context: None,
-                    hash: 0,
+                    block_context: BlockContext {
+                        encryption_context: None,
+                        hash: 0,
+                    },
                 }],
                 false,
             );
@@ -4603,8 +4629,10 @@ mod up_test {
                     eid: 0,
                     offset: Block::new_512(7),
                     data: Bytes::from(vec![1]),
-                    encryption_context: None,
-                    hash: 0,
+                    block_context: BlockContext {
+                        encryption_context: None,
+                        hash: 0,
+                    },
                 }],
                 false,
             );
@@ -4663,8 +4691,10 @@ mod up_test {
                     eid: 0,
                     offset: Block::new_512(7),
                     data: Bytes::from(vec![1]),
-                    encryption_context: None,
-                    hash: 0,
+                    block_context: BlockContext {
+                        encryption_context: None,
+                        hash: 0,
+                    },
                 }],
                 false,
             );


### PR DESCRIPTION
Previous to this commit, `truncate_encryption_contexts_and_hashes` was removing all but the last entered encryption context and hash rows for any given block, and this is incorrect - **any** of the encryption context and hash rows could be valid in the presense of a crash. The only guarantee that the OS gives us is that after a flush, the last write to an extent will be on the physical disk, but any of the extent writes could be on the disk between flushes.

This commit adds an on-disk hash to a block's context that the Downstairs uses to remove rows that do not match what is on disk after a flush. It also combines the encryption context and hash tables into one called block_context, and similarly combines the encryption context and hash that are fields in ReadResponse and Write into a BlockContext.

I originally thought this commit would degrade performance, but using crudd to write and then read 1GiB shows an average write bandwidth of 56.5MiB/s and an average read bandwidth of 68.6MiB/s! I'm sure that there is more potential for improvement, namely in how truncate_encryption_contexts_and_hashes is called.