### PR TITLE
Make size info available during volume creation without requiring activation

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -122,6 +122,9 @@ pub enum CrucibleError {
 
     #[error("Failed reconciliation")]
     RegionAssembleError,
+
+    #[error("Property not available: {0}")]
+    PropertyNotAvailable(String),
 }
 
 impl From<std::io::Error> for CrucibleError {

--- a/crucible-client-types/src/lib.rs
+++ b/crucible-client-types/src/lib.rs
@@ -32,9 +32,7 @@ pub enum VolumeConstructionRequest {
     },
 }
 
-#[derive(
-    Debug, Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq,
-)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct RegionExtentInfo {
     pub blocks_per_extent: u64,
     pub extent_count: u32,

--- a/crucible-client-types/src/lib.rs
+++ b/crucible-client-types/src/lib.rs
@@ -22,6 +22,8 @@ pub enum VolumeConstructionRequest {
     },
     Region {
         block_size: u64,
+        blocks_per_extent: u64,
+        extent_count: u32,
         opts: CrucibleOpts,
         gen: u64,
     },
@@ -30,12 +32,6 @@ pub enum VolumeConstructionRequest {
         block_size: u64,
         path: String,
     },
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq)]
-pub struct RegionExtentInfo {
-    pub blocks_per_extent: u64,
-    pub extent_count: u32,
 }
 
 #[derive(
@@ -52,7 +48,6 @@ pub struct CrucibleOpts {
     pub root_cert_pem: Option<String>,
     pub control: Option<SocketAddr>,
     pub read_only: bool,
-    pub expected_extent_info: Option<RegionExtentInfo>,
 }
 
 impl CrucibleOpts {

--- a/crucible-client-types/src/lib.rs
+++ b/crucible-client-types/src/lib.rs
@@ -35,6 +35,14 @@ pub enum VolumeConstructionRequest {
 #[derive(
     Debug, Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq,
 )]
