### PR TITLE
Add validation and flush tests

### DIFF
--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -3243,8 +3243,14 @@ mod test {
     #[test]
     fn test_flush_removes_partial_writes() -> Result<()> {
         // Validate that incorrect context rows are removed by a flush so that a
-        // repair will get rid of partial writes' block context rows (this is
-        // necessary for write_unwritten to work after a crash).
+        // repair will get rid of partial writes' block context rows. This is
+        // necessary for write_unwritten to work after a crash.
+        //
+        // Specifically, this test checks for the case where we had a brand new
+        // block and a write to that blocks that failed such that only the
+        // write's block context was persisted, leaving the data all zeros. In
+        // this case, there is no data, so we should remove the invalid block
+        // context row.
 
         let dir = tempdir()?;
         let mut region = Region::create(&dir, new_region_options())?;

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -238,6 +238,8 @@ impl Inner {
         &mut self,
         block_contexts: &[&DownstairsBlockContext],
     ) -> Result<()> {
+        self.set_dirty()?;
+
         let tx = self.metadb.transaction()?;
 
         for block_context in block_contexts {
@@ -3234,6 +3236,75 @@ mod test {
         }
 
         assert_eq!(buffer, read_from_region);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_flush_removes_partial_writes() -> Result<()> {
+        // Validate that incorrect context rows are removed by a flush so that a
+        // repair will get rid of partial writes' block context rows (this is
+        // necessary for write_unwritten to work after a crash).
+
+        let dir = tempdir()?;
+        let mut region = Region::create(&dir, new_region_options())?;
+        region.extend(1)?;
+
+        // A write of some sort only wrote a block context row
+
+        {
+            let ext = &region.extents[0];
+            let mut inner = ext.inner();
+            inner.set_block_contexts(&[&DownstairsBlockContext {
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash: 1024,
+                },
+                block: 0,
+                on_disk_hash: 65536,
+            }])?;
+        }
+
+        region.region_flush(1, 1, &None, 123)?;
+
+        // Verify no block context rows exist
+
+        {
+            let ext = &region.extents[0];
+            let inner = ext.inner();
+            assert!(inner.get_block_contexts(0, 1)?[0].is_empty());
+        }
+
+        // Assert write unwritten will write to the first block
+
+        let data = Bytes::from(vec![0x55; 512]);
+        let hash = integrity_hash(&[&data[..]]);
+
+        region.region_write(
+            &[crucible_protocol::Write {
+                eid: 0,
+                offset: Block::new_512(0),
+                data,
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash,
+                },
+            }],
+            124,
+            true, // only_write_unwritten
+        )?;
+
+        let responses = region.region_read(
+            &[crucible_protocol::ReadRequest {
+                eid: 0,
+                offset: Block::new_512(0),
+            }],
+            125,
+        )?;
+
+        let response = &responses[0];
+
+        assert_eq!(response.data.to_vec(), vec![0x55; 512]);
 
         Ok(())
     }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2834,8 +2834,8 @@ impl Downstairs {
         // 1) remove block context rows and cause a denial of service, or
         // 2) roll back a block by writing an old data and block context
 
-        // In the encrypted case, blocks that have not yet been written to will
-        // have no block context rows in the database.
+        // In the unencrypted case, blocks that have not yet been written to
+        // will have no block context rows in the database.
 
         if response.block_contexts.is_empty()
             && response.data[..].iter().all(|&x| x == 0)

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -448,6 +448,401 @@ mod up_test {
         Ok(())
     }
 
+    // Validate that an encrypted read response with one context can be
+    // decrypted
+    #[test]
+    pub fn test_upstairs_validate_encrypted_read_response() -> Result<()> {
+        // Set up the encryption context
+        use rand::{thread_rng, Rng};
+        let mut key = vec![0u8; 32];
+        thread_rng().fill(&mut key[..]);
+        let context = EncryptionContext::new(key.clone(), 512);
+
+        // Encrypt some random data
+        let mut data = BytesMut::with_capacity(512);
+        data.resize(512, 0u8);
+        thread_rng().fill(&mut data[..]);
+
+        let original_data = data.clone();
+
+        let (nonce, tag, _) = context.encrypt_in_place(&mut data[..])?;
+
+        assert_ne!(original_data, data);
+
+        let read_response_hash = integrity_hash(&[&nonce, &tag, &data[..]]);
+
+        // Create the read response
+        let mut read_response = ReadResponse {
+            eid: 0,
+            offset: Block::new_512(0),
+            data,
+            block_contexts: vec![BlockContext {
+                hash: read_response_hash,
+                encryption_context: Some(
+                    crucible_protocol::EncryptionContext {
+                        nonce: nonce.to_vec(),
+                        tag: tag.to_vec(),
+                    },
+                ),
+            }],
+        };
+
+        // Validate it
+        let successful_hash = Downstairs::validate_encrypted_read_response(
+            &mut read_response,
+            &Arc::new(context),
+            &csl(),
+        )?;
+
+        assert_eq!(successful_hash, Some(read_response_hash));
+
+        // `Downstairs::validate_encrypted_read_response` will mutate the read
+        // response's data value, make sure it decrypted
+
+        assert_eq!(original_data, read_response.data);
+
+        Ok(())
+    }
+
+    // Validate that an encrypted read response with multiple contexts can be
+    // decrypted (skipping ones that don't match)
+    #[test]
+    pub fn test_upstairs_validate_encrypted_read_response_multiple_contexts(
+    ) -> Result<()> {
+        // Set up the encryption context
+        use rand::{thread_rng, Rng};
+        let mut key = vec![0u8; 32];
+        thread_rng().fill(&mut key[..]);
+        let context = EncryptionContext::new(key.clone(), 512);
+
+        // Encrypt some random data
+        let mut data = BytesMut::with_capacity(512);
+        data.resize(512, 0u8);
+        thread_rng().fill(&mut data[..]);
+
+        let original_data = data.clone();
+
+        let (nonce, tag, _) = context.encrypt_in_place(&mut data[..])?;
+
+        assert_ne!(original_data, data);
+
+        let read_response_hash = integrity_hash(&[&nonce, &tag, &data[..]]);
+
+        // Create the read response
+        let mut read_response = ReadResponse {
+            eid: 0,
+            offset: Block::new_512(0),
+            data,
+            block_contexts: vec![
+                // The first context here doesn't match
+                BlockContext {
+                    hash: thread_rng().gen(),
+                    encryption_context: Some(
+                        crucible_protocol::EncryptionContext {
+                            nonce: thread_rng().gen::<[u8; 12]>().to_vec(),
+                            tag: thread_rng().gen::<[u8; 16]>().to_vec(),
+                        },
+                    ),
+                },
+                // This context matches
+                BlockContext {
+                    hash: read_response_hash,
+                    encryption_context: Some(
+                        crucible_protocol::EncryptionContext {
+                            nonce: nonce.to_vec(),
+                            tag: tag.to_vec(),
+                        },
+                    ),
+                },
+                // The last context does not
+                BlockContext {
+                    hash: thread_rng().gen(),
+                    encryption_context: Some(
+                        crucible_protocol::EncryptionContext {
+                            nonce: thread_rng().gen::<[u8; 12]>().to_vec(),
+                            tag: thread_rng().gen::<[u8; 16]>().to_vec(),
+                        },
+                    ),
+                },
+            ],
+        };
+
+        // Validate it
+        let successful_hash = Downstairs::validate_encrypted_read_response(
+            &mut read_response,
+            &Arc::new(context),
+            &csl(),
+        )?;
+
+        assert_eq!(successful_hash, Some(read_response_hash));
+
+        // `Downstairs::validate_encrypted_read_response` will mutate the read
+        // response's data value, make sure it decrypted
+
+        assert_eq!(original_data, read_response.data);
+
+        Ok(())
+    }
+
+    // TODO if such a set of nonces and tags can be found:
+    //
+    //   let hash1 = integrity_hash(
+    //      &[&ctx1.nonce[..], &ctx1.tag[..], &response.data[..]]
+    //   );
+    //   let hash2 = integrity_hash(
+    //      &[&ctx2.nonce[..], &ctx2.tag[..], &response.data[..]]
+    //   );
+    //
+    //   hash1 == hash2
+    //
+    // then write a test which validates that an encrypted read response with
+    // multiple contexts that match the integrity hash (where only one is
+    // correct) can be decrypted.
+
+    // Validate that reading a blank block works
+    #[test]
+    pub fn test_upstairs_validate_encrypted_read_response_blank_block(
+    ) -> Result<()> {
+        // Set up the encryption context
+        use rand::{thread_rng, Rng};
+        let mut key = vec![0u8; 32];
+        thread_rng().fill(&mut key[..]);
+        let context = EncryptionContext::new(key.clone(), 512);
+
+        let mut data = BytesMut::with_capacity(512);
+        data.resize(512, 0u8);
+
+        // Create the read response
+        let mut read_response = ReadResponse {
+            eid: 0,
+            offset: Block::new_512(0),
+            data: data.clone(),
+            block_contexts: vec![],
+        };
+
+        // Validate it
+        let successful_hash = Downstairs::validate_encrypted_read_response(
+            &mut read_response,
+            &Arc::new(context),
+            &csl(),
+        )?;
+
+        // The above function will return None for a blank block
+        assert_eq!(successful_hash, None);
+        assert_eq!(data, vec![0u8; 512]);
+
+        Ok(())
+    }
+
+    // Validate that reading a blank block works, even if there are more than
+    // one block contexts (this can occur if there was a crash before the data
+    // was flushed to disk)
+    #[test]
+    pub fn test_upstairs_validate_encrypted_read_response_blank_block_before_flush(
+    ) -> Result<()> {
+        // Set up the encryption context
+        use rand::{thread_rng, Rng};
+        let mut key = vec![0u8; 32];
+        thread_rng().fill(&mut key[..]);
+        let context = EncryptionContext::new(key.clone(), 512);
+
+        let mut data = BytesMut::with_capacity(512);
+        data.resize(512, 0u8);
+
+        // Create the read response
+        let mut read_response = ReadResponse {
+            eid: 0,
+            offset: Block::new_512(0),
+            data: data.clone(),
+            block_contexts: vec![
+                // This BlockContext would be from a write
+                BlockContext {
+                    hash: thread_rng().gen(),
+                    encryption_context: Some(
+                        crucible_protocol::EncryptionContext {
+                            nonce: thread_rng().gen::<[u8; 12]>().to_vec(),
+                            tag: thread_rng().gen::<[u8; 16]>().to_vec(),
+                        },
+                    ),
+                },
+            ],
+        };
+
+        // Validate it
+        let successful_hash = Downstairs::validate_encrypted_read_response(
+            &mut read_response,
+            &Arc::new(context),
+            &csl(),
+        )?;
+
+        // The above function will return None for a blank block
+        assert_eq!(successful_hash, None);
+        assert_eq!(data, vec![0u8; 512]);
+
+        Ok(())
+    }
+
+    #[test]
+    pub fn test_upstairs_validate_unencrypted_read_response() -> Result<()> {
+        use rand::{thread_rng, Rng};
+
+        let mut data = BytesMut::with_capacity(512);
+        data.resize(512, 0u8);
+        thread_rng().fill(&mut data[..]);
+
+        let read_response_hash = integrity_hash(&[&data[..]]);
+        let original_data = data.clone();
+
+        // Create the read response
+        let mut read_response = ReadResponse {
+            eid: 0,
+            offset: Block::new_512(0),
+            data,
+            block_contexts: vec![BlockContext {
+                hash: read_response_hash,
+                encryption_context: None,
+            }],
+        };
+
+        // Validate it
+        let successful_hash = Downstairs::validate_unencrypted_read_response(
+            &mut read_response,
+            &csl(),
+        )?;
+
+        assert_eq!(successful_hash, Some(read_response_hash));
+        assert_eq!(read_response.data, original_data);
+
+        Ok(())
+    }
+
+    #[test]
+    pub fn test_upstairs_validate_unencrypted_read_response_blank_block(
+    ) -> Result<()> {
+        let mut data = BytesMut::with_capacity(512);
+        data.resize(512, 0u8);
+
+        let original_data = data.clone();
+
+        // Create the read response
+        let mut read_response = ReadResponse {
+            eid: 0,
+            offset: Block::new_512(0),
+            data,
+            block_contexts: vec![],
+        };
+
+        // Validate it
+        let successful_hash = Downstairs::validate_unencrypted_read_response(
+            &mut read_response,
+            &csl(),
+        )?;
+
+        assert_eq!(successful_hash, None);
+        assert_eq!(read_response.data, original_data);
+
+        Ok(())
+    }
+
+    #[test]
+    pub fn test_upstairs_validate_unencrypted_read_response_multiple_contexts(
+    ) -> Result<()> {
+        use rand::{thread_rng, Rng};
+
+        let mut data = BytesMut::with_capacity(512);
+        data.resize(512, 0u8);
+        thread_rng().fill(&mut data[..]);
+
+        let read_response_hash = integrity_hash(&[&data[..]]);
+        let original_data = data.clone();
+
+        // Create the read response
+        let mut read_response = ReadResponse {
+            eid: 0,
+            offset: Block::new_512(0),
+            data,
+            block_contexts: vec![
+                // The context here doesn't match
+                BlockContext {
+                    hash: thread_rng().gen(),
+                    encryption_context: None,
+                },
+                // The context here doesn't match
+                BlockContext {
+                    hash: thread_rng().gen(),
+                    encryption_context: None,
+                },
+                // Correct one
+                BlockContext {
+                    hash: read_response_hash,
+                    encryption_context: None,
+                },
+                // The context here doesn't match
+                BlockContext {
+                    hash: thread_rng().gen(),
+                    encryption_context: None,
+                },
+            ],
+        };
+
+        // Validate it
+        let successful_hash = Downstairs::validate_unencrypted_read_response(
+            &mut read_response,
+            &csl(),
+        )?;
+
+        assert_eq!(successful_hash, Some(read_response_hash));
+        assert_eq!(read_response.data, original_data);
+
+        Ok(())
+    }
+
+    // Validate that an unencrypted read response with multiple contexts that
+    // match the integrity hash works. This can happen if the Upstairs
+    // repeatedly writes the same block data.
+    #[test]
+    pub fn test_upstairs_validate_unencrypted_read_response_multiple_hashes(
+    ) -> Result<()> {
+        use rand::{thread_rng, Rng};
+
+        let mut data = BytesMut::with_capacity(512);
+        data.resize(512, 0u8);
+        thread_rng().fill(&mut data[..]);
+
+        let read_response_hash = integrity_hash(&[&data[..]]);
+        let original_data = data.clone();
+
+        // Create the read response
+        let mut read_response = ReadResponse {
+            eid: 0,
+            offset: Block::new_512(0),
+            data,
+            block_contexts: vec![
+                // Correct one
+                BlockContext {
+                    hash: read_response_hash,
+                    encryption_context: None,
+                },
+                // Correct one
+                BlockContext {
+                    hash: read_response_hash,
+                    encryption_context: None,
+                },
+            ],
+        };
+
+        // Validate it
+        let successful_hash = Downstairs::validate_unencrypted_read_response(
+            &mut read_response,
+            &csl(),
+        )?;
+
+        assert_eq!(successful_hash, Some(read_response_hash));
+        assert_eq!(read_response.data, original_data);
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn work_flush_three_ok() {
         let upstairs = Upstairs::default();

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -745,6 +745,41 @@ mod up_test {
     }
 
     #[test]
+    pub fn test_upstairs_validate_unencrypted_read_response_blank_block_before_flush(
+    ) -> Result<()> {
+        use rand::{thread_rng, Rng};
+
+        let mut data = BytesMut::with_capacity(512);
+        data.resize(512, 0u8);
+
+        // Create the read response
+        let mut read_response = ReadResponse {
+            eid: 0,
+            offset: Block::new_512(0),
+            data: data.clone(),
+            block_contexts: vec![
+                // This BlockContext would be from a write
+                BlockContext {
+                    hash: thread_rng().gen(),
+                    encryption_context: None,
+                },
+            ],
+        };
+
+        // Validate it
+        let successful_hash = Downstairs::validate_unencrypted_read_response(
+            &mut read_response,
+            &csl(),
+        )?;
+
+        // The above function will return None for a blank block
+        assert_eq!(successful_hash, None);
+        assert_eq!(data, vec![0u8; 512]);
+
+        Ok(())
+    }
+
+    #[test]
     pub fn test_upstairs_validate_unencrypted_read_response_multiple_contexts(
     ) -> Result<()> {
         use rand::{thread_rng, Rng};


### PR DESCRIPTION
This commit introduces a bunch of tests for validating unencrypted and encrypted read responses ~~, and in writing those tests uncovered an issue: if a write to a blank block (where there were previously no block contexts) is not flushed, then an Upstairs with encryption will reject the block. This is fixed by detecting this case, and returning Ok(None).~~