### PR TITLE
Updates for test_up.sh script and buildomat

### DIFF
--- a/.github/buildomat/jobs/test-up-encrypted.sh
+++ b/.github/buildomat/jobs/test-up-encrypted.sh
@@ -4,7 +4,7 @@
 #: variety = "basic"
 #: target = "helios"
 #: output_rules = [
-#:	"/tmp/*.txt",
+#:	"/tmp/test_up/*.txt",
 #: ]
 #: skip_clone = true
 #:
@@ -32,6 +32,6 @@ done
 export BINDIR=/var/tmp/bins
 
 banner test_up_encrypted
-ptime -m bash "$input/scripts/test_up.sh" encrypted
+ptime -m bash "$input/scripts/test_up.sh" -N encrypted
 
 # Save the output files?

--- a/.github/buildomat/jobs/test-up-unencrypted.sh
+++ b/.github/buildomat/jobs/test-up-unencrypted.sh
@@ -4,7 +4,7 @@
 #: variety = "basic"
 #: target = "helios"
 #: output_rules = [
-#:	"/tmp/*.txt",
+#:	"/tmp/test_up/*.txt",
 #: ]
 #: skip_clone = true
 #:
@@ -32,6 +32,6 @@ done
 export BINDIR=/var/tmp/bins
 
 banner test_up_unencrypted
-ptime -m bash "$input/scripts/test_up.sh" unencrypted
+ptime -m bash "$input/scripts/test_up.sh" -N unencrypted
 
 # Save the output files?


### PR DESCRIPTION
Updated test_up.sh to start dsc in two steps instead of all at once. 
This allows slower systems to take the time they need to create the regions.

Plumbed the no color option through to the dump command so buildomat 
does not have to print color codes.

Fixed the archive file list for the test_up tests, as the location had changed and 
buildomat was not longer getting the files.