### PR TITLE
Move Rust to 2021 edition

### DIFF
--- a/agent-client/Cargo.toml
+++ b/agent-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crucible-agent-client"
 version = "0.0.1"
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crucible-agent"
 version = "0.0.1"
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -3,7 +3,7 @@ name = "crucible-common"
 version = "0.0.0"
 authors = ["Joshua M. Clulow <jmc@oxide.computer>", "Alan Hanson <alan@oxide.computer>"]
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1"

--- a/control-client/Cargo.toml
+++ b/control-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crucible-control-client"
 version = "0.0.1"
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0"

--- a/crucadm/Cargo.toml
+++ b/crucadm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crucadm"
 version = "0.1.0"
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 clap = { version = "3.2", features = ["derive", "env"] }

--- a/crudd/Cargo.toml
+++ b/crudd/Cargo.toml
@@ -3,7 +3,7 @@ name = "crudd"
 version = "0.1.0"
 authors = ["Artemis Everfree <artemis@oxide.computer>"]
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1"

--- a/crutest/Cargo.toml
+++ b/crutest/Cargo.toml
@@ -3,7 +3,7 @@ name = "crutest"
 version = "0.1.0"
 authors = ["Joshua M. Clulow <jmc@oxide.computer>", "Alan Hanson <alan@oxide.computer"]
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1"

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -3,7 +3,7 @@ name = "crucible-downstairs"
 version = "0.0.1"
 authors = ["Joshua M. Clulow <jmc@oxide.computer>", "Alan Hanson <alan@oxide.computer"]
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1"

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1351,6 +1351,7 @@ pub struct Downstairs {
     log: Logger,
 }
 
+#[allow(clippy::too_many_arguments)]
 impl Downstairs {
     fn new(
         region: Region,

--- a/dsc-client/Cargo.toml
+++ b/dsc-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dsc-client"
 version = "0.0.1"
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0"

--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dsc"
 version = "0.1.0"
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1"

--- a/hammer/Cargo.toml
+++ b/hammer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crucible-hammer"
 version = "0.1.0"
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "James MacMahon <james@oxide.computer>"
 ]
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [dev-dependencies]
 anyhow = "1"

--- a/measure_iops/Cargo.toml
+++ b/measure_iops/Cargo.toml
@@ -2,7 +2,7 @@
 name = "measure-iops"
 version = "0.0.1"
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1"

--- a/nbd_server/Cargo.toml
+++ b/nbd_server/Cargo.toml
@@ -3,7 +3,7 @@ name = "crucible-nbd-server"
 version = "0.1.0"
 authors = ["Joshua M. Clulow <jmc@oxide.computer>", "Alan Hanson <alan@oxide.computer>", "James MacMahon <james@oxide.computer>"]
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1"

--- a/pantry-client/Cargo.toml
+++ b/pantry-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crucible-pantry-client"
 version = "0.0.1"
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -3,7 +3,7 @@ name = "crucible-protocol"
 version = "0.0.0"
 authors = ["Joshua M. Clulow <jmc@oxide.computer>"]
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 tokio-util = { version = "0.7", features = [ "codec" ] }

--- a/repair-client/Cargo.toml
+++ b/repair-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "repair-client"
 version = "0.0.1"
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0"

--- a/smf/Cargo.toml
+++ b/smf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crucible-smf"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 libc = "0.2.137"

--- a/upstairs/Cargo.toml
+++ b/upstairs/Cargo.toml
@@ -3,7 +3,7 @@ name = "crucible"
 version = "0.0.1"
 authors = ["Joshua M. Clulow <jmc@oxide.computer>", "Alan Hanson <alan@oxide.computer"]
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "crucible"


### PR DESCRIPTION
Move to 2021 Rust edition.

Also fixed a clippy nit that snuck in.