### PR TITLE
always specify branch in git dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,12 +415,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,7 +626,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "percent-encoding",
- "progenitor",
+ "progenitor 0.1.2-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
  "reqwest",
  "schemars",
  "serde",
@@ -673,7 +667,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "percent-encoding",
- "progenitor",
+ "progenitor 0.1.2-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
  "reqwest",
  "schemars",
  "serde",
@@ -849,7 +843,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "percent-encoding",
- "progenitor",
+ "progenitor 0.1.2-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
  "reqwest",
  "schemars",
  "serde",
@@ -1143,7 +1137,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "percent-encoding",
- "progenitor",
+ "progenitor 0.1.2-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
  "reqwest",
  "schemars",
  "serde",
@@ -2012,7 +2006,7 @@ source = "git+https://github.com/oxidecomputer/omicron?branch=main#b20ed23095790
 dependencies = [
  "chrono",
  "omicron-common",
- "progenitor",
+ "progenitor 0.1.2-dev (git+https://github.com/oxidecomputer/progenitor)",
  "reqwest",
  "serde",
  "serde_json",
@@ -2159,7 +2153,7 @@ dependencies = [
  "ipnetwork",
  "macaddr",
  "parse-display",
- "progenitor",
+ "progenitor 0.1.2-dev (git+https://github.com/oxidecomputer/progenitor)",
  "rand 0.8.5",
  "reqwest",
  "ring",
@@ -2219,10 +2213,10 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openapi-lint"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/openapi-lint#9e3ada82808ef882fdefe2d01a39eeeb219c8778"
+version = "0.2.0"
+source = "git+https://github.com/oxidecomputer/openapi-lint?branch=main#91f0af87bdaed0e41c8b43f4b0d85cc706d6a961"
 dependencies = [
- "convert_case",
+ "heck 0.4.0",
  "indexmap",
  "openapiv3",
 ]
@@ -2684,14 +2678,42 @@ dependencies = [
 [[package]]
 name = "progenitor"
 version = "0.1.2-dev"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#d3441861bc36247af11c774c8e1de43e0c37bf4b"
+dependencies = [
+ "anyhow",
+ "getopts",
+ "openapiv3",
+ "progenitor-client 0.1.2-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
+ "progenitor-impl 0.1.2-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
+ "progenitor-macro 0.1.2-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "progenitor"
+version = "0.1.2-dev"
 source = "git+https://github.com/oxidecomputer/progenitor#d3441861bc36247af11c774c8e1de43e0c37bf4b"
 dependencies = [
  "anyhow",
  "getopts",
  "openapiv3",
- "progenitor-client",
- "progenitor-impl",
- "progenitor-macro",
+ "progenitor-client 0.1.2-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor-impl 0.1.2-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "progenitor-macro 0.1.2-dev (git+https://github.com/oxidecomputer/progenitor)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "progenitor-client"
+version = "0.1.2-dev"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#d3441861bc36247af11c774c8e1de43e0c37bf4b"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "percent-encoding",
+ "reqwest",
  "serde",
  "serde_json",
 ]
@@ -2707,6 +2729,28 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "progenitor-impl"
+version = "0.1.2-dev"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#d3441861bc36247af11c774c8e1de43e0c37bf4b"
+dependencies = [
+ "getopts",
+ "heck 0.4.0",
+ "indexmap",
+ "openapiv3",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustfmt-wrapper",
+ "schemars",
+ "serde",
+ "serde_json",
+ "syn",
+ "thiserror",
+ "typify",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2734,11 +2778,26 @@ dependencies = [
 [[package]]
 name = "progenitor-macro"
 version = "0.1.2-dev"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#d3441861bc36247af11c774c8e1de43e0c37bf4b"
+dependencies = [
+ "openapiv3",
+ "proc-macro2",
+ "progenitor-impl 0.1.2-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
+ "quote",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "syn",
+]
+
+[[package]]
+name = "progenitor-macro"
+version = "0.1.2-dev"
 source = "git+https://github.com/oxidecomputer/progenitor#d3441861bc36247af11c774c8e1de43e0c37bf4b"
 dependencies = [
  "openapiv3",
  "proc-macro2",
- "progenitor-impl",
+ "progenitor-impl 0.1.2-dev (git+https://github.com/oxidecomputer/progenitor)",
  "quote",
  "serde",
  "serde_json",
@@ -3008,7 +3067,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "percent-encoding",
- "progenitor",
+ "progenitor 0.1.2-dev (git+https://github.com/oxidecomputer/progenitor?branch=main)",
  "reqwest",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2213,10 +2219,10 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openapi-lint"
-version = "0.2.0"
-source = "git+https://github.com/oxidecomputer/openapi-lint?branch=main#91f0af87bdaed0e41c8b43f4b0d85cc706d6a961"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/openapi-lint?branch=main#9e3ada82808ef882fdefe2d01a39eeeb219c8778"
 dependencies = [
- "heck 0.4.0",
+ "convert_case",
  "indexmap",
  "openapiv3",
 ]

--- a/agent-client/Cargo.toml
+++ b/agent-client/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 anyhow = "1.0"
 chrono = { version = "0.4", features = [ "serde" ] }
 percent-encoding = "2.2"
-progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
+progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 schemars = "0.8.11"
 serde_json = "1.0"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -25,5 +25,5 @@ uuid = { version = "1.2.2", features = [ "serde", "v4" ] }
 [dev-dependencies]
 expectorate = "1.0.5"
 openapiv3 = "1.0"
-openapi-lint = { git = "https://github.com/oxidecomputer/openapi-lint" }
+openapi-lint = { git = "https://github.com/oxidecomputer/openapi-lint", branch = "main" }
 subprocess = "0.2.9"

--- a/control-client/Cargo.toml
+++ b/control-client/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 percent-encoding = "2.2"
-progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
+progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 schemars = "0.8.11"
 serde_json = "1.0"

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -53,7 +53,7 @@ uuid = { version = "1.2.2", features = [ "serde", "v4" ] }
 [dev-dependencies]
 expectorate = "1.0.5"
 openapiv3 = "1.0.1"
-openapi-lint = { git = "https://github.com/oxidecomputer/openapi-lint" }
+openapi-lint = { git = "https://github.com/oxidecomputer/openapi-lint", branch = "main" }
 rand_chacha = "0.3.1"
 tempfile = "3"
 

--- a/dsc-client/Cargo.toml
+++ b/dsc-client/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 percent-encoding = "2.2"
-progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
+progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 schemars = "0.8.11"
 serde_json = "1.0"

--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -21,6 +21,6 @@ tokio = { version = "1.22.0", features = ["full"] }
 [dev-dependencies]
 expectorate = "1.0.5"
 openapiv3 = "1.0.1"
-openapi-lint = { git = "https://github.com/oxidecomputer/openapi-lint" }
+openapi-lint = { git = "https://github.com/oxidecomputer/openapi-lint", branch = "main" }
 tempfile = "3"
 serde_json = "1"

--- a/pantry-client/Cargo.toml
+++ b/pantry-client/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 anyhow = "1.0"
 chrono = { version = "0.4", features = [ "serde" ] }
 percent-encoding = "2.2"
-progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
+progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 reqwest = { version = "0.11", default-features = false, features = ["json"] }
 schemars = "0.8.11"
 serde_json = "1.0"

--- a/pantry/Cargo.toml
+++ b/pantry/Cargo.toml
@@ -30,5 +30,5 @@ sha2 = "0.10"
 [dev-dependencies]
 expectorate = "1.0.5"
 openapiv3 = "1.0"
-openapi-lint = { git = "https://github.com/oxidecomputer/openapi-lint" }
+openapi-lint = { git = "https://github.com/oxidecomputer/openapi-lint", branch = "main" }
 subprocess = "0.2.9"

--- a/repair-client/Cargo.toml
+++ b/repair-client/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 anyhow = "1.0"
 chrono = { version = "0.4", features = [ "serde" ] }
 percent-encoding = "2.2"
-progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
+progenitor = { git = "https://github.com/oxidecomputer/progenitor", branch = "main" }
 reqwest = { version = "0.11", features = ["json", "stream"] }
 schemars = "0.8.11"
 serde_json = "1.0"

--- a/upstairs/Cargo.toml
+++ b/upstairs/Cargo.toml
@@ -56,7 +56,7 @@ features = [ "max_level_trace", "release_max_level_debug" ]
 [dev-dependencies]
 expectorate = "1.0.5"
 openapiv3 = "1.0.1"
-openapi-lint = { git = "https://github.com/oxidecomputer/openapi-lint" }
+openapi-lint = { git = "https://github.com/oxidecomputer/openapi-lint", branch = "main" }
 tokio-test = "*"
 tempfile = "3"
 


### PR DESCRIPTION
This is PR 1 of 3 to make sure that omicron doesn't get two separate
dependencies, one for progenitor with main and one for progenitor
without main.

We choose this strategy over not doing so to maintain uniformity in
cases where a non-default branch must be used.