+pub struct RegionExtentInfo {
+    pub blocks_per_extent: u64,
+    pub extent_count: u32,
+}
+
+#[derive(
+    Debug, Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq,
+)]
 pub struct CrucibleOpts {
     pub id: Uuid,
     pub target: Vec<SocketAddr>,
@@ -46,6 +54,7 @@ pub struct CrucibleOpts {
     pub root_cert_pem: Option<String>,
     pub control: Option<SocketAddr>,
     pub read_only: bool,
+    pub expected_extent_info: Option<RegionExtentInfo>,
 }
 
 impl CrucibleOpts {

--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -561,7 +561,7 @@ async fn main() -> Result<()> {
     let guest = Arc::new(Guest::new());
 
     let _join_handle =
-        up_main(crucible_opts, opt.gen, guest.clone(), None).await?;
+        up_main(crucible_opts, opt.gen, None, guest.clone(), None).await?;
     eprintln!("Crucible runtime is spawned");
 
     // IO time

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -472,6 +472,7 @@ async fn main() -> Result<()> {
         root_cert_pem: opt.root_cert_pem,
         control: opt.control,
         read_only: false,
+        expected_extent_info: None,
     };
 
     /*

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -472,7 +472,6 @@ async fn main() -> Result<()> {
         root_cert_pem: opt.root_cert_pem,
         control: opt.control,
         read_only: false,
-        expected_extent_info: None,
     };
 
     /*

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -521,7 +521,7 @@ async fn main() -> Result<()> {
     }
 
     let _join_handle =
-        up_main(crucible_opts, opt.gen, guest.clone(), pr).await?;
+        up_main(crucible_opts, opt.gen, None, guest.clone(), pr).await?;
     println!("Crucible runtime is spawned");
 
     if let Workload::CliServer { listen, port } = opt.workload {

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -90,7 +90,6 @@ async fn main() -> Result<()> {
         root_cert_pem: opt.root_cert_pem,
         control: opt.control,
         read_only: false,
-        expected_extent_info: None,
     };
 
     if let Some(tracing_endpoint) = opt.tracing_endpoint {

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -133,9 +133,14 @@ async fn main() -> Result<()> {
         let guest = Arc::new(Guest::new());
 
         let gen: u64 = i as u64 + opt.gen;
-        let _join_handle =
-            up_main(crucible_opts.clone(), gen as u64, guest.clone(), None)
-                .await?;
+        let _join_handle = up_main(
+            crucible_opts.clone(),
+            gen as u64,
+            None,
+            guest.clone(),
+            None,
+        )
+        .await?;
         println!("Crucible runtime is spawned");
 
         cpfs.push(crucible::CruciblePseudoFile::from(guest)?);

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -90,6 +90,7 @@ async fn main() -> Result<()> {
         root_cert_pem: opt.root_cert_pem,
         control: opt.control,
         read_only: false,
+        expected_extent_info: None,
     };
 
     if let Some(tracing_endpoint) = opt.tracing_endpoint {

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -181,6 +181,7 @@ mod test {
                 root_cert_pem: None,
                 control: None,
                 read_only,
+                expected_extent_info: None,
             };
 
             Ok(TestDownstairsSet {

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -287,17 +287,18 @@ mod test {
     async fn integration_test_two_layers() -> Result<()> {
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();
-        integration_test_two_layers_common(opts, false).await
+        integration_test_two_layers_common(tds, opts, false).await
     }
 
     #[tokio::test]
     async fn integration_test_two_layers_write_unwritten() -> Result<()> {
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();
-        integration_test_two_layers_common(opts, true).await
+        integration_test_two_layers_common(tds, opts, true).await
     }
 
     async fn integration_test_two_layers_common(
+        tds: TestDownstairsSet,
         opts: CrucibleOpts,
         is_write_unwritten: bool,
     ) -> Result<()> {
@@ -329,8 +330,8 @@ mod test {
                 opts,
                 volume::RegionExtentInfo {
                     block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: 10,
-                    extent_count: 1,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
                 },
                 1,
                 None,
@@ -1101,7 +1102,7 @@ mod test {
     async fn integration_test_two_layers_parent_smaller() -> Result<()> {
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();
-        integration_test_two_layers_small_common(opts, false).await
+        integration_test_two_layers_small_common(tds, opts, false).await
     }
 
     #[tokio::test]
@@ -1109,10 +1110,11 @@ mod test {
     {
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();
-        integration_test_two_layers_small_common(opts, true).await
+        integration_test_two_layers_small_common(tds, opts, true).await
     }
 
     async fn integration_test_two_layers_small_common(
+        tds: TestDownstairsSet,
         opts: CrucibleOpts,
         is_write_unwritten: bool,
     ) -> Result<()> {
@@ -1148,8 +1150,8 @@ mod test {
                 opts,
                 volume::RegionExtentInfo {
                     block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: 5,
-                    extent_count: 1,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
                 },
                 1,
                 None,
@@ -1228,8 +1230,8 @@ mod test {
                 opts,
                 volume::RegionExtentInfo {
                     block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: 10,
-                    extent_count: 1,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
                 },
                 1,
                 None,
@@ -1311,8 +1313,8 @@ mod test {
                 opts,
                 volume::RegionExtentInfo {
                     block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: 5,
-                    extent_count: 1,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
                 },
                 1,
                 None,
@@ -1415,8 +1417,8 @@ mod test {
                 opts,
                 volume::RegionExtentInfo {
                     block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: 5,
-                    extent_count: 1,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
                 },
                 1,
                 None,
@@ -1510,8 +1512,8 @@ mod test {
                 opts,
                 volume::RegionExtentInfo {
                     block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: 10,
-                    extent_count: 1,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
                 },
                 1,
                 None,

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -1984,7 +1984,7 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, gc, None).await?;
+        let _join_handle = up_main(opts, 1, None, gc, None).await?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -2028,7 +2028,7 @@ mod test {
         let gc = guest.clone();
 
         // Read-only Upstairs should return errors if writes are attempted.
-        let _join_handle = up_main(opts, 1, gc, None).await?;
+        let _join_handle = up_main(opts, 1, None, gc, None).await?;
 
         guest.activate().await?;
 
@@ -2062,7 +2062,7 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, gc, None).await?;
+        let _join_handle = up_main(opts, 1, None, gc, None).await?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -2135,7 +2135,7 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, gc, None).await?;
+        let _join_handle = up_main(opts, 1, None, gc, None).await?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -2193,7 +2193,7 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, gc, None).await?;
+        let _join_handle = up_main(opts, 1, None, gc, None).await?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -2252,7 +2252,7 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, gc, None).await?;
+        let _join_handle = up_main(opts, 1, None, gc, None).await?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -2309,7 +2309,7 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, gc, None).await?;
+        let _join_handle = up_main(opts, 1, None, gc, None).await?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -2366,7 +2366,7 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, gc, None).await?;
+        let _join_handle = up_main(opts, 1, None, gc, None).await?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -81,6 +81,7 @@ async fn main() -> Result<()> {
         root_cert_pem: opt.root_cert_pem,
         control: None,
         read_only: false,
+        expected_extent_info: None,
     };
 
     /*

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -105,7 +105,7 @@ async fn main() -> Result<()> {
 
     let guest = Arc::new(guest);
     let _join_handle =
-        up_main(crucible_opts, opt.gen, guest.clone(), None).await?;
+        up_main(crucible_opts, opt.gen, None, guest.clone(), None).await?;
     println!("Crucible runtime is spawned");
 
     guest.activate().await?;

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -81,7 +81,6 @@ async fn main() -> Result<()> {
         root_cert_pem: opt.root_cert_pem,
         control: None,
         read_only: false,
-        expected_extent_info: None,
     };
 
     /*

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -94,7 +94,7 @@ async fn main() -> Result<()> {
     let guest = Arc::new(Guest::new());
 
     let _join_handle =
-        up_main(crucible_opts, opt.gen, guest.clone(), None).await?;
+        up_main(crucible_opts, opt.gen, None, guest.clone(), None).await?;
     println!("Crucible runtime is spawned");
 
     // NBD server

--- a/openapi/crucible-pantry.json
+++ b/openapi/crucible-pantry.json
@@ -373,6 +373,14 @@
             "nullable": true,
             "type": "string"
           },
+          "expected_extent_info": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RegionExtentInfo"
+              }
+            ]
+          },
           "flush_timeout": {
             "nullable": true,
             "type": "integer",
@@ -489,6 +497,25 @@
         },
         "required": [
           "job_is_finished"
+        ]
+      },
+      "RegionExtentInfo": {
+        "type": "object",
+        "properties": {
+          "blocks_per_extent": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "extent_count": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "blocks_per_extent",
+          "extent_count"
         ]
       },
       "ScrubResponse": {

--- a/openapi/crucible-pantry.json
+++ b/openapi/crucible-pantry.json
@@ -373,14 +373,6 @@
             "nullable": true,
             "type": "string"
           },
-          "expected_extent_info": {
-            "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/RegionExtentInfo"
-              }
-            ]
-          },
           "flush_timeout": {
             "nullable": true,
             "type": "integer",
@@ -499,25 +491,6 @@
           "job_is_finished"
         ]
       },
-      "RegionExtentInfo": {
-        "type": "object",
-        "properties": {
-          "blocks_per_extent": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "extent_count": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          }
-        },
-        "required": [
-          "blocks_per_extent",
-          "extent_count"
-        ]
-      },
       "ScrubResponse": {
         "type": "object",
         "properties": {
@@ -619,6 +592,16 @@
                 "format": "uint64",
                 "minimum": 0
               },
+              "blocks_per_extent": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0
+              },
+              "extent_count": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
               "gen": {
                 "type": "integer",
                 "format": "uint64",
@@ -636,6 +619,8 @@
             },
             "required": [
               "block_size",
+              "blocks_per_extent",
+              "extent_count",
               "gen",
               "opts",
               "type"

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -7876,7 +7876,7 @@ async fn up_listen(
 pub async fn up_main(
     opt: CrucibleOpts,
     gen: u64,
-    expected_region_def: Option<RegionDefinition>,
+    region_def: Option<RegionDefinition>,
     guest: Arc<Guest>,
     producer_registry: Option<ProducerRegistry>,
 ) -> Result<tokio::task::JoinHandle<()>> {
@@ -7898,7 +7898,7 @@ pub async fn up_main(
      * Build the Upstairs struct that we use to share data between
      * the different async tasks
      */
-    let up = Upstairs::new(&opt, gen, expected_region_def, guest, log);
+    let up = Upstairs::new(&opt, gen, region_def, guest, log);
 
     /*
      * Use this channel to receive updates on target status from each task

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -3825,7 +3825,6 @@ impl Upstairs {
             root_cert_pem: None,
             control: None,
             read_only: false,
-            expected_extent_info: None,
         };
 
         // Register DTrace, and setup slog logging to use it.
@@ -4684,7 +4683,7 @@ impl Upstairs {
         let impacted_blocks = extent_from_offset(
             *ddef,
             offset,
-            Block::from_bytes(data.len(), &ddef),
+            Block::from_bytes(data.len(), ddef),
         );
 
         /*

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -7612,7 +7612,10 @@ async fn process_new_io(
                         "Block size not available (active: {})",
                         up.guest_io_ready().await
                     );
-                    req.send_err(CrucibleError::UpstairsInactive).await;
+                    req.send_err(CrucibleError::PropertyNotAvailable(
+                        "block size".to_string(),
+                    ))
+                    .await;
                     return;
                 }
             };
@@ -7628,7 +7631,10 @@ async fn process_new_io(
                         "Total size not available (active: {})",
                         up.guest_io_ready().await
                     );
-                    req.send_err(CrucibleError::UpstairsInactive).await;
+                    req.send_err(CrucibleError::PropertyNotAvailable(
+                        "total size".to_string(),
+                    ))
+                    .await;
                     return;
                 }
             };
@@ -7646,7 +7652,10 @@ async fn process_new_io(
                         "Extent size not available (active: {})",
                         up.guest_io_ready().await
                     );
-                    req.send_err(CrucibleError::UpstairsInactive).await;
+                    req.send_err(CrucibleError::PropertyNotAvailable(
+                        "extent size".to_string(),
+                    ))
+                    .await;
                     return;
                 }
             };

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -5670,10 +5670,6 @@ impl Upstairs {
          * XXX The expected per-client UUIDs should eventually be provided
          * when the upstairs stairs. When that happens, they can be
          * verified here.
-         *
-         * REVIEW(gjc): is the UUID expected to be the same for all three
-         * downstairs? Can we check it against the expected/previous region
-         * definition?
          */
         let mut ds = self.downstairs.lock().await;
         if let Some(uuid) = ds.ds_uuid.get(&client_id) {
@@ -5714,7 +5710,7 @@ impl Upstairs {
                     != client_ddef.extent_size().block_size_in_bytes()
                 || prev_def.extent_count() != client_ddef.extent_count()
             {
-                // XXX Figure out if we can handle this error. Possibly not.
+                // TODO(#558) Figure out if we can handle this error. Possibly not.
                 panic!(
                     "New downstairs region info mismatch {:?} vs. {:?}",
                     *ddef, client_ddef

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -3825,6 +3825,7 @@ impl Upstairs {
             root_cert_pem: None,
             control: None,
             read_only: false,
+            expected_extent_info: None,
         };
 
         // Register DTrace, and setup slog logging to use it.

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -110,7 +110,7 @@ mod up_test {
             ..Default::default()
         };
 
-        Upstairs::new(&opts, 0, def, Arc::new(Guest::new()), csl())
+        Upstairs::new(&opts, 0, Some(def), Arc::new(Guest::new()), csl())
     }
 
     /*

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -122,9 +122,9 @@ mod up_test {
         offset: Block,
         num_blocks: u64,
     ) -> Vec<(u64, Block)> {
-        let ddef = up.ddef.lock().await;
+        let ddef = up.ddef.lock().await.get_def().unwrap();
         let num_blocks = Block::new_with_ddef(num_blocks, &ddef);
-        extent_from_offset(*ddef, offset, num_blocks).tuples()
+        extent_from_offset(ddef, offset, num_blocks).tuples()
     }
 
     #[tokio::test]
@@ -3031,7 +3031,7 @@ mod up_test {
         // Verify that the flush takes three completions.
         // Verify that deactivate done returns the upstairs to init.
 
-        let up = Upstairs::default();
+        let up = make_upstairs();
         up.set_active().await.unwrap();
         let mut ds = up.downstairs.lock().await;
         ds.ds_state[0] = DsState::Active;
@@ -3215,7 +3215,7 @@ mod up_test {
         // Verify that we can't deactivate without a flush as the
         // last job on the list
 
-        let up = Upstairs::default();
+        let up = make_upstairs();
         up.set_active().await.unwrap();
         let mut ds = up.downstairs.lock().await;
         ds.ds_state[0] = DsState::Active;

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -162,8 +162,6 @@ impl Volume {
             up_main(opts, gen, region_def, guest_clone, producer_registry)
                 .await?;
 
-        guest.activate().await?;
-
         self.add_subvolume(guest).await
     }
 

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -135,8 +135,10 @@ impl Volume {
 
         // Spawn crucible tasks
         let guest_clone = guest.clone();
+
+        // TODO(gjc) extract region definition out of the CrucibleOpts
         let _join_handle =
-            up_main(opts, gen, guest_clone, producer_registry).await?;
+            up_main(opts, gen, None, guest_clone, producer_registry).await?;
 
         guest.activate().await?;
 


### PR DESCRIPTION
Allow a `Volume` to have a valid block size and total size from its creation by requiring users of `VolumeConstructionRequest::Region` to pass extent sizes and counts in addition to block sizes. This allows callers to create a `Volume` and query its sizes before anyone has activated, which in turn allows Propolis to defer volume activation until late in migration, solving the problems outlined in #440 and #543. Callers who want to create an upstairs without a VolumeConstructionRequest (e.g. tools like `crudd` and `hammer`) can still do so (they will get the old "accept information from the first downstairs" behavior).

**NOTE**: Because this changes `VolumeConstructionRequest`'s definition, this PR is a breaking change for Propolis/Omicron. I have a draft of the Propolis changes needed to adopt the new struct format, but still need to do the corresponding Omicron changes. I'm happy to wait to merge until the Omicron bits are also ready--just let me know (I wanted to go ahead and start getting this reviewed regardless).

Open issues to review:

- I'm unsure about how volume/region UUIDs are supposed to work. I left a `REVIEW(gjc)` comment in upstairs/src/lib.rs in a spot where this was important (it affects what sort of checks we can do when processing incoming region definitions).

Tests:
- `cargo test`
- PHD tests, including migration-under-load test with Propolis fixes in place that shows that this approach works to allow Crucible-backed VMs to migrate

Fixes #440. Fixes #543.