### PR TITLE
DTrace probes for upstairs work queue

### DIFF
--- a/tools/dtrace/README.md
+++ b/tools/dtrace/README.md
@@ -271,7 +271,7 @@ pfexec dtrace -s upstairs_info.d
 ```
 
 You start crucible, then run the above script.  Output should start appearing
-with a few seconds.
+within a few seconds.
 
 The output has several columns.  The first three will list the state of each
 of the three downstairs.  Following that the remaining columns all indicate

--- a/tools/dtrace/README.md
+++ b/tools/dtrace/README.md
@@ -263,7 +263,7 @@ Trace a downstairs IO and measure time for in in the following three parts:
 * 3rd report is OS done to downstairs sending the ACK back to upstairs
 
 ## upstairs_info.d
-This is a dtrace script for printing some simple upstairs state info.
+This is a dtrace script for printing upstairs state and work queue info.
 If the upstairs is not yet running, add the -Z flag to dtrace so it will
 wait to find the matching probe.
 ```
@@ -271,16 +271,23 @@ pfexec dtrace -s upstairs_info.d
 ```
 
 You start crucible, then run the above script.  Output should start appearing
-right away with the state of the three downstairs and a count of active
-jobs for upstairs and downstairs.
+with a few seconds.  Output will state of each of the three downstairs and
+a count of active jobs for the guest side (UPW) and for the downstairs side
+(DSW).  Jobs for the downstairs can be in one of five possible states:
+  New, In Progress, Done, Skipped, Error,
+For each downstairs/state, we print a count of jobs in that state.
 
 Here is an example of how it might look:
 ```
 alan@cat:crucible$ pfexec dtrace -s upstairs_info.d
-["Active","Active","Active"] Upstairs:   1 Downstairs:   3
-["Active","Active","Active"] Upstairs:   1 Downstairs:   3
-["Active","Active","Active"] Upstairs:   1 Downstairs:   6
-["Active","Active","Active"] Upstairs:   1 Downstairs:   6
+DS 0 STATE   DS 1 STATE   DS 2 STATE   UPW  DSW  NEW0 NEW1 NEW2   IP0  IP1  IP2    D0   D1   D2    S0   S1   S2  E0 E1 E2
+    active       active       active     1    2     1    1    1     0    0    0     1    1    1     0    0    0   0  0  0
+    active       active       active     4 1259     1    1    1     2    2    2  1256 1256 1256     0    0    0   0  0  0
+    active       active       active     3  557     1    1   77     2    2   99   554  554  381     0    0    0   0  0  0
+    active       active       active     2 1364     0    0  446     1    1  100  1363 1363  818     0    0    0   0  0  0
+    active       active       active     9 1510     1    1   47     8    8  100  1501 1501 1363     0    0    0   0  0  0
+    active       active       active     9 1508     1    1 1317     8    8    0  1499 1499  191     0    0    0   0  0  0
+    active       active       active     9 2175     1    1  576     8    8  100  2166 2166 1499     0    0    0   0  0  0
 ```
 
 ## tracegw.d

--- a/tools/dtrace/README.md
+++ b/tools/dtrace/README.md
@@ -272,6 +272,7 @@ pfexec dtrace -s upstairs_info.d
 
 You start crucible, then run the above script.  Output should start appearing
 with a few seconds.
+
 The output has several columns.  The first three will list the state of each
 of the three downstairs.  Following that the remaining columns all indicate
 various work queues and job state for work internal to the Upstairs.  Before we
@@ -281,19 +282,22 @@ upstairs is needed.
 Inside the Upstairs there are two work queues.
 * The upstairs (or guest) side
 * The downstairs side.
+
 For the upstairs side, this holds jobs the upstairs has received from the
-guest that we have not Acked yet.  For every upstairs side, there is one or more
-corresponding downstairs jobs that track the progress of the work required
+guest that we have not Acked yet.  For every upstairs side, there is one or
+more corresponding downstairs jobs that track the progress of the work required
 to complete this job.  For each downstairs job, there is a state for that job
 on each of the three downstairs.
 
 Now, back to the columns.
-Columns 4 and 5 show the count of active jobs for the guest side (UPW) and
-for the downstairs side (DSW).
+Columns four and five show the count of active jobs for the guest side (UPW)
+and for the downstairs side (DSW).
+
+
 The remaining columns 6-20 show the count of job states on each downstairs.
 Jobs for the downstairs can be in one of five possible states:
-  New, In Progress, Done, Skipped, Error,
-For each downstairs/state, we print a count of jobs in that state.
+ `New`, `In Progress`, `Done`, `Skipped`, `Error`.
+For each state/downstairs, we print a count of jobs in that state.
 
 Here is an example of how it might look:
 ```

