### PR TITLE
Update internal bookkeeping for crutest write counter

### DIFF
--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -1992,33 +1992,6 @@ async fn burst_workload(
 /*
  * issue some random number of IOs, then wait for an ACK for all.
  * We try to exit this test and leave jobs outstanding.
- * The write log works by counting the number of writes to a block, and
- * writing that value in the block as the data. When we write, we add one
- * to the write counter.  We use that write counter to verify that each
- * block has a number that we expect. It crude, but does add some value.
- *
- * When we issue a flush, we replace the minimum with the current and
- * continue. This gives us a "window" of possible values for our write counter. When
- * dealing with this test, we intentionally try to issue writes without a flush and then let
- * the repair happen, but we can only verify a "range" of possible values, as we don't actually
- * know what write finished last, and with repair, we only know if a block is dirty, we don't
- * know which block has the "newest" dirty data, so it's possible that during repair we
- * actually go back to a previous write (up to the most recent flush).
- *
- * The repair test does 30 IOs, but will issue a "commit" of the internal write log if it issues
- * (and gets and ACK) back from a flush. This commit of the write means we know the write
- * counter on disk is "at least" as high as the current (and after the commit, the minimum) in
- * our write log.
- *
- * The problem would be that the test would do a bunch of IO, but never issue a flush, then the
- * test would quit and restart, and then the next test would run, but the first thing the test
- * does is "commit" the current write log. This initial commit is not correct, as we never had
- * a flush, so we can't yet update the minimum.
- *
- * This was also a rare occurrence as usually their would be 1 flush in 30 operations, and even
- * if there was no a flush, we also have to have a block having data older than the write logs
- * current value at the time of the new test starting and issuing the commit (meaning a repair
- * happened, and it did pick the extent with "older" data).
  */
 async fn repair_workload(
     guest: &Arc<Guest>,

--- a/tools/test_repair.sh
+++ b/tools/test_repair.sh
@@ -172,6 +172,7 @@ for (( i = 0; i < 100; i += 1 )); do
         ds2_pid=$!
     fi
 
+    cp "$verify_file" ${verify_file}.last
     echo "Verifying data now"
     echo ${ct} verify ${target_args} --verify-out "$verify_file" --verify-in "$verify_file" --range -q -g "$generation" > "$test_log"
     if ! ${ct} verify ${target_args} --verify-out "$verify_file" --verify-in "$verify_file" --range -q -g "$generation" >> "$test_log" 2>&1
@@ -181,6 +182,16 @@ for (( i = 0; i < 100; i += 1 )); do
         cleanup
         exit 1
     fi
+    set +o errexit
+    if diff -q "$verify_file" ${verify_file}.last; then
+        echo "No change after verify"
+    else
+        diff "$verify_file" ${verify_file}.last
+        echo "diff found after verify"
+        cp "$verify_file" ${verify_file}.original
+        cp ${verify_file}.last ${verify_file}.withdiff
+    fi
+    set -o errexit
     (( generation += 1))
 
     echo "Loop: $i  Downstairs dump after verify (and repair):"


### PR DESCRIPTION
This fixes two old bug with the crutest write verification that would crop up in a few situations.
1) Some situations where the write counter crossed a u8 boundary.
2) When we repaired downstairs 2 and 3 using 1 as the source when after running the`repair_workload` test and none of the 30 operations were a flush.
 
Updated the way the crutest write counter works, added more tests to be sure the counts increment as expected when dealing with ranges.

Added a little more debug information to the `test_repair.sh` script.
Added and improved the debug messages that show up with crutest detects a mismatch.

Update the crutest `verify_workload` test to read the whole region and not just quit on the first error it finds.
