### PR TITLE
Add timeout test to perf test

### DIFF
--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -61,7 +61,7 @@ for t in crucible-downstairs crucible-hammer crutest dsc crudd; do
 done
 
 mkdir -p /work/scripts
-for s in tools/test_perf.sh tools/crudd-speed-battery.sh; do
+for s in tools/test_perf.sh tools/crudd-speed-battery.sh tools/dtrace/perf-downstairs-tick.d; do
 	cp "$s" /work/scripts/
 done
 

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -6,6 +6,7 @@
 #: output_rules = [
 #:  "/tmp/perf*.csv",
 #:  "/tmp/perfout.txt",
+#:  "/tmp/debug/*.txt",
 #: ]
 #: skip_clone = true
 #:
@@ -36,6 +37,16 @@ export BINDIR=/var/tmp/bins
 
 banner perf
 pfexec plimit -n 9123456 $$
+
+echo "Setup debug logging"
+mkdir /tmp/debug
+prstat -d d -mLc 1 > /tmp/debug/prstat.txt &
+iostat -T d -xn 1 > /tmp/debug/iostat.txt &
+mpstat -T d 1 > /tmp/debug/mpstat.txt &
+vmstat -T d -p 1 >/tmp/debug/paging.txt &
+
+echo "Start self timeout"
+jobpid=$$; (sleep $(( 2 * 60 )); ps -ef; kill $jobpid) &
 
 echo "Now try with bash prefix"
 bash $input/scripts/test_perf.sh

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -37,9 +37,8 @@ export BINDIR=/var/tmp/bins
 banner perf
 pfexec plimit -n 9123456 $$
 
-echo "Going to call exit 1 now"
-exit 1
 ptime -m bash "$input/scripts/test_perf.sh"
+echo "$? was our result"
 echo "Test finished"
 ps -ef
 exit 0

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -37,6 +37,8 @@ export BINDIR=/var/tmp/bins
 banner perf
 pfexec plimit -n 9123456 $$
 
+echo "Going to call exit 1 now"
+exit 1
 ptime -m bash "$input/scripts/test_perf.sh"
 echo "Test finished"
 ps -ef

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -34,7 +34,7 @@ banner setup
 pfexec plimit -n 9123456 $$
 
 echo "Setup self timeout"
-jobpid=$$; (sleep $(( 240 * 60 )); ps -ef; zfs list;kill $jobpid) &
+jobpid=$$; (sleep $(( 240 * 60 )); ps -ef; zfs list;kill $jobpid) & disown
 
 echo "Setup debug logging"
 mkdir /tmp/debug
@@ -50,4 +50,5 @@ banner start
 bash $input/scripts/test_perf.sh > /tmp/debug/test_perf.txt 2>&1
 echo "$? was our result"
 echo "Test finished"
+sleep 5
 ps -ef

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -39,14 +39,14 @@ banner perf
 pfexec plimit -n 9123456 $$
 
 echo "Setup self timeout"
-jobpid=$$; (sleep $(( 2 * 60 )); ps -ef; kill $jobpid) &
+jobpid=$$; (sleep $(( 25 * 60 )); ps -ef; kill $jobpid) &
 
 echo "Setup debug logging"
 mkdir /tmp/debug
 prstat -d d -mLc 1 </dev/null > /tmp/debug/prstat.txt 2>&1 & disown
-# iostat -T d -xn 1 > /tmp/debug/iostat.txt &
-# mpstat -T d 1 > /tmp/debug/mpstat.txt &
-# vmstat -T d -p 1 >/tmp/debug/paging.txt &
+iostat -T d -xn 1 </dev/null > /tmp/debug/iostat.txt 2>&1 & disown
+mpstat -T d 1 </dev/null > /tmp/debug/mpstat.txt 2>&1 & disown
+vmstat -T d -p 1 </dev/null >/tmp/debug/paging.txt 2>&1 & disown
 
 disown -a
 echo "Now try with bash prefix"

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -39,7 +39,7 @@ banner perf
 pfexec plimit -n 9123456 $$
 
 echo "Setup self timeout"