--- a/tools/dtrace/README.md
+++ b/tools/dtrace/README.md
@@ -271,9 +271,27 @@ pfexec dtrace -s upstairs_info.d
 ```
 
 You start crucible, then run the above script.  Output should start appearing
-with a few seconds.  Output will state of each of the three downstairs and
-a count of active jobs for the guest side (UPW) and for the downstairs side
-(DSW).  Jobs for the downstairs can be in one of five possible states:
+with a few seconds.
+The output has several columns.  The first three will list the state of each
+of the three downstairs.  Following that the remaining columns all indicate
+various work queues and job state for work internal to the Upstairs.  Before we
+describe the columns, a bit of detail about the internal structure of Crucible
+upstairs is needed.
+
+Inside the Upstairs there are two work queues.
+* The upstairs (or guest) side
+* The downstairs side.
+For the upstairs side, this holds jobs the upstairs has received from the
+guest that we have not Acked yet.  For every upstairs side, there is one or more
+corresponding downstairs jobs that track the progress of the work required
+to complete this job.  For each downstairs job, there is a state for that job
+on each of the three downstairs.
+
+Now, back to the columns.
+Columns 4 and 5 show the count of active jobs for the guest side (UPW) and
+for the downstairs side (DSW).
+The remaining columns 6-20 show the count of job states on each downstairs.
+Jobs for the downstairs can be in one of five possible states:
   New, In Progress, Done, Skipped, Error,
 For each downstairs/state, we print a count of jobs in that state.
 

--- a/tools/dtrace/upstairs_info.d
+++ b/tools/dtrace/upstairs_info.d
@@ -2,9 +2,88 @@
  * Display internal Upstairs status.
  */
 #pragma D option quiet
+/*
+ * Print the header right away
+ */
+dtrace:::BEGIN
+{
+    show = 21;
+}
+
+/*
+ * Every second, check and see if we have printed enough that it is
+ * time to print the header again
+ */
+tick-1s
+/show > 20/
+{
+    printf("  DS STATE 0   DS STATE 1   DS STATE 2");
+    printf("   UPW  DSW");
+    printf("  NEW0 NEW1 NEW2");
+    printf("   IP0  IP1  IP2");
+    printf("    D0   D1   D2");
+    printf("    S0   S1   S2");
+    printf("  E0 E1 E2");
+    printf("\n");
+    show = 0;
+}
+
 crucible_upstairs*:::up-status
 {
-    printf("%s ", json(copyinstr(arg1), "ok.ds_state"));
-    printf("Upstairs:%4s ", json(copyinstr(arg1), "ok.up_count"));
-    printf("Downstairs:%4s\n", json(copyinstr(arg1), "ok.ds_count"));
+    show = show + 1;
+    /*
+     * State for the three downstiars
+     */
+    printf("%12s", json(copyinstr(arg1), "ok.ds_state[0]"));
+    printf(" %12s", json(copyinstr(arg1), "ok.ds_state[1]"));
+    printf(" %12s", json(copyinstr(arg1), "ok.ds_state[2]"));
+
+    /*
+     * Work queue counts for Upstairs and Downstairs
+     */
+    printf(" ");
+    printf(" %4s", json(copyinstr(arg1), "ok.up_count"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_count"));
+
+    /*
+     * New jobs on the work list for each downstairs
+     */
+    printf(" ");
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.new[0]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.new[1]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.new[2]"));
+
+    /*
+     * In progress jobs on the work list for each downstairs
+     */
+    printf(" ");
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.in_progress[0]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.in_progress[1]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.in_progress[2]"));
+
+    /*
+     * Completed (done) jobs on the work list for each downstairs
+     */
+    printf(" ");
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.done[0]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.done[1]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.done[2]"));
+
+    /*
+     * Skipped jobs on the work list for each downstairs
+     */
+    printf(" ");
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.skipped[0]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.skipped[1]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.skipped[2]"));
+
+    /*
+     * Jobs that are done with errors on the work list for each downstairs
+     */
+    printf(" ");
+    printf(" %2s", json(copyinstr(arg1), "ok.ds_io_count.error[0]"));
+    printf(" %2s", json(copyinstr(arg1), "ok.ds_io_count.error[1]"));
+    printf(" %2s", json(copyinstr(arg1), "ok.ds_io_count.error[2]"));
+
+    printf("\n");
 }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2207,6 +2207,11 @@ struct Downstairs {
      * The logger for messages sent from downstairs methods.
      */
     log: Logger,
+
+    /**
+     * Counters for the in flight work for the downstairs
+     */
+    io_state_count: IOStateCount,
 }
 
 impl Downstairs {
@@ -2226,6 +2231,7 @@ impl Downstairs {
             reconcile_repaired: 0,
             reconcile_repair_needed: 0,
             log: log.new(o!("" => "downstairs".to_string())),
+            io_state_count: IOStateCount::new(),
         }
     }
 
@@ -2250,18 +2256,20 @@ impl Downstairs {
     fn in_progress(&mut self, ds_id: u64, client_id: u8) -> Option<IOop> {
         let job = self.ds_active.get_mut(&ds_id).unwrap();
 
-        let newstate = match &self.downstairs_errors.get(&client_id) {
+        let new_state = match &self.downstairs_errors.get(&client_id) {
             Some(_) => IOState::Skipped,
             None => IOState::InProgress,
         };
 
-        let oldstate = job.state.insert(client_id, newstate.clone());
-        assert_eq!(oldstate, Some(IOState::New));
+        let old_state = job.state.insert(client_id, new_state.clone()).unwrap();
+        assert_eq!(old_state, IOState::New);
+        self.io_state_count.decr(&old_state, client_id);
+        self.io_state_count.incr(&new_state, client_id);
 
-        match newstate {
+        match new_state {
             IOState::Skipped => None,
             IOState::InProgress => Some(job.work.clone()),
-            _ => panic!("bad state in in_progress!"),
+            _ => panic!("bad state {} in in_progress!", new_state),
         }
     }
 
@@ -2334,7 +2342,7 @@ impl Downstairs {
             return None;
         }
         if let Some(job) = &mut self.reconcile_current_work {
-            let oldstate = job.state.insert(client_id, IOState::InProgress);
+            let old_state = job.state.insert(client_id, IOState::InProgress);
 
             /*
              * It is possible in reconnect states that multiple messages
@@ -2342,7 +2350,7 @@ impl Downstairs {
              * work for this client to do. Make sure we don't send the the
              * same message twice.
              */
-            if oldstate != Some(IOState::New) {
+            if old_state != Some(IOState::New) {
                 info!(
                     self.log,
                     "[{}] rep_in_progress ignore submitted job {:?}",
@@ -2367,8 +2375,8 @@ impl Downstairs {
      */
     fn rep_done(&mut self, client_id: u8, rep_id: u64) -> bool {
         if let Some(job) = &mut self.reconcile_current_work {
-            let oldstate = job.state.insert(client_id, IOState::Done);
-            assert_eq!(oldstate, Some(IOState::InProgress));
+            let old_state = job.state.insert(client_id, IOState::Done).unwrap();
+            assert_eq!(old_state, IOState::InProgress);
             assert_eq!(job.id, rep_id);
             let mut done = 0;
 
@@ -2494,7 +2502,10 @@ impl Downstairs {
 
             if *state == IOState::InProgress || *state == IOState::New {
                 info!(self.log, "{} change {} to skipped", client_id, ds_id);
-                job.state.insert(client_id, IOState::Skipped);
+                let old_state =
+                    job.state.insert(client_id, IOState::Skipped).unwrap();
+                self.io_state_count.decr(&old_state, client_id);
+                self.io_state_count.incr(&IOState::Skipped, client_id);
             }
         }
     }
@@ -2581,8 +2592,12 @@ impl Downstairs {
                     }
                 }
             }
-            job.state.insert(client_id, IOState::New);
+            let old_state = job.state.insert(client_id, IOState::New).unwrap();
             job.replay = true;
+            if old_state != IOState::New {
+                self.io_state_count.decr(&old_state, client_id);
+                self.io_state_count.incr(&IOState::New, client_id);
+            }
         }
     }
 
@@ -2632,6 +2647,10 @@ impl Downstairs {
      * Enqueue a new downstairs request.
      */
     fn enqueue(&mut self, io: DownstairsIO) {
+        for cid in 0..3 {
+            assert_eq!(io.state[&cid], IOState::New);
+            self.io_state_count.incr(&IOState::New, cid);
+        }
         self.ds_active.insert(io.ds_id, io);
     }
 
@@ -3075,7 +3094,7 @@ impl Downstairs {
                 }
             };
 
-        let newstate = if let Err(ref e) = read_data {
+        let new_state = if let Err(ref e) = read_data {
             warn!(
                 self.log,
                 "[{}] Reports error {:?} on job {}, {:?}",
@@ -3090,20 +3109,22 @@ impl Downstairs {
             IOState::Done
         };
 
-        let oldstate = job.state.insert(client_id, newstate.clone()).unwrap();
+        let old_state = job.state.insert(client_id, new_state.clone()).unwrap();
+        self.io_state_count.decr(&old_state, client_id);
+        self.io_state_count.incr(&new_state, client_id);
 
         /*
          * Verify the job was InProgress
          */
-        if oldstate != IOState::InProgress {
+        if old_state != IOState::InProgress {
             bail!(
                 "[{}] job completed while not InProgress: {:?}",
                 client_id,
-                oldstate
+                old_state
             );
         }
 
-        if let IOState::Error(e) = newstate {
+        if let IOState::Error(e) = new_state {
             // Some errors can be returned without considering the Downstairs
             // bad. For example, it's still an error if a snapshot exists
             // already but we should not increment downstairs_errors and
@@ -3179,7 +3200,7 @@ impl Downstairs {
                 }
             }
         } else if job.ack_status == AckStatus::Acked {
-            assert_eq!(newstate, IOState::Done);
+            assert_eq!(new_state, IOState::Done);
             /*
              * If this job is already acked, then we don't have much
              * more to do here.  If it's a flush, then we want to be
@@ -3232,7 +3253,7 @@ impl Downstairs {
                 _ => { /* Write and WriteUnwritten IOs have no action here */ }
             }
         } else {
-            assert_eq!(newstate, IOState::Done);
+            assert_eq!(new_state, IOState::Done);
             assert_ne!(job.ack_status, AckStatus::Acked);
 
             let read_data: Vec<ReadResponse> = read_data.unwrap();
@@ -3426,6 +3447,10 @@ impl Downstairs {
                 let oj = self.ds_active.remove(id).unwrap();
                 assert_eq!(oj.ack_status, AckStatus::Acked);
                 self.completed.push(*id);
+                for cid in 0..3 {
+                    let old_state = oj.state.get(&cid).unwrap();
+                    self.io_state_count.decr(old_state, cid);
+                }
             }
         }
     }
@@ -3848,12 +3873,14 @@ impl Upstairs {
         let up_count = self.up_work_active().await;
         let ds_count = self.ds_work_active().await;
         let ds_state = self.ds_state_copy().await;
+        let ds_io_count = self.downstairs.lock().await.io_state_count;
 
         cdt::up__status!(|| {
             let arg = Arg {
                 up_count,
                 ds_count,
                 ds_state,
+                ds_io_count,
             };
             (msg, arg)
         });
@@ -6178,7 +6205,7 @@ impl fmt::Display for IOState {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Copy, Clone, Serialize)]
 struct IOStateCount {
     new: [u32; 3],
     in_progress: [u32; 3],
@@ -6258,6 +6285,28 @@ impl IOStateCount {
             }
             IOState::Error(_) => {
                 self.error[cid] += 1;
+            }
+        }
+    }
+
+    pub fn decr(&mut self, state: &IOState, cid: u8) {
+        assert!(cid < 3);
+        let cid = cid as usize;
+        match state {
+            IOState::New => {
+                self.new[cid] -= 1;
+            }
+            IOState::InProgress => {
+                self.in_progress[cid] -= 1;
+            }
+            IOState::Done => {
+                self.done[cid] -= 1;
+            }
+            IOState::Skipped => {
+                self.skipped[cid] -= 1;
+            }
+            IOState::Error(_) => {
+                self.error[cid] -= 1;
             }
         }
     }
@@ -7561,6 +7610,7 @@ pub struct Arg {
     up_count: u32,
     ds_count: u32,
     ds_state: Vec<DsState>,
+    ds_io_count: IOStateCount,
 }
 
 /**
@@ -8031,11 +8081,10 @@ fn create_flush(
  * the clients.
  */
 async fn show_all_work(up: &Arc<Upstairs>) -> WQCounts {
-    let mut iosc: IOStateCount = IOStateCount::new();
     let gior = up.guest_io_ready().await;
     let up_count = up.guest.guest_work.lock().await.active.len();
 
-    let ds = up.downstairs.lock().await;
+    let mut ds = up.downstairs.lock().await;
     let mut kvec: Vec<u64> = ds.ds_active.keys().cloned().collect::<Vec<u64>>();
     println!(
         "----------------------------------------------------------------"
@@ -8131,7 +8180,6 @@ async fn show_all_work(up: &Arc<Upstairs>) -> WQCounts {
                         // XXX I have no idea why this is two spaces instead of
                         // one...
                         print!("  {0:>5}", state);
-                        iosc.incr(state, cid);
                     }
                     _x => {
                         print!("  {0:>5}", "????");
@@ -8142,7 +8190,7 @@ async fn show_all_work(up: &Arc<Upstairs>) -> WQCounts {
 
             println!();
         }
-        iosc.show_all();
+        ds.io_state_count.show_all();
         print!("Last Flush: ");
         for lf in ds.ds_last_flush.iter() {
             print!("{} ", lf);


### PR DESCRIPTION
Added internal counters for job states in the upstairs and hooked those into the dtrace probes we already had.

Updated the dtrace info script to print out these counters.