### PR TITLE
dsc no auto restart

### DIFF
--- a/openapi/dsc-control.json
+++ b/openapi/dsc-control.json
@@ -423,7 +423,8 @@
           "Starting",
           "Running",
           "Exit",
-          "Error"
+          "Error",
+          "Failed"
         ]
       },
       "Error": {

--- a/tools/test_perf.sh
+++ b/tools/test_perf.sh
@@ -37,6 +37,10 @@ function perf_round() {
         echo "Failed to start dsc"
         exit 1
     fi
+    if ! "$dsc" cmd disable-restart-all; then
+        echo "Failed to disable auto-restart on dsc"
+        exit 1
+    fi
     echo "IOPs for es=$es ec=$ec" >> "$outfile"
     echo "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
     "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"

--- a/tools/test_reconnect.sh
+++ b/tools/test_reconnect.sh
@@ -54,8 +54,17 @@ if ! "$crucible_test" fill "${args[@]}" -q \
     ${dsc} cmd shutdown
 fi
 
+# Tell dsc to restart downstairs.
+if ! "$dsc" cmd enable-restart-all; then
+    echo "Failed to enable auto-restart on dsc"
+    exit 1
+fi
+
 # Allow the downstairs to start restarting now.
-${dsc} cmd enable-random-stop
+if ! ${dsc} cmd enable-random-stop; then
+    echo "Failed to enable random-stop on dsc"
+    exit 1
+fi
 sleep 5
 
 # Now run the quick crucible client test in a loop

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -119,6 +119,13 @@ if ! pgrep -P $dsc_pid > /dev/null; then
     exit 1
 fi
 
+# We don't want auto-restart of downstairs, so be sure that is not enabled.
+echo "Disable automatic restart on all downstairs"
+if ! "${dsc}" cmd disable-restart-all; then
+    echo "Failed to disable auto restart"
+    exit 1
+fi
+
 echo ""
 echo "Begin tests, output goes to ${log_prefix}_out.txt"
 res=0


### PR DESCRIPTION
**Updates to the `dsc` test program**

Update dsc to not restart exiting downstairs by default. 
This could have hid some test issues where a downstairs would restart and the test would continue (thanks to replay) and never actually know that things had restarted.  

Update dsc to know the difference between a downstairs that exited after being killed by dsc, and a downstairs that exited because it panicked.  When a downstairs panics, the auto-restarter will not restart it. We now have a new downstairs state in `dsc` to reflect this.

Updated the dsc test script

Updated test_perf.sh and test_up.sh to be explicit to disable auto downstairs restart. If a downstairs fails, these test should also fail.

Updated test_reconnect.sh to specifically turn on auto restart as it is no longer the default.