### PR TITLE
Take the generation out of activation

### DIFF
--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -565,7 +565,7 @@ async fn main() -> Result<()> {
     eprintln!("Crucible runtime is spawned");
 
     // IO time
-    guest.activate(opt.gen).await?;
+    guest.activate().await?;
 
     let (early_shutdown_sender, early_shutdown_receiver) = mpsc::channel(1);
 

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -713,7 +713,7 @@ async fn process_cli_command(
     verify_output: Option<PathBuf>,
 ) -> Result<()> {
     match cmd {
-        CliMessage::Activate(gen) => match guest.activate(gen).await {
+        CliMessage::Activate(gen) => match guest.activate_with_gen(gen).await {
             Ok(_) => fw.send(CliMessage::DoneOk).await,
             Err(e) => fw.send(CliMessage::Error(e)).await,
         },

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -537,13 +537,13 @@ async fn main() -> Result<()> {
     }
 
     if opt.retry_activate {
-        while let Err(e) = guest.activate(opt.gen).await {
+        while let Err(e) = guest.activate_with_gen(opt.gen).await {
             println!("Activate returns: {:#}  Retrying", e);
             tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
         }
         println!("Activate successful");
     } else {
-        guest.activate(opt.gen).await?;
+        guest.activate_with_gen(opt.gen).await?;
     }
 
     println!("Wait for a query_work_queue command to finish before sending IO");
@@ -1756,7 +1756,7 @@ async fn deactivate_workload(
         );
         let mut retry = 1;
         gen += 1;
-        while let Err(e) = guest.activate(gen).await {
+        while let Err(e) = guest.activate_with_gen(gen).await {
             println!(
                 "{:>0width$}/{:>0width$}, Retry:{} activate {:?}",
                 c,

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -38,7 +38,7 @@ pub struct Opt {
     #[clap(short, long, action)]
     key: Option<String>,
 
-    #[clap(short, long, default_value = "0", action)]
+    #[clap(short, long, default_value = "1", action)]
     gen: u64,
 
     /*
@@ -123,7 +123,7 @@ async fn main() -> Result<()> {
     let mut cpfs: Vec<crucible::CruciblePseudoFile<Guest>> =
         Vec::with_capacity(opt.num_upstairs);
 
-    for gen in 0..opt.num_upstairs {
+    for i in 0..opt.num_upstairs {
         /*
          * The structure we use to send work from outside crucible into the
          * Upstairs main task.
@@ -132,6 +132,7 @@ async fn main() -> Result<()> {
          */
         let guest = Arc::new(Guest::new());
 
+        let gen: u64 = i as u64 + opt.gen;
         let _join_handle =
             up_main(crucible_opts.clone(), gen as u64, guest.clone(), None)
                 .await?;

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -91,7 +91,6 @@ async fn main() -> Result<()> {
         control: opt.control,
         read_only: false,
     };
-    let mut generation_number = opt.gen;
 
     if let Some(tracing_endpoint) = opt.tracing_endpoint {
         let tracer = opentelemetry_jaeger::new_pipeline()
@@ -124,7 +123,7 @@ async fn main() -> Result<()> {
     let mut cpfs: Vec<crucible::CruciblePseudoFile<Guest>> =
         Vec::with_capacity(opt.num_upstairs);
 
-    for _ in 0..opt.num_upstairs {
+    for gen in 0..opt.num_upstairs {
         /*
          * The structure we use to send work from outside crucible into the
          * Upstairs main task.
@@ -133,13 +132,9 @@ async fn main() -> Result<()> {
          */
         let guest = Arc::new(Guest::new());
 
-        let _join_handle = up_main(
-            crucible_opts.clone(),
-            opt.gen, // XXX increase gen per upstairs
-            guest.clone(),
-            None,
-        )
-        .await?;
+        let _join_handle =
+            up_main(crucible_opts.clone(), gen as u64, guest.clone(), None)
+                .await?;
         println!("Crucible runtime is spawned");
 
         cpfs.push(crucible::CruciblePseudoFile::from(guest)?);
@@ -153,8 +148,7 @@ async fn main() -> Result<()> {
     let mut cpf_idx = 0;
 
     println!("Initial Handing off to CPF {}", cpf_idx);
-    cpfs[cpf_idx].activate(generation_number).await?;
-    generation_number += 1;
+    cpfs[cpf_idx].activate().await?;
     println!(
         "Initial Hand off to CPF {} {:?}",
         cpf_idx,
@@ -186,8 +180,7 @@ async fn main() -> Result<()> {
             println!("Round {} Handing off to CPF {}", idx, cpf_idx);
 
             let cpf = &mut cpfs[cpf_idx];
-            cpf.activate(generation_number).await?;
-            generation_number += 1;
+            cpf.activate().await?;
 
             println!(
                 "Round {} Handed off to CPF {} {:?}",

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -231,7 +231,7 @@ mod test {
 
         let volume = Arc::new(Volume::construct(vcr, None).await?);
 
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         // Verify contents are zero on init
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -304,7 +304,7 @@ mod test {
         volume.add_subvolume_create_guest(opts, 1, None).await?;
         volume.add_read_only_parent(in_memory_data.clone()).await?;
 
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         // Verify contents are 11 on init
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -401,7 +401,7 @@ mod test {
             })
             .await?;
 
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         // Verify contents are 11 on init
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -484,7 +484,7 @@ mod test {
             };
 
         let volume = Volume::construct(vcr, None).await?;
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         // Read one block: should be all 0xff
         let buffer = Buffer::new(BLOCK_SIZE);
@@ -535,7 +535,7 @@ mod test {
             };
 
         let volume = Volume::construct(vcr, None).await?;
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         // Read one block: should be all 0x00
         let buffer = Buffer::new(BLOCK_SIZE);
@@ -581,7 +581,7 @@ mod test {
 
         let volume = Arc::new(Volume::construct(vcr, None).await?);
 
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         // Write data in
         volume
@@ -650,7 +650,7 @@ mod test {
 
         let volume = Arc::new(Volume::construct(vcr, None).await?);
 
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         // Write data in
         volume
@@ -721,7 +721,7 @@ mod test {
 
         let volume = Arc::new(Volume::construct(vcr, None).await?);
 
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         // Write data at block 0
         volume
@@ -802,7 +802,7 @@ mod test {
 
         let volume = Arc::new(Volume::construct(vcr, None).await?);
 
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         let full_volume_size = BLOCK_SIZE * 20;
         // Write data in
@@ -884,7 +884,7 @@ mod test {
 
         let volume = Arc::new(Volume::construct(vcr, None).await?);
 
-        volume.activate(1).await?;
+        volume.activate().await?;
         let full_volume_size = BLOCK_SIZE * 20;
 
         // Write data to last block of first vol, and first block of
@@ -988,7 +988,7 @@ mod test {
 
         let volume = Arc::new(Volume::construct(vcr, None).await?);
 
-        volume.activate(1).await?;
+        volume.activate().await?;
         let full_volume_size = BLOCK_SIZE * 20;
 
         // Write data to last block of first vol, and first block of
@@ -1088,7 +1088,7 @@ mod test {
         volume.add_subvolume_create_guest(opts, 1, None).await?;
         volume.add_read_only_parent(in_memory_data).await?;
 
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         // Verify parent contents in one read
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -1157,7 +1157,7 @@ mod test {
         volume.add_subvolume_create_guest(opts, 1, None).await?;
         volume.add_read_only_parent(in_memory_data).await?;
 
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         // Verify contents are 11 at startup
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -1229,7 +1229,7 @@ mod test {
         volume.add_subvolume_create_guest(opts, 1, None).await?;
         volume.add_read_only_parent(in_memory_data).await?;
 
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         // Verify contents of RO parent are 1s at startup
         let buffer = Buffer::new(BLOCK_SIZE * 5);
@@ -1322,7 +1322,7 @@ mod test {
         volume.add_subvolume_create_guest(opts, 1, None).await?;
         volume.add_read_only_parent(in_memory_data).await?;
 
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         // SV: |--2-------|
         volume
@@ -1406,7 +1406,7 @@ mod test {
         volume.add_subvolume_create_guest(opts, 1, None).await?;
         volume.add_read_only_parent(in_memory_data).await?;
 
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         // Verify contents are 11 at startup
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -1508,7 +1508,7 @@ mod test {
             })
             .await?;
 
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         // Write data to last block of first vol, and first block of
         // second vol.
@@ -1629,7 +1629,7 @@ mod test {
             })
             .await?;
 
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         // Write data to last block of first vol, and first block of
         // second vol, AKA write A.
@@ -1734,10 +1734,10 @@ mod test {
             };
 
         let volume1 = Volume::construct(vcr_1, None).await?;
-        volume1.activate(1).await?;
+        volume1.activate().await?;
 
         let volume2 = Volume::construct(vcr_2, None).await?;
-        volume2.activate(1).await?;
+        volume2.activate().await?;
 
         // Read one block: should be all 0x00
         let buffer = Buffer::new(BLOCK_SIZE);
@@ -1779,7 +1779,7 @@ mod test {
         let mut volume = Volume::new(BLOCK_SIZE as u64);
         volume.add_subvolume_create_guest(opts, 1, None).await?;
 
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         // Verify contents are 00 at startup
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -1832,7 +1832,7 @@ mod test {
             .add_subvolume_create_guest(test_downstairs_set.opts(), 1, None)
             .await?;
 
-        volume.activate(1).await?;
+        volume.activate().await?;
 
         let random_buffer = {
             let mut random_buffer =
@@ -1861,7 +1861,7 @@ mod test {
                 .add_subvolume_create_guest(test_downstairs_set.opts(), 2, None)
                 .await?;
 
-            volume.activate(2).await?;
+            volume.activate().await?;
 
             let buffer = Buffer::new(volume.total_size().await? as usize);
             volume
@@ -1914,7 +1914,7 @@ mod test {
             };
 
         let volume = Volume::construct(vcr, None).await?;
-        volume.activate(3).await?;
+        volume.activate().await?;
 
         // Validate that source blocks originally come from the read-only parent
         {
@@ -1965,6 +1965,8 @@ mod test {
     // layers above (in general) will eventually call a BlockIO trait
     // on a guest layer.
 
+    // ZZZ Make a test of guest.activate_with_gen both fail and pass.
+    // Maybe in a different place?  We need downstairs to do this.
     #[tokio::test]
     async fn integration_test_guest_downstairs() -> Result<()> {
         // Test using the guest layer to verify a new region is
@@ -1978,9 +1980,9 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 0, gc, None).await?;
+        let _join_handle = up_main(opts, 1, gc, None).await?;
 
-        guest.activate(1).await?;
+        guest.activate().await?;
         guest.query_work_queue().await?;
 
         // Verify contents are zero on init
@@ -2022,9 +2024,9 @@ mod test {
         let gc = guest.clone();
 
         // Read-only Upstairs should return errors if writes are attempted.
-        let _join_handle = up_main(opts, 0, gc, None).await?;
+        let _join_handle = up_main(opts, 1, gc, None).await?;
 
-        guest.activate(1).await?;
+        guest.activate().await?;
 
         // Expect an error attempting to write.
         let write_result = guest
@@ -2056,9 +2058,9 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 0, gc, None).await?;
+        let _join_handle = up_main(opts, 1, gc, None).await?;
 
-        guest.activate(1).await?;
+        guest.activate().await?;
         guest.query_work_queue().await?;
 
         // Write_unwritten data in
@@ -2129,9 +2131,9 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 0, gc, None).await?;
+        let _join_handle = up_main(opts, 1, gc, None).await?;
 
-        guest.activate(1).await?;
+        guest.activate().await?;
         guest.query_work_queue().await?;
 
         // Write_unwritten data in the first block
@@ -2187,9 +2189,9 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 0, gc, None).await?;
+        let _join_handle = up_main(opts, 1, gc, None).await?;
 
-        guest.activate(1).await?;
+        guest.activate().await?;
         guest.query_work_queue().await?;
 
         // Write_unwritten data in the second block
@@ -2246,9 +2248,9 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 0, gc, None).await?;
+        let _join_handle = up_main(opts, 1, gc, None).await?;
 
-        guest.activate(1).await?;
+        guest.activate().await?;
         guest.query_work_queue().await?;
 
         // Write_unwritten data in the third block
@@ -2303,9 +2305,9 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 0, gc, None).await?;
+        let _join_handle = up_main(opts, 1, gc, None).await?;
 
-        guest.activate(1).await?;
+        guest.activate().await?;
         guest.query_work_queue().await?;
 
         // Write_unwritten data in last block of the extent
@@ -2360,9 +2362,9 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 0, gc, None).await?;
+        let _join_handle = up_main(opts, 1, gc, None).await?;
 
-        guest.activate(1).await?;
+        guest.activate().await?;
         guest.query_work_queue().await?;
 
         // Write_unwritten data in last block of the extent
@@ -2495,7 +2497,7 @@ mod test {
 
         // read the data to verify import
 
-        let dur = std::time::Duration::from_secs(5);
+        let dur = std::time::Duration::from_secs(15);
         let client = reqwest::ClientBuilder::new()
             .connect_timeout(dur)
             .timeout(dur)
@@ -2523,7 +2525,7 @@ mod test {
                 read_only_parent: None,
             };
         let volume = Volume::construct(vcr, None).await.unwrap();
-        volume.activate(2).await.unwrap();
+        volume.activate().await.unwrap();
 
         let buffer = Buffer::new(bytes.len());
         volume
@@ -2673,7 +2675,7 @@ mod test {
         // Verify contents are zero on init
         {
             let volume = Volume::construct(vcr.clone(), None).await.unwrap();
-            volume.activate(1).await.unwrap();
+            volume.activate().await.unwrap();
 
             let buffer = Buffer::new(5120);
             volume
@@ -2765,7 +2767,7 @@ mod test {
                 read_only_parent: None,
             };
         let volume = Volume::construct(vcr, None).await.unwrap();
-        volume.activate(3).await.unwrap();
+        volume.activate().await.unwrap();
 
         let buffer = Buffer::new(5120);
         volume
@@ -2930,7 +2932,7 @@ mod test {
                 read_only_parent: None,
             };
         let volume = Volume::construct(vcr, None).await.unwrap();
-        volume.activate(2).await.unwrap();
+        volume.activate().await.unwrap();
 
         let buffer = Buffer::new(5120);
         volume
@@ -3031,7 +3033,7 @@ mod test {
                 read_only_parent: None,
             };
         let volume = Volume::construct(vcr, None).await.unwrap();
-        volume.activate(2).await.unwrap();
+        volume.activate().await.unwrap();
 
         let buffer =
             Buffer::new(crucible_pantry::pantry::PantryEntry::MAX_CHUNK_SIZE);
@@ -3056,7 +3058,7 @@ mod test {
         let url = format!("{}/OVMF_CODE_20220922.fd", base_url);
 
         let data = {
-            let dur = std::time::Duration::from_secs(5);
+            let dur = std::time::Duration::from_secs(15);
             let client = reqwest::ClientBuilder::new()
                 .connect_timeout(dur)
                 .timeout(dur)
@@ -3104,7 +3106,7 @@ mod test {
         // Verify contents match data on init
         {
             let volume = Volume::construct(vcr, None).await.unwrap();
-            volume.activate(1).await.unwrap();
+            volume.activate().await.unwrap();
 
             let buffer = Buffer::new(data.len());
             volume
@@ -3198,7 +3200,7 @@ mod test {
         // Attach, validate random data got imported
 
         let volume = Volume::construct(vcr, None).await.unwrap();
-        volume.activate(2).await.unwrap();
+        volume.activate().await.unwrap();
 
         let buffer = Buffer::new(data.len());
         volume

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -108,7 +108,7 @@ async fn main() -> Result<()> {
         up_main(crucible_opts, opt.gen, guest.clone(), None).await?;
     println!("Crucible runtime is spawned");
 
-    guest.activate(opt.gen).await?;
+    guest.activate().await?;
 
     let mut rng = rand::thread_rng();
 

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -99,14 +99,12 @@ async fn main() -> Result<()> {
 
     // NBD server
 
-    guest.activate(opt.gen).await?;
-    let volume = Volume::from_block_io(guest).await?;
-    let mut cpf = crucible::CruciblePseudoFile::from(Arc::new(volume))?;
+    guest.activate().await?;
+    let mut cpf = crucible::CruciblePseudoFile::from(guest)?;
 
     let listener = TcpListener::bind("127.0.0.1:10809").unwrap();
 
     // sent to NBD client during handshake through Export struct
-    cpf.activate(opt.gen).await?;
     println!("NBD advertised size as {} bytes", cpf.sz());
 
     for stream in listener.incoming() {

--- a/pantry/src/pantry.rs
+++ b/pantry/src/pantry.rs
@@ -260,8 +260,7 @@ impl Pantry {
 
         info!(self.log, "volume {} constructed ok", volume_id);
 
-        // XXX activation number going away?
-        volume.activate(0).await?;
+        volume.activate().await?;
 
         info!(self.log, "volume {} activated ok", volume_id);
 

--- a/tools/test_perf.sh
+++ b/tools/test_perf.sh
@@ -43,7 +43,7 @@ function perf_round() {
     fi
     echo "IOPs for es=$es ec=$ec" >> "$outfile"
     echo "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
-    "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
+    timeout 900 "$ct" perf $args --perf-out /tmp/perf-ES-"$es"-EC-"$ec".csv | tee -a "$outfile"
     echo "" >> "$outfile"
     echo Perf test completed, stop all downstairs
     "$dsc" cmd shutdown
@@ -74,7 +74,7 @@ for bin in $dsc $ct $downstairs; do
     fi
 done
 
-echo "Perf test begins at $(date)" > "$outfile"
+echo "Perf test (with timeout) begins at $(date)" > "$outfile"
 
 #            ES   EC
 perf_round  4096 6400

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -170,6 +170,7 @@ done
 
 echo "" >> "${log_prefix}_out.txt"
 echo "Running hammer" | tee -a "${log_prefix}_out.txt"
+echo "$ch" -g "$gen" "${args[@]}" >> "${log_prefix}_out.txt"
 if ! "$ch" -g "$gen" "${args[@]}" >> "${log_prefix}_out.txt" 2>&1; then
     echo "Failed hammer test"
     echo "Failed hammer test" >> "$fail_log"

--- a/upstairs/src/block_io.rs
+++ b/upstairs/src/block_io.rs
@@ -36,7 +36,7 @@ impl FileBlockIO {
 
 #[async_trait]
 impl BlockIO for FileBlockIO {
-    async fn activate(&self, _gen: u64) -> Result<(), CrucibleError> {
+    async fn activate(&self) -> Result<(), CrucibleError> {
         Ok(())
     }
 
@@ -181,7 +181,7 @@ impl ReqwestBlockIO {
 
 #[async_trait]
 impl BlockIO for ReqwestBlockIO {
-    async fn activate(&self, _gen: u64) -> Result<(), CrucibleError> {
+    async fn activate(&self) -> Result<(), CrucibleError> {
         Ok(())
     }
 

--- a/upstairs/src/in_memory.rs
+++ b/upstairs/src/in_memory.rs
@@ -29,7 +29,7 @@ impl InMemoryBlockIO {
 
 #[async_trait]
 impl BlockIO for InMemoryBlockIO {
-    async fn activate(&self, _gen: u64) -> Result<(), CrucibleError> {
+    async fn activate(&self) -> Result<(), CrucibleError> {
         Ok(())
     }
 

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -152,8 +152,8 @@ impl<T: BlockIO> CruciblePseudoFile<T> {
         self.sz
     }
 
-    pub async fn activate(&mut self, gen: u64) -> Result<(), CrucibleError> {
-        if let Err(e) = self.block_io.activate(gen).await {
+    pub async fn activate(&mut self) -> Result<(), CrucibleError> {
+        if let Err(e) = self.block_io.activate().await {
             match e {
                 CrucibleError::UpstairsAlreadyActive => {
                     // underlying block io is already active, but pseudo file


### PR DESCRIPTION
This removes the generation number requirement from the BlockIO activate.  When the upstairs is started, it should receive a generation number from the caller (most likely from a VolumeConstructionRequest) and that value should be used when the volume (or subvolume, or guest) is activated.

A guest specific activate_with_gen method still exists for now that will enable a different generation number to be used.
This allows tests and possibly migration to still have the ability to deactivate and then re-activate a single upstairs 
instance without having to start over.