### PR TITLE
Update rustfmt for 2021, no more comment width

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,2 @@
 max_width = 80
-edition = "2018"
-comment_width = 80
-wrap_comments = true
+edition = "2021"


### PR DESCRIPTION
Remove the no longer supported options from the rust format config file.
This removes a bunch of warnings.