-jobpid=$$; (sleep $(( 6 * 60 )); ps -ef; kill $jobpid) &
+jobpid=$$; (sleep $(( 36 * 60 )); ps -ef; kill $jobpid) &
 
 echo "Setup debug logging"
 mkdir /tmp/debug
@@ -49,9 +49,8 @@ mpstat -T d 1 </dev/null > /tmp/debug/mpstat.txt 2>&1 & disown
 vmstat -T d -p 1 </dev/null >/tmp/debug/paging.txt 2>&1 & disown
 
 disown -a
-echo "Now try with bash prefix"
+banner start
 bash $input/scripts/test_perf.sh > /tmp/debug/test_perf.txt 2>&1
-echo "$? was our 2nd result"
+echo "$? was our result"
 echo "Test finished"
 ps -ef
-exit 0

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -46,7 +46,7 @@ mkdir /tmp/debug
 prstat -d d -mLc 1 </dev/null > /tmp/debug/prstat.txt 2>&1 & disown
 iostat -T d -xn 1 </dev/null > /tmp/debug/iostat.txt 2>&1 & disown
 mpstat -T d 1 </dev/null > /tmp/debug/mpstat.txt 2>&1 & disown
-# vmstat -T d -p 1 </dev/null >/tmp/debug/paging.txt 2>&1 & disown
+vmstat -T d -p 1 </dev/null >/tmp/debug/paging.txt 2>&1 & disown
 
 disown -a
 echo "Now try with bash prefix"

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -39,13 +39,13 @@ banner perf
 pfexec plimit -n 9123456 $$
 
 echo "Setup self timeout"
-jobpid=$$; (sleep $(( 2 * 60 )); ps -ef; kill $jobpid) &
+jobpid=$$; (sleep $(( 6 * 60 )); ps -ef; kill $jobpid) &
 
 echo "Setup debug logging"
 mkdir /tmp/debug
 prstat -d d -mLc 1 </dev/null > /tmp/debug/prstat.txt 2>&1 & disown
 iostat -T d -xn 1 </dev/null > /tmp/debug/iostat.txt 2>&1 & disown
-# mpstat -T d 1 </dev/null > /tmp/debug/mpstat.txt 2>&1 & disown
+mpstat -T d 1 </dev/null > /tmp/debug/mpstat.txt 2>&1 & disown
 # vmstat -T d -p 1 </dev/null >/tmp/debug/paging.txt 2>&1 & disown
 
 disown -a

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -35,7 +35,7 @@ banner setup
 pfexec plimit -n 9123456 $$
 
 echo "Setup self timeout"
-jobpid=$$; (sleep $(( 40 * 60 )); ps -ef; zfs list;kill $jobpid) &
+jobpid=$$; (sleep $(( 10 * 60 )); ps -ef; zfs list;kill $jobpid) &
 
 echo "Setup debug logging"
 mkdir /tmp/debug

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -7,6 +7,7 @@
 #:  "=/tmp/perf*.csv",
 #:  "/tmp/perfout.txt",
 #:  "%/tmp/debug/*.txt",
+#:  "/tmp/dsc/*.txt",
 #: ]
 #: skip_clone = true
 #:
@@ -40,10 +41,11 @@ echo "Setup debug logging"
 mkdir /tmp/debug
 psrinfo -v > /tmp/debug/psrinfo.txt
 df -h > /tmp/debug/df.txt
-prstat -d d -mLc 1 </dev/null > /tmp/debug/prstat.txt 2>&1 &
-iostat -T d -xn 1 </dev/null > /tmp/debug/iostat.txt 2>&1 &
-mpstat -T d 1 </dev/null > /tmp/debug/mpstat.txt 2>&1 &
-vmstat -T d -p 1 </dev/null >/tmp/debug/paging.txt 2>&1 &
+prstat -d d -mLc 1 > /tmp/debug/prstat.txt 2>&1 &
+iostat -T d -xn 1 > /tmp/debug/iostat.txt 2>&1 &
+mpstat -T d 1 > /tmp/debug/mpstat.txt 2>&1 &
+vmstat -T d -p 1 < /dev/null > /tmp/debug/paging.txt 2>&1 &
+dtrace -Z -s $input/scripts/perf-downstairs-tick.d > /tmp/debug/dtrace.txt 2>&1 &
 
 banner start
 bash $input/scripts/test_perf.sh > /tmp/debug/test_perf.txt 2>&1

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -39,4 +39,5 @@ pfexec plimit -n 9123456 $$
 
 ptime -m bash "$input/scripts/test_perf.sh"
 echo "Test finished"
