### PR TITLE
Remove Boolean specifier from crucible-agent to comply with clap update

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -910,7 +910,7 @@ fn worker_region_create(
         .arg(region.extent_size.to_string())
         .arg("--extent-count")
         .arg(region.extent_count.to_string())
-        .arg(format!("--encrypted={}", region.encrypted))
+        .arg(if region.encrypted { "--encrypted" } else { "" })
         .output()?;
 
     if cmd.status.success() {

--- a/tools/create-generic-ds.sh
+++ b/tools/create-generic-ds.sh
@@ -81,8 +81,8 @@ for port in 8810 8820 8830; do
             res=1
         fi
     else
-        echo "$cds" create -u 12345678-"$port"-"$port"-"$port"-00000000"$port" -d var/"$port" --extent-count "$extent_count" --extent-size "$extent_size"  --block-size "$block_size" --encrypted=true
-        if ! time "$cds" create -u 12345678-"$port"-"$port"-"$port"-00000000"$port" -d var/"$port" --extent-count "$extent_count" --extent-size "$extent_size"  --block-size "$block_size" --encrypted=true; then
+        echo "$cds" create -u 12345678-"$port"-"$port"-"$port"-00000000"$port" -d var/"$port" --extent-count "$extent_count" --extent-size "$extent_size"  --block-size "$block_size" --encrypted
+        if ! time "$cds" create -u 12345678-"$port"-"$port"-"$port"-00000000"$port" -d var/"$port" --extent-count "$extent_count" --extent-size "$extent_size"  --block-size "$block_size" --encrypted; then
             echo "Failed to create downstairs $port"
             res=1
         fi


### PR DESCRIPTION
The upgrade to clap v4 (#566) changed the behavior of the crucible-downstairs `--encrypted` flag such that it no longer takes an explicit Boolean value. Instead, the presence or absence of the flag determines the value produced by parsing, and explicitly passing "true" or "false" causes an error. Make the Crucible agent play by these new rules so that Omicron can pick up Crucible packages including the clap v4 change. Without this, creating a new disk fails during region creation because crucible-downstairs rejects crucible-agent's `--encrypted true` arguments.

Tested by building the Crucible package, deploying the private package into an Omicron build, and observing that instance creation succeeds.