### PR TITLE
Don't rehash blocks in flush. Do it in extent open

### DIFF
--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -486,6 +486,7 @@ async fn cmd_write<T: BlockIO>(
         if early_shutdown.try_recv().is_ok() {
             eprintln!("shutting down early in response to SIGUSR1");
             join_all(futures).await?;
+            crucible.flush(None).await?;
             return Ok(total_bytes_written);
         }
     }
@@ -521,6 +522,9 @@ async fn cmd_write<T: BlockIO>(
             futures,
         )
         .await?;
+    } else {
+        join_all(futures).await?;
+        crucible.flush(None).await?;
     }
 
     Ok(total_bytes_written)

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -25,7 +25,7 @@ mime_guess = "2.0.4"
 omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
-rand = "0.8.5"
+rand = { version = "0.8.5", features = ["min_const_gen"] }
 repair-client = { path = "../repair-client" }
 reqwest = { version = "0.11", features = ["json"] }
 ringbuffer = "0.12"

--- a/downstairs/src/admin.rs
+++ b/downstairs/src/admin.rs
@@ -71,6 +71,7 @@ pub async fn run_downstairs_for_region(
         run_params.read_only,
         None,
     )
+    .await
     .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
 
     let _join_handle = start_downstairs(

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -45,7 +45,7 @@ pub async fn dump_region(
     assert!(!region_dir.is_empty());
     for (index, dir) in region_dir.iter().enumerate() {
         // Open Region read only
-        let region = Region::open(dir, Default::default(), false, true, &log)?;
+        let region = Region::open(dir, Default::default(), false, true, &log).await?;
 
         blocks_per_extent = region.def().extent_size().value;
         total_extents = region.def().extent_count();
@@ -539,7 +539,7 @@ async fn show_extent(
         for (index, dir) in region_dir.iter().enumerate() {
             // Open Region read only
             let region =
-                Region::open(dir, Default::default(), false, true, &log)?;
+                Region::open(dir, Default::default(), false, true, &log).await?;
 
             let mut responses = region
                 .region_read(
@@ -653,7 +653,7 @@ async fn show_extent_block(
      */
     for (index, dir) in region_dir.iter().enumerate() {
         // Open Region read only
-        let region = Region::open(dir, Default::default(), false, true, &log)?;
+        let region = Region::open(dir, Default::default(), false, true, &log).await?;
 
         let mut responses = region
             .region_read(

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -45,7 +45,8 @@ pub async fn dump_region(
     assert!(!region_dir.is_empty());
     for (index, dir) in region_dir.iter().enumerate() {
         // Open Region read only
-        let region = Region::open(dir, Default::default(), false, true, &log).await?;
+        let region =
+            Region::open(dir, Default::default(), false, true, &log).await?;
 
         blocks_per_extent = region.def().extent_size().value;
         total_extents = region.def().extent_count();
@@ -539,7 +540,8 @@ async fn show_extent(
         for (index, dir) in region_dir.iter().enumerate() {
             // Open Region read only
             let region =
-                Region::open(dir, Default::default(), false, true, &log).await?;
+                Region::open(dir, Default::default(), false, true, &log)
+                    .await?;
 
             let mut responses = region
                 .region_read(
@@ -653,7 +655,8 @@ async fn show_extent_block(
      */
     for (index, dir) in region_dir.iter().enumerate() {
         // Open Region read only
-        let region = Region::open(dir, Default::default(), false, true, &log).await?;
+        let region =
+            Region::open(dir, Default::default(), false, true, &log).await?;
 
         let mut responses = region
             .region_read(

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -396,28 +396,42 @@ pub mod cdt {
     fn submit__writeunwritten__done(_: u64) {}
     fn submit__write__done(_: u64) {}
     fn submit__flush__done(_: u64) {}
-    fn extent__flush__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
-    fn extent__flush__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
-    fn extent__flush__file__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
-    fn extent__flush__file__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
-    fn extent__flush__rehash__start(
+    fn extent__flush__start(job_id: u64, extent_id: u32, extent_size: u64) {}
+    fn extent__flush__done(job_id: u64, extent_id: u32, extent_size: u64) {}
+    fn extent__flush__file__start(
         job_id: u64,
         extent_id: u32,
-        n_blocks: u64,
+        extent_size: u64,
     ) {
     }
-    fn extent__flush__rehash__done(job_id: u64, extent_id: u32, n_blocks: u64) {
+    fn extent__flush__file__done(
+        job_id: u64,
+        extent_id: u32,
+        extent_size: u64,
+    ) {
+    }
+    fn extent__flush__collect__hashes__start(
+        job_id: u64,
+        extent_id: u32,
+        extent_size: u64,
+    ) {
+    }
+    fn extent__flush__collect__hashes__done(
+        job_id: u64,
+        extent_id: u32,
+        extent_size: u64,
+    ) {
     }
     fn extent__flush__sqlite__insert__start(
         job_id: u64,
         extent_id: u32,
-        n_blocks: u64,
+        extent_size: u64,
     ) {
     }
     fn extent__flush__sqlite__insert__done(
         _job_id: u64,
         _extent_id: u32,
-        n_blocks: u64,
+        extent_size: u64,
     ) {
     }
     fn extent__write__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
@@ -464,6 +478,9 @@ pub mod cdt {
     }
     fn extent__read__file__start(job_id: u64, extent_id: u32, n_blocks: u64) {}
     fn extent__read__file__done(job_id: u64, extent_id: u32, n_blocks: u64) {}
+
+    fn extent__context__truncate__start(n_deletions: u64) {}
+    fn extent__context__truncate__done() {}
 }
 
 // Check if a Message is valid on this downstairs or not.

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -2821,7 +2821,8 @@ pub async fn build_downstairs_for_region(
             Logger::root(drain.fuse(), o!())
         }
     };
-    let region = Region::open(data, Default::default(), true, read_only, &log).await?;
+    let region =
+        Region::open(data, Default::default(), true, read_only, &log).await?;
 
     info!(log, "UUID: {:?}", region.def().uuid());
     info!(
@@ -3201,7 +3202,8 @@ mod test {
             false,
             false,
             Some(csl()),
-        ).await?;
+        )
+        .await?;
 
         // This happens in proc() function.
         let upstairs_connection = UpstairsConnection {
@@ -5026,7 +5028,8 @@ mod test {
             false, // flush errors
             read_only,
             Some(csl()),
-        ).await
+        )
+        .await
     }
 
     #[tokio::test]
@@ -5468,7 +5471,8 @@ mod test {
             false,
             false,
             Some(csl()),
-        ).await?;
+        )
+        .await?;
 
         // This happens in proc() function.
         let upstairs_connection_1 = UpstairsConnection {
@@ -5562,7 +5566,8 @@ mod test {
             false,
             false,
             Some(csl()),
-        ).await?;
+        )
+        .await?;
 
         // This happens in proc() function.
         let upstairs_connection_1 = UpstairsConnection {
@@ -5656,7 +5661,8 @@ mod test {
             false,
             false,
             Some(csl()),
-        ).await?;
+        )
+        .await?;
 
         // This happens in proc() function.
         let upstairs_connection_1 = UpstairsConnection {

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -2060,7 +2060,7 @@ impl Downstairs {
                     error!(self.log, "Upstairs inactive error");
                     Err(CrucibleError::UpstairsInactive)
                 } else {
-                    self.region.reopen_extent(*extent)
+                    self.region.reopen_extent(*extent).await
                 };
                 Ok(Some(Message::ExtentLiveAckId {
                     upstairs_id: job.upstairs_connection.upstairs_id,
@@ -3261,7 +3261,7 @@ mod test {
 
     // Test function to create a simple downstairs with the given block
     // and extent values.  Returns the Downstairs.
-    fn create_test_downstairs(
+    async fn create_test_downstairs(
         block_size: u64,
         extent_size: u64,
         extent_count: u32,
@@ -3278,8 +3278,8 @@ mod test {
         region_options.set_uuid(Uuid::new_v4());
 
         mkdir_for_file(dir.path())?;
-        let mut region = Region::create(dir, region_options, csl())?;
-        region.extend(extent_count)?;
+        let mut region = Region::create(dir, region_options, csl()).await?;
+        region.extend(extent_count).await?;
 
         let path_dir = dir.as_ref().to_path_buf();
         let ads = build_downstairs_for_region(
@@ -3290,7 +3290,8 @@ mod test {
             false,
             false,
             Some(csl()),
-        )?;
+        )
+        .await?;
 
         Ok(ads)
     }
@@ -3309,7 +3310,8 @@ mod test {
         let extent_size = 4;
         let dir = tempdir()?;
 
-        let ads = create_test_downstairs(block_size, extent_size, 5, &dir)?;
+        let ads =
+            create_test_downstairs(block_size, extent_size, 5, &dir).await?;
 
         // This happens in proc() function.
         let upstairs_connection = UpstairsConnection {
@@ -3398,7 +3400,8 @@ mod test {
         let dir = tempdir()?;
         let gen = 10;
 
-        let ads = create_test_downstairs(block_size, extent_size, 5, &dir)?;
+        let ads =
+            create_test_downstairs(block_size, extent_size, 5, &dir).await?;
 
         // This happens in proc() function.
         let upstairs_connection = UpstairsConnection {
@@ -3570,7 +3573,8 @@ mod test {
         let dir = tempdir()?;
         let gen = 10;
 
-        let ads = create_test_downstairs(block_size, extent_size, 5, &dir)?;
+        let ads =
+            create_test_downstairs(block_size, extent_size, 5, &dir).await?;
 
         let upstairs_connection = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
@@ -3690,7 +3694,8 @@ mod test {
         let dir = tempdir()?;
         let gen = 10;
 
-        let ads = create_test_downstairs(block_size, extent_size, 5, &dir)?;
+        let ads =
+            create_test_downstairs(block_size, extent_size, 5, &dir).await?;
 
         let upstairs_connection = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
@@ -3798,7 +3803,8 @@ mod test {
         let dir = tempdir()?;
         let gen = 10;
 
-        let ads = create_test_downstairs(block_size, extent_size, 5, &dir)?;
+        let ads =
+            create_test_downstairs(block_size, extent_size, 5, &dir).await?;
 
         // This happens in proc() function.
         let upstairs_connection = UpstairsConnection {
@@ -3915,7 +3921,8 @@ mod test {
         let dir = tempdir()?;
         let gen = 10;
 
-        let ads = create_test_downstairs(block_size, extent_size, 5, &dir)?;
+        let ads =
+            create_test_downstairs(block_size, extent_size, 5, &dir).await?;
         let upstairs_connection = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -224,7 +224,7 @@ async fn main() -> Result<()> {
                 uuid,
                 encrypted,
                 log.clone(),
-            )?;
+            ).await?;
 
             if let Some(ref ip) = import_path {
                 downstairs_import(&mut region, ip).await.unwrap();
@@ -278,7 +278,7 @@ async fn main() -> Result<()> {
                 true,
                 true,
                 &log,
-            )?;
+            ).await?;
 
             downstairs_export(&mut region, export_path, skip, count).await?;
             Ok(())
@@ -334,7 +334,7 @@ async fn main() -> Result<()> {
                 flush_errors,
                 read_only,
                 Some(log),
-            )?;
+            ).await?;
 
             let downstairs_join_handle = start_downstairs(
                 d,

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -224,7 +224,8 @@ async fn main() -> Result<()> {
                 uuid,
                 encrypted,
                 log.clone(),
-            ).await?;
+            )
+            .await?;
 
             if let Some(ref ip) = import_path {
                 downstairs_import(&mut region, ip).await.unwrap();
@@ -278,7 +279,8 @@ async fn main() -> Result<()> {
                 true,
                 true,
                 &log,
-            ).await?;
+            )
+            .await?;
 
             downstairs_export(&mut region, export_path, skip, count).await?;
             Ok(())
@@ -334,7 +336,8 @@ async fn main() -> Result<()> {
                 flush_errors,
                 read_only,
                 Some(log),
-            ).await?;
+            )
+            .await?;
 
             let downstairs_join_handle = start_downstairs(
                 d,

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -623,7 +623,9 @@ impl Extent {
 
         // Clean out any irrelevant block contexts, which may be present if
         // downstairs crashed between a write() and a flush().
-        extent.fully_rehash_and_clean_all_stale_contexts(false).await?;
+        extent
+            .fully_rehash_and_clean_all_stale_contexts(false)
+            .await?;
 
         Ok(extent)
     }
@@ -1158,7 +1160,6 @@ impl Extent {
             (job_id, self.number, writes.len() as u64)
         });
 
-
         // PERFORMANCE TODO: While sqlite is the bulk of our performance cost
         // in writes, we're still paying quite the price on small writes
         // here. It would be nice if we could improve that a bit. An easy win
@@ -1618,20 +1619,14 @@ impl Region {
                 if create {
                     Extent::create(&dir, &def, eid)
                 } else {
-                    Extent::open(
-                        dir,
-                        &def,
-                        eid,
-                        read_only,
-                        &log,
-                    ).await
+                    Extent::open(dir, &def, eid, read_only, &log).await
                 }
             });
             these_extent_handles.push(handle);
         }
 
         let mut these_extents = Vec::with_capacity(these_extent_handles.len());
-        for handle in these_extent_handles  {
+        for handle in these_extent_handles {
             these_extents.push(handle.await??);
         }
 
@@ -1667,7 +1662,10 @@ impl Region {
     /**
      * Re open an extent that was previously closed
      */
-    pub async fn reopen_extent(&mut self, eid: usize) -> Result<(), CrucibleError> {
+    pub async fn reopen_extent(
+        &mut self,
+        eid: usize,
+    ) -> Result<(), CrucibleError> {
         /*
          * Make sure the extent :
          *
@@ -1685,7 +1683,8 @@ impl Region {
             eid as u32,
             self.read_only,
             &self.log,
-        ).await?;
+        )
+        .await?;
         self.extents[eid] = new_extent;
         Ok(())
     }
@@ -2112,9 +2111,7 @@ impl Region {
         );
 
         let extent = &self.extents[eid];
-        extent
-            .flush(flush_number, gen_number, 0, &self.log)
-            .await?;
+        extent.flush(flush_number, gen_number, 0, &self.log).await?;
 
         Ok(())
     }
@@ -2462,7 +2459,8 @@ mod test {
         // Create the copy directory, make sure it exists.
         // Remove the copy directory, make sure it goes away.
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(3).await?;
 
         let ext_one = &mut region.extents[1];
@@ -2481,8 +2479,9 @@ mod test {
         // Create the copy directory, make sure it exists.
         // Verify a second create will fail.
         let dir = tempdir().unwrap();
-        let mut region =
-            Region::create(&dir, new_region_options(), csl()).await.unwrap();
+        let mut region = Region::create(&dir, new_region_options(), csl())
+            .await
+            .unwrap();
         region.extend(3).await.unwrap();
 
         let ext_one = &mut region.extents[1];
@@ -2496,7 +2495,8 @@ mod test {
     async fn close_extent() -> Result<()> {
         // Create the region, make three extents
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(3).await?;
 
         // Close extent 1
@@ -2534,7 +2534,8 @@ mod test {
         // opened with that directory present.
         // Create the region, make three extents
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(3).await?;
 
         // Close extent 1
@@ -2564,7 +2565,8 @@ mod test {
         // when an extent is re-opened.
         // Create the region, make three extents
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(3).await?;
 
         // Close extent 1
@@ -2605,7 +2607,8 @@ mod test {
         // metadata files.
         // Create the region, make three extents
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(3).await?;
 
         // Close extent 1
@@ -2670,7 +2673,8 @@ mod test {
         // extent after the reopen has cleaned them up.
         // Create the region, make three extents
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(3).await?;
 
         // Close extent 1
@@ -2750,7 +2754,8 @@ mod test {
 
         // Create the region, make three extents
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(3).await?;
 
         // Make copy directory for this extent
@@ -2777,7 +2782,8 @@ mod test {
 
         // Open up the region read_only now.
         let mut region =
-            Region::open(&dir, new_region_options(), false, true, &csl()).await?;
+            Region::open(&dir, new_region_options(), false, true, &csl())
+                .await?;
 
         // Verify extent 1 has opened again.
         let ext_one = &mut region.extents[1];
@@ -2889,7 +2895,8 @@ mod test {
     async fn reopen_all_extents() -> Result<()> {
         // Create the region, make three extents
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(5).await?;
 
         // Close extent 1
@@ -2946,7 +2953,8 @@ mod test {
             false,
             &csl(),
         )
-        .await.unwrap();
+        .await
+        .unwrap();
     }
 
     #[test]
@@ -3121,7 +3129,9 @@ mod test {
          * Create a region, give it actual size
          */
         let dir = tempdir()?;
-        let mut r1 = Region::create(&dir, new_region_options(), csl()).await.unwrap();
+        let mut r1 = Region::create(&dir, new_region_options(), csl())
+            .await
+            .unwrap();
         r1.extend(2).await?;
 
         /*
@@ -3147,9 +3157,12 @@ mod test {
         /*
          * Create the regions, give them some actual size
          */
-        let mut r1 = Region::create(&dir, new_region_options(), csl()).await.unwrap();
-        let mut r2 =
-            Region::create(&dir2, new_region_options(), csl()).await.unwrap();
+        let mut r1 = Region::create(&dir, new_region_options(), csl())
+            .await
+            .unwrap();
+        let mut r2 = Region::create(&dir2, new_region_options(), csl())
+            .await
+            .unwrap();
         r1.extend(2).await?;
         r2.extend(2).await?;
 
@@ -3181,10 +3194,13 @@ mod test {
         /*
          * Create the regions, give them some actual size
          */
-        let mut r1 = Region::create(&dir, new_region_options(), csl()).await.unwrap();
+        let mut r1 = Region::create(&dir, new_region_options(), csl())
+            .await
+            .unwrap();
         r1.extend(3).await?;
-        let mut r2 =
-            Region::create(&dir2, new_region_options(), csl()).await.unwrap();
+        let mut r2 = Region::create(&dir2, new_region_options(), csl())
+            .await
+            .unwrap();
         r2.extend(3).await?;
 
         /*
@@ -3207,7 +3223,8 @@ mod test {
     #[tokio::test]
     async fn encryption_context() -> Result<()> {
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(1).await?;
 
         let ext = &region.extents[0];
@@ -3360,7 +3377,8 @@ mod test {
     #[tokio::test]
     async fn multiple_context() -> Result<()> {
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(1).await?;
 
         let ext = &region.extents[0];
@@ -3555,7 +3573,8 @@ mod test {
     #[tokio::test]
     async fn test_big_write() -> Result<()> {
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(3).await?;
 
         let ddef = region.def();
@@ -3648,7 +3667,8 @@ mod test {
         // context row.
 
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(1).await?;
 
         // A write of some sort only wrote a block context row
@@ -3670,7 +3690,6 @@ mod test {
             extent.close().await?;
         }
         region.reopen_all_extents().await?;
-
 
         // Verify no block context rows exist
 
@@ -3726,7 +3745,8 @@ mod test {
     ) -> Result<()> {
         // Make a region. It's empty, and should stay that way
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(1).await?;
 
         let ext = &region.extents[0];
@@ -3835,7 +3855,8 @@ mod test {
     async fn test_fully_rehash_marks_blocks_unwritten_if_data_never_hit_disk(
     ) -> Result<()> {
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(1).await?;
 
         let ext = &region.extents[0];
@@ -3898,7 +3919,8 @@ mod test {
     #[tokio::test]
     async fn test_ok_hash_ok() -> Result<()> {
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(1).await?;
 
         let data = BytesMut::from(&[1u8; 512][..]);
@@ -3929,7 +3951,8 @@ mod test {
         // Verify that a read fill does write to a block when there is
         // no data written yet.
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(1).await?;
 
         // Fill a buffer with "9"'s (random)
@@ -3978,7 +4001,8 @@ mod test {
         // Verify that a read fill does not write to the block when
         // there is data written already.
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(1).await?;
 
         // Fill a buffer with "9"'s (random)
@@ -4046,7 +4070,8 @@ mod test {
         // there is data written already.  This time run a flush after the
         // first write.  Verify correct state of dirty bit as well.
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(1).await?;
 
         // Fill a buffer with "9"'s
@@ -4132,7 +4157,8 @@ mod test {
         // Do a multi block write where all blocks start new (unwritten)
         // Verify only empty blocks have data.
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(3).await?;
 
         let ddef = region.def();
@@ -4214,7 +4240,8 @@ mod test {
         // only_write_unwritten set. Verify block zero is the first write, and
         // the remaining blocks have the contents from the multi block fill.
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(3).await?;
 
         let ddef = region.def();
@@ -4329,7 +4356,8 @@ mod test {
         // the other blocks have the data from the multi block fill.
 
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(3).await?;
 
         let ddef = region.def();
@@ -4446,7 +4474,8 @@ mod test {
         // three blocks have the data from the multi block read fill.
 
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(5).await?;
 
         let ddef = region.def();
@@ -4551,7 +4580,8 @@ mod test {
         // Do a multi block write_unwritten where a few different blocks have
         // data. Verify only unwritten blocks get the data.
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(4).await?;
 
         let ddef = region.def();
@@ -4779,7 +4809,8 @@ mod test {
     #[tokio::test]
     async fn test_bad_hash_bad() -> Result<()> {
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(1).await?;
 
         let data = BytesMut::from(&[1u8; 512][..]);
@@ -4819,7 +4850,8 @@ mod test {
     #[tokio::test]
     async fn test_blank_block_read_ok() -> Result<()> {
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(1).await?;
 
         let responses = region

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -3,21 +3,22 @@ use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 use std::fmt;
 use std::fs::{rename, File, OpenOptions};
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{BufReader, Read, Seek, SeekFrom, Write};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use tokio::sync::{Mutex, MutexGuard};
 
 use anyhow::{bail, Result};
-use crucible_common::*;
-use crucible_protocol::{EncryptionContext, SnapshotDetails};
 use futures::TryStreamExt;
-use repair_client::types::FileType;
-use repair_client::Client;
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 use tokio::macros::support::Pin;
 use tracing::instrument;
+
+use crucible_common::*;
+use crucible_protocol::{EncryptionContext, SnapshotDetails};
+use repair_client::types::FileType;
+use repair_client::Client;
 
 use super::*;
 
@@ -51,6 +52,10 @@ pub struct DownstairsBlockContext {
 pub struct Inner {
     file: File,
     metadb: Connection,
+
+    /// Map of block number to on_disk_hash of the block. Stores blocks that
+    /// have been written since the last flush.
+    dirty_blocks: HashMap<usize, u64>,
 }
 
 impl Inner {
@@ -229,10 +234,6 @@ impl Inner {
         Ok(())
     }
 
-    pub fn metadb_transaction(&mut self) -> Result<rusqlite::Transaction> {
-        Ok(self.metadb.transaction()?)
-    }
-
     #[cfg(test)]
     fn set_block_contexts(
         &mut self,
@@ -251,10 +252,10 @@ impl Inner {
         Ok(())
     }
 
-    /*
-     * Get rid of all block context rows except those that match the on-disk
-     * hash that is computed after a flush.
-     */
+    /// Get rid of all block context rows except those that match the on-disk
+    /// hash that is computed after a flush. For best performance, make sure
+    /// `extent_block_indexes_and_hashes` is sorted by block number before
+    /// calling this function.
     fn truncate_encryption_contexts_and_hashes(
         &mut self,
         extent_block_indexes_and_hashes: Vec<(usize, u64)>,
@@ -262,12 +263,18 @@ impl Inner {
         let tx = self.metadb.transaction()?;
 
         let stmt = "DELETE FROM block_context where block == ?1 and on_disk_hash != ?2";
+        let mut stmt = tx.prepare_cached(stmt)?;
 
+        let n_blocks = extent_block_indexes_and_hashes.len();
+
+        cdt::extent__context__truncate__start!(|| n_blocks as u64);
         for (block, on_disk_hash) in extent_block_indexes_and_hashes {
-            let _rows_affected = tx
-                .prepare_cached(stmt)?
-                .execute(params![block, on_disk_hash.to_le_bytes()])?;
+            let _rows_affected =
+                stmt.execute(params![block, on_disk_hash.to_le_bytes()])?;
         }
+        cdt::extent__context__truncate__done!(|| ());
+
+        drop(stmt);
 
         tx.commit()?;
 
@@ -408,6 +415,7 @@ pub fn replace_dir<P: AsRef<Path>>(dir: P, number: u32) -> PathBuf {
     out.set_extension("replace");
     out
 }
+
 /**
  * Produce a PathBuf that refers to the completed directory we use for
  * a given extent "number".  This directory is generated (see below) when
@@ -604,13 +612,23 @@ impl Extent {
 
         // XXX: schema updates?
 
-        Ok(Extent {
+        let extent = Extent {
             number,
             read_only,
             block_size: def.block_size(),
             extent_size: def.extent_size(),
-            inner: Some(Mutex::new(Inner { file, metadb })),
-        })
+            inner: Some(Mutex::new(Inner {
+                file,
+                metadb,
+                dirty_blocks: HashMap::new(),
+            })),
+        };
+
+        // Clean out any irrelevant block contexts, which may be present if downstairs
+        // crashed between a write() and a flush().
+        extent.fully_rehash_and_clean_all_stale_contexts(false)?;
+
+        Ok(extent)
     }
 
     /**
@@ -728,6 +746,7 @@ impl Extent {
             // Any of the context rows written between flushes could be valid
             // until we call flush and remove context rows where the integrity
             // hash does not match what was actually flushed to disk.
+
             metadb.execute(
                 "CREATE TABLE block_context (
                     block INTEGER,
@@ -762,7 +781,11 @@ impl Extent {
             read_only: false,
             block_size: def.block_size(),
             extent_size: def.extent_size(),
-            inner: Some(Mutex::new(Inner { file, metadb })),
+            inner: Some(Mutex::new(Inner {
+                file,
+                metadb,
+                dirty_blocks: HashMap::new(),
+            })),
         })
     }
 
@@ -986,6 +1009,11 @@ impl Extent {
         });
 
         let mut inner = self.inner().await;
+        // I realize this looks like some nonsense but what this is doing is
+        // borrowing the inner up-front from the MutexGuard, which will allow
+        // us to later disjointly borrow fields. Basically, we're helping the
+        // borrow-checker do its job.
+        let inner = &mut *inner;
 
         for write in writes {
             self.check_input(write.offset, &write.data)?;
@@ -1096,23 +1124,41 @@ impl Extent {
         cdt::extent__write__sqlite__insert__start!(|| {
             (job_id, self.number, writes.len() as u64)
         });
-        let tx = inner.metadb_transaction()?;
+        let tx = inner.metadb.transaction()?;
         for write in writes {
             if writes_to_skip.contains(&write.offset.value) {
                 debug_assert!(only_write_unwritten);
                 continue;
             }
 
+            // TODO it would be nice if we could profile what % of time we're
+            // spending on hashes locally vs sqlite
+            let on_disk_hash = integrity_hash(&[&write.data[..]]);
+
             Inner::tx_set_block_context(
                 &tx,
                 &DownstairsBlockContext {
                     block_context: write.block_context.clone(),
                     block: write.offset.value,
-                    on_disk_hash: integrity_hash(&[&write.data[..]]),
+                    on_disk_hash,
                 },
             )?;
+
+            // Worth some thought: this could happen inside
+            // tx_set_block_context, if we passed a reference to dirty_blocks
+            // into that function too. This might be nice, since then a block
+            // context could never be set without marking the block as dirty.
+            // On the other paw, our test suite very much likes the fact that
+            // tx_set_block_context would mark blocks as dirty, since it lets
+            // us easily test specific edge-cases of the database state.
+            // Could make another function that wraps tx_set_block_context
+            // and handles this as well.
+            let _ = inner
+                .dirty_blocks
+                .insert(write.offset.value as usize, on_disk_hash);
         }
         tx.commit()?;
+
         cdt::extent__write__sqlite__insert__done!(|| {
             (job_id, self.number, writes.len() as u64)
         });
@@ -1121,6 +1167,27 @@ impl Extent {
         // chosen somewhat arbitrarily.
         let mut write_buffer = [0u8; 65536];
 
+        // PERFORMANCE TODO: While sqlite is the bulk of our performance cost
+        // in writes, we're still paying quite the price on small writes
+        // here. It would be nice if we could improve that a bit. An easy win
+        // would be to replace the seek+write with the syscall that does both
+        // in one go. I also wonder whether memory-mapping would be
+        // advantageous here.
+        //
+        // Something else worth considering for small writes is that, based on
+        // my memory of conversations we had with propolis folks about what
+        // OSes expect out of an NVMe driver, I believe our contract with the
+        // upstairs doesn't require us to have the writes inside the file
+        // until after a flush() returns. If that is indeed true, we could
+        // buffer a certain amount of writes, only actually writing that
+        // buffer when either a flush is issued or the buffer exceeds some
+        // set size(based on our memory constraints). This would have
+        // benefits on any workload that frequently writes to the same block
+        // between flushes, would have benefits for small contiguous writes
+        // issued over multiple write commands by letting us batch them into
+        // a larger write, and(speculation) may benefit non-contiguous writes
+        // by cutting down the number of sqlite transactions. But, it
+        // introduces complexity.
         cdt::extent__write__file__start!(|| {
             (job_id, self.number, writes.len() as u64)
         });
@@ -1174,7 +1241,7 @@ impl Extent {
     }
 
     #[instrument]
-    pub async fn flush_block(
+    pub async fn flush(
         &self,
         new_flush: u64,
         new_gen: u64,
@@ -1226,27 +1293,37 @@ impl Extent {
         });
 
         // Clear old block contexts. In order to be crash consistent, only
-        // perform this after the extent fsync is done. Read each block in the
-        // extent and find out the integrity hash. Then, remove all block
-        // context rows where the integrity hash does not match.
-        cdt::extent__flush__rehash__start!(|| {
+        // perform this after the extent fsync is done. For each block written
+        // since the last flush, remove all block context rows where the integrity
+        // hash does not map the last-written value. This is safe, because we
+        // know the process has not crashed since those values were written.
+        // When the region is first opened, the entire file is rehashed, since
+        // in that case we don't have that luxury.
+
+        cdt::extent__flush__collect__hashes__start!(|| {
             (job_id, self.number, self.extent_size.value)
         });
 
-        let total_bytes: usize =
-            self.extent_size.value as usize * self.block_size as usize;
-        let mut extent_data: Vec<u8> = vec![0; total_bytes];
+        let mut extent_block_indexes_and_hashes: Vec<(usize, u64)> =
+            inner.dirty_blocks.drain().collect();
 
-        inner.file.seek(SeekFrom::Start(0))?;
-        inner.file.read_exact(&mut extent_data)?;
+        // Sorting here is extremely important to get good performance out of
+        // truncate_encryption_contexts_and_hashes() later.
+        //
+        // Benchmarks show that sorting by just block doubles how fast this sort
+        // happens compared to a sort_unstable() that considers block and value.
+        extent_block_indexes_and_hashes
+            .sort_unstable_by(|(l, _), (r, _)| l.cmp(r));
 
-        let extent_block_indexes_and_hashes = extent_data
-            .chunks(self.block_size as usize)
-            .enumerate()
-            .map(|(i, data)| (i, integrity_hash(&[data])))
-            .collect();
+        // We could shrink this to 0, but it's nice not to have to expand the
+        // dirty_blocks HashMap on small writes. They have a hard enough time
+        // as it is. We don't want our maps to be keeping a lot of memory
+        // allocated though. With 16 entries max, even a 32TiB region of
+        // 128MiB extents would only be spending ~64MiB of ram on on this,
+        // across the entire region. There's potential for tuning here.
+        inner.dirty_blocks.shrink_to(16);
 
-        cdt::extent__flush__rehash__done!(|| {
+        cdt::extent__flush__collect__hashes__done!(|| {
             (job_id, self.number, self.extent_size.value)
         });
 
@@ -1262,7 +1339,6 @@ impl Extent {
 
         // Reset the file's seek offset to 0, and set the flush number and gen
         // number
-
         inner.file.seek(SeekFrom::Start(0))?;
 
         inner.set_flush_number(new_flush, new_gen)?;
@@ -1270,6 +1346,75 @@ impl Extent {
         cdt::extent__flush__done!(|| {
             (job_id, self.number, self.extent_size.value)
         });
+
+        Ok(())
+    }
+
+    /// Rehash the entire file. Remove any stored hash/encryption contexts
+    /// that do not correlate to data currently stored on disk. This is
+    /// primarily when opening an extent after recovering from a crash, since
+    /// irrelevant hashes will normally be cleared out during a flush().
+    ///
+    /// By default this function will only do work if the extent is marked
+    /// dirty. Set `force_override_dirty` to `true` to override this behavior.
+    /// This override should generally not be necessary, as the dirty flag
+    /// is set before any contexts are written.
+    #[instrument]
+    fn fully_rehash_and_clean_all_stale_contexts(
+        &self,
+        force_override_dirty: bool,
+    ) -> Result<(), CrucibleError> {
+        let mut inner = self.inner().await;
+
+        if !force_override_dirty && !inner.dirty()? {
+            return Ok(());
+        }
+
+        // Just in case, let's be very sure that the file on disk is what it should be
+        if let Err(e) = inner.file.sync_all() {
+            crucible_bail!(
+                IoError,
+                "extent {}: fsync 1 failure during full rehash: {:?}",
+                self.number,
+                e
+            );
+        }
+
+        inner.file.seek(SeekFrom::Start(0))?;
+
+        // Buffer the file so we dont spend all day waiting on syscall
+        let mut inner_file_buffered =
+            BufReader::with_capacity(64 * 1024, &inner.file);
+
+        // This gets filled one block at a time for hashing
+        let mut block = vec![0; self.block_size as usize];
+
+        // The vec of hashes that we'll pass off to truncate...()
+        let mut extent_block_indexes_and_hashes =
+            Vec::with_capacity(self.extent_size.value as usize);
+
+        // Stream the contents of the file and rehash them.
+        for i in 0..self.extent_size.value as usize {
+            inner_file_buffered.read_exact(&mut block)?;
+            extent_block_indexes_and_hashes
+                .push((i, integrity_hash(&[&block])));
+        }
+
+        // NOTE on safety: Unlike BufWriter, BufReader drop() does not have
+        // side-effects. There are no unhandled errors here.
+        drop(inner_file_buffered);
+
+        inner.truncate_encryption_contexts_and_hashes(
+            extent_block_indexes_and_hashes,
+        )?;
+
+        inner.file.seek(SeekFrom::Start(0))?;
+
+        // XXX should we be clearing the dirty flag here? If we do, should we
+        // also increment the generation/flush number like flush() does?
+        // We don't have them coming in during the open, so if we updated them
+        // we'd need to increment the database values, and who are we to assume
+        // we're an authority on the matter here?
 
         Ok(())
     }
@@ -2165,14 +2310,17 @@ pub async fn save_stream_to_file(
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::dump::dump_region;
-    use bytes::{BufMut, BytesMut};
-    use rand::{Rng, RngCore};
     use std::fs::rename;
     use std::path::PathBuf;
+
+    use bytes::{BufMut, BytesMut};
+    use rand::{Rng, RngCore};
     use tempfile::tempdir;
     use uuid::Uuid;
+
+    use crate::dump::dump_region;
+
+    use super::*;
 
     fn p(s: &str) -> PathBuf {
         PathBuf::from(s)
@@ -2184,6 +2332,7 @@ mod test {
         let inn = Inner {
             file: ff,
             metadb: Connection::open_in_memory().unwrap(),
+            dirty_blocks: HashMap::new(),
         };
 
         /*
@@ -2779,30 +2928,37 @@ mod test {
     fn extent_name_basic() {
         assert_eq!(extent_file_name(4, ExtentType::Data), "004");
     }
+
     #[test]
     fn extent_name_basic_ext() {
         assert_eq!(extent_file_name(4, ExtentType::Db), "004.db");
     }
+
     #[test]
     fn extent_name_basic_ext_shm() {
         assert_eq!(extent_file_name(4, ExtentType::DbShm), "004.db-shm");
     }
+
     #[test]
     fn extent_name_basic_ext_wal() {
         assert_eq!(extent_file_name(4, ExtentType::DbWal), "004.db-wal");
     }
+
     #[test]
     fn extent_name_basic_two() {
         assert_eq!(extent_file_name(10, ExtentType::Data), "00A");
     }
+
     #[test]
     fn extent_name_basic_three() {
         assert_eq!(extent_file_name(59, ExtentType::Data), "03B");
     }
+
     #[test]
     fn extent_name_max() {
         assert_eq!(extent_file_name(u32::MAX, ExtentType::Data), "FFF");
     }
+
     #[test]
     fn extent_name_min() {
         assert_eq!(extent_file_name(u32::MIN, ExtentType::Data), "000");
@@ -2820,6 +2976,7 @@ mod test {
             p("/var/region/FF/FFF")
         );
     }
+
     #[test]
     fn extent_dir_min() {
         assert_eq!(
@@ -2835,6 +2992,7 @@ mod test {
             p("/var/region/00/000/000")
         );
     }
+
     #[test]
     fn copy_path_basic() {
         assert_eq!(
@@ -3391,10 +3549,11 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_flush_removes_partial_writes() -> Result<()> {
-        // Validate that incorrect context rows are removed by a flush so that a
-        // repair will get rid of partial writes' block context rows. This is
-        // necessary for write_unwritten to work after a crash.
+    fn test_flush_removes_partial_writes() -> Result<()> {
+        // Validate that incorrect context rows are removed by a full rehash,
+        // so that opening an extent will get rid of partial writes' block
+        // context rows. This is necessary for write_unwritten to work after
+        // a crash.
         //
         // Specifically, this test checks for the case where we had a brand new
         // block and a write to that blocks that failed such that only the
@@ -3421,7 +3580,12 @@ mod test {
             }])?;
         }
 
-        region.region_flush(1, 1, &None, 123).await?;
+        // This should clear out the invalid context
+        for extent in &mut region.extents {
+            extent.close()?;
+        }
+        region.reopen_all_extents()?;
+
 
         // Verify no block context rows exist
 

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -4895,9 +4895,8 @@ mod test {
     }
 
     #[tokio::test]
-    /// We need to make sure that a flush will properly adjust the DB hashes
-    /// after issuing multiple writes to different disconnected sections of
-    /// an extent
+    /// This test ensures that our flush logic works even for full-extent
+    /// flushes. That's the case where the set of modified blocks will be full.
     async fn test_big_extent_full_write_and_flush() -> Result<()> {
         let dir = tempdir()?;
 

--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -281,7 +281,8 @@ mod test {
         // the expected names of files here in that test, rather than
         // determine them through some programmatic means.
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(3).await?;
 
         // Determine the directory and name for expected extent files.
@@ -301,7 +302,8 @@ mod test {
         // what we expect. In this case we expect the extent data file and
         // the .db file, but not the .db-shm or .db-wal database files.
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(3).await?;
 
         // Determine the directory and name for expected extent files.
@@ -332,7 +334,8 @@ mod test {
         // We close the extent here first, and on illumos that behaves
         // a little different than elsewhere.
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(3).await?;
 
         let ext_one = &mut region.extents[1];
@@ -364,7 +367,8 @@ mod test {
         // Verify that we get an error if the expected extent.db file
         // is missing.
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(3).await?;
 
         // Determine the directory and name for expected extent files.
@@ -386,7 +390,8 @@ mod test {
         // Verify that we get an error if the expected extent file
         // is missing.
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        let mut region =
+            Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(3).await?;
 
         // Determine the directory and name for expected extent files.

--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -281,8 +281,8 @@ mod test {
         // the expected names of files here in that test, rather than
         // determine them through some programmatic means.
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl())?;
-        region.extend(3)?;
+        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        region.extend(3).await?;
 
         // Determine the directory and name for expected extent files.
         let ed = extent_dir(&dir, 1);
@@ -301,8 +301,8 @@ mod test {
         // what we expect. In this case we expect the extent data file and
         // the .db file, but not the .db-shm or .db-wal database files.
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl())?;
-        region.extend(3)?;
+        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        region.extend(3).await?;
 
         // Determine the directory and name for expected extent files.
         let extent_dir = extent_dir(&dir, 1);
@@ -332,8 +332,8 @@ mod test {
         // We close the extent here first, and on illumos that behaves
         // a little different than elsewhere.
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl())?;
-        region.extend(3)?;
+        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        region.extend(3).await?;
 
         let ext_one = &mut region.extents[1];
         ext_one.close().await?;
@@ -364,8 +364,8 @@ mod test {
         // Verify that we get an error if the expected extent.db file
         // is missing.
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl())?;
-        region.extend(3)?;
+        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        region.extend(3).await?;
 
         // Determine the directory and name for expected extent files.
         let extent_dir = extent_dir(&dir, 2);
@@ -386,8 +386,8 @@ mod test {
         // Verify that we get an error if the expected extent file
         // is missing.
         let dir = tempdir()?;
-        let mut region = Region::create(&dir, new_region_options(), csl())?;
-        region.extend(3)?;
+        let mut region = Region::create(&dir, new_region_options(), csl()).await?;
+        region.extend(3).await?;
 
         // Determine the directory and name for expected extent files.
         let extent_dir = extent_dir(&dir, 1);

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -53,7 +53,8 @@ mod test {
                 Uuid::new_v4(),
                 encrypted,
                 csl(),
-            ).await?;
+            )
+            .await?;
 
             let downstairs = build_downstairs_for_region(
                 tempdir.path(),
@@ -63,7 +64,8 @@ mod test {
                 false, /* flush errors */
                 read_only,
                 Some(csl()),
-            ).await?;
+            )
+            .await?;
 
             let _join_handle = start_downstairs(
                 downstairs.clone(),
@@ -93,7 +95,8 @@ mod test {
                 false, /* flush errors */
                 true,
                 Some(csl()),
-            ).await?;
+            )
+            .await?;
 
             let _join_handle = start_downstairs(
                 self.downstairs.clone(),

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -53,7 +53,7 @@ mod test {
                 Uuid::new_v4(),
                 encrypted,
                 csl(),
-            )?;
+            ).await?;
 
             let downstairs = build_downstairs_for_region(
                 tempdir.path(),
@@ -63,7 +63,7 @@ mod test {
                 false, /* flush errors */
                 read_only,
                 Some(csl()),
-            )?;
+            ).await?;
 
             let _join_handle = start_downstairs(
                 downstairs.clone(),
@@ -93,7 +93,7 @@ mod test {
                 false, /* flush errors */
                 true,
                 Some(csl()),
-            )?;
+            ).await?;
 
             let _join_handle = start_downstairs(
                 self.downstairs.clone(),

--- a/tools/dtrace/perf-downstairs-finegrain-extent-timings.d
+++ b/tools/dtrace/perf-downstairs-finegrain-extent-timings.d
@@ -28,9 +28,9 @@ crucible_downstairs*:::extent-flush-file-start
     extent_flush_file_start[pid,arg0,arg1] = timestamp;
 }
 
-crucible_downstairs*:::extent-flush-rehash-start
+crucible_downstairs*:::extent-flush-collect-hashes-start
 {
-    extent_flush_rehash_start[pid,arg0,arg1] = timestamp;
+    extent_flush_collect_hashes_start[pid,arg0,arg1] = timestamp;
 }
 
 crucible_downstairs*:::extent-flush-sqlite-insert-start
@@ -54,11 +54,11 @@ crucible_downstairs*:::extent-flush-file-done
     extent_flush_file_start[pid,arg0,arg1] = 0;
 }
 
-crucible_downstairs*:::extent-flush-rehash-done
-/extent_flush_rehash_start[pid,arg0,arg1]/
+crucible_downstairs*:::extent-flush-collect-hashes-done
+/extent_flush_collect_hashes_start[pid,arg0,arg1]/
 {
-    @time["flush_rehash"] = quantize((timestamp - extent_flush_rehash_start[pid,arg0,arg1]) / arg2);
-    extent_flush_rehash_start[pid,arg0,arg1] = 0;
+    @time["flush_collect_hashes"] = quantize((timestamp - extent_flush_collect_hashes_start[pid,arg0,arg1]) / arg2);
+    extent_flush_collect_hashes_start[pid,arg0,arg1] = 0;
 }
 
 crucible_downstairs*:::extent-flush-sqlite-insert-done
@@ -166,3 +166,16 @@ crucible_downstairs*:::extent-read-get-contexts-done
     extent_read_get_contexts_start[pid,arg0,arg1] = 0;
 }
 
+
+
+crucible_downstairs*:::extent-context-truncate-start {
+    this->truncate_start = timestamp;
+    @truncate_sizes["truncation blocks"] = quantize(arg0);
+}
+
+crucible_downstairs*:::extent-context-truncate-done
+/this->truncate_start/
+{
+    @time["truncate-loop"] = quantize(timestamp - this->truncate_start);
+    this->truncate_start = 0;
+}


### PR DESCRIPTION
A few weeks ago, the team noticed a few edge cases in crash consistency that
were addressed by associating a hash of the on-disk data with each block
context. With that change, extent flush function rehashed the entire
extent during a flush, and ran a sqlite DELETE query for every single
block in the extent. This was rather slow.

This commit introduces an in-memory cache of `on_disk_hash`es for
the latest write to each block since the last flush. That is to say, if
a write is issued for blocks `0..=5` and blocks `2..=7`, we store 8
hashes, one for each of blocks `0..=7`. Later hashes shadow previous
hashes in this in-memory cache. This cache is cleared during a flush.

All of the hashes are still present in the sqlite database prior to the
flush; that behavior is preserved.

When it comes time to flush, we use our in-memory cache of hashes to
execute `DELETE` statements for only the blocks that have changed since
the previous flush. Additionally, since we kept the hash around from the
last write, we don't need to re-read that data from disk. This operates
under the assumption that because our process has not crashed since the
last flush, the data on disk after the fsync is the same as the data we
wrote.

This optimization reduces the cost of a flush a minor amount if the
entire extent is dirty, and reduces the cost significantly if only a few
blocks are dirty. It is *roughly* linear with the number of dirty
blocks. Flushes that took many milliseconds now do not.

When recovering from a crash, this optimization means that flushes will
not automatically clear out invalid contexts for blocks written between a
flush() and the crash. Therefore this commit introduces a new function:
`Inner::fully_rehash_and_clean_all_stale_contexts`. As the name implies,
this function performs the behavior that the old flush did, rehashing
the entire contents of the extent on disk and clearing out any invalid
contexts from the database. `Extent::open` calls this function.

This rehashing only happens if the extent is marked dirty, as the extent
is marked dirty before any contexts are written. This optimization keeps
startup performance impact to a minimum. This rehashing does not then
mark the extent as not-dirty when it's done. Maybe it should mark the
extent as not-dirty. Please comment on this!