+ps -ef
 exit 0

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -45,6 +45,7 @@ iostat -T d -xn 1 > /tmp/debug/iostat.txt &
 mpstat -T d 1 > /tmp/debug/mpstat.txt &
 vmstat -T d -p 1 >/tmp/debug/paging.txt &
 
+disown -a
 echo "Start self timeout"
 jobpid=$$; (sleep $(( 2 * 60 )); ps -ef; kill $jobpid) &
 

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -35,7 +35,8 @@ banner setup
 pfexec plimit -n 9123456 $$
 
 echo "Setup self timeout"
-jobpid=$$; (sleep $(( 14 * 60 )); ps -ef; zfs list;kill $jobpid) &
+# This timeout is from issue 520
+jobpid=$$; (sleep $(( 40 * 60 )); ps -ef; zfs list;kill $jobpid) &
 
 echo "Setup debug logging"
 mkdir /tmp/debug

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -35,7 +35,7 @@ banner setup
 pfexec plimit -n 9123456 $$
 
 echo "Setup self timeout"
-jobpid=$$; (sleep $(( 10 * 60 )); ps -ef; zfs list;kill $jobpid) &
+jobpid=$$; (sleep $(( 14 * 60 )); ps -ef; zfs list;kill $jobpid) &
 
 echo "Setup debug logging"
 mkdir /tmp/debug
@@ -45,7 +45,7 @@ prstat -d d -mLc 1 > /tmp/debug/prstat.txt 2>&1 &
 iostat -T d -xn 1 > /tmp/debug/iostat.txt 2>&1 &
 mpstat -T d 1 > /tmp/debug/mpstat.txt 2>&1 &
 vmstat -T d -p 1 < /dev/null > /tmp/debug/paging.txt 2>&1 &
-dtrace -Z -s $input/scripts/perf-downstairs-tick.d > /tmp/debug/dtrace.txt 2>&1 &
+pfexec dtrace -Z -s $input/scripts/perf-downstairs-tick.d > /tmp/debug/dtrace.txt 2>&1 &
 
 banner start
 bash $input/scripts/test_perf.sh > /tmp/debug/test_perf.txt 2>&1

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -34,18 +34,17 @@ banner setup
 pfexec plimit -n 9123456 $$
 
 echo "Setup self timeout"
-jobpid=$$; (sleep $(( 240 * 60 )); ps -ef; zfs list;kill $jobpid) & disown
+jobpid=$$; (sleep $(( 240 * 60 )); ps -ef; zfs list;kill $jobpid) &
 
 echo "Setup debug logging"
 mkdir /tmp/debug
 psrinfo -v > /tmp/debug/psrinfo.txt
 df -h > /tmp/debug/df.txt
-prstat -d d -mLc 1 </dev/null > /tmp/debug/prstat.txt 2>&1 & disown
-iostat -T d -xn 1 </dev/null > /tmp/debug/iostat.txt 2>&1 & disown
-mpstat -T d 1 </dev/null > /tmp/debug/mpstat.txt 2>&1 & disown
-vmstat -T d -p 1 </dev/null >/tmp/debug/paging.txt 2>&1 & disown
+prstat -d d -mLc 1 </dev/null > /tmp/debug/prstat.txt 2>&1 &
+iostat -T d -xn 1 </dev/null > /tmp/debug/iostat.txt 2>&1 &
+mpstat -T d 1 </dev/null > /tmp/debug/mpstat.txt 2>&1 &
+vmstat -T d -p 1 </dev/null >/tmp/debug/paging.txt 2>&1 &
 
