### PR TITLE
region IO dtrace probes

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -360,10 +360,26 @@ pub mod cdt {
     fn extent__flush__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
     fn extent__flush__file__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
     fn extent__flush__file__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
-    fn extent__flush__rehash__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
-    fn extent__flush__rehash__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
-    fn extent__flush__sqlite__insert__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
-    fn extent__flush__sqlite__insert__done(_job_id: u64, _extent_id: u32, n_blocks: u64) {}
+    fn extent__flush__rehash__start(
+        job_id: u64,
+        extent_id: u32,
+        n_blocks: u64,
+    ) {
+    }
+    fn extent__flush__rehash__done(job_id: u64, extent_id: u32, n_blocks: u64) {
+    }
+    fn extent__flush__sqlite__insert__start(
+        job_id: u64,
+        extent_id: u32,
+        n_blocks: u64,
+    ) {
+    }
+    fn extent__flush__sqlite__insert__done(
+        _job_id: u64,
+        _extent_id: u32,
+        n_blocks: u64,
+    ) {
+    }
     fn extent__write__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
     fn extent__write__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
     fn extent__write__get__hashes__start(

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -356,6 +356,18 @@ pub mod cdt {
     fn submit__writeunwritten__done(_: u64) {}
     fn submit__write__done(_: u64) {}
     fn submit__flush__done(_: u64) {}
+    fn extent__flush__start(job_id: u64, extent_id: u64) {}
+    fn extent__flush__done(job_id: u64, extent_id: u64) {}
+    fn extent__flush__file__start(job_id: u64, extent_id: u64) {}
+    fn extent__flush__file__done(job_id: u64, extent_id: u64) {}
+    fn extent__flush__rehash__start(job_id: u64, extent_id: u64) {}
+    fn extent__flush__rehash__done(job_id: u64, extent_id: u64) {}
+    fn extent__flush__sqlite__insert__start(job_id: u64, extent_id: u64) {}
+    fn extent__flush__sqlite__insert__done(_job_id: u64, _extent_id: u64) {}
+    fn extent__write__file__start(job_id: u64, extent_id: u64, n_blocks: u64) {}
+    fn extent__write__file__done(job_id: u64, extent_id: u64, n_blocks: u64) {}
+    fn extent__write__sqlite__start(job_id: u64, extent_id: u64, n_blocks: u64) {}
+    fn extent__write__sqlite__done(job_id: u64, extent_id: u64, n_blocks: u64) {}
 }
 /*
  * A new IO request has been received.

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -356,18 +356,18 @@ pub mod cdt {
     fn submit__writeunwritten__done(_: u64) {}
     fn submit__write__done(_: u64) {}
     fn submit__flush__done(_: u64) {}
-    fn extent__flush__start(job_id: u64, extent_id: u64) {}
-    fn extent__flush__done(job_id: u64, extent_id: u64) {}
-    fn extent__flush__file__start(job_id: u64, extent_id: u64) {}
-    fn extent__flush__file__done(job_id: u64, extent_id: u64) {}
-    fn extent__flush__rehash__start(job_id: u64, extent_id: u64) {}
-    fn extent__flush__rehash__done(job_id: u64, extent_id: u64) {}
-    fn extent__flush__sqlite__insert__start(job_id: u64, extent_id: u64) {}
-    fn extent__flush__sqlite__insert__done(_job_id: u64, _extent_id: u64) {}
-    fn extent__write__file__start(job_id: u64, extent_id: u64, n_blocks: u64) {}
-    fn extent__write__file__done(job_id: u64, extent_id: u64, n_blocks: u64) {}
-    fn extent__write__sqlite__start(job_id: u64, extent_id: u64, n_blocks: u64) {}
-    fn extent__write__sqlite__done(job_id: u64, extent_id: u64, n_blocks: u64) {}
+    fn extent__flush__start(job_id: u64, extent_id: u32) {}
+    fn extent__flush__done(job_id: u64, extent_id: u32) {}
+    fn extent__flush__file__start(job_id: u64, extent_id: u32) {}
+    fn extent__flush__file__done(job_id: u64, extent_id: u32) {}
+    fn extent__flush__rehash__start(job_id: u64, extent_id: u32) {}
+    fn extent__flush__rehash__done(job_id: u64, extent_id: u32) {}
+    fn extent__flush__sqlite__insert__start(job_id: u64, extent_id: u32) {}
+    fn extent__flush__sqlite__insert__done(_job_id: u64, _extent_id: u32) {}
+    fn extent__write__file__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__write__file__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__write__sqlite__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__write__sqlite__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
 }
 /*
  * A new IO request has been received.

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -366,16 +366,46 @@ pub mod cdt {
     fn extent__flush__sqlite__insert__done(_job_id: u64, _extent_id: u32) {}
     fn extent__write__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
     fn extent__write__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
-    fn extent__write__get__hashes__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
-    fn extent__write__get__hashes__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__write__get__hashes__start(
+        job_id: u64,
+        extent_id: u32,
+        n_blocks: u64,
+    ) {
+    }
+    fn extent__write__get__hashes__done(
+        job_id: u64,
+        extent_id: u32,
+        n_blocks: u64,
+    ) {
+    }
     fn extent__write__file__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
     fn extent__write__file__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
-    fn extent__write__sqlite__insert__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
-    fn extent__write__sqlite__insert__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__write__sqlite__insert__start(
+        job_id: u64,
+        extent_id: u32,
+        n_blocks: u64,
+    ) {
+    }
+    fn extent__write__sqlite__insert__done(
+        job_id: u64,
+        extent_id: u32,
+        n_blocks: u64,
+    ) {
+    }
     fn extent__read__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
     fn extent__read__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
-    fn extent__read__get__contexts__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
-    fn extent__read__get__contexts__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__read__get__contexts__start(
+        job_id: u64,
+        extent_id: u32,
+        n_blocks: u64,
+    ) {
+    }
+    fn extent__read__get__contexts__done(
+        job_id: u64,
+        extent_id: u32,
+        n_blocks: u64,
+    ) {
+    }
     fn extent__read__file__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
     fn extent__read__file__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
 }

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -356,14 +356,14 @@ pub mod cdt {
     fn submit__writeunwritten__done(_: u64) {}
     fn submit__write__done(_: u64) {}
     fn submit__flush__done(_: u64) {}
-    fn extent__flush__start(job_id: u64, extent_id: u32) {}
-    fn extent__flush__done(job_id: u64, extent_id: u32) {}
-    fn extent__flush__file__start(job_id: u64, extent_id: u32) {}
-    fn extent__flush__file__done(job_id: u64, extent_id: u32) {}
-    fn extent__flush__rehash__start(job_id: u64, extent_id: u32) {}
-    fn extent__flush__rehash__done(job_id: u64, extent_id: u32) {}
-    fn extent__flush__sqlite__insert__start(job_id: u64, extent_id: u32) {}
-    fn extent__flush__sqlite__insert__done(_job_id: u64, _extent_id: u32) {}
+    fn extent__flush__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__flush__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__flush__file__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__flush__file__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__flush__rehash__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__flush__rehash__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__flush__sqlite__insert__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__flush__sqlite__insert__done(_job_id: u64, _extent_id: u32, n_blocks: u64) {}
     fn extent__write__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
     fn extent__write__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
     fn extent__write__get__hashes__start(

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -364,10 +364,20 @@ pub mod cdt {
     fn extent__flush__rehash__done(job_id: u64, extent_id: u32) {}
     fn extent__flush__sqlite__insert__start(job_id: u64, extent_id: u32) {}
     fn extent__flush__sqlite__insert__done(_job_id: u64, _extent_id: u32) {}
+    fn extent__write__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__write__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__write__get__hashes__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__write__get__hashes__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
     fn extent__write__file__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
     fn extent__write__file__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
-    fn extent__write__sqlite__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
-    fn extent__write__sqlite__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__write__sqlite__insert__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__write__sqlite__insert__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__read__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__read__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__read__get__contexts__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__read__get__contexts__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__read__file__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
+    fn extent__read__file__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
 }
 /*
  * A new IO request has been received.

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1196,13 +1196,17 @@ impl Extent {
             crucible_bail!(ModifyingReadOnlyRegion);
         }
 
-        cdt::extent__flush__start!(|| { (job_id, self.number, self.extent_size.value) });
+        cdt::extent__flush__start!(|| {
+            (job_id, self.number, self.extent_size.value)
+        });
 
         /*
          * We must first fsync to get any outstanding data written to disk.
          * This must be done before we update the flush number.
          */
-        cdt::extent__flush__file__start!(|| { (job_id, self.number, self.extent_size.value) });
+        cdt::extent__flush__file__start!(|| {
+            (job_id, self.number, self.extent_size.value)
+        });
         if let Err(e) = inner.file.sync_all() {
             /*
              * XXX Retry?  Mark extent as broken?
@@ -1214,13 +1218,17 @@ impl Extent {
                 e
             );
         }
-        cdt::extent__flush__file__done!(|| { (job_id, self.number, self.extent_size.value) });
+        cdt::extent__flush__file__done!(|| {
+            (job_id, self.number, self.extent_size.value)
+        });
 
         // Clear old block contexts. In order to be crash consistent, only
         // perform this after the extent fsync is done. Read each block in the
         // extent and find out the integrity hash. Then, remove all block
         // context rows where the integrity hash does not match.
-        cdt::extent__flush__rehash__start!(|| { (job_id, self.number, self.extent_size.value) });
+        cdt::extent__flush__rehash__start!(|| {
+            (job_id, self.number, self.extent_size.value)
+        });
 
         let total_bytes: usize =
             self.extent_size.value as usize * self.block_size as usize;
@@ -1235,7 +1243,9 @@ impl Extent {
             .map(|(i, data)| (i, integrity_hash(&[data])))
             .collect();
 
-        cdt::extent__flush__rehash__done!(|| { (job_id, self.number, self.extent_size.value) });
+        cdt::extent__flush__rehash__done!(|| {
+            (job_id, self.number, self.extent_size.value)
+        });
 
         cdt::extent__flush__sqlite__insert__start!(|| {
             (job_id, self.number, self.extent_size.value)
@@ -1243,7 +1253,9 @@ impl Extent {
         inner.truncate_encryption_contexts_and_hashes(
             extent_block_indexes_and_hashes,
         )?;
-        cdt::extent__flush__sqlite__insert__done!(|| { (job_id, self.number, self.extent_size.value) });
+        cdt::extent__flush__sqlite__insert__done!(|| {
+            (job_id, self.number, self.extent_size.value)
+        });
 
         // Reset the file's seek offset to 0, and set the flush number and gen
         // number
@@ -1252,7 +1264,9 @@ impl Extent {
 
         inner.set_flush_number(new_flush, new_gen)?;
 
-        cdt::extent__flush__done!(|| { (job_id, self.number, self.extent_size.value) });
+        cdt::extent__flush__done!(|| {
+            (job_id, self.number, self.extent_size.value)
+        });
 
         Ok(())
     }

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1196,13 +1196,13 @@ impl Extent {
             crucible_bail!(ModifyingReadOnlyRegion);
         }
 
-        cdt::extent__flush__start!(|| { (job_id, self.number) });
+        cdt::extent__flush__start!(|| { (job_id, self.number, self.extent_size.value) });
 
         /*
          * We must first fsync to get any outstanding data written to disk.
          * This must be done before we update the flush number.
          */
-        cdt::extent__flush__file__start!(|| { (job_id, self.number) });
+        cdt::extent__flush__file__start!(|| { (job_id, self.number, self.extent_size.value) });
         if let Err(e) = inner.file.sync_all() {
             /*
              * XXX Retry?  Mark extent as broken?
@@ -1214,13 +1214,13 @@ impl Extent {
                 e
             );
         }
-        cdt::extent__flush__file__done!(|| { (job_id, self.number) });
+        cdt::extent__flush__file__done!(|| { (job_id, self.number, self.extent_size.value) });
 
         // Clear old block contexts. In order to be crash consistent, only
         // perform this after the extent fsync is done. Read each block in the
         // extent and find out the integrity hash. Then, remove all block
         // context rows where the integrity hash does not match.
-        cdt::extent__flush__rehash__start!(|| { (job_id, self.number) });
+        cdt::extent__flush__rehash__start!(|| { (job_id, self.number, self.extent_size.value) });
 
         let total_bytes: usize =
             self.extent_size.value as usize * self.block_size as usize;
@@ -1235,15 +1235,15 @@ impl Extent {
             .map(|(i, data)| (i, integrity_hash(&[data])))
             .collect();
 
-        cdt::extent__flush__rehash__done!(|| { (job_id, self.number) });
+        cdt::extent__flush__rehash__done!(|| { (job_id, self.number, self.extent_size.value) });
 
         cdt::extent__flush__sqlite__insert__start!(|| {
-            (job_id, self.number)
+            (job_id, self.number, self.extent_size.value)
         });
         inner.truncate_encryption_contexts_and_hashes(
             extent_block_indexes_and_hashes,
         )?;
-        cdt::extent__flush__sqlite__insert__done!(|| { (job_id, self.number) });
+        cdt::extent__flush__sqlite__insert__done!(|| { (job_id, self.number, self.extent_size.value) });
 
         // Reset the file's seek offset to 0, and set the flush number and gen
         // number
@@ -1252,7 +1252,7 @@ impl Extent {
 
         inner.set_flush_number(new_flush, new_gen)?;
 
-        cdt::extent__flush__done!(|| { (job_id, self.number) });
+        cdt::extent__flush__done!(|| { (job_id, self.number, self.extent_size.value) });
 
         Ok(())
     }

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1199,6 +1199,8 @@ impl Extent {
 
         inner.set_flush_number(new_flush, new_gen)?;
 
+        cdt::extent__flush__done!(|| { (job_id, self.number) });
+
         Ok(())
     }
 }

--- a/tools/dtrace/perf-downstairs-finegrain-extent-timings.d
+++ b/tools/dtrace/perf-downstairs-finegrain-extent-timings.d
@@ -43,28 +43,28 @@ crucible_downstairs*:::extent-flush-sqlite-insert-start
 crucible_downstairs*:::extent-flush-done
 /extent_flush_start[pid,arg0,arg1]/
 {
-    @time["flush"] = quantize(timestamp - extent_flush_start[pid,arg0,arg1]);
+    @time["flush"] = quantize((timestamp - extent_flush_start[pid,arg0,arg1]) / arg2);
     extent_flush_start[pid,arg0,arg1] = 0;
 }
 
 crucible_downstairs*:::extent-flush-file-done
 /extent_flush_file_start[pid,arg0,arg1]/
 {
-    @time["flush_file"] = quantize(timestamp - extent_flush_file_start[pid,arg0,arg1]);
+    @time["flush_file"] = quantize((timestamp - extent_flush_file_start[pid,arg0,arg1]) / arg2);
     extent_flush_file_start[pid,arg0,arg1] = 0;
 }
 
 crucible_downstairs*:::extent-flush-rehash-done
 /extent_flush_rehash_start[pid,arg0,arg1]/
 {
-    @time["flush_rehash"] = quantize(timestamp - extent_flush_rehash_start[pid,arg0,arg1]);
+    @time["flush_rehash"] = quantize((timestamp - extent_flush_rehash_start[pid,arg0,arg1]) / arg2);
     extent_flush_rehash_start[pid,arg0,arg1] = 0;
 }
 
 crucible_downstairs*:::extent-flush-sqlite-insert-done
 /extent_flush_sqlite_insert_start[pid,arg0,arg1]/
 {
-    @time["flush_sqlite_insert"] = quantize(timestamp - extent_flush_sqlite_insert_start[pid,arg0,arg1]);
+    @time["flush_sqlite_insert"] = quantize((timestamp - extent_flush_sqlite_insert_start[pid,arg0,arg1]) / arg2);
     extent_flush_sqlite_insert_start[pid,arg0,arg1] = 0;
 }
 

--- a/tools/dtrace/perf-downstairs-finegrain-extent-timings.d
+++ b/tools/dtrace/perf-downstairs-finegrain-extent-timings.d
@@ -1,0 +1,168 @@
+/*
+ * Trace how long extent IO takes.
+ * Measure
+ * - Total time to flush
+ *   - Time to flush the OS file handle
+ *   - Time to re-read the file from disk to re-hash (may be removed later)
+ *   - Time to insert new hashes into sqlite DB
+ */
+
+
+
+/*
+ * arg0 is job ID
+ * arg1 is extent number
+ * arg2 is number of blocks, when relevant (writes/reads)
+ */
+
+/*
+ * flushes
+ */
+crucible_downstairs*:::extent-flush-start
+{
+    extent_flush_start[pid,arg0,arg1] = timestamp;
+}
+
+crucible_downstairs*:::extent-flush-file-start
+{
+    extent_flush_file_start[pid,arg0,arg1] = timestamp;
+}
+
+crucible_downstairs*:::extent-flush-rehash-start
+{
+    extent_flush_rehash_start[pid,arg0,arg1] = timestamp;
+}
+
+crucible_downstairs*:::extent-flush-sqlite-insert-start
+{
+    extent_flush_sqlite_insert_start[pid,arg0,arg1] = timestamp;
+}
+
+
+/* and collections */
+crucible_downstairs*:::extent-flush-done
+/extent_flush_start[pid,arg0,arg1]/
+{
+    @time["flush"] = quantize(timestamp - extent_flush_start[pid,arg0,arg1]);
+    extent_flush_start[pid,arg0,arg1] = 0;
+}
+
+crucible_downstairs*:::extent-flush-file-done
+/extent_flush_file_start[pid,arg0,arg1]/
+{
+    @time["flush_file"] = quantize(timestamp - extent_flush_file_start[pid,arg0,arg1]);
+    extent_flush_file_start[pid,arg0,arg1] = 0;
+}
+
+crucible_downstairs*:::extent-flush-rehash-done
+/extent_flush_rehash_start[pid,arg0,arg1]/
+{
+    @time["flush_rehash"] = quantize(timestamp - extent_flush_rehash_start[pid,arg0,arg1]);
+    extent_flush_rehash_start[pid,arg0,arg1] = 0;
+}
+
+crucible_downstairs*:::extent-flush-sqlite-insert-done
+/extent_flush_sqlite_insert_start[pid,arg0,arg1]/
+{
+    @time["flush_sqlite_insert"] = quantize(timestamp - extent_flush_sqlite_insert_start[pid,arg0,arg1]);
+    extent_flush_sqlite_insert_start[pid,arg0,arg1] = 0;
+}
+
+
+/*
+ * writes
+ */
+crucible_downstairs*:::extent-write-start
+{
+    extent_write_start[pid,arg0,arg1] = timestamp;
+}
+
+crucible_downstairs*:::extent-write-file-start
+{
+    extent_write_file_start[pid,arg0,arg1] = timestamp;
+}
+
+crucible_downstairs*:::extent-write-get-hashes-start
+{
+    extent_write_get_hashes_start[pid,arg0,arg1] = timestamp;
+}
+
+crucible_downstairs*:::extent-write-sqlite-insert-start
+{
+    extent_write_sqlite_insert_start[pid,arg0,arg1] = timestamp;
+}
+
+
+/* and collections */
+crucible_downstairs*:::extent-write-done
+/extent_write_start[pid,arg0,arg1]/
+{
+    @time["write"] = quantize((timestamp - extent_write_start[pid,arg0,arg1]) / arg2);
+    extent_write_start[pid,arg0,arg1] = 0;
+}
+
+crucible_downstairs*:::extent-write-file-done
+/extent_write_file_start[pid,arg0,arg1]/
+{
+    @time["write_file"] = quantize((timestamp - extent_write_file_start[pid,arg0,arg1]) / arg2);
+    extent_write_file_start[pid,arg0,arg1] = 0;
+}
+
+crucible_downstairs*:::extent-write-get-hashes-done
+/extent_write_get_hashes_start[pid,arg0,arg1]/
+{
+    @time["write_get_hashes"] = quantize((timestamp - extent_write_get_hashes_start[pid,arg0,arg1]) / arg2);
+    extent_write_get_hashes_start[pid,arg0,arg1] = 0;
+}
+
+crucible_downstairs*:::extent-write-sqlite-insert-done
+/extent_write_sqlite_insert_start[pid,arg0,arg1]/
+{
+    @time["write_sqlite_insert"] = quantize((timestamp - extent_write_sqlite_insert_start[pid,arg0,arg1]) / arg2);
+    extent_write_sqlite_insert_start[pid,arg0,arg1] = 0;
+}
+
+
+
+
+/*
+ * reads
+ */
+crucible_downstairs*:::extent-read-start
+{
+    extent_read_start[pid,arg0,arg1] = timestamp;
+}
+
+crucible_downstairs*:::extent-read-file-start
+{
+    extent_read_file_start[pid,arg0,arg1] = timestamp;
+}
+
+crucible_downstairs*:::extent-read-get-contexts-start
+{
+    extent_read_get_contexts_start[pid,arg0,arg1] = timestamp;
+}
+
+
+/* and collections */
+crucible_downstairs*:::extent-read-done
+/extent_read_start[pid,arg0,arg1]/
+{
+    @time["read"] = quantize((timestamp - extent_read_start[pid,arg0,arg1]) / arg2);
+    extent_read_start[pid,arg0,arg1] = 0;
+}
+
+crucible_downstairs*:::extent-read-file-done
+/extent_read_file_start[pid,arg0,arg1]/
+{
+    @time["read_file"] = quantize((timestamp - extent_read_file_start[pid,arg0,arg1]) / arg2);
+    extent_read_file_start[pid,arg0,arg1] = 0;
+}
+
+crucible_downstairs*:::extent-read-get-contexts-done
+/extent_read_get_contexts_start[pid,arg0,arg1]/
+{
+    @time["read_get_contexts"] = quantize((timestamp - extent_read_get_contexts_start[pid,arg0,arg1]) / arg2);
+    extent_read_get_contexts_start[pid,arg0,arg1] = 0;
+}
+


### PR DESCRIPTION
this adds a bunch of dtrace probes to region IO to get some numbers on how long each part of the IO is taking

in the dtrace script, i accumulate the entire time of flushes, but for reads/writes i divide by the number of blocks to get a per-block measurement.

I also threaded job_id in to read/write so i can report that in the dtrace probe.

I'm not differentiating between PID for the accumulations right now since I just want more data to average, and im only running one set of 3 downstairs anyway. We could change it to differentiate the PIDs if we want to.