### PR TITLE
A little more error injection control on the downstairs.

### DIFF
--- a/downstairs/src/admin.rs
+++ b/downstairs/src/admin.rs
@@ -21,7 +21,9 @@ pub struct RunDownstairsForRegionParams {
     lossy: bool,
     port: u16,
     rport: u16,
-    return_errors: bool,
+    read_errors: bool,
+    write_errors: bool,
+    flush_errors: bool,
     cert_pem: Option<String>,
     key_pem: Option<String>,
     root_cert_pem: Option<String>,
@@ -63,7 +65,9 @@ pub async fn run_downstairs_for_region(
     let d = build_downstairs_for_region(
         &run_params.data,
         run_params.lossy,
-        run_params.return_errors,
+        run_params.read_errors,
+        run_params.write_errors,
+        run_params.flush_errors,
         run_params.read_only,
         None,
     )

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1338,8 +1338,10 @@ pub struct ActiveUpstairs {
 #[derive(Debug)]
 pub struct Downstairs {
     pub region: Region,
-    lossy: bool,         // Test flag, enables pauses and skipped jobs
-    return_errors: bool, // Test flag
+    lossy: bool,        // Test flag, enables pauses and skipped jobs
+    read_errors: bool,  // Test flag
+    write_errors: bool, // Test flag
+    flush_errors: bool, // Test flag
     active_upstairs: HashMap<Uuid, ActiveUpstairs>,
     dss: DsStatOuter,
     read_only: bool,
@@ -1353,7 +1355,9 @@ impl Downstairs {
     fn new(
         region: Region,
         lossy: bool,
-        return_errors: bool,
+        read_errors: bool,
+        write_errors: bool,
+        flush_errors: bool,
         read_only: bool,
         encrypted: bool,
         log: Logger,
@@ -1366,7 +1370,9 @@ impl Downstairs {
         Downstairs {
             region,
             lossy,
-            return_errors,
+            read_errors,
+            write_errors,
+            flush_errors,
             active_upstairs: HashMap::new(),
             dss,
             read_only,
@@ -1562,7 +1568,7 @@ impl Downstairs {
                  * Any error from an IO should be intercepted here and passed
                  * back to the upstairs.
                  */
-                let responses = if self.return_errors && random() && random() {
+                let responses = if self.read_errors && random() && random() {
                     warn!(self.log, "returning error on read!");
                     Err(CrucibleError::GenericError("test error".to_string()))
                 } else if !self.is_active(job.upstairs_connection) {
@@ -1587,7 +1593,7 @@ impl Downstairs {
                  * Any error from an IO should be intercepted here and passed
                  * back to the upstairs.
                  */
-                let result = if self.return_errors && random() && random() {
+                let result = if self.write_errors && random() && random() {
                     warn!(self.log, "returning error on writeunwritten!");
                     Err(CrucibleError::GenericError("test error".to_string()))
                 } else if !self.is_active(job.upstairs_connection) {
@@ -1610,7 +1616,7 @@ impl Downstairs {
                 dependencies: _dependencies,
                 writes,
             } => {
-                let result = if self.return_errors && random() && random() {
+                let result = if self.write_errors && random() && random() {
                     warn!(self.log, "returning error on write!");
                     Err(CrucibleError::GenericError("test error".to_string()))
                 } else if !self.is_active(job.upstairs_connection) {
@@ -1633,7 +1639,7 @@ impl Downstairs {
                 gen_number,
                 snapshot_details,
             } => {
-                let result = if self.return_errors && random() && random() {
+                let result = if self.flush_errors && random() && random() {
                     warn!(self.log, "returning error on flush!");
                     Err(CrucibleError::GenericError("test error".to_string()))
                 } else if !self.is_active(job.upstairs_connection) {
@@ -2339,7 +2345,9 @@ pub fn create_region(
 pub fn build_downstairs_for_region(
     data: &Path,
     lossy: bool,
-    return_errors: bool,
+    read_errors: bool,
+    write_errors: bool,
+    flush_errors: bool,
     read_only: bool,
     log_request: Option<Logger>,
 ) -> Result<Arc<Mutex<Downstairs>>> {
@@ -2377,7 +2385,9 @@ pub fn build_downstairs_for_region(
     Ok(Arc::new(Mutex::new(Downstairs::new(
         region,
         lossy,
-        return_errors,
+        read_errors,
+        write_errors,
+        flush_errors,
         read_only,
         encrypted,
         log,
@@ -2733,6 +2743,8 @@ mod test {
         let path_dir = dir.as_ref().to_path_buf();
         let ads = build_downstairs_for_region(
             &path_dir,
+            false,
+            false,
             false,
             false,
             false,
@@ -3672,7 +3684,9 @@ mod test {
         build_downstairs_for_region(
             &path_dir,
             false, // lossy
-            false, // return_errors
+            false, // read errors
+            false, // write errors
+            false, // flush errors
             read_only,
             Some(csl()),
         )
@@ -4114,6 +4128,8 @@ mod test {
             false,
             false,
             false,
+            false,
+            false,
             Some(csl()),
         )?;
 
@@ -4206,6 +4222,8 @@ mod test {
             false,
             false,
             false,
+            false,
+            false,
             Some(csl()),
         )?;
 
@@ -4295,6 +4313,8 @@ mod test {
         let path_dir = dir.as_ref().to_path_buf();
         let ads = build_downstairs_for_region(
             &path_dir,
+            false,
+            false,
             false,
             false,
             false,

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -153,8 +153,17 @@ enum Args {
         #[clap(short, long, default_value = "9000", action)]
         port: u16,
 
+        /// Randomly return read errors
         #[clap(long, action)]
-        return_errors: bool,
+        read_errors: bool,
+
+        /// Randomly return write errors
+        #[clap(long, action)]
+        write_errors: bool,
+
+        /// Randomly return flush errors
+        #[clap(long, action)]
+        flush_errors: bool,
 
         #[clap(short, long, action)]
         trace_endpoint: Option<String>,
@@ -286,7 +295,9 @@ async fn main() -> Result<()> {
             oximeter,
             lossy,
             port,
-            return_errors,
+            read_errors,
+            write_errors,
+            flush_errors,
             trace_endpoint,
             cert_pem,
             key_pem,
@@ -324,7 +335,9 @@ async fn main() -> Result<()> {
             let d = build_downstairs_for_region(
                 &data,
                 lossy,
-                return_errors,
+                read_errors,
+                write_errors,
+                flush_errors,
                 read_only,
                 Some(log),
             )?;

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -71,7 +71,9 @@ mod test {
             let downstairs = build_downstairs_for_region(
                 tempdir.path(),
                 false, /* lossy */
-                false, /* return_errors */
+                false, /* read errors */
+                false, /* write errors */
+                false, /* flush errors */
                 read_only,
                 Some(csl()),
             )?;
@@ -99,7 +101,9 @@ mod test {
             self.downstairs = build_downstairs_for_region(
                 self.tempdir.path(),
                 false, /* lossy */
-                false, /* return_errors */
+                false, /* read errors */
+                false, /* write errors */
+                false, /* flush errors */
                 true,
                 Some(csl()),
             )?;


### PR DESCRIPTION
The original error injection was just return IO errors 25% of the time.  
Updated that to something only a tiny bit better by allowing the option to select 25% error on Write/Read/Flush independently of each other.  

This is really a stop-gap to allow for building out the online repair code path.  A better error injection setup
can come in later.