-disown -a
 banner start
 bash $input/scripts/test_perf.sh > /tmp/debug/test_perf.txt 2>&1
 echo "$? was our result"

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -37,9 +37,9 @@ export BINDIR=/var/tmp/bins
 banner perf
 pfexec plimit -n 9123456 $$
 
-chmod +x $input/scripts/test_perf.sh
-$input/scripts/test_perf.sh
-echo "$? was our result"
+echo "Now try with bash prefix"
+bash $input/scripts/test_perf.sh
+echo "$? was our 2nd result"
 echo "Test finished"
 ps -ef
 exit 0

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -34,7 +34,7 @@ banner setup
 pfexec plimit -n 9123456 $$
 
 echo "Setup self timeout"
-jobpid=$$; (sleep $(( 240 * 60 )); ps -ef; zfs list;kill $jobpid) &
+jobpid=$$; (sleep $(( 40 * 60 )); ps -ef; zfs list;kill $jobpid) &
 
 echo "Setup debug logging"
 mkdir /tmp/debug

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -39,10 +39,12 @@ banner perf
 pfexec plimit -n 9123456 $$
 
 echo "Setup self timeout"
-jobpid=$$; (sleep $(( 36 * 60 )); ps -ef; kill $jobpid) &
+jobpid=$$; (sleep $(( 240 * 60 )); ps -ef; df -h;kill $jobpid) &
 
 echo "Setup debug logging"
 mkdir /tmp/debug
+psrinfo -v > /tmp/debug/psrinfo.txt
+df -h > /tmp/debug/df.txt
 prstat -d d -mLc 1 </dev/null > /tmp/debug/prstat.txt 2>&1 & disown
 iostat -T d -xn 1 </dev/null > /tmp/debug/iostat.txt 2>&1 & disown
 mpstat -T d 1 </dev/null > /tmp/debug/mpstat.txt 2>&1 & disown

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -38,19 +38,19 @@ export BINDIR=/var/tmp/bins
 banner perf
 pfexec plimit -n 9123456 $$
 
-echo "Setup debug logging"
-mkdir /tmp/debug
-prstat -d d -mLc 1 > /tmp/debug/prstat.txt &
-iostat -T d -xn 1 > /tmp/debug/iostat.txt &
-mpstat -T d 1 > /tmp/debug/mpstat.txt &
-vmstat -T d -p 1 >/tmp/debug/paging.txt &
-
-disown -a
-echo "Start self timeout"
+echo "Setup self timeout"
 jobpid=$$; (sleep $(( 2 * 60 )); ps -ef; kill $jobpid) &
 
+echo "Setup debug logging"
+mkdir /tmp/debug
+prstat -d d -mLc 1 </dev/null > /tmp/debug/prstat.txt 2>&1 & disown
+# iostat -T d -xn 1 > /tmp/debug/iostat.txt &
+# mpstat -T d 1 > /tmp/debug/mpstat.txt &
+# vmstat -T d -p 1 >/tmp/debug/paging.txt &
+
+disown -a
 echo "Now try with bash prefix"
-bash $input/scripts/test_perf.sh
+bash $input/scripts/test_perf.sh > /tmp/debug/test_perf.txt 2>&1
 echo "$? was our 2nd result"
 echo "Test finished"
 ps -ef

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -37,7 +37,7 @@ export BINDIR=/var/tmp/bins
 banner perf
 pfexec plimit -n 9123456 $$
 
-ptime -m bash "$input/scripts/test_perf.sh"
+$input/scripts/test_perf.sh
 echo "$? was our result"
 echo "Test finished"
 ps -ef

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -37,6 +37,7 @@ export BINDIR=/var/tmp/bins
 banner perf
 pfexec plimit -n 9123456 $$
 
+chmod +x $input/scripts/test_perf.sh
 $input/scripts/test_perf.sh
 echo "$? was our result"
 echo "Test finished"

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -44,7 +44,7 @@ jobpid=$$; (sleep $(( 2 * 60 )); ps -ef; kill $jobpid) &
 echo "Setup debug logging"
 mkdir /tmp/debug
 prstat -d d -mLc 1 </dev/null > /tmp/debug/prstat.txt 2>&1 & disown
