### PR TITLE
Correct generation number requirement for activation.

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -116,6 +116,12 @@ pub enum CrucibleError {
 
     #[error("Generation number is too low: {0}")]
     GenerationNumberTooLow(String),
+
+    #[error("No longer active")]
+    NoLongerActive,
+
+    #[error("Failed reconciliation")]
+    RegionAssembleError,
 }
 
 impl From<std::io::Error> for CrucibleError {

--- a/crudd/test.sh
+++ b/crudd/test.sh
@@ -31,8 +31,8 @@ tmpbytes=$(( 512 * 1024 * 1024))
 dd if=/dev/urandom of="$tmpfile" bs=4M count=$((tmpbytes / ( 4 * 1024 * 1024 ) ))
 
 # test aligned write/read
-cat "$tmpfile" | cargo run --release -- -b 0 -n $tmpbytes -t "$1" -t "$2" -t "$3" write
-cargo run --release -- -b 0 -n "$tmpbytes" -t "$1" -t "$2" -t "$3" 3>"$tmpout" read
+cat "$tmpfile" | cargo run --release -- -g 1 -b 0 -n $tmpbytes -t "$1" -t "$2" -t "$3" write
+cargo run --release -- -g 2 -b 0 -n "$tmpbytes" -t "$1" -t "$2" -t "$3" 3>"$tmpout" read
 
 if diff -q "$tmpfile" "$tmpout"; then
   echo "Success: aligned read/write"
@@ -43,8 +43,8 @@ fi
 
 # misaligned write/read
 dd if=/dev/urandom of="$tmpfile" bs=4M count=$((tmpbytes / ( 4 * 1024 * 1024 ) ))
-cat "$tmpfile" | cargo run --release -- -b 29 -n $tmpbytes -t "$1" -t "$2" -t "$3" write
-cargo run --release -- -b 29 -n "$tmpbytes" -t "$1" -t "$2" -t "$3" 3>"$tmpout" read
+cat "$tmpfile" | cargo run --release -- -g 3 -b 29 -n $tmpbytes -t "$1" -t "$2" -t "$3" write
+cargo run --release -- -g 4 -b 29 -n "$tmpbytes" -t "$1" -t "$2" -t "$3" 3>"$tmpout" read
 
 if diff -q "$tmpfile" "$tmpout"; then
   echo "Success: misaligned read/write"
@@ -55,8 +55,8 @@ fi
 # nano-read/write
 nanosize=39
 dd if=/dev/urandom of="$tmpfile" bs=$nanosize count=1
-cat "$tmpfile" | cargo run --release -- -b 647 -n $nanosize -t "$1" -t "$2" -t "$3" write
-cargo run --release -- -b 647 -n $nanosize -t "$1" -t "$2" -t "$3" 3>"$tmpout" read
+cat "$tmpfile" | cargo run --release -- -g 5 -b 647 -n $nanosize -t "$1" -t "$2" -t "$3" write
+cargo run --release -- -g 6 -b 647 -n $nanosize -t "$1" -t "$2" -t "$3" 3>"$tmpout" read
 
 if diff -q "$tmpfile" "$tmpout"; then
   echo "Success: nano read/write"

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -36,16 +36,16 @@ enum Workload {
     Burst,
     /// Starts a CLI client
     Cli {
-        /// Address to connect to
+        /// Address the cli client will try to connect to
         #[clap(long, short, default_value = "0.0.0.0:5050", action)]
         attach: SocketAddr,
     },
     /// Start a server and listen on the given address and port
     CliServer {
-        /// Address to listen on
+        /// Address for the cliserver to listen on
         #[clap(long, short, default_value = "0.0.0.0", action)]
         listen: IpAddr,
-        /// Port to listen on
+        /// Port for the cliserver to listen on
         #[clap(long, short, default_value = "5050", action)]
         port: u16,
     },
@@ -1755,6 +1755,7 @@ async fn deactivate_workload(
             width = count_width
         );
         let mut retry = 1;
+        gen += 1;
         while let Err(e) = guest.activate(gen).await {
             println!(
                 "{:>0width$}/{:>0width$}, Retry:{} activate {:?}",
@@ -1770,7 +1771,6 @@ async fn deactivate_workload(
             }
             retry += 1;
         }
-        gen += 1;
     }
     println!("One final");
     generic_workload(guest, 20, ri).await?;

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -3775,7 +3775,7 @@ mod test {
     async fn test_promote_to_active_multi_read_write_different_uuid_lower_gen(
     ) -> Result<()> {
         // Attempting to activate multiple read-write (where it's different
-        // Upstairs) but with the same gen should be blocked
+        // Upstairs) but with a lower gen should be blocked.
         let ads = build_test_downstairs(false)?;
 
         let upstairs_connection_1 = UpstairsConnection {

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -7,6 +7,7 @@
 
 use futures::executor;
 use futures::lock::{Mutex, MutexGuard};
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
 use std::fs::File;
@@ -968,7 +969,9 @@ where
                             upstairs_connection.unwrap());
 
                         let mut fw = fw.lock().await;
-                        fw.send(Message::YesItsMe { version: 1, repair_addr }).await?;
+                        fw.send(
+                            Message::YesItsMe { version: 1, repair_addr }
+                        ).await?;
                     }
                     Some(Message::PromoteToActive {
                         upstairs_id,
@@ -995,17 +998,17 @@ where
                                         upstairs_connection.upstairs_id,
                                 }
                             ).await?;
+                            bail!(
+                                "Upstairs connection expected \
+                                upstairs_id:{} session_id:{}  received \
+                                upstairs_id:{} session_id:{}",
+                                upstairs_connection.upstairs_id,
+                                upstairs_connection.session_id,
+                                upstairs_id,
+                                session_id
+                            );
 
-                            /*
-                             * At this point, should we just return error?
-                             * XXX
-                             */
                         } else {
-                            // matches_self above should include a check for
-                            // gen, but gen number may change between
-                            // negotiation and activation (see `XXX because the
-                            // generation number` upstairs). update generation
-                            // number here.
                             if upstairs_connection.gen != gen {
                                 warn!(
                                     log,
@@ -1842,12 +1845,64 @@ impl Downstairs {
                 }
 
                 1 => {
-                    // Kick out this session. Do this while holding the work
-                    // lock.
+                    // There is an existing session.  Determine if this new
+                    // request to promote to active should move forward or
+                    // be blocked.
+                    let active_upstairs = self
+                        .active_upstairs
+                        .get(&currently_active_upstairs_uuids[0])
+                        .unwrap();
+
+                    println!(
+                        "Attempting RW takeover from {:?} to {:?}",
+                        active_upstairs.upstairs_connection,
+                        upstairs_connection,
+                    );
+
+                    // Compare the new generaion number to what the existing
+                    // connection is and take action based on that.
+                    match upstairs_connection
+                        .gen
+                        .cmp(&active_upstairs.upstairs_connection.gen)
+                    {
+                        Ordering::Less => {
+                            // If the new connection has a lower generation
+                            // number than the current connection, we don't
+                            // allow it to take over.
+                            bail!(
+                                "Current gen {} is > requested gen of {}",
+                                active_upstairs.upstairs_connection.gen,
+                                upstairs_connection.gen,
+                            );
+                        }
+                        Ordering::Equal => {
+                            // The generation numbers match, the only way we
+                            // allow this new connection to take over is if the
+                            // upstairs_id and the session_id are the same,
+                            // which means the whole structures need to be
+                            // identical.
+                            if active_upstairs.upstairs_connection
+                                != upstairs_connection
+                            {
+                                bail!(
+                                    "Same gen, but UUIDs {:?} don't match {:?}",
+                                    active_upstairs.upstairs_connection,
+                                    upstairs_connection,
+                                );
+                            }
+                        }
+                        // The only remaining case is the new generation
+                        // number is higher than the existing.
+                        Ordering::Greater => {}
+                    }
+
+                    // Now that we know we can remove/replace it, go ahead
+                    // and take it off the list.
                     let active_upstairs = self
                         .active_upstairs
                         .remove(&currently_active_upstairs_uuids[0])
                         .unwrap();
+
                     let mut work = active_upstairs.work.lock().await;
 
                     warn!(
@@ -1904,7 +1959,8 @@ impl Downstairs {
                     // for.
                     work.clear();
 
-                    // Insert a new session
+                    // Insert or replace the session
+
                     self.active_upstairs.insert(
                         upstairs_connection.upstairs_id,
                         ActiveUpstairs {
@@ -3665,10 +3721,10 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_promote_to_active_multi_read_write_different_uuid(
+    async fn test_promote_to_active_multi_read_write_different_uuid_same_gen(
     ) -> Result<()> {
         // Attempting to activate multiple read-write (where it's different
-        // Upstairs) should kick out the other connection
+        // Upstairs) but with the same gen should be blocked
         let ads = build_test_downstairs(false)?;
 
         let upstairs_connection_1 = UpstairsConnection {
@@ -3696,23 +3752,84 @@ mod test {
         assert!(matches!(rx1.try_recv().err().unwrap(), TryRecvError::Empty));
         assert!(matches!(rx2.try_recv().err().unwrap(), TryRecvError::Empty));
 
-        ds.promote_to_active(upstairs_connection_2, tx2).await?;
-        assert_eq!(rx1.try_recv().unwrap(), upstairs_connection_2);
-        assert!(matches!(rx2.try_recv().unwrap_err(), TryRecvError::Empty));
+        let res = ds.promote_to_active(upstairs_connection_2, tx2).await;
+        assert!(res.is_err());
+
+        assert!(matches!(rx1.try_recv().unwrap_err(), TryRecvError::Empty));
+        assert!(matches!(
+            rx2.try_recv().unwrap_err(),
+            TryRecvError::Disconnected
+        ));
 
         assert_eq!(ds.active_upstairs().len(), 1);
 
-        assert!(!ds.is_active(upstairs_connection_1));
-        assert!(ds.is_active(upstairs_connection_2));
+        // Original connection is still active.
+        assert!(ds.is_active(upstairs_connection_1));
+        // New connection was blocked.
+        assert!(!ds.is_active(upstairs_connection_2));
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_promote_to_active_multi_read_write_same_uuid() -> Result<()> {
+    async fn test_promote_to_active_multi_read_write_different_uuid_lower_gen(
+    ) -> Result<()> {
+        // Attempting to activate multiple read-write (where it's different
+        // Upstairs) but with the same gen should be blocked
+        let ads = build_test_downstairs(false)?;
+
+        let upstairs_connection_1 = UpstairsConnection {
+            upstairs_id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+            gen: 2,
+        };
+
+        let upstairs_connection_2 = UpstairsConnection {
+            upstairs_id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+            gen: 1,
+        };
+
+        let (tx1, mut rx1) = channel(1);
+        let tx1 = Arc::new(tx1);
+
+        let (tx2, mut rx2) = channel(1);
+        let tx2 = Arc::new(tx2);
+
+        let mut ds = ads.lock().await;
+        println!("ds1: {:?}", ds);
+        ds.promote_to_active(upstairs_connection_1, tx1).await?;
+        println!("\nds2: {:?}\n", ds);
+
+        assert_eq!(ds.active_upstairs().len(), 1);
+        assert!(matches!(rx1.try_recv().err().unwrap(), TryRecvError::Empty));
+        assert!(matches!(rx2.try_recv().err().unwrap(), TryRecvError::Empty));
+
+        let res = ds.promote_to_active(upstairs_connection_2, tx2).await;
+        assert!(res.is_err());
+
+        assert!(matches!(rx1.try_recv().unwrap_err(), TryRecvError::Empty));
+        assert!(matches!(
+            rx2.try_recv().unwrap_err(),
+            TryRecvError::Disconnected
+        ));
+
+        assert_eq!(ds.active_upstairs().len(), 1);
+
+        // Original connection is still active.
+        assert!(ds.is_active(upstairs_connection_1));
+        // New connection was blocked.
+        assert!(!ds.is_active(upstairs_connection_2));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_promote_to_active_multi_read_write_same_uuid_same_gen(
+    ) -> Result<()> {
         // Attempting to activate multiple read-write (where it's the same
-        // Upstairs but a different session) should kick out the other
-        // connection
+        // Upstairs but a different session) will block the "new" connection
+        // if it has the same generation number.
         let ads = build_test_downstairs(false)?;
 
         let upstairs_connection_1 = UpstairsConnection {
@@ -3725,6 +3842,56 @@ mod test {
             upstairs_id: upstairs_connection_1.upstairs_id,
             session_id: Uuid::new_v4(),
             gen: 1,
+        };
+
+        let (tx1, mut rx1) = channel(1);
+        let tx1 = Arc::new(tx1);
+
+        let (tx2, mut rx2) = channel(1);
+        let tx2 = Arc::new(tx2);
+
+        let mut ds = ads.lock().await;
+        ds.promote_to_active(upstairs_connection_1, tx1).await?;
+
+        assert_eq!(ds.active_upstairs().len(), 1);
+        assert!(matches!(rx1.try_recv().err().unwrap(), TryRecvError::Empty));
+        assert!(matches!(rx2.try_recv().err().unwrap(), TryRecvError::Empty));
+
+        let res = ds.promote_to_active(upstairs_connection_2, tx2).await;
+        assert!(res.is_err());
+
+        assert!(matches!(rx1.try_recv().unwrap_err(), TryRecvError::Empty));
+        assert!(matches!(
+            rx2.try_recv().unwrap_err(),
+            TryRecvError::Disconnected
+        ));
+
+        assert_eq!(ds.active_upstairs().len(), 1);
+
+        assert!(ds.is_active(upstairs_connection_1));
+        assert!(!ds.is_active(upstairs_connection_2));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_promote_to_active_multi_read_write_same_uuid_larger_gen(
+    ) -> Result<()> {
+        // Attempting to activate multiple read-write where it's the same
+        // Upstairs, but a different session, and with a larger generation
+        // should allow the new connection to take over.
+        let ads = build_test_downstairs(false)?;
+
+        let upstairs_connection_1 = UpstairsConnection {
+            upstairs_id: Uuid::new_v4(),
+            session_id: Uuid::new_v4(),
+            gen: 1,
+        };
+
+        let upstairs_connection_2 = UpstairsConnection {
+            upstairs_id: upstairs_connection_1.upstairs_id,
+            session_id: Uuid::new_v4(),
+            gen: 2,
         };
 
         let (tx1, mut rx1) = channel(1);
@@ -4101,7 +4268,8 @@ mod test {
     }
 
     // Validate that `complete_work` can see None if the same Upstairs
-    // reconnects
+    // reconnects.  We know it's the same Upstairs because the session and
+    // upstairs ids will match.
     #[tokio::test]
     async fn test_complete_work_can_see_none() -> Result<()> {
         // Test region create and a read of one block.

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -202,14 +202,14 @@ mod test {
                 sub_volumes: vec![VolumeConstructionRequest::Region {
                     block_size: BLOCK_SIZE as u64,
                     opts,
-                    gen: 0,
+                    gen: 1,
                 }],
                 read_only_parent: None,
             };
 
         let volume = Arc::new(Volume::construct(vcr, None).await?);
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         // Verify contents are zero on init
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -279,10 +279,10 @@ mod test {
         assert_eq!(vec![11; BLOCK_SIZE * 10], *buffer.as_vec().await);
 
         let mut volume = Volume::new(BLOCK_SIZE as u64);
-        volume.add_subvolume_create_guest(opts, 0, None).await?;
+        volume.add_subvolume_create_guest(opts, 1, None).await?;
         volume.add_read_only_parent(in_memory_data.clone()).await?;
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         // Verify contents are 11 on init
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -364,7 +364,7 @@ mod test {
                 sub_volumes: vec![VolumeConstructionRequest::Region {
                     block_size: BLOCK_SIZE as u64,
                     opts,
-                    gen: 0,
+                    gen: 1,
                 }],
                 read_only_parent: None,
             };
@@ -379,7 +379,7 @@ mod test {
             })
             .await?;
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         // Verify contents are 11 on init
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -445,7 +445,7 @@ mod test {
                 sub_volumes: vec![VolumeConstructionRequest::Region {
                     block_size: BLOCK_SIZE as u64,
                     opts,
-                    gen: 0,
+                    gen: 1,
                 }],
                 read_only_parent: Some(Box::new(
                     VolumeConstructionRequest::Volume {
@@ -462,7 +462,7 @@ mod test {
             };
 
         let volume = Volume::construct(vcr, None).await?;
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         // Read one block: should be all 0xff
         let buffer = Buffer::new(BLOCK_SIZE);
@@ -507,13 +507,13 @@ mod test {
                     VolumeConstructionRequest::Region {
                         block_size: BLOCK_SIZE as u64,
                         opts,
-                        gen: 0,
+                        gen: 1,
                     },
                 )),
             };
 
         let volume = Volume::construct(vcr, None).await?;
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         // Read one block: should be all 0x00
         let buffer = Buffer::new(BLOCK_SIZE);
@@ -552,14 +552,14 @@ mod test {
                 sub_volumes: vec![VolumeConstructionRequest::Region {
                     block_size: BLOCK_SIZE as u64,
                     opts,
-                    gen: 0,
+                    gen: 1,
                 }],
                 read_only_parent: None,
             };
 
         let volume = Arc::new(Volume::construct(vcr, None).await?);
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         // Write data in
         volume
@@ -621,14 +621,14 @@ mod test {
                 sub_volumes: vec![VolumeConstructionRequest::Region {
                     block_size: BLOCK_SIZE as u64,
                     opts,
-                    gen: 0,
+                    gen: 1,
                 }],
                 read_only_parent: None,
             };
 
         let volume = Arc::new(Volume::construct(vcr, None).await?);
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         // Write data in
         volume
@@ -692,14 +692,14 @@ mod test {
                 sub_volumes: vec![VolumeConstructionRequest::Region {
                     block_size: BLOCK_SIZE as u64,
                     opts,
-                    gen: 0,
+                    gen: 1,
                 }],
                 read_only_parent: None,
             };
 
         let volume = Arc::new(Volume::construct(vcr, None).await?);
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         // Write data at block 0
         volume
@@ -760,14 +760,14 @@ mod test {
         sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             opts,
-            gen: 0,
+            gen: 1,
         });
         let tds2 = TestDownstairsSet::new(false).await?;
         let opts = tds2.opts();
         sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             opts,
-            gen: 0,
+            gen: 1,
         });
 
         let vcr: VolumeConstructionRequest =
@@ -780,7 +780,7 @@ mod test {
 
         let volume = Arc::new(Volume::construct(vcr, None).await?);
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         let full_volume_size = BLOCK_SIZE * 20;
         // Write data in
@@ -842,14 +842,14 @@ mod test {
         sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             opts,
-            gen: 0,
+            gen: 1,
         });
         let tds2 = TestDownstairsSet::new(false).await?;
         let opts = tds2.opts();
         sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             opts,
-            gen: 0,
+            gen: 1,
         });
 
         let vcr: VolumeConstructionRequest =
@@ -862,7 +862,7 @@ mod test {
 
         let volume = Arc::new(Volume::construct(vcr, None).await?);
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
         let full_volume_size = BLOCK_SIZE * 20;
 
         // Write data to last block of first vol, and first block of
@@ -946,14 +946,14 @@ mod test {
         sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             opts,
-            gen: 0,
+            gen: 1,
         });
         let tds2 = TestDownstairsSet::new(false).await?;
         let opts = tds2.opts();
         sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             opts,
-            gen: 0,
+            gen: 1,
         });
 
         let vcr: VolumeConstructionRequest =
@@ -966,7 +966,7 @@ mod test {
 
         let volume = Arc::new(Volume::construct(vcr, None).await?);
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
         let full_volume_size = BLOCK_SIZE * 20;
 
         // Write data to last block of first vol, and first block of
@@ -1063,10 +1063,10 @@ mod test {
         assert_eq!(vec![11; BLOCK_SIZE * 5], *buffer.as_vec().await);
 
         let mut volume = Volume::new(BLOCK_SIZE as u64);
-        volume.add_subvolume_create_guest(opts, 0, None).await?;
+        volume.add_subvolume_create_guest(opts, 1, None).await?;
         volume.add_read_only_parent(in_memory_data).await?;
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         // Verify parent contents in one read
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -1132,10 +1132,10 @@ mod test {
             .await?;
 
         let mut volume = Volume::new(BLOCK_SIZE as u64);
-        volume.add_subvolume_create_guest(opts, 0, None).await?;
+        volume.add_subvolume_create_guest(opts, 1, None).await?;
         volume.add_read_only_parent(in_memory_data).await?;
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         // Verify contents are 11 at startup
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -1204,10 +1204,10 @@ mod test {
             .await?;
 
         let mut volume = Volume::new(BLOCK_SIZE as u64);
-        volume.add_subvolume_create_guest(opts, 0, None).await?;
+        volume.add_subvolume_create_guest(opts, 1, None).await?;
         volume.add_read_only_parent(in_memory_data).await?;
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         // Verify contents of RO parent are 1s at startup
         let buffer = Buffer::new(BLOCK_SIZE * 5);
@@ -1297,10 +1297,10 @@ mod test {
             .await?;
 
         let mut volume = Volume::new(BLOCK_SIZE as u64);
-        volume.add_subvolume_create_guest(opts, 0, None).await?;
+        volume.add_subvolume_create_guest(opts, 1, None).await?;
         volume.add_read_only_parent(in_memory_data).await?;
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         // SV: |--2-------|
         volume
@@ -1381,10 +1381,10 @@ mod test {
             .await?;
 
         let mut volume = Volume::new(BLOCK_SIZE as u64);
-        volume.add_subvolume_create_guest(opts, 0, None).await?;
+        volume.add_subvolume_create_guest(opts, 1, None).await?;
         volume.add_read_only_parent(in_memory_data).await?;
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         // Verify contents are 11 at startup
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -1458,14 +1458,14 @@ mod test {
         sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             opts,
-            gen: 0,
+            gen: 1,
         });
         let tds2 = TestDownstairsSet::new(false).await?;
         let opts = tds2.opts();
         sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             opts,
-            gen: 0,
+            gen: 1,
         });
 
         let vcr: VolumeConstructionRequest =
@@ -1486,7 +1486,7 @@ mod test {
             })
             .await?;
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         // Write data to last block of first vol, and first block of
         // second vol.
@@ -1579,14 +1579,14 @@ mod test {
         sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             opts,
-            gen: 0,
+            gen: 1,
         });
         let tds2 = TestDownstairsSet::new(false).await?;
         let opts = tds2.opts();
         sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             opts,
-            gen: 0,
+            gen: 1,
         });
 
         let vcr: VolumeConstructionRequest =
@@ -1607,7 +1607,7 @@ mod test {
             })
             .await?;
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         // Write data to last block of first vol, and first block of
         // second vol, AKA write A.
@@ -1689,7 +1689,7 @@ mod test {
                     VolumeConstructionRequest::Region {
                         block_size: BLOCK_SIZE as u64,
                         opts: opts.clone(),
-                        gen: 0,
+                        gen: 1,
                     },
                 )),
             };
@@ -1706,16 +1706,16 @@ mod test {
                     VolumeConstructionRequest::Region {
                         block_size: BLOCK_SIZE as u64,
                         opts,
-                        gen: 0,
+                        gen: 1,
                     },
                 )),
             };
 
         let volume1 = Volume::construct(vcr_1, None).await?;
-        volume1.activate(0).await?;
+        volume1.activate(1).await?;
 
         let volume2 = Volume::construct(vcr_2, None).await?;
-        volume2.activate(0).await?;
+        volume2.activate(1).await?;
 
         // Read one block: should be all 0x00
         let buffer = Buffer::new(BLOCK_SIZE);
@@ -1755,9 +1755,9 @@ mod test {
         let opts = tds.opts();
 
         let mut volume = Volume::new(BLOCK_SIZE as u64);
-        volume.add_subvolume_create_guest(opts, 0, None).await?;
+        volume.add_subvolume_create_guest(opts, 1, None).await?;
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         // Verify contents are 00 at startup
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -1807,10 +1807,10 @@ mod test {
 
         let mut volume = Volume::new(BLOCK_SIZE as u64);
         volume
-            .add_subvolume_create_guest(test_downstairs_set.opts(), 0, None)
+            .add_subvolume_create_guest(test_downstairs_set.opts(), 1, None)
             .await?;
 
-        volume.activate(0).await?;
+        volume.activate(1).await?;
 
         let random_buffer = {
             let mut random_buffer =
@@ -1836,10 +1836,10 @@ mod test {
         {
             let mut volume = Volume::new(BLOCK_SIZE as u64);
             volume
-                .add_subvolume_create_guest(test_downstairs_set.opts(), 0, None)
+                .add_subvolume_create_guest(test_downstairs_set.opts(), 2, None)
                 .await?;
 
-            volume.activate(0).await?;
+            volume.activate(2).await?;
 
             let buffer = Buffer::new(volume.total_size().await? as usize);
             volume
@@ -1875,7 +1875,7 @@ mod test {
                 sub_volumes: vec![VolumeConstructionRequest::Region {
                     block_size: BLOCK_SIZE as u64,
                     opts: top_layer_opts,
-                    gen: 0,
+                    gen: 3,
                 }],
                 read_only_parent: Some(Box::new(
                     VolumeConstructionRequest::Volume {
@@ -1884,7 +1884,7 @@ mod test {
                         sub_volumes: vec![VolumeConstructionRequest::Region {
                             block_size: BLOCK_SIZE as u64,
                             opts: bottom_layer_opts,
-                            gen: 0,
+                            gen: 3,
                         }],
                         read_only_parent: None,
                     },
@@ -1892,7 +1892,7 @@ mod test {
             };
 
         let volume = Volume::construct(vcr, None).await?;
-        volume.activate(0).await?;
+        volume.activate(3).await?;
 
         // Validate that source blocks originally come from the read-only parent
         {
@@ -1958,7 +1958,7 @@ mod test {
 
         let _join_handle = up_main(opts, 0, gc, None).await?;
 
-        guest.activate(0).await?;
+        guest.activate(1).await?;
         guest.query_work_queue().await?;
 
         // Verify contents are zero on init
@@ -2002,7 +2002,7 @@ mod test {
         // Read-only Upstairs should return errors if writes are attempted.
         let _join_handle = up_main(opts, 0, gc, None).await?;
 
-        guest.activate(0).await?;
+        guest.activate(1).await?;
 
         // Expect an error attempting to write.
         let write_result = guest

--- a/tools/crudd-speed-battery.sh
+++ b/tools/crudd-speed-battery.sh
@@ -30,6 +30,7 @@ print_err() {
 # $1 = mode (read or write)
 # $2 = request size in blocks
 # $3 = pipeline length
+# $4 = generation number for the upstairs/downstairs.
 # runs for a maximum time specified by the use of timeout in the function
 # prints the average throughput in bytes/second to stdout.
 crudd_benchmark() {

--- a/tools/crudd-speed-battery.sh
+++ b/tools/crudd-speed-battery.sh
@@ -36,6 +36,7 @@ crudd_benchmark() {
   local mode="$1"
   local req_size="$2"
   local pipeline_len="$3"
+  local generation_number="$4"
 
   local start_time="$(date '+%s')"
 
@@ -49,7 +50,7 @@ crudd_benchmark() {
   timeout --signal=USR1 "$MAX_ITERATION_DURATION" \
     "$BINDIR/crudd" -t $DOWNSTAIRS_1 -t $DOWNSTAIRS_2 -t $DOWNSTAIRS_3 \
       -n $REGION_SIZE_BYTES -i "$req_size" -p "$pipeline_len" \
-      --benchmarking-mode "$BENCHMARK_RESULTS_TMPFILE" \
+      -g "$generation_number" --benchmarking-mode "$BENCHMARK_RESULTS_TMPFILE" \
       "$mode" \
       1>&2
 
@@ -124,27 +125,36 @@ perform_benchmarks_with_parameters() {
 
   local req_size="$1"
   local pipeline_len="$2"
+  local generation_number=1
 
   # test read speed before writing any data
-  local read_speed_uninit=$(crudd_benchmark read "$req_size" "$pipeline_len")
+  local read_speed_uninit=$(crudd_benchmark read "$req_size" "$pipeline_len" \
+    "$generation_number")
+  (( generation_number += 1 ))
 
   # test write speed before writing any data (first write)
-  local write_speed_uninit=$(crudd_benchmark write "$req_size" "$pipeline_len")
+  local write_speed_uninit=$(crudd_benchmark write "$req_size" "$pipeline_len" \
+    "$generation_number")
+  (( generation_number += 1 ))
 
   # make sure the entire region is written
   # we use a close to optimal write pattern to make this quick regardless of
   # the benchmark we're running, since we're not timing it out
   "$BINDIR/crudd" -t $DOWNSTAIRS_1 -t $DOWNSTAIRS_2 -t $DOWNSTAIRS_3 \
-    -n $REGION_SIZE_BYTES -i 32768 -p 4 \
+    -n $REGION_SIZE_BYTES -i 32768 -p 4 -g "$generation_number" \
     write \
     < /dev/zero 1>&2
+  (( generation_number += 1 ))
 
 
   # test read speed after writing data
-  local read_speed_init=$(crudd_benchmark read "$req_size" "$pipeline_len")
+  local read_speed_init=$(crudd_benchmark read "$req_size" "$pipeline_len" \
+    "$generation_number")
+  (( generation_number += 1 ))
 
   # test write speed after writing data
-  local write_speed_init=$(crudd_benchmark write "$req_size" "$pipeline_len")
+  local write_speed_init=$(crudd_benchmark write "$req_size" "$pipeline_len" \
+    "$generation_number")
 
   # shut it down
   stop_downstairs

--- a/tools/test_repair.sh
+++ b/tools/test_repair.sh
@@ -96,7 +96,7 @@ fi
 
 # Do initial volume population.
 generation=1
-echo "$ct with $target_args  $dump_args $ds0_pid $ds1_pid $ds2_pid"
+echo "$ct with $target_args $dump_args $ds0_pid $ds1_pid $ds2_pid"
 if ! ${ct} fill ${target_args} --verify-out "$verify_file" -q -g "$generation"
 then
     echo "ERROR: Exit on initial fill"

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -962,7 +962,7 @@ where
                             );
 
                             up.ds_transition(up_coms.client_id, DsState::New).await;
-                            up.set_inactive().await;
+                            up.set_inactive(CrucibleError::UuidMismatch).await;
                             return Err(CrucibleError::UuidMismatch.into());
                         }
 
@@ -993,7 +993,7 @@ where
                         );
 
                         up.ds_transition(up_coms.client_id, DsState::New).await;
-                        up.set_inactive().await;
+                        up.set_inactive(CrucibleError::NoLongerActive).await;
 
                         // What if the newly active upstairs has the same UUID?
                         if up.uuid == new_upstairs_id {
@@ -1191,7 +1191,7 @@ where
                         up.ds_transition(
                             up_coms.client_id, DsState::Disabled
                         ).await;
-                        up.set_inactive().await;
+                        up.set_inactive(CrucibleError::UuidMismatch).await;
                         if up.uuid == expected_id {
                             /*
                              * Now, this is really going off the rails. Our
@@ -1394,7 +1394,7 @@ where
                             new_gen,
                         );
                         up.ds_transition(up_coms.client_id, DsState::Disabled).await;
-                        up.set_inactive().await;
+                        up.set_inactive(CrucibleError::NoLongerActive).await;
 
                         // What if the newly active upstairs has the same UUID?
                         if up.uuid == new_upstairs_id {
@@ -1463,7 +1463,7 @@ where
                          * UUID be used as a denial of service?
                          */
                         up.ds_transition(up_coms.client_id, DsState::Disabled).await;
-                        up.set_inactive().await;
+                        up.set_inactive(CrucibleError::UuidMismatch).await;
                         bail!(
                             "[{}] received UuidMismatch, expecting {:?}!",
                             up_coms.client_id, expected_id
@@ -3592,6 +3592,7 @@ enum UpState {
 struct UpstairsState {
     active_request: bool,
     up_state: UpState,
+    req: Option<BlockReq>,
 }
 
 impl UpstairsState {
@@ -3599,6 +3600,7 @@ impl UpstairsState {
         UpstairsState {
             active_request: false,
             up_state: UpState::Initializing,
+            req: None,
         }
     }
 
@@ -3611,7 +3613,7 @@ impl UpstairsState {
      * that happens on initial startup. This is because the running
      * upstairs has some state it can use to re-verify a downstairs.
      */
-    fn set_active(&mut self) -> Result<(), CrucibleError> {
+    async fn set_active(&mut self) -> Result<(), CrucibleError> {
         if self.up_state == UpState::Active {
             crucible_bail!(UpstairsAlreadyActive);
         } else if self.up_state == UpState::Deactivating {
@@ -3624,7 +3626,10 @@ impl UpstairsState {
         }
         self.active_request = false;
         self.up_state = UpState::Active;
-
+        let req = self.req.take();
+        if let Some(req) = req {
+            req.send_ok().await;
+        }
         Ok(())
     }
 }
@@ -3857,7 +3862,7 @@ impl Upstairs {
     async fn set_generation(&self, new_gen: u64) {
         let mut gen = self.generation.lock().await;
         *gen = new_gen;
-        info!(self.log, "Set generation to :{}", *gen);
+        info!(self.log, "Set desired generation to :{}", *gen);
     }
 
     async fn get_generation(&self) -> u64 {
@@ -3879,7 +3884,7 @@ impl Upstairs {
     async fn set_active(&self) -> Result<(), CrucibleError> {
         let mut active = self.active.lock().await;
         self.stats.add_activation().await;
-        active.set_active()?;
+        active.set_active().await?;
         info!(
             self.log,
             "{} is now active with session: {}", self.uuid, self.session_id
@@ -3891,10 +3896,16 @@ impl Upstairs {
      * This is called if the upstairs has determined that something is
      * wrong and it should deactivate itself.
      */
-    async fn set_inactive(&self) {
+    async fn set_inactive(&self, err: CrucibleError) {
         let mut active = self.active.lock().await;
         active.active_request = false;
         active.up_state = UpState::Initializing;
+
+        // If something is waiting for activation, they can give up now.
+        let req = active.req.take();
+        if let Some(req) = req {
+            req.send_err(err).await;
+        }
         info!(
             self.log,
             "{} set inactive, session {}", self.uuid, self.session_id
@@ -4137,11 +4148,17 @@ impl Upstairs {
     /*
      * The guest has requested this upstairs go active.
      */
-    async fn set_active_request(&self) -> Result<(), CrucibleError> {
+    async fn set_active_request(
+        &self,
+        req: BlockReq,
+    ) -> Result<(), CrucibleError> {
         let mut active = self.active.lock().await;
         match active.up_state {
             UpState::Initializing => {
+                assert!(!active.active_request);
+                assert!(active.req.is_none());
                 active.active_request = true;
+                active.req = Some(req);
                 info!(self.log, "{} active request set", self.uuid);
                 Ok(())
             }
@@ -4150,6 +4167,7 @@ impl Upstairs {
                     self.log,
                     "{} active denied while Deactivating", self.uuid
                 );
+                req.send_err(CrucibleError::UpstairsDeactivating).await;
                 crucible_bail!(UpstairsDeactivating);
             }
             UpState::Active => {
@@ -4157,6 +4175,7 @@ impl Upstairs {
                     self.log,
                     "{} Request to activate upstairs already active", self.uuid
                 );
+                req.send_err(CrucibleError::UpstairsAlreadyActive).await;
                 crucible_bail!(UpstairsAlreadyActive);
             }
         }
@@ -4961,10 +4980,10 @@ impl Upstairs {
      * Compare downstairs region metadata and based on the results:
      *
      * Determine the global flush number for this region set.
-     * Verify the guest given gen number is highest (TODO)
+     * Verify the guest given gen number is highest.
      * Decide if we need repair, and if so create the repair list
      */
-    async fn collate_downstairs(&self, ds: &mut Downstairs) -> bool {
+    async fn collate_downstairs(&self, ds: &mut Downstairs) -> Result<bool> {
         /*
          * Show some (or all if small) of the info from each region.
          *
@@ -5014,33 +5033,36 @@ impl Upstairs {
             }
         }
 
+        info!(self.log, "Max found gen is {}", max_gen);
         /*
-         * XXX because the generation number is not plumbed up yet in
-         * nexus, we are manually increasing it here.  Whatever the highest
-         * number we find during our initial scan, we add one and use that.
-         * When we start receiving a gen from outside, then we need to
-         * take this out.  To support reconciliation working correctly, the
-         * generation coming from Propolis/Nexus must be larger than what
-         * we find on the downstairs, as the correct generation number is
-         * required to break ties under some failure conditions.
+         * Verify that the generation number that the guest has requested
+         * is higher than what we have from the three downstairs.
          */
-        let cur_max_gen = self.get_generation().await;
-        if cur_max_gen == 0 {
-            warn!(self.log, "XXX Manual generation setting to {}", max_gen);
-            self.set_generation(max_gen).await;
-        } else if cur_max_gen < max_gen {
+        let requested_gen = self.get_generation().await;
+        if requested_gen == 0 {
+            error!(self.log, "generation number should be at least 1");
+            bail!("Generation number should be at least 1");
+        } else if requested_gen < max_gen {
             /*
-             * This may eventually be a panic, or a refusal to start the
-             * upstairs if we find generation numbers higher than we expect.
-             * XXX
+             * We refuse to connect. The provided generation number is not
+             * high enough to let us connect to these downstairs.
              */
-            warn!(
+            error!(
                 self.log,
                 "found/using gen number {}, larger than requested: {}",
                 max_gen,
-                cur_max_gen,
+                requested_gen,
             );
-            self.set_generation(max_gen).await;
+            bail!(
+                "found/using gen number {}, larger than requested: {}",
+                max_gen,
+                requested_gen,
+            );
+        } else {
+            info!(
+                self.log,
+                "Generation requested: {} > found:{}", requested_gen, max_gen,
+            );
         }
 
         /*
@@ -5081,10 +5103,10 @@ impl Upstairs {
             );
             ds.convert_rc_to_messages(reconcile_list.mend, max_flush, max_gen);
             ds.reconcile_repair_needed = ds.reconcile_task_list.len();
-            true
+            Ok(true)
         } else {
             info!(self.log, "All extents match");
-            false
+            Ok(false)
         }
     }
 
@@ -5233,10 +5255,10 @@ impl Upstairs {
      * Return false if we are not ready, or if things failed.
      * If we failed, then we will update the DsState for what failed.
      *
-     * XXX How do we make sure our current generation number is higher
-     * than what we received from the downstairs?  Think about that
-     * failure case where one downstairs got a higher gen number, can
-     * that exist?
+     * If we have enough downstairs and we can activate, then we should
+     * notify the requestor of activation.
+     * If we have enough downstairs and can't activate, then we should
+     * also notify the requestor.
      *
      * If we have a problem here, we can't activate the upstairs.
      */
@@ -5254,6 +5276,7 @@ impl Upstairs {
          */
         let need_repair;
         let repair_commands;
+        let failed_collate;
         {
             let active = self.active.lock().await;
             if active.up_state != UpState::Initializing {
@@ -5279,16 +5302,60 @@ impl Upstairs {
             }
 
             /*
-             * While holding the downstairs lock, we figure out if
-             * there is any reconciliation to do, and if so, we build
-             * the list of operations that will repair the extents that
-             * are not in sync
+             * While holding the downstairs lock, we figure out if there is
+             * any reconciliation to do, and if so, we build the list of
+             * operations that will repair the extents that are not in sync.
+             *
+             * If we fail to collate, then we need to kick out all the
+             * downstairs out, forget any activation requests, and the
+             * upstairs goes back to waiting for another activation request.
              */
-            need_repair = self.collate_downstairs(&mut ds).await;
+            match self.collate_downstairs(&mut ds).await {
+                Ok(res) => {
+                    need_repair = res;
+                    failed_collate = false;
+                }
+                Err(e) => {
+                    need_repair = false;
+                    failed_collate = true;
+                    error!(self.log, "Failed collate with {}", e);
+                }
+            }
             repair_commands = ds.reconcile_task_list.len();
         }
 
-        if need_repair {
+        if failed_collate {
+            // We failed to collate the three downstairs, so we need
+            // to reset that activation request, and kick all the downstairs
+            // to FailedRepair
+            //
+            self.set_inactive(CrucibleError::RegionAssembleError).await;
+            let _active = self.active.lock().await;
+            let mut ds = self.downstairs.lock().await;
+
+            // While collating, downstairs should all be DsState::Repair.
+            // As we have released then locked the downstairs, we have to
+            // verify that the downstairs are all in the state we expect them
+            // to be.  Any change means that downstairs went away, but any
+            // downstairs still repairing should be moved to failed repair.
+            assert_eq!(ds.active.len(), 0);
+            assert_eq!(ds.reconcile_task_list.len(), 0);
+
+            for (i, s) in ds.ds_state.iter_mut().enumerate() {
+                if *s == DsState::WaitQuorum {
+                    *s = DsState::FailedRepair;
+                    warn!(
+                        self.log,
+                        "Mark {} as FAILED Collate in final check", i
+                    );
+                } else {
+                    warn!(
+                        self.log,
+                        "downstairs in state {} after failed collate", *s
+                    );
+                }
+            }
+        } else if need_repair {
             self.do_reconciliation(
                 dst,
                 lastcast,
@@ -5358,7 +5425,7 @@ impl Upstairs {
                 for s in ds.ds_state.iter_mut() {
                     *s = DsState::Active;
                 }
-                active.set_active()?;
+                active.set_active().await?;
                 info!(
                     self.log,
                     "{} is now active with session: {}",
@@ -5392,7 +5459,7 @@ impl Upstairs {
                 for s in ds.ds_state.iter_mut() {
                     *s = DsState::Active;
                 }
-                active.set_active()?;
+                active.set_active().await?;
                 info!(
                     self.log,
                     "{} is now active with session: {}",
@@ -5419,7 +5486,7 @@ impl Upstairs {
 
         info!(
             self.log,
-            "Notify all downstairs for a final check of reconcile queue."
+            "Notify all downstairs, region set compare is done."
         );
         send_reconcile_work(dst, *lastcast);
         *lastcast += 1;
@@ -7004,24 +7071,10 @@ impl Guest {
 impl BlockIO for Guest {
     async fn activate(&self, gen: u64) -> Result<(), CrucibleError> {
         let waiter = self.send(BlockOp::GoActive { gen }).await;
-        println!("The guest is requesting activation with gen:{}", gen);
+        println!("The guest has requested activation with gen:{}", gen);
         waiter.wait().await?;
-
-        /*
-         * XXX Figure out how long to wait for this.  The time to go active
-         * will include the time to reconcile all three downstairs.
-         */
-        loop {
-            if self.query_is_active().await? {
-                println!("This guest Upstairs is now active");
-                return Ok(());
-            } else {
-                println!(
-                    "Upstairs is not yet active, waiting in activate function"
-                );
-                tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-            }
-        }
+        println!("The guest has finished waiting for activation with:{}", gen);
+        Ok(())
     }
 
     /// Disable any more IO from this guest and deactivate the downstairs.
@@ -7341,8 +7394,7 @@ async fn process_new_io(
              * If we are deactivating, then reject this re-connect and
              * let the deactivate finish.
              */
-            if let Err(e) = up.set_active_request().await {
-                req.send_err(e).await;
+            if let Err(_e) = up.set_active_request(req).await {
                 return;
             }
             /*
@@ -7351,9 +7403,12 @@ async fn process_new_io(
              * upstairs will have to recover and either self update the
              * generation number, or get the new one from propolis.
              */
+
+            // Put the req waiter into the upstairs so we have a hook on
+            // who to notify when the answer comes back.
+            // We must do this before we tell all the tasks for downstairs.
             up.set_generation(gen).await;
             send_active(dst, gen);
-            req.send_ok().await;
         }
         BlockOp::QueryGuestIOReady { data } => {
             *data.lock().await = up.guest_io_ready().await;
@@ -7612,7 +7667,7 @@ async fn up_listen(
                             &mut lastcast,
                             &mut ds_reconcile_done_rx,
                         ).await {
-                            info!(
+                            error!(
                                 up.log,
                                 "Reconciliation attempt reported error {}",
                                 e


### PR DESCRIPTION
This enables and enforces the proper generation number during activation of an upstairs.  Now all upstairs trying to activate with a downstairs region will be required to have provided a >= generation number to what the downstairs report as their highest found generation number.

Added better logic in the downstairs on how to handle generation number comparisons and who should be active when faced with various situations.

Added a bunch of tests to cover the various generation number situations to verify their correct behavior.

Added proper generation number accounting to all the tests I could find that needed it.  Minor improvements to logging in test scripts.

Fixed hammer_loop.sh test, it now passes.

Before this can go in (or before crucible can be used by propolis/omicron) the[ generation number changes work in omicron](https://github.com/oxidecomputer/omicron/pull/1897) will need to be approved and merged.
