### PR TITLE
Remove Guest's idea of active and locking in len()

### DIFF
--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -213,11 +213,7 @@ async fn cli_read(
     let vec: Vec<u8> = vec![255; length];
     let data = crucible::Buffer::from_vec(vec);
 
-    println!(
-        "Read  at block {:5}, len:{:7}",
-        offset.value,
-        data.len().await
-    );
+    println!("Read  at block {:5}, len:{:7}", offset.value, data.len());
     guest.read(offset, data.clone()).await?;
 
     let mut dl = data.as_vec().await.to_vec();

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -1250,7 +1250,7 @@ async fn generic_workload(
                     c,
                     count,
                     offset.value,
-                    data.len().await,
+                    data.len(),
                     width = count_width,
                 );
                 guest.read(offset, data.clone()).await?;
@@ -1684,11 +1684,7 @@ async fn one_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
     let vec: Vec<u8> = vec![255; length];
     let data = crucible::Buffer::from_vec(vec);
 
-    println!(
-        "Read  at block {:5}, len:{:7}",
-        offset.value,
-        data.len().await
-    );
+    println!("Read  at block {:5}, len:{:7}", offset.value, data.len());
     guest.read(offset, data.clone()).await?;
 
     let dl = data.as_vec().await.to_vec();
@@ -2014,7 +2010,7 @@ async fn repair_workload(
                     c,
                     count,
                     offset.value,
-                    data.len().await,
+                    data.len(),
                     width = count_width,
                     bw = block_width,
                     sw = size_width,
@@ -2322,7 +2318,7 @@ async fn dep_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
                     my_count,
                     ioc,
                     my_offset,
-                    data.len().await
+                    data.len()
                 );
                 let future = guest.read_from_byte_offset(my_offset, data);
                 futureslist.push(future);

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -6961,6 +6961,8 @@ impl BlockIO for Guest {
     }
 
     async fn show_work(&self) -> Result<WQCounts, CrucibleError> {
+        // Note: for this implementation, BlockOp::ShowWork will be sent and
+        // processed by the Upstairs even if it isn't active.
         let wc = WQCounts {
             up_count: 0,
             ds_count: 0,
@@ -7295,6 +7297,7 @@ async fn process_new_io(
             req.send_ok().await;
         }
         BlockOp::QueryWorkQueue { data } => {
+            // TODO should this first check if the Upstairs is active?
             *data.lock().await = WQCounts {
                 up_count: up.guest.guest_work.lock().await.active.len(),
                 ds_count: up.downstairs.lock().await.active.len(),
@@ -7302,6 +7305,7 @@ async fn process_new_io(
             req.send_ok().await;
         }
         BlockOp::ShowWork { data } => {
+            // TODO should this first check if the Upstairs is active?
             *data.lock().await = show_all_work(up).await;
             req.send_ok().await;
         }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -6090,7 +6090,7 @@ impl Buffer {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.len == 0
     }
 
     pub async fn as_vec(&self) -> MutexGuard<'_, Vec<u8>> {

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -3841,7 +3841,6 @@ mod up_test {
     #[tokio::test]
     async fn test_no_iop_limit() -> Result<()> {
         let guest = Guest::new();
-        guest.set_active().await;
 
         assert!(guest.consume_req().await.is_none());
 
@@ -3882,7 +3881,6 @@ mod up_test {
     #[tokio::test]
     async fn test_set_iop_limit() -> Result<()> {
         let mut guest = Guest::new();
-        guest.set_active().await;
         guest.set_iop_limit(16000, 2);
 
         assert!(guest.consume_req().await.is_none());
@@ -3938,7 +3936,6 @@ mod up_test {
     #[tokio::test]
     async fn test_flush_does_not_consume_iops() -> Result<()> {
         let mut guest = Guest::new();
-        guest.set_active().await;
 
         // Set 0 as IOP limit
         guest.set_iop_limit(16000, 0);
@@ -3972,7 +3969,6 @@ mod up_test {
     #[tokio::test]
     async fn test_set_bw_limit() -> Result<()> {
         let mut guest = Guest::new();
-        guest.set_active().await;
         guest.set_bw_limit(1024 * 1024); // 1 KiB
 
         assert!(guest.consume_req().await.is_none());
@@ -4028,7 +4024,6 @@ mod up_test {
     #[tokio::test]
     async fn test_flush_does_not_consume_bw() -> Result<()> {
         let mut guest = Guest::new();
-        guest.set_active().await;
 
         // Set 0 as bandwidth limit
         guest.set_bw_limit(0);
@@ -4062,7 +4057,6 @@ mod up_test {
     #[tokio::test]
     async fn test_iop_and_bw_limit() -> Result<()> {
         let mut guest = Guest::new();
-        guest.set_active().await;
 
         guest.set_iop_limit(16384, 500); // 1 IOP is 16 KiB
         guest.set_bw_limit(6400 * 1024); // 16384 B * 400 = 6400 KiB/s
@@ -4176,7 +4170,6 @@ mod up_test {
     #[tokio::test]
     async fn test_impossible_io() -> Result<()> {
         let mut guest = Guest::new();
-        guest.set_active().await;
 
         guest.set_iop_limit(1024 * 1024 / 2, 10); // 1 IOP is half a KiB
         guest.set_bw_limit(1024 * 1024); // 1 KiB

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -533,7 +533,7 @@ impl BlockIO for Volume {
 
         let affected_sub_volumes = self.sub_volumes_for_lba_range(
             offset.value,
-            data.len().await as u64 / self.block_size,
+            data.len() as u64 / self.block_size,
         );
 
         // TODO parallel dispatch!
@@ -655,7 +655,7 @@ impl BlockIO for Volume {
             data_index += sz;
         }
 
-        assert_eq!(data.len().await, data_index);
+        assert_eq!(data.len(), data_index);
 
         cdt::volume__read__done!(|| (cc, self.uuid));
         Ok(())


### PR DESCRIPTION
Guest previously had its own idea of active, and this is slightly confusing. This commit removes that, and instead lets the Upstairs tell consumers if it is active or not.

Additionally, getting the length of a Buffer shouldn't take a lock. Make `len()` and `is_empty()` synchronous by storing the length (it shouldn't change!).

Closes https://github.com/oxidecomputer/crucible/issues/461