-# iostat -T d -xn 1 </dev/null > /tmp/debug/iostat.txt 2>&1 & disown
+iostat -T d -xn 1 </dev/null > /tmp/debug/iostat.txt 2>&1 & disown
 # mpstat -T d 1 </dev/null > /tmp/debug/mpstat.txt 2>&1 & disown
 # vmstat -T d -p 1 </dev/null >/tmp/debug/paging.txt 2>&1 & disown
 

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -4,9 +4,9 @@
 #: variety = "basic"
 #: target = "helios"
 #: output_rules = [
-#:  "/tmp/perf*.csv",
+#:  "=/tmp/perf*.csv",
 #:  "/tmp/perfout.txt",
-#:  "/tmp/debug/*.txt",
+#:  "%/tmp/debug/*.txt",
 #: ]
 #: skip_clone = true
 #:
@@ -19,11 +19,6 @@ set -o errexit
 set -o pipefail
 set -o xtrace
 
-echo "input rbins dir contains:"
-ls -ltr "$input"/rbins || true
-echo "input scripts dir contains:"
-ls -ltr "$input"/scripts || true
-
 banner unpack
 mkdir -p /var/tmp/bins
 for t in "$input/rbins/"*.gz; do
@@ -35,11 +30,11 @@ done
 
 export BINDIR=/var/tmp/bins
 
-banner perf
+banner setup
 pfexec plimit -n 9123456 $$
 
 echo "Setup self timeout"
-jobpid=$$; (sleep $(( 240 * 60 )); ps -ef; df -h;kill $jobpid) &
+jobpid=$$; (sleep $(( 240 * 60 )); ps -ef; zfs list;kill $jobpid) &
 
 echo "Setup debug logging"
 mkdir /tmp/debug

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -39,14 +39,14 @@ banner perf
 pfexec plimit -n 9123456 $$
 
 echo "Setup self timeout"
-jobpid=$$; (sleep $(( 25 * 60 )); ps -ef; kill $jobpid) &
+jobpid=$$; (sleep $(( 2 * 60 )); ps -ef; kill $jobpid) &
 
 echo "Setup debug logging"
 mkdir /tmp/debug
 prstat -d d -mLc 1 </dev/null > /tmp/debug/prstat.txt 2>&1 & disown
-iostat -T d -xn 1 </dev/null > /tmp/debug/iostat.txt 2>&1 & disown
-mpstat -T d 1 </dev/null > /tmp/debug/mpstat.txt 2>&1 & disown
-vmstat -T d -p 1 </dev/null >/tmp/debug/paging.txt 2>&1 & disown
+# iostat -T d -xn 1 </dev/null > /tmp/debug/iostat.txt 2>&1 & disown
+# mpstat -T d 1 </dev/null > /tmp/debug/mpstat.txt 2>&1 & disown
+# vmstat -T d -p 1 </dev/null >/tmp/debug/paging.txt 2>&1 & disown
 
 disown -a
 echo "Now try with bash prefix"

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -38,3 +38,5 @@ banner perf
 pfexec plimit -n 9123456 $$
 
 ptime -m bash "$input/scripts/test_perf.sh"
+echo "Test finished"
+exit 0

