### PR TITLE
Add longer timeout to some pantry tests

### DIFF
--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -2495,7 +2495,7 @@ mod test {
 
         // read the data to verify import
 
-        let dur = std::time::Duration::from_secs(5);
+        let dur = std::time::Duration::from_secs(25);
         let client = reqwest::ClientBuilder::new()
             .connect_timeout(dur)
             .timeout(dur)
@@ -3056,7 +3056,7 @@ mod test {
         let url = format!("{}/OVMF_CODE_20220922.fd", base_url);
 
         let data = {
-            let dur = std::time::Duration::from_secs(5);
+            let dur = std::time::Duration::from_secs(25);
             let client = reqwest::ClientBuilder::new()
                 .connect_timeout(dur)
                 .timeout(dur)


### PR DESCRIPTION
Update the two pantry tests that make requests that require internet access.  Yes, we have to replace these tests with something that does not require internet access, but until then, at least give it a reasonable try before giving up.