### PR TITLE
Some minor updates while plumbing the scrubber in Propolis.

### DIFF
--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1830,6 +1830,7 @@ impl Region {
         // snapshots currently only work with ZFS
         if cfg!(feature = "zfs_snapshot") {
             if let Some(snapshot_details) = snapshot_details {
+                info!(self.log, "Flush and snap request received");
                 // Check if the path exists, return an error if it does
                 let test_path = format!(
                     "{}/.zfs/snapshot/{}",
@@ -1885,8 +1886,9 @@ impl Region {
                     );
                 }
             }
+        } else if snapshot_details.is_some() {
+            error!(self.log, "Snapshot request received on unsupported binary");
         }
-
         Ok(())
     }
 }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -1147,7 +1147,7 @@ mod test {
 
         // Call the scrubber.  This should replace all data from the
         // RO parent into the main volume.
-        volume.scrub(&csl()).await.unwrap();
+        volume.scrub(&csl(), None, None).await.unwrap();
 
         // Now, try a write_unwritten, this should not change our
         // data as the scrubber has finished.
@@ -1227,7 +1227,7 @@ mod test {
 
         // Call the scrubber.  This should replace all data from the
         // RO parent into the main volume.
-        volume.scrub(&csl()).await.unwrap();
+        volume.scrub(&csl(), None, None).await.unwrap();
 
         // Now, try a write_unwritten, this should not change our
         // unwritten data as the scrubber has finished.
@@ -1321,7 +1321,7 @@ mod test {
         // Call the scrubber.  This should replace all data from the
         // RO parent into the main volume except where new writes have
         // landed
-        volume.scrub(&csl()).await.unwrap();
+        volume.scrub(&csl(), None, None).await.unwrap();
 
         // Read and verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -1403,7 +1403,7 @@ mod test {
             .await?;
 
         // Call the scrubber.  This should do nothing
-        volume.scrub(&csl()).await.unwrap();
+        volume.scrub(&csl(), None, None).await.unwrap();
 
         // Read and verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -1514,7 +1514,7 @@ mod test {
             .await?;
 
         // Call the scrubber
-        volume.scrub(&csl()).await.unwrap();
+        volume.scrub(&csl(), None, None).await.unwrap();
 
         // Read full volume
         let buffer = Buffer::new(BLOCK_SIZE * 20);
@@ -1646,7 +1646,7 @@ mod test {
             .await?;
 
         // Call the scrubber
-        volume.scrub(&csl()).await.unwrap();
+        volume.scrub(&csl(), None, None).await.unwrap();
 
         // Read full volume
         let buffer = Buffer::new(BLOCK_SIZE * 20);
@@ -1776,7 +1776,7 @@ mod test {
             .await?;
 
         // Call the scrubber.  This should do nothing
-        volume.scrub(&csl()).await.unwrap();
+        volume.scrub(&csl(), None, None).await.unwrap();
 
         // Read and verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);

--- a/pantry/src/pantry.rs
+++ b/pantry/src/pantry.rs
@@ -176,7 +176,7 @@ impl PantryEntry {
     }
 
     pub async fn scrub(&self, log: &Logger) -> Result<()> {
-        self.volume.scrub(log).await?;
+        self.volume.scrub(log, None, None).await?;
         Ok(())
     }
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -4257,6 +4257,9 @@ impl Upstairs {
         let next_flush = self.next_flush_id().await;
         cdt::gw__flush__start!(|| (gw_id));
 
+        if snapshot_details.is_some() {
+            info!(self.log, "flush with snap requested");
+        }
         /*
          * To build the dependency list for this flush, iterate from the end
          * of the downstairs work active list in reverse order and

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -302,7 +302,7 @@ impl Volume {
             // 256 KiB IOs during the scrub. Here we select how many blocks
             // this is.
             // TODO: Determine if this value should be adjusted.
-            let mut block_count = 262144 / bs;
+            let mut block_count = 131072 / bs;
             info!(
                 log,
                 "Scrubs from block {:?} to {:?} in ({}) {:?} size IOs pm:{}",


### PR DESCRIPTION
Added a method on the volume object Propolis can use to determine if a scrub is needed.

The scrubber now takes two additional options.
1. A number of seconds to delay before starting.
2. A intern scrub "pause" after ever operation.

These will help us tune the scrubber as well as let the scrubber behave differently when it's attached to propolis vs. when it's attached to the pantry.

Count needs to be an Arc so the scrubber can clone it in Propolis.

Added a log message or two when a snapshot is taken.