--- a/tools/dtrace/perf-downstairs-tick.d
+++ b/tools/dtrace/perf-downstairs-tick.d
@@ -1,0 +1,143 @@
+/*
+ * Watch a downstairs IO.
+ * 1st report is submit to sending it to the OS.
+ * 2nd report is OS time (for flush, to flush all extents)
+ * 3rd report is OS done to sending ACK back to upstairs
+ *
+ * arg0 is the job ID number.
+ */
+crucible_downstairs*:::submit-flush-start
+{
+    start[pid,arg0] = timestamp;
+}
+
+crucible_downstairs*:::os-flush-start
+/start[pid,arg0]/
+{
+    @timeone[pid,"flush submit-OS"] = quantize(timestamp - start[pid,arg0]);
+    start[pid,arg0] = 0;
+    substart[pid,arg0] = timestamp;
+}
+
+crucible_downstairs*:::os-flush-done
+/substart[pid,arg0]/
+{
+    @timetwo[pid,"flush OS"] = quantize(timestamp - substart[pid,arg0]);
+    substart[pid,arg0] = 0;
+    final[pid,arg0] = timestamp;
+}
+
+crucible_downstairs*:::submit-flush-done
+/final[pid,arg0]/
+{
+    @timethree[pid,"flush OS-done"] = quantize(timestamp - final[pid,arg0]);
+    final[pid,arg0] = 0;
+}
+
+/*
+ * Now the same, but for writes
+ */
+crucible_downstairs*:::submit-write-start
+{
+    start[pid,arg0] = timestamp;
+}
+
+crucible_downstairs*:::os-write-start
+/start[pid,arg0]/
+{
+    @timeone[pid,"write submit-OS"] = quantize(timestamp - start[pid,arg0]);
+    start[pid,arg0] = 0;
+    substart[pid,arg0] = timestamp;
+}
+
+crucible_downstairs*:::os-write-done
+/substart[pid,arg0]/
+{
+    @timetwo[pid,"write OS"] = quantize(timestamp - substart[pid,arg0]);
+    substart[pid,arg0] = 0;
+    final[pid,arg0] = timestamp;
+}
+
+crucible_downstairs*:::submit-write-done
+/final[pid,arg0]/
+{
+    @timethree[pid,"write OS-done"] = quantize(timestamp - final[pid,arg0]);
+    final[pid,arg0] = 0;
+}
+
+/*
+ * Now the same, but for reads
+ */
+crucible_downstairs*:::submit-read-start
+{
+    start[pid,arg0] = timestamp;
+}
+
+crucible_downstairs*:::os-read-start
+/start[pid,arg0]/
+{
+    @timeone[pid,"read submit-OS"] = quantize(timestamp - start[pid,arg0]);
+    start[pid,arg0] = 0;
+    substart[pid,arg0] = timestamp;
+}
+
+crucible_downstairs*:::os-read-done
+/substart[pid,arg0]/
+{
+    @timetwo[pid,"read OS"] = quantize(timestamp - substart[pid,arg0]);
+    substart[pid,arg0] = 0;
+    final[pid,arg0] = timestamp;
+}
+
+crucible_downstairs*:::submit-read-done
+/final[pid,arg0]/
+{
+    @timethree[pid,"read OS-done"] = quantize(timestamp - final[pid,arg0]);
+    final[pid,arg0] = 0;
+}
+
+/*
+ * Now the same, but for write unwritten
+ */
+crucible_downstairs*:::submit-writeunwritten-start
+{
+    start[pid,arg0] = timestamp;
+}
+
+crucible_downstairs*:::os-writeunwritten-start
+/start[pid,arg0]/
+{
+    @timeone[pid,"read submit-OS"] = quantize(timestamp - start[pid,arg0]);
+    start[pid,arg0] = 0;
+    substart[pid,arg0] = timestamp;
+}
+
+crucible_downstairs*:::os-writeunwritten-done
+/substart[pid,arg0]/
+{
+    @timetwo[pid,"read OS"] = quantize(timestamp - substart[pid,arg0]);
+    substart[pid,arg0] = 0;
+    final[pid,arg0] = timestamp;
+}
+
+crucible_downstairs*:::submit-writeunwritten-done
+/final[pid,arg0]/
+{
+    @timethree[pid,"read OS-done"] = quantize(timestamp - final[pid,arg0]);
+    final[pid,arg0] = 0;
+}
+
+tick-60s
+{
+    printa(@timeone)
+}
+
+tick-60s
+{
+    printa(@timetwo)
+}
+
+tick-60s
+{
+    printa(@timethree)
+}

