### PR TITLE
Add encrypted option to dsc

### DIFF
--- a/tools/test_dsc.sh
+++ b/tools/test_dsc.sh
@@ -114,11 +114,13 @@ rm -rf ${testdir} ${r1} ${r2} ${r3}
 
 echo "$dsc" create --ds-bin "$downstairs" --extent-count 5 \
     --extent-size 5 --output-dir "$testdir" \
-    --region-dir "$testdir" | tee "$outfile"
+    --region-dir "$testdir" \
+    --encrypted | tee "$outfile"
 
 ${dsc} create --ds-bin "$downstairs" --extent-count 5 \
     --extent-size 5 --output-dir "$testdir" \
-    --region-dir "$testdir" | tee -a "$outfile"
+    --region-dir "$testdir" \
+    --encrypted | tee -a "$outfile"
 
 echo "Running dsc:"
 echo "${dsc}" start --ds-bin "$downstairs" \

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -67,9 +67,9 @@ case ${1} in
     "unencrypted")
         ;;
     "encrypted")
-        ssl_key=$(openssl rand -base64 32)
-        echo "Upstairs using SSL key: $ssl_key"
-        args+=( --key "$ssl_key" )
+        upstairs_key=$(openssl rand -base64 32)
+        echo "Upstairs using key: $upstairs_key"
+        args+=( --key "$upstairs_key" )
         dsc_args+=( --encrypted )
         ;;
     *)

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -36,6 +36,14 @@ for bin in $cds $ct $ch $dsc; do
     fi
 done
 
+# Control-C to cleanup.
+trap ctrl_c INT
+function ctrl_c() {
+	echo "Stopping at your request"
+    ${dsc} cmd shutdown
+    exit 1
+}
+
 # Downstairs regions go in this directory
 testdir="/var/tmp/test_up"
 if [[ -d ${testdir} ]]; then
@@ -79,6 +87,7 @@ dsc_output="${test_output_dir}/dsc-out.txt"
 dsc_args+=( --cleanup --create )
 dsc_args+=( --extent-size 10 --extent-count 5 )
 dsc_args+=( --output-dir "$dsc_output_dir" )
+dsc_args+=( --ds-bin "$cds" )
 
 # Note, this should match the default for DSC
 port_base=8810

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -98,6 +98,15 @@ dsc_pid=$!
 sleep 2
 if ! pgrep -P $dsc_pid > /dev/null; then
     echo "Gosh diddly darn it, dsc at $dsc_pid did not start"
+    echo downstairs:
+    ps -ef | grep downstairs
+    echo dsc:
+    ps -ef | grep dsc
+    echo files:
+    ls -l /tmp/test_up
+    ls -l /tmp/test_up/dsc
+    echo cat:
+    cat /tmp/test_up/dsc-out.txt
     exit 1
 fi
 


### PR DESCRIPTION
This adds an `--encrypted` option to the start/create paths of `dsc`.

Updated the `tools/test_up.sh` script to use `dsc` instead of hand crafted downstairs and bash process management.