--- a/tools/test_perf.sh
+++ b/tools/test_perf.sh
@@ -43,7 +43,7 @@ function perf_round() {
     fi
     echo "IOPs for es=$es ec=$ec" >> "$outfile"
     echo "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
-    timeout 1200 "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
+    timeout 200 "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
     echo "" >> "$outfile"
     echo Perf test completed, stop all downstairs
     "$dsc" cmd shutdown
@@ -77,9 +77,9 @@ done
 echo "Perf test with timeout begins at $(date)" > "$outfile"
 
 #            ES   EC
-perf_round  4096 6400
-perf_round  8192 3200
-perf_round 16384 1600
+#perf_round  4096 6400
+#perf_round  8192 3200
+#perf_round 16384 1600
 perf_round 32768  800
 
 # Print out a nice summary of all the perf results.  This depends

--- a/tools/test_perf.sh
+++ b/tools/test_perf.sh
@@ -9,8 +9,8 @@ set -o pipefail
 trap ctrl_c INT
 function ctrl_c() {
     echo "Stopping at your request"
-    if [[ -n "$fds" ]]; then
-        "$dsc" cmd shutdown
+    if [[ -n "$dsc" ]]; then
+        "$dsc" cmd shutdown > /dev/null 2>&1 || true
     fi
     exit 1
 }

--- a/tools/test_perf.sh
+++ b/tools/test_perf.sh
@@ -43,7 +43,13 @@ function perf_round() {
     fi
     echo "IOPs for es=$es ec=$ec" >> "$outfile"
     echo "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
+    set +o errexit
     timeout 200 "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
+    if [[ $? -ne 0 ]]; then
+        echo "perf test result was bad"
+        exit 1
+    fi
+    set +o errexit
     echo "" >> "$outfile"
     echo Perf test completed, stop all downstairs
     "$dsc" cmd shutdown

--- a/tools/test_perf.sh
+++ b/tools/test_perf.sh
@@ -43,12 +43,7 @@ function perf_round() {
     fi
     echo "IOPs for es=$es ec=$ec" >> "$outfile"
     echo "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
-    set +o errexit
-    timeout 200 "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
-    if [[ $? -ne 0 ]]; then
-        echo "perf test result was bad"
-        exit 1
-    fi
+    "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
     set +o errexit
     echo "" >> "$outfile"
     echo Perf test completed, stop all downstairs

--- a/tools/test_perf.sh
+++ b/tools/test_perf.sh
@@ -77,6 +77,7 @@ done
 echo "Perf test with timeout begins at $(date)" > "$outfile"
 
 #            ES   EC
+# XXX TODO: put this back with things start working better
 #perf_round  4096 6400
 #perf_round  8192 3200
 #perf_round 16384 1600

--- a/tools/test_perf.sh
+++ b/tools/test_perf.sh
@@ -43,7 +43,7 @@ function perf_round() {
     fi
     echo "IOPs for es=$es ec=$ec" >> "$outfile"
     echo "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
-    "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
+    timeout 1200 "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
     echo "" >> "$outfile"
     echo Perf test completed, stop all downstairs
     "$dsc" cmd shutdown
@@ -74,7 +74,7 @@ for bin in $dsc $ct $downstairs; do
     fi
 done
 
-echo "Perf test begins at $(date)" > "$outfile"
+echo "Perf test with timeout begins at $(date)" > "$outfile"
 
 #            ES   EC
 perf_round  4096 6400

--- a/tools/test_perf.sh
+++ b/tools/test_perf.sh
@@ -43,8 +43,7 @@ function perf_round() {
     fi
     echo "IOPs for es=$es ec=$ec" >> "$outfile"
     echo "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
-    "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
-    set +o errexit
+    "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv 2>&1 | tee -a "$outfile"
     echo "" >> "$outfile"
     echo Perf test completed, stop all downstairs
     "$dsc" cmd shutdown


### PR DESCRIPTION
test_perf.sh is currently taking waaaaaay to long to finish, and while
performance issues that this test is tripping over are worked out, the 
script has been both reduced in what it does, and limited to 40 minutes 
of runtime.

Added a new dtrace script to log performance for this test, as well
as collect a bunch of other debug information that could be useful
when a test does hit a timeout.

Minor cleanup of the test_perf.sh script, send logs and error to the
proper places for collection.
