### PR TITLE
Switch ImpactedBlocks from bitvec to a range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,22 +209,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "block-buffer"
@@ -572,7 +575,6 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "base64 0.21.0",
- "bitvec",
  "bytes",
  "chrono",
  "crucible-client-types",
@@ -588,6 +590,7 @@ dependencies = [
  "openapiv3",
  "oximeter",
  "oximeter-producer",
+ "proptest",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "reqwest",
@@ -600,6 +603,7 @@ dependencies = [
  "slog-dtrace",
  "slog-term",
  "tempfile",
+ "test-strategy",
  "tokio",
  "tokio-rustls",
  "tokio-test",
@@ -1346,12 +1350,6 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -2855,6 +2853,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift 0.3.0",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quote"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2862,12 +2892,6 @@ checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2884,7 +2908,7 @@ dependencies = [
  "rand_jitter",
  "rand_os",
  "rand_pcg",
- "rand_xorshift",
+ "rand_xorshift 0.1.1",
  "winapi",
 ]
 
@@ -3003,6 +3027,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -3278,6 +3311,18 @@ name = "rustversion"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3854,12 +3899,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "tar"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3902,6 +3941,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-strategy"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d6408d1406657be2f9d1701fbae379331d30d2f6e92050710edb0d34eeb480"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta",
+ "syn",
 ]
 
 [[package]]
@@ -4530,6 +4581,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4881,15 +4941,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -12,7 +12,8 @@ use tempfile::NamedTempFile;
 
 mod region;
 pub use region::{
-    Block, RegionDefinition, RegionOptions, MAX_BLOCK_SIZE, MIN_BLOCK_SIZE,
+    Block, RegionDefinition, RegionOptions, MAX_BLOCK_SIZE, MAX_SHIFT,
+    MIN_BLOCK_SIZE, MIN_SHIFT,
 };
 
 pub mod x509;

--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -14,8 +14,9 @@ use uuid::Uuid;
  * on what a block is. It wouldn't make sense to pass Block { 2, 9 } when the
  * downstairs expects Block { 2, 12 }.
  */
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Deserialize, Serialize, Copy, Clone, Debug, PartialEq, PartialOrd)]
+#[derive(
+    Deserialize, Serialize, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord,
+)]
 pub struct Block {
     // Value could mean a size or offset
     pub value: u64,

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -220,7 +220,7 @@ pub fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
         let nblocks = Block::from_bytes(total, &rm);
         let mut pos = Block::from_bytes(0, &rm);
         let mut writes = vec![];
-        for (eid, offset) in extent_from_offset(rm, offset, nblocks).tuples() {
+        for (eid, offset) in extent_from_offset(&rm, offset, nblocks).blocks(&rm) {
             let len = Block::new_with_ddef(1, &region.def());
             let data = &buffer[pos.bytes()..(pos.bytes() + len.bytes())];
             let mut buffer = BytesMut::with_capacity(data.len());

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -220,7 +220,9 @@ pub fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
         let nblocks = Block::from_bytes(total, &rm);
         let mut pos = Block::from_bytes(0, &rm);
         let mut writes = vec![];
-        for (eid, offset) in extent_from_offset(&rm, offset, nblocks).blocks(&rm) {
+        for (eid, offset) in
+            extent_from_offset(&rm, offset, nblocks).blocks(&rm)
+        {
             let len = Block::new_with_ddef(1, &region.def());
             let data = &buffer[pos.bytes()..(pos.bytes() + len.bytes())];
             let mut buffer = BytesMut::with_capacity(data.len());

--- a/upstairs/Cargo.toml
+++ b/upstairs/Cargo.toml
@@ -17,7 +17,6 @@ anyhow = "1"
 async-trait = "0.1.61"
 async-recursion = "1.0.0"
 base64 = "0.21.0"
-bitvec = "1"
 bytes = "1"
 chrono = { version = "0.4.23", features = [ "serde" ] }
 crucible-common = { path = "../common" }
@@ -59,6 +58,8 @@ openapiv3 = "1.0"
 openapi-lint = { git = "https://github.com/oxidecomputer/openapi-lint", branch = "main" }
 tokio-test = "*"
 tempfile = "3"
+test-strategy = "0.2.1"
+proptest = "1.0.0"
 
 [build-dependencies]
 version_check = "0.9.4"

--- a/upstairs/src/impacted_blocks.rs
+++ b/upstairs/src/impacted_blocks.rs
@@ -2,97 +2,237 @@
 
 use super::*;
 
-use bitvec::prelude::*;
-use itertools::Itertools;
-use std::ops::BitAnd;
+use std::{iter::FusedIterator, ops::RangeInclusive};
 
-/// Store a list of impacted blocks for later job dependency calculation
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Debug, Default, PartialEq)]
-pub struct ImpactedBlocks {
-    ddef: RegionDefinition,
-
-    // extent id -> list of block offsets
-    blocks: HashMap<u64, BitVec>,
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ImpactedAddr {
+    pub extent_id: u64,
+    pub block: u64,
 }
 
-impl ImpactedBlocks {
-    pub fn new(ddef: RegionDefinition) -> Self {
-        ImpactedBlocks {
-            ddef,
-            blocks: HashMap::default(),
+/// Store a list of impacted blocks for later job dependency calculation
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ImpactedBlocks {
+    // Note that there is no extent size stored here. This is intentional! If
+    // we stored an extent size we'd need to do all sorts of messy checks
+    // when comparing two ImpactedBlocks ranges to make sure their extent
+    // sizes match. Instead, if something wants a list of blocks, they tell
+    // us how big they think an extent is, and we give them what they want.
+    /// No blocks are impacted
+    Empty,
+
+    /// First impacted block and last impacted block (inclusive!)
+    InclusiveRange(ImpactedAddr, ImpactedAddr),
+}
+
+/// An iteration over the blocks in an ImpactedBlocks range
+pub struct ImpactedBlockIter {
+    extent_size: u64,
+    block_shift: u32,
+    active_range: Option<(ImpactedAddr, ImpactedAddr)>,
+}
+
+impl Iterator for ImpactedBlockIter {
+    type Item = (u64, Block);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.active_range {
+            None => None,
+            Some((first, last)) => {
+                let result = (
+                    first.extent_id,
+                    Block::new(first.block, self.block_shift),
+                );
+
+                // If next == last, then the iterator is now done. Otherwise,
+                // increment next.
+                if first == last {
+                    self.active_range = None
+                } else if first.block == self.extent_size - 1 {
+                    first.block = 0;
+                    first.extent_id += 1;
+                } else {
+                    first.block += 1;
+                }
+
+                Some(result)
+            }
         }
     }
 
-    pub fn blocks_in_extent(&self) -> usize {
-        self.ddef.extent_size().value as usize
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
     }
 
-    pub fn add(&mut self, extent_id: u64, block: Block) {
-        let blocks_in_extent = self.blocks_in_extent();
-        let bv = self.blocks.entry(extent_id).or_insert_with(|| {
-            let mut bv = BitVec::with_capacity(blocks_in_extent);
-            bv.resize(blocks_in_extent, false);
-            bv
-        });
+    fn count(self) -> usize {
+        self.len()
+    }
 
-        bv.set(block.value as usize, true);
+    fn last(self) -> Option<Self::Item>
+    where
+        Self: Sized,
+    {
+        self.active_range.map(|(_, last)| {
+            (last.extent_id, Block::new(last.block, self.block_shift))
+        })
+    }
+}
+
+impl ExactSizeIterator for ImpactedBlockIter {
+    fn len(&self) -> usize {
+        match self.active_range {
+            None => 0,
+            Some((fst, lst)) => {
+                let extents = lst.extent_id - fst.extent_id;
+                (extents * self.extent_size + lst.block - fst.block + 1)
+                    as usize
+            }
+        }
+    }
+}
+
+impl DoubleEndedIterator for ImpactedBlockIter {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match &mut self.active_range {
+            None => None,
+            Some((first, last)) => {
+                let result =
+                    (last.extent_id, Block::new(last.block, self.block_shift));
+
+                // If first == last, then the iterator is now done. Otherwise,
+                // increment first.
+                if first == last {
+                    self.active_range = None
+                } else if last.block == 0 {
+                    last.block = self.extent_size - 1;
+                    last.extent_id -= 1;
+                } else {
+                    last.block -= 1;
+                }
+
+                Some(result)
+            }
+        }
+    }
+}
+
+impl FusedIterator for ImpactedBlockIter {}
+
+impl ImpactedBlocks {
+    /// Create a new ImpactedBlocks range from first and last impacted blocks
+    /// (inclusive) Returns Empty if last_impacted < first_impacted.
+    pub fn new(
+        first_impacted: ImpactedAddr,
+        last_impacted: ImpactedAddr,
+    ) -> Self {
+        if first_impacted <= last_impacted {
+            ImpactedBlocks::InclusiveRange(first_impacted, last_impacted)
+        } else {
+            ImpactedBlocks::Empty
+        }
+    }
+
+    /// Create a new ImpactedBlocks range starting at a given offset, and
+    /// stretching n_blocks further into the extent. Panics an error if
+    /// `extent_size` is 0. Returns ImpactedBlocks::Empty if n_blocks is 0.
+    pub fn from_offset(
+        extent_size: u64,
+        first_impacted: ImpactedAddr,
+        n_blocks: u64,
+    ) -> Self {
+        debug_assert!(extent_size > 0);
+
+        if n_blocks == 0 {
+            return ImpactedBlocks::Empty;
+        }
+
+        // So because we're inclusive, if we have 1 block then the first impacted should be the same as the last impacted. If we have 2 blocks, it's +1. etc.
+        let ending_block = n_blocks + first_impacted.block - 1;
+
+        let last_impacted = ImpactedAddr {
+            extent_id: first_impacted.extent_id + ending_block / extent_size,
+            block: ending_block % extent_size,
+        };
+
+        ImpactedBlocks::InclusiveRange(first_impacted, last_impacted)
+    }
+
+    pub fn intersection(&self, other: &ImpactedBlocks) -> ImpactedBlocks {
+        let ImpactedBlocks::InclusiveRange(fst_self, lst_self) = self else {
+            return ImpactedBlocks::Empty;
+        };
+
+        let ImpactedBlocks::InclusiveRange(fst_other, lst_other) = other else {
+            return ImpactedBlocks::Empty;
+        };
+
+        let fst = fst_self.max(fst_other);
+        let lst = lst_self.min(lst_other);
+        if lst >= fst {
+            ImpactedBlocks::InclusiveRange(*fst, *lst)
+        } else {
+            ImpactedBlocks::Empty
+        }
+    }
+
+    pub fn union(&self, other: &ImpactedBlocks) -> ImpactedBlocks {
+        let ImpactedBlocks::InclusiveRange(fst_self, lst_self) = self else {
+            return *other;
+        };
+
+        let ImpactedBlocks::InclusiveRange(fst_other, lst_other) = other else {
+            return *self;
+        };
+        let fst = fst_self.min(fst_other);
+        let lst = lst_self.max(lst_other);
+        ImpactedBlocks::InclusiveRange(*fst, *lst)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self == &ImpactedBlocks::Empty
     }
 
     /// Return true if this list of impacted blocks overlaps with another.
     pub fn conflicts(&self, other: &ImpactedBlocks) -> bool {
-        for shared_key in self
-            .blocks
-            .keys()
-            .filter(|key| other.blocks.contains_key(key))
-        {
-            // TODO any way to avoid this clone?
-            let bv = self.blocks[shared_key].clone();
-            if bv.bitand(&other.blocks[shared_key]).any() {
-                return true;
-            }
-        }
-
-        false
+        !self.intersection(other).is_empty()
     }
 
-    /// Return a list of impacted extents
-    #[cfg(test)]
-    pub fn extents(&self) -> Vec<&u64> {
-        self.blocks.keys().collect()
+    pub fn fully_contains(&self, other: &ImpactedBlocks) -> bool {
+        !self.is_empty()
+            && !other.is_empty()
+            && self.intersection(other) == *other
     }
 
-    /// Returns (extent id, block) tuples
-    pub fn tuples(&self) -> Vec<(u64, Block)> {
-        let mut result = Vec::with_capacity(self.len());
-
-        let sorted_keys = self.blocks.keys().sorted();
-        for eid in sorted_keys {
-            let block_offsets =
-                self.blocks[eid].iter_ones().collect::<Vec<usize>>();
-            for i in block_offsets.iter().sorted() {
-                result
-                    .push((*eid, Block::new_with_ddef(*i as u64, &self.ddef)));
+    /// Return a range of impacted extents
+    pub fn extents(&self) -> Option<RangeInclusive<u64>> {
+        match self {
+            ImpactedBlocks::Empty => None, /* empty range */
+            ImpactedBlocks::InclusiveRange(fst, lst) => {
+                Some(fst.extent_id..=lst.extent_id)
             }
         }
+    }
 
-        result
+    pub fn blocks(&self, ddef: &RegionDefinition) -> ImpactedBlockIter {
+        let extent_size = ddef.extent_size().value;
+        let block_shift = ddef.block_size().trailing_zeros();
+        let active_range = match self {
+            ImpactedBlocks::Empty => None,
+            ImpactedBlocks::InclusiveRange(fst, lst) => Some((*fst, *lst)),
+        };
+
+        ImpactedBlockIter {
+            extent_size,
+            block_shift,
+            active_range,
+        }
     }
 
     /// Returns the number of impacted blocks
-    pub fn len(&self) -> usize {
-        let mut len = 0;
-
-        for bv in self.blocks.values() {
-            len += bv.iter_ones().count();
-        }
-
-        len
-    }
-
-    #[allow(dead_code)]
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
+    pub fn len(&self, ddef: &RegionDefinition) -> usize {
+        self.blocks(ddef).len()
     }
 }
 
@@ -120,83 +260,95 @@ impl ImpactedBlocks {
 ///    eid1 -> [0, 1, 2],
 ///  }
 pub fn extent_from_offset(
-    ddef: RegionDefinition,
+    ddef: &RegionDefinition,
     offset: Block,
     num_blocks: Block,
 ) -> ImpactedBlocks {
-    assert!(num_blocks.value > 0);
-    assert!(
-        (offset.value + num_blocks.value)
-            <= (ddef.extent_size().value * ddef.extent_count() as u64)
-    );
-    assert_eq!(offset.block_size_in_bytes() as u64, ddef.block_size());
+    let extent_size = ddef.extent_size().value;
 
-    let mut result = ImpactedBlocks::new(ddef);
-    let mut o: u64 = offset.value;
-    let mut blocks_left: u64 = num_blocks.value;
+    // I don't really think these assertions belong here, but we have a test
+    // for it I guess
+    let shift = ddef.block_size().trailing_zeros();
+    debug_assert_eq!(offset.shift, shift);
+    debug_assert_eq!(num_blocks.shift, shift);
 
-    while blocks_left > 0 {
-        /*
-         * XXX We only support a single region (downstairs). When we grow to
-         * support a LBA size that is larger than a single region, then we
-         * will need to write more code.
-         */
-        let eid: u64 = o / ddef.extent_size().value;
-        assert!((eid as u32) < ddef.extent_count());
+    let fst = ImpactedAddr {
+        extent_id: offset.value / extent_size,
+        block: offset.value % extent_size,
+    };
 
-        let extent_offset: u64 = o % ddef.extent_size().value;
-        let sz: u64 = 1; // one block at a time
-
-        result.add(eid, Block::new_with_ddef(extent_offset, &ddef));
-
-        match blocks_left.checked_sub(sz) {
-            Some(v) => {
-                blocks_left = v;
-            }
-            None => {
-                break;
-            }
-        }
-
-        o += sz;
+    // If offset is outside the region, Empty
+    if fst.extent_id >= ddef.extent_count() as u64 {
+        return ImpactedBlocks::Empty;
     }
 
-    result
+    let mut impact = ImpactedBlocks::from_offset(
+        ddef.extent_size().value,
+        fst,
+        num_blocks.value,
+    );
+
+    // Clamp range to last block in region
+    if let ImpactedBlocks::InclusiveRange(_, lst) = &mut impact {
+        if lst.extent_id >= ddef.extent_count() as u64 {
+            lst.extent_id = ddef.extent_count() as u64 - 1;
+            lst.block = extent_size - 1;
+        }
+    }
+
+    impact
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use proptest::prelude::*;
+    use std::panic;
+    use std::panic::AssertUnwindSafe;
+    use test_strategy::{proptest, Arbitrary};
 
     fn extent_tuple(eid: u64, offset: u64) -> (u64, Block) {
         (eid, Block::new_512(offset))
     }
 
-    #[test]
-    fn test_extent_from_offset() {
+    fn basic_region_definition(
+        extent_size: u64,
+        extent_count: u32,
+    ) -> RegionDefinition {
         let mut ddef = RegionDefinition::default();
         ddef.set_block_size(512);
-        ddef.set_extent_size(Block::new_512(2));
-        ddef.set_extent_count(10);
+        ddef.set_extent_size(Block::new_512(extent_size));
+        ddef.set_extent_count(extent_count);
+        ddef
+    }
+
+    #[test]
+    /// extent_from_offset is currently the main interface by which other parts
+    /// of the codebase interact with ImpactedBlocks.
+    fn test_extent_from_offset() {
+        let ddef = &basic_region_definition(2, 10);
 
         // Test block size, less than extent size
         assert_eq!(
             extent_from_offset(ddef, Block::new_512(0), Block::new_512(1))
-                .tuples(),
+                .blocks(ddef)
+                .collect::<Vec<(u64, Block)>>(),
             vec![extent_tuple(0, 0)],
         );
 
         // Test greater than block size, less than extent size
         assert_eq!(
             extent_from_offset(ddef, Block::new_512(0), Block::new_512(2))
-                .tuples(),
-            vec![extent_tuple(0, 0), extent_tuple(0, 1),],
+                .blocks(ddef)
+                .collect::<Vec<(u64, Block)>>(),
+            vec![extent_tuple(0, 0), extent_tuple(0, 1)],
         );
 
         // Test greater than extent size
         assert_eq!(
             extent_from_offset(ddef, Block::new_512(0), Block::new_512(4))
-                .tuples(),
+                .blocks(ddef)
+                .collect::<Vec<(u64, Block)>>(),
             vec![
                 extent_tuple(0, 0),
                 extent_tuple(0, 1),
@@ -208,7 +360,8 @@ mod test {
         // Test offsets
         assert_eq!(
             extent_from_offset(ddef, Block::new_512(1), Block::new_512(4))
-                .tuples(),
+                .blocks(ddef)
+                .collect::<Vec<(u64, Block)>>(),
             vec![
                 extent_tuple(0, 1),
                 extent_tuple(1, 0),
@@ -219,7 +372,8 @@ mod test {
 
         assert_eq!(
             extent_from_offset(ddef, Block::new_512(2), Block::new_512(4))
-                .tuples(),
+                .blocks(ddef)
+                .collect::<Vec<(u64, Block)>>(),
             vec![
                 extent_tuple(1, 0),
                 extent_tuple(1, 1),
@@ -230,7 +384,8 @@ mod test {
 
         assert_eq!(
             extent_from_offset(ddef, Block::new_512(2), Block::new_512(16))
-                .tuples(),
+                .blocks(ddef)
+                .collect::<Vec<(u64, Block)>>(),
             vec![
                 extent_tuple(1, 0),
                 extent_tuple(1, 1),
@@ -254,10 +409,7 @@ mod test {
 
     #[test]
     fn test_extent_from_offset_single_block_only() {
-        let mut ddef = RegionDefinition::default();
-        ddef.set_block_size(512);
-        ddef.set_extent_size(Block::new_512(2));
-        ddef.set_extent_count(10);
+        let ddef = &basic_region_definition(2, 10);
 
         assert_eq!(
             extent_from_offset(
@@ -265,8 +417,9 @@ mod test {
                 Block::new_512(2), // offset
                 Block::new_512(1), // num_blocks
             )
-            .tuples(),
-            vec![extent_tuple(1, 0),]
+            .blocks(ddef)
+            .collect::<Vec<(u64, Block)>>(),
+            vec![extent_tuple(1, 0)]
         );
 
         assert_eq!(
@@ -275,8 +428,9 @@ mod test {
                 Block::new_512(2), // offset
                 Block::new_512(2), // num_blocks
             )
-            .tuples(),
-            vec![extent_tuple(1, 0), extent_tuple(1, 1),]
+            .blocks(ddef)
+            .collect::<Vec<(u64, Block)>>(),
+            vec![extent_tuple(1, 0), extent_tuple(1, 1)]
         );
 
         assert_eq!(
@@ -285,8 +439,731 @@ mod test {
                 Block::new_512(2), // offset
                 Block::new_512(3), // num_blocks
             )
-            .tuples(),
-            vec![extent_tuple(1, 0), extent_tuple(1, 1), extent_tuple(2, 0),]
+            .blocks(ddef)
+            .collect::<Vec<(u64, Block)>>(),
+            vec![extent_tuple(1, 0), extent_tuple(1, 1), extent_tuple(2, 0)]
         );
+    }
+
+    #[test]
+    /// If we create an impacted range where the last block comes before the
+    /// first block, that range should be empty.
+    fn test_new_range_empty_when_last_before_first() {
+        // Extent id ordering works
+        assert_eq!(
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 1,
+                    block: 0,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 0,
+                },
+            ),
+            ImpactedBlocks::Empty
+        );
+
+        // Block ordering works
+        assert_eq!(
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 1,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 0,
+                },
+            ),
+            ImpactedBlocks::Empty
+        );
+    }
+
+    #[test]
+    /// This tests all sorts of combinations of ImpactedBlocks::from_offset.
+    /// Basically all the weird edge-cases that are slightly hard to code
+    /// around, where the problems are likely to happen
+    fn test_impacted_blocks_from_offset() {
+        const EXTENT_SIZE: u64 = 512;
+
+        // Test that extent-aligned creation works
+        let fst = ImpactedAddr {
+            extent_id: 2,
+            block: 20,
+        };
+        let control = ImpactedBlocks::new(
+            fst,
+            ImpactedAddr {
+                extent_id: 4,
+                block: 19,
+            },
+        );
+        assert_eq!(
+            control,
+            ImpactedBlocks::from_offset(EXTENT_SIZE, fst, EXTENT_SIZE * 2)
+        );
+
+        // Single block within a single extent
+        let fst = ImpactedAddr {
+            extent_id: 2,
+            block: 20,
+        };
+        let control = ImpactedBlocks::new(
+            fst,
+            ImpactedAddr {
+                extent_id: 2,
+                block: 20,
+            },
+        );
+        assert_eq!(control, ImpactedBlocks::from_offset(EXTENT_SIZE, fst, 1));
+
+        // Ending on the end of an extent should work
+        let fst = ImpactedAddr {
+            extent_id: 2,
+            block: 20,
+        };
+        let control = ImpactedBlocks::new(
+            fst,
+            ImpactedAddr {
+                extent_id: 2,
+                block: EXTENT_SIZE - 1,
+            },
+        );
+        assert_eq!(
+            control,
+            ImpactedBlocks::from_offset(
+                EXTENT_SIZE,
+                fst,
+                EXTENT_SIZE - fst.block,
+            )
+        );
+
+        // Ending on the start of an extent should work
+        let fst = ImpactedAddr {
+            extent_id: 2,
+            block: 20,
+        };
+        let control = ImpactedBlocks::new(
+            fst,
+            ImpactedAddr {
+                extent_id: 3,
+                block: 0,
+            },
+        );
+        assert_eq!(
+            control,
+            ImpactedBlocks::from_offset(
+                EXTENT_SIZE,
+                fst,
+                EXTENT_SIZE - fst.block + 1,
+            )
+        );
+
+        // 0-length should be empty
+        assert_eq!(
+            ImpactedBlocks::from_offset(EXTENT_SIZE, fst, 0),
+            ImpactedBlocks::Empty
+        );
+    }
+
+    // Proptest time
+
+    #[derive(Arbitrary, Debug)]
+    struct ArbitraryRegionDefinition {
+        // Need at least one extent
+        #[strategy(1..=u32::MAX)]
+        extent_count: u32,
+
+        // extent_count * extent_size must be <= u64::MAX.
+        //
+        // extent_size must be >= 1
+        //    satisfied by adding one to the left side of the range
+        //
+        // Therefor, extent_size =     [1..(usize::MAX / extent_count)]
+        #[strategy(1 ..= (u64::MAX / #extent_count as u64))]
+        extent_size: u64,
+
+        #[strategy(crucible_common::MIN_SHIFT..=crucible_common::MAX_SHIFT)]
+        block_shift: u32,
+    }
+
+    #[derive(Arbitrary, Debug)]
+    enum ArbitraryImpactedBlocks {
+        // Weighted this way because we want to test lots of InclusiveRanges
+        // against each other, since Empty is a very simple case.
+        #[weight(19)]
+        InclusiveRange(
+            (proptest::sample::Index, proptest::sample::Index),
+            (proptest::sample::Index, proptest::sample::Index),
+        ),
+
+        #[weight(1)]
+        Empty,
+    }
+
+    fn reify_region_definition(
+        test_ddef: ArbitraryRegionDefinition,
+    ) -> RegionDefinition {
+        let mut ddef = RegionDefinition::default();
+        ddef.set_extent_size(Block::new(
+            test_ddef.extent_size,
+            test_ddef.block_shift,
+        ));
+        ddef.set_extent_count(test_ddef.extent_count);
+        ddef.set_block_size(1 << test_ddef.block_shift);
+        ddef
+    }
+
+    fn reify_impacted_blocks(
+        test_iblocks: ArbitraryImpactedBlocks,
+        extent_count: usize,
+        extent_size: usize,
+    ) -> ImpactedBlocks {
+        match test_iblocks {
+            ArbitraryImpactedBlocks::Empty => ImpactedBlocks::Empty,
+            ArbitraryImpactedBlocks::InclusiveRange(
+                (left_eid, left_block),
+                (right_eid_offset, right_block_offset),
+            ) => {
+                let left_addr = ImpactedAddr {
+                    extent_id: left_eid.index(extent_count) as u64,
+                    block: left_block.index(extent_size) as u64,
+                };
+
+                let right_addr = ImpactedAddr {
+                    extent_id: right_eid_offset
+                        .index(extent_count - left_addr.extent_id as usize)
+                        as u64
+                        + left_addr.extent_id,
+                    block: right_block_offset
+                        .index(extent_size - left_addr.block as usize)
+                        as u64
+                        + left_addr.block,
+                };
+
+                ImpactedBlocks::InclusiveRange(left_addr, right_addr)
+            }
+        }
+    }
+
+    /// Map the index of a TestImpactedBlocks to fit within the region
+    fn reify_impacted_blocks_in_region(
+        test_iblocks: ArbitraryImpactedBlocks,
+        ddef: &RegionDefinition,
+    ) -> ImpactedBlocks {
+        reify_impacted_blocks(
+            test_iblocks,
+            ddef.extent_count() as usize,
+            ddef.extent_size().value as usize,
+        )
+    }
+
+    /// Map the ImpactedBlocks to the full range of possible values
+    fn reify_impacted_blocks_without_region(
+        test_iblocks: ArbitraryImpactedBlocks,
+    ) -> ImpactedBlocks {
+        reify_impacted_blocks(test_iblocks, usize::MAX, usize::MAX)
+    }
+
+    fn region_def_strategy() -> impl Strategy<Value = RegionDefinition> {
+        any::<ArbitraryRegionDefinition>().prop_map(reify_region_definition)
+    }
+
+    /// Generate a random region definition, and a pair of ImpactedBlocks ranges
+    /// that fit within it
+    fn region_and_impacted_pair_strategy(
+    ) -> impl Strategy<Value = (RegionDefinition, ImpactedBlocks, ImpactedBlocks)>
+    {
+        any::<(
+            ArbitraryRegionDefinition,
+            ArbitraryImpactedBlocks,
+            ArbitraryImpactedBlocks,
+        )>()
+        .prop_map(|(test_ddef, test_iblocks_a, test_iblocks_b)| {
+            let ddef = reify_region_definition(test_ddef);
+            let iblocks_a =
+                reify_impacted_blocks_in_region(test_iblocks_a, &ddef);
+            let iblocks_b =
+                reify_impacted_blocks_in_region(test_iblocks_b, &ddef);
+            (ddef, iblocks_a, iblocks_b)
+        })
+    }
+
+    /// Generate a random region definition, and a single ImpactedBlocks range
+    /// within it.
+    fn region_and_impacted_blocks_strategy(
+    ) -> impl Strategy<Value = (RegionDefinition, ImpactedBlocks)> {
+        any::<(ArbitraryRegionDefinition, ArbitraryImpactedBlocks)>().prop_map(
+            |(test_ddef, test_iblocks)| {
+                let ddef = reify_region_definition(test_ddef);
+                let iblocks =
+                    reify_impacted_blocks_in_region(test_iblocks, &ddef);
+                (ddef, iblocks)
+            },
+        )
+    }
+
+    fn any_impacted_blocks_strategy() -> impl Strategy<Value = ImpactedBlocks> {
+        any::<ArbitraryImpactedBlocks>()
+            .prop_map(reify_impacted_blocks_without_region)
+    }
+
+    #[proptest]
+    fn intersection_produces_less_than_or_equal_block_count(
+        #[strategy(region_and_impacted_pair_strategy())]
+        region_and_impacted_pair: (
+            RegionDefinition,
+            ImpactedBlocks,
+            ImpactedBlocks,
+        ),
+    ) {
+        let (ddef, iblocks_a, iblocks_b) = region_and_impacted_pair;
+        let intersection = iblocks_a.intersection(&iblocks_b);
+
+        let len_a = iblocks_a.len(&ddef);
+        let len_b = iblocks_b.len(&ddef);
+        let len_intersection = intersection.len(&ddef);
+
+        prop_assert!(len_intersection <= len_a);
+        prop_assert!(len_intersection <= len_b);
+    }
+
+    #[proptest]
+    fn union_produces_greater_than_or_equal_block_count(
+        #[strategy(region_and_impacted_pair_strategy())]
+        region_and_impacted_pair: (
+            RegionDefinition,
+            ImpactedBlocks,
+            ImpactedBlocks,
+        ),
+    ) {
+        let (ddef, iblocks_a, iblocks_b) = region_and_impacted_pair;
+        let union = iblocks_a.union(&iblocks_b);
+
+        let len_a = iblocks_a.len(&ddef);
+        let len_b = iblocks_b.len(&ddef);
+        let len_union = union.len(&ddef);
+
+        prop_assert!(len_union >= len_a);
+        prop_assert!(len_union >= len_b);
+    }
+
+    #[proptest]
+    fn intersection_with_empty_is_empty(
+        #[strategy(any_impacted_blocks_strategy())] iblocks: ImpactedBlocks,
+    ) {
+        // a . Empty == Empty
+        prop_assert_eq!(
+            iblocks.intersection(&ImpactedBlocks::Empty),
+            ImpactedBlocks::Empty
+        );
+    }
+
+    #[proptest]
+    fn union_with_empty_is_identity(
+        #[strategy(any_impacted_blocks_strategy())] iblocks: ImpactedBlocks,
+    ) {
+        // a . Empty == a
+        prop_assert_eq!(iblocks.union(&ImpactedBlocks::Empty), iblocks);
+    }
+
+    #[proptest]
+    fn intersection_is_commutative(
+        #[strategy(any_impacted_blocks_strategy())] iblocks_a: ImpactedBlocks,
+        #[strategy(any_impacted_blocks_strategy())] iblocks_b: ImpactedBlocks,
+    ) {
+        // a . b == b . a
+        prop_assert_eq!(
+            iblocks_a.intersection(&iblocks_b),
+            iblocks_b.intersection(&iblocks_a)
+        );
+    }
+
+    #[proptest]
+    fn union_is_commutative(
+        #[strategy(any_impacted_blocks_strategy())] iblocks_a: ImpactedBlocks,
+        #[strategy(any_impacted_blocks_strategy())] iblocks_b: ImpactedBlocks,
+    ) {
+        // a . b == b . a
+        prop_assert_eq!(
+            iblocks_a.union(&iblocks_b),
+            iblocks_b.union(&iblocks_a)
+        );
+    }
+
+    #[proptest]
+    fn intersection_is_associative(
+        #[strategy(any_impacted_blocks_strategy())] iblocks_a: ImpactedBlocks,
+        #[strategy(any_impacted_blocks_strategy())] iblocks_b: ImpactedBlocks,
+        #[strategy(any_impacted_blocks_strategy())] iblocks_c: ImpactedBlocks,
+    ) {
+        // a . (b . c)
+        let l = iblocks_a.intersection(&iblocks_b.intersection(&iblocks_c));
+
+        // (a . b) . c
+        let r = iblocks_a.intersection(&iblocks_b).intersection(&iblocks_c);
+
+        // a . (b . c) == (a . b) . c
+        prop_assert_eq!(l, r);
+    }
+
+    #[proptest]
+    fn union_is_associative(
+        #[strategy(any_impacted_blocks_strategy())] iblocks_a: ImpactedBlocks,
+        #[strategy(any_impacted_blocks_strategy())] iblocks_b: ImpactedBlocks,
+        #[strategy(any_impacted_blocks_strategy())] iblocks_c: ImpactedBlocks,
+    ) {
+        // a . (b . c)
+        let l = iblocks_a.union(&iblocks_b.union(&iblocks_c));
+
+        // (a . b) . c
+        let r = iblocks_a.union(&iblocks_b).union(&iblocks_c);
+
+        // a . (b . c) == (a . b) . c
+        prop_assert_eq!(l, r);
+    }
+
+    #[proptest]
+    fn iblocks_from_offset_is_empty_for_zero_blocks(
+        #[strategy(1..=u64::MAX)] extent_size: u64,
+        start_eid: u64,
+        #[strategy(0..#extent_size)] start_block: u64,
+    ) {
+        prop_assert_eq!(
+            ImpactedBlocks::from_offset(
+                extent_size,
+                ImpactedAddr {
+                    extent_id: start_eid,
+                    block: start_block
+                },
+                0
+            ),
+            ImpactedBlocks::Empty
+        );
+    }
+
+    #[proptest]
+    fn iblocks_from_offset_with_zero_extent_size_panics(
+        start_eid: u64,
+        start_block: u64,
+        n_blocks: u64,
+    ) {
+        let unwind = panic::catch_unwind(AssertUnwindSafe(|| {
+            ImpactedBlocks::from_offset(
+                0,
+                ImpactedAddr {
+                    extent_id: start_eid,
+                    block: start_block,
+                },
+                n_blocks,
+            )
+        }));
+        prop_assert!(unwind.is_err());
+    }
+
+    #[proptest]
+    /// Make sure that when the right address is less than the left address,
+    /// ImpactedBlocks::new() returns Empty
+    fn iblocks_new_is_empty_for_flipped_polarity(
+        #[strategy(0..=u64::MAX - 1)] start_eid: u64,
+        #[strategy(0..=u64::MAX - 1)] start_block: u64,
+
+        #[strategy(#start_eid + 1 ..= u64::MAX)] end_eid: u64,
+        #[strategy(#start_block + 1 ..= u64::MAX)] end_block: u64,
+    ) {
+        let start_addr = ImpactedAddr {
+            extent_id: start_eid,
+            block: start_block,
+        };
+
+        let end_addr = ImpactedAddr {
+            extent_id: end_eid,
+            block: end_block,
+        };
+
+        // Now define the impacted blocks backwards, with end of the left
+        // and start on the right
+        prop_assert_eq!(
+            ImpactedBlocks::new(end_addr, start_addr),
+            ImpactedBlocks::Empty
+        );
+    }
+
+    #[proptest]
+    fn iblocks_blocks_iterates_over_all_blocks(
+        // Keep these reasonably sized so we don't OOM running this test
+        #[strategy(1..=128u32)] extent_count: u32,
+        #[strategy(1..=128u64)] extent_size: u64,
+
+        #[strategy(0..#extent_count as u64)] start_eid: u64,
+        #[strategy(0..#extent_size)] start_block: u64,
+
+        #[strategy(#start_eid..#extent_count as u64)] end_eid: u64,
+        #[strategy(#start_block..#extent_size)] end_block: u64,
+    ) {
+        // Set up our iblocks
+        let iblocks = ImpactedBlocks::new(
+            ImpactedAddr {
+                extent_id: start_eid,
+                block: start_block,
+            },
+            ImpactedAddr {
+                extent_id: end_eid,
+                block: end_block,
+            },
+        );
+
+        let mut ddef = RegionDefinition::default();
+        ddef.set_extent_count(extent_count);
+        ddef.set_extent_size(Block::new_512(extent_size));
+        ddef.set_block_size(512);
+
+        // Generate reference data
+        let mut expected_addresses = Vec::new();
+        let mut cur_eid = start_eid;
+        let mut cur_block = start_block;
+        loop {
+            expected_addresses.push((cur_eid, Block::new_512(cur_block)));
+            if cur_eid == end_eid && cur_block == end_block {
+                break;
+            }
+
+            cur_block += 1;
+            if cur_block == extent_size {
+                cur_block = 0;
+                cur_eid += 1;
+            }
+        }
+
+        prop_assert_eq!(
+            iblocks.blocks(&ddef).collect::<Vec<(u64, Block)>>(),
+            expected_addresses
+        );
+    }
+
+    #[proptest]
+    fn iblocks_conflicts_is_commutative(
+        #[strategy(any_impacted_blocks_strategy())] iblocks_a: ImpactedBlocks,
+        #[strategy(any_impacted_blocks_strategy())] iblocks_b: ImpactedBlocks,
+    ) {
+        // a . b == b . a
+        prop_assert_eq!(
+            iblocks_a.conflicts(&iblocks_b),
+            iblocks_b.conflicts(&iblocks_a)
+        );
+    }
+
+    #[proptest]
+    fn empty_impacted_blocks_never_conflict(
+        #[strategy(any_impacted_blocks_strategy())] iblocks: ImpactedBlocks,
+    ) {
+        prop_assert!(!iblocks.conflicts(&ImpactedBlocks::Empty));
+    }
+
+    #[proptest]
+    fn overlapping_impacted_blocks_should_conflict(
+        // 4 random points, we'll make two overlapping ranges out of them
+        point_a: (u64, u64),
+        point_b: (u64, u64),
+        point_c: (u64, u64),
+        point_d: (u64, u64),
+    ) {
+        // First we need to sort the points so we can use them correctly.
+        let mut sorted_points = vec![point_a, point_b, point_c, point_d];
+        sorted_points.sort();
+        let (eid_a, block_a) = sorted_points[0];
+        let (eid_b, block_b) = sorted_points[1];
+        let (eid_c, block_c) = sorted_points[2];
+        let (eid_d, block_d) = sorted_points[3];
+
+        // After sorting, if we make ranges from the pairs (a,c) and (b,d)
+        // then they are guaranteed to overlap.
+        let iblocks_a = ImpactedBlocks::new(
+            ImpactedAddr {
+                extent_id: eid_a,
+                block: block_a,
+            },
+            ImpactedAddr {
+                extent_id: eid_c,
+                block: block_c,
+            },
+        );
+
+        let iblocks_b = ImpactedBlocks::new(
+            ImpactedAddr {
+                extent_id: eid_b,
+                block: block_b,
+            },
+            ImpactedAddr {
+                extent_id: eid_d,
+                block: block_d,
+            },
+        );
+
+        // And thus they should conflict
+        prop_assert!(iblocks_a.conflicts(&iblocks_b),
+            "These overlapping ImpactedBlocks should conflict, but don't:\n    {:?}\n    {:?}",
+            iblocks_a,
+            iblocks_b);
+    }
+
+    #[proptest]
+    fn nothing_contains_empty(
+        #[strategy(any_impacted_blocks_strategy())] iblocks: ImpactedBlocks,
+    ) {
+        prop_assert!(!iblocks.fully_contains(&ImpactedBlocks::Empty));
+    }
+
+    #[proptest]
+    fn empty_contains_nothing(
+        #[strategy(any_impacted_blocks_strategy())] iblocks: ImpactedBlocks,
+    ) {
+        prop_assert!(!ImpactedBlocks::Empty.fully_contains(&iblocks));
+    }
+
+    #[proptest]
+    fn subregions_are_contained(
+        // proptest doesn't implement strategies for tuple-ranges for some
+        // reason, so I'm using a u128 in place of a (u64, u64)
+        #[strategy(0..=u128::MAX)] outer_start: u128,
+        #[strategy(#outer_start..=u128::MAX)] outer_end: u128,
+
+        // Inner must be within outer
+        #[strategy(#outer_start ..= #outer_end)] inner_start: u128,
+        #[strategy(#inner_start ..= #outer_end)] inner_end: u128,
+    ) {
+        let (outer_eid_a, outer_block_a) =
+            ((outer_start >> 64) as u64, outer_start as u64);
+        let (outer_eid_b, outer_block_b) =
+            ((outer_end >> 64) as u64, outer_end as u64);
+        let (inner_eid_a, inner_block_a) =
+            ((inner_start >> 64) as u64, inner_start as u64);
+        let (inner_eid_b, inner_block_b) =
+            ((inner_end >> 64) as u64, inner_end as u64);
+
+        let outer_iblocks = ImpactedBlocks::new(
+            ImpactedAddr {
+                extent_id: outer_eid_a,
+                block: outer_block_a,
+            },
+            ImpactedAddr {
+                extent_id: outer_eid_b,
+                block: outer_block_b,
+            },
+        );
+
+        let inner_iblocks = ImpactedBlocks::new(
+            ImpactedAddr {
+                extent_id: inner_eid_a,
+                block: inner_block_a,
+            },
+            ImpactedAddr {
+                extent_id: inner_eid_b,
+                block: inner_block_b,
+            },
+        );
+
+        prop_assert!(outer_iblocks.fully_contains(&inner_iblocks),
+            "Outer ImpactedBlocks does not contain inner ImpactedBlocks:\n    Outer: {:?}\n    Inner: {:?}",
+            outer_iblocks,
+            inner_iblocks);
+    }
+
+    #[proptest]
+    /// We have a manual test of extent_from_offset above, but here's another
+    /// for good measure. We'll generate an ImpactedBlocks in a region, and then
+    /// make sure we can re-create it using extent_from_offset
+    fn extent_from_offset_can_recreate_iblocks(
+        #[strategy(region_and_impacted_blocks_strategy())]
+        #[filter(!#region_and_iblocks.1.is_empty())]
+        region_and_iblocks: (RegionDefinition, ImpactedBlocks),
+    ) {
+        let (ddef, iblocks) = region_and_iblocks;
+
+        let shift = ddef.block_size().trailing_zeros();
+        let (first_eid, first_block) = iblocks.blocks(&ddef).next().unwrap();
+        let first = Block::new(
+            first_block.value + first_eid * ddef.extent_size().value,
+            shift,
+        );
+        let num_blocks = Block::new(iblocks.len(&ddef) as u64, shift);
+
+        prop_assert_eq!(extent_from_offset(&ddef, first, num_blocks), iblocks);
+    }
+
+    #[proptest]
+    fn extent_from_offset_clamps_num_blocks_to_region(
+        // First block should be inside the region
+        #[strategy(0..#ddef.extent_count() as u64 * #ddef.extent_size().value)]
+        first_block: u64,
+
+        // At least one block
+        #[strategy(1..=u64::MAX)] n_blocks: u64,
+
+        #[strategy(region_def_strategy())] ddef: RegionDefinition,
+    ) {
+        let shift = ddef.block_size().trailing_zeros();
+        let first = Block::new(first_block, shift);
+        let num_blocks = Block::new(n_blocks as u64, shift);
+
+        let clamped = extent_from_offset(&ddef, first, num_blocks);
+
+        // New ImpactedBlocks should fit within region
+        let (first_clamped_eid, first_clamped_block) =
+            clamped.blocks(&ddef).next().unwrap();
+        let (last_clamped_eid, last_clamped_block) =
+            clamped.blocks(&ddef).last().unwrap();
+
+        prop_assert!(first_clamped_eid < ddef.extent_count() as u64);
+        prop_assert!(first_clamped_block.value < ddef.extent_size().value);
+        prop_assert!(last_clamped_eid < ddef.extent_count() as u64);
+        prop_assert!(last_clamped_block.value < ddef.extent_size().value);
+    }
+
+    #[proptest]
+    fn extent_from_offset_is_empty_for_offsets_outside_region(
+        // First block should be outside the region
+        #[strategy(#ddef.extent_count() as u64 * #ddef.extent_size().value..u64::MAX)]
+        first_block: u64,
+
+        // At least one block
+        #[strategy(1..=u64::MAX)] n_blocks: u64,
+
+        #[strategy(region_def_strategy())] ddef: RegionDefinition,
+    ) {
+        let shift = ddef.block_size().trailing_zeros();
+        let first = Block::new(first_block, shift);
+        let num_blocks = Block::new(n_blocks as u64, shift);
+
+        let empty = extent_from_offset(&ddef, first, num_blocks);
+
+        prop_assert!(empty.is_empty());
+    }
+
+    #[proptest]
+    fn iblocks_extents_returns_correct_extents(
+        eid_a: u64,
+        block_a: u64,
+
+        eid_b: u64,
+        block_b: u64,
+    ) {
+        let addr_a = ImpactedAddr {
+            extent_id: eid_a,
+            block: block_a,
+        };
+        let addr_b = ImpactedAddr {
+            extent_id: eid_b,
+            block: block_b,
+        };
+        let iblocks = ImpactedBlocks::new(addr_a, addr_b);
+
+        if addr_a > addr_b {
+            // Should be empty in this case because polarity is flipped
+            prop_assert_eq!(iblocks.extents(), None);
+        } else {
+            prop_assert_eq!(iblocks.extents(), Some(eid_a..=eid_b));
+        }
     }
 }

--- a/upstairs/src/impacted_blocks.rs
+++ b/upstairs/src/impacted_blocks.rs
@@ -1108,7 +1108,7 @@ mod test {
     ) {
         let shift = ddef.block_size().trailing_zeros();
         let first = Block::new(first_block, shift);
-        let num_blocks = Block::new(n_blocks as u64, shift);
+        let num_blocks = Block::new(n_blocks, shift);
 
         prop_should_panic(|| extent_from_offset(&ddef, first, num_blocks))?;
     }
@@ -1126,7 +1126,7 @@ mod test {
     ) {
         let shift = ddef.block_size().trailing_zeros();
         let first = Block::new(first_block, shift);
-        let num_blocks = Block::new(n_blocks as u64, shift);
+        let num_blocks = Block::new(n_blocks, shift);
 
         prop_should_panic(|| extent_from_offset(&ddef, first, num_blocks))?;
     }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -6039,7 +6039,8 @@ impl fmt::Display for DsState {
  */
 #[derive(Debug)]
 struct DownstairsIO {
-    ds_id: u64,    // This MUST match our hashmap index
+    ds_id: u64, // This MUST match our hashmap index
+
     guest_id: u64, // The hahsmap ID from the parent guest work.
     work: IOop,
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -4400,7 +4400,6 @@ impl Upstairs {
          * Build the flush request, and take note of the request ID that
          * will be assigned to this new piece of work.
          */
-        let ddef = self.ddef.lock().await;
         let fl = create_flush(
             next_id,
             dep,
@@ -4408,7 +4407,7 @@ impl Upstairs {
             gw_id,
             self.get_generation().await,
             snapshot_details,
-            ImpactedBlocks::new(ddef.get_def().unwrap()),
+            ImpactedBlocks::Empty,
         );
 
         let mut sub = HashMap::new();
@@ -4469,11 +4468,11 @@ impl Upstairs {
          * byte offset that translates into. Keep in mind that an offset
          * and length may span two extents, and eventually XXX, two regions.
          */
-        let ddef = self.ddef.lock().await;
+        let ddef = &self.ddef.lock().await.get_def().unwrap();
         let impacted_blocks = extent_from_offset(
-            ddef.get_def().unwrap(),
+            ddef,
             offset,
-            Block::from_bytes(data.len(), &ddef.get_def().unwrap()),
+            Block::from_bytes(data.len(), ddef),
         );
 
         /*
@@ -4556,10 +4555,10 @@ impl Upstairs {
         }
 
         let mut writes: Vec<crucible_protocol::Write> =
-            Vec::with_capacity(impacted_blocks.tuples().len());
+            Vec::with_capacity(impacted_blocks.len(ddef));
 
-        for (eid, bo) in impacted_blocks.tuples() {
-            let byte_len: usize = ddef.get_def().unwrap().block_size() as usize;
+        for (eid, offset) in impacted_blocks.blocks(ddef) {
+            let byte_len: usize = ddef.block_size() as usize;
 
             let (sub_data, encryption_context, hash) = if let Some(context) =
                 &self.encryption_context
@@ -4601,7 +4600,7 @@ impl Upstairs {
 
             writes.push(crucible_protocol::Write {
                 eid,
-                offset: bo,
+                offset,
                 data: sub_data,
                 block_context: BlockContext {
                     hash,
@@ -4675,10 +4674,9 @@ impl Upstairs {
          * byte offset that translates into. Keep in mind that an offset
          * and length may span many extents, and eventually, TODO, regions.
          */
-        let ddef_state = self.ddef.lock().await;
-        let ddef = &ddef_state.get_def().unwrap();
+        let ddef = &self.ddef.lock().await.get_def().unwrap();
         let impacted_blocks = extent_from_offset(
-            *ddef,
+            ddef,
             offset,
             Block::from_bytes(data.len(), ddef),
         );
@@ -4739,10 +4737,10 @@ impl Upstairs {
          * from extent_from_offset.
          */
         let mut requests: Vec<ReadRequest> =
-            Vec::with_capacity(impacted_blocks.len());
+            Vec::with_capacity(impacted_blocks.len(ddef));
 
-        for (eid, bo) in impacted_blocks.tuples() {
-            requests.push(ReadRequest { eid, offset: bo });
+        for (eid, offset) in impacted_blocks.blocks(ddef) {
+            requests.push(ReadRequest { eid, offset });
         }
 
         sub.insert(next_id, 0); // XXX does this value matter?

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -123,9 +123,11 @@ mod up_test {
         offset: Block,
         num_blocks: u64,
     ) -> Vec<(u64, Block)> {
-        let ddef = up.ddef.lock().await.get_def().unwrap();
-        let num_blocks = Block::new_with_ddef(num_blocks, &ddef);
-        extent_from_offset(ddef, offset, num_blocks).tuples()
+        let ddef = &up.ddef.lock().await.get_def().unwrap();
+        let num_blocks = Block::new_with_ddef(num_blocks, ddef);
+        extent_from_offset(ddef, offset, num_blocks)
+            .blocks(ddef)
+            .collect()
     }
 
     #[tokio::test]
@@ -218,10 +220,9 @@ mod up_test {
      * Testing various invalid inputs
      */
     #[tokio::test]
-    #[should_panic]
     async fn off_to_extent_length_zero() {
         let up = make_upstairs();
-        up_efo(&up, Block::new_512(0), 0).await;
+        assert_eq!(up_efo(&up, Block::new_512(0), 0).await, vec![]);
     }
 
     #[tokio::test]
@@ -231,10 +232,12 @@ mod up_test {
     }
 
     #[tokio::test]
-    #[should_panic]
     async fn off_to_extent_length_too_big() {
         let up = make_upstairs();
-        up_efo(&up, Block::new_512(0), 1001).await;
+        assert_eq!(
+            up_efo(&up, Block::new_512(0), 1001).await,
+            up_efo(&up, Block::new_512(0), 1000).await
+        );
     }
 
     #[tokio::test]
@@ -244,17 +247,16 @@ mod up_test {
     }
 
     #[tokio::test]
-    #[should_panic]
     async fn off_to_extent_length_and_offset_too_big() {
         let up = make_upstairs();
-        up_efo(&up, Block::new_512(900), 101).await;
+        assert_eq!(up_efo(&up, Block::new_512(1000), 1).await, vec![]);
     }
 
     #[tokio::test]
     #[should_panic]
     async fn not_right_block_size() {
         let up = make_upstairs();
-        up_efo(&up, Block::new(900 * 4096, 4096), 101).await;
+        up_efo(&up, Block::new_4096(900), 1).await;
     }
 
     // key material made with `openssl rand -base64 32`
@@ -711,7 +713,7 @@ mod up_test {
             0,
             0,
             None,
-            ImpactedBlocks::default(),
+            ImpactedBlocks::Empty,
         );
 
         ds.enqueue(op);
@@ -776,7 +778,7 @@ mod up_test {
             0,
             0,
             None,
-            ImpactedBlocks::default(),
+            ImpactedBlocks::Empty,
         );
 
         ds.enqueue(op);
@@ -841,7 +843,7 @@ mod up_test {
             0,
             0,
             None,
-            ImpactedBlocks::default(),
+            ImpactedBlocks::Empty,
         );
 
         ds.enqueue(op);
@@ -908,7 +910,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         ds.enqueue(op);
@@ -967,7 +978,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         ds.enqueue(op);
@@ -1030,7 +1050,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         ds.enqueue(op);
@@ -1096,7 +1125,16 @@ mod up_test {
             vec![],
             10,
             vec![request],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         ds.enqueue(op);
@@ -1167,7 +1205,16 @@ mod up_test {
                 vec![],
                 10,
                 vec![request.clone()],
-                ImpactedBlocks::default(),
+                ImpactedBlocks::new(
+                    ImpactedAddr {
+                        extent_id: 0,
+                        block: 7,
+                    },
+                    ImpactedAddr {
+                        extent_id: 0,
+                        block: 7,
+                    },
+                ),
             );
 
             ds.enqueue(op);
@@ -1238,7 +1285,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         ds.enqueue(op);
@@ -1287,7 +1343,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         ds.enqueue(op);
@@ -1333,7 +1398,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         ds.enqueue(op);
@@ -1383,7 +1457,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         ds.enqueue(op);
@@ -1433,7 +1516,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         ds.enqueue(op);
@@ -1483,7 +1575,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         ds.enqueue(op);
@@ -1526,7 +1627,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         ds.enqueue(op);
@@ -1588,7 +1698,16 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         ds.enqueue(op);
@@ -1644,7 +1763,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         ds.enqueue(op);
@@ -1690,7 +1818,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         ds.enqueue(op);
@@ -1757,7 +1894,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         ds.enqueue(op);
@@ -1828,7 +1974,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         ds.enqueue(op);
@@ -1885,7 +2040,7 @@ mod up_test {
             0,
             0,
             None,
-            ImpactedBlocks::default(),
+            ImpactedBlocks::Empty,
         );
 
         ds.enqueue(op);
@@ -1975,7 +2130,16 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
         ds.enqueue(op);
 
@@ -1993,7 +2157,16 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
         ds.enqueue(op);
 
@@ -2034,7 +2207,7 @@ mod up_test {
             0,
             0,
             None,
-            ImpactedBlocks::default(),
+            ImpactedBlocks::Empty,
         );
         ds.enqueue(op);
 
@@ -2144,7 +2317,7 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
-            ImpactedBlocks::default(),
+            ImpactedBlocks::Empty,
         );
         // Put the write on the queue.
         ds.enqueue(op);
@@ -2199,7 +2372,7 @@ mod up_test {
             0,
             0,
             None,
-            ImpactedBlocks::default(),
+            ImpactedBlocks::Empty,
         );
         ds.enqueue(op);
 
@@ -2285,7 +2458,16 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
         ds.enqueue(op);
 
@@ -2303,7 +2485,16 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
         ds.enqueue(op);
 
@@ -2344,7 +2535,7 @@ mod up_test {
             0,
             0,
             None,
-            ImpactedBlocks::default(),
+            ImpactedBlocks::Empty,
         );
         ds.enqueue(op);
 
@@ -2437,7 +2628,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
         ds.enqueue(op);
 
@@ -2489,7 +2689,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
         ds.enqueue(op);
 
@@ -2563,7 +2772,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
         ds.enqueue(op);
 
@@ -2652,7 +2870,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
         ds.enqueue(op);
 
@@ -2740,7 +2967,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
         ds.enqueue(op);
 
@@ -2836,7 +3072,16 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
         ds.enqueue(op);
 
@@ -2911,7 +3156,16 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
         ds.enqueue(op);
 
@@ -3056,7 +3310,16 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
         ds.enqueue(op);
 
@@ -3240,7 +3503,16 @@ mod up_test {
                 },
             }],
             is_write_unwritten,
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
         ds.enqueue(op);
 
@@ -4130,7 +4402,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         let context = Arc::new(EncryptionContext::new(
@@ -4211,7 +4492,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         ds.enqueue(op);
@@ -4262,7 +4552,16 @@ mod up_test {
             vec![],
             10,
             vec![request.clone()],
-            ImpactedBlocks::default(),
+            ImpactedBlocks::new(
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+                ImpactedAddr {
+                    extent_id: 0,
+                    block: 7,
+                },
+            ),
         );
 
         let context = Arc::new(EncryptionContext::new(
@@ -4735,7 +5034,16 @@ mod up_test {
                     },
                 }],
                 false,
-                ImpactedBlocks::default(),
+                ImpactedBlocks::new(
+                    ImpactedAddr {
+                        extent_id: 0,
+                        block: 7,
+                    },
+                    ImpactedAddr {
+                        extent_id: 0,
+                        block: 7,
+                    },
+                ),
             );
 
             ds.enqueue(op);
@@ -4822,7 +5130,16 @@ mod up_test {
                     },
                 }],
                 false,
-                ImpactedBlocks::default(),
+                ImpactedBlocks::new(
+                    ImpactedAddr {
+                        extent_id: 0,
+                        block: 7,
+                    },
+                    ImpactedAddr {
+                        extent_id: 0,
+                        block: 7,
+                    },
+                ),
             );
 
             ds.enqueue(op);
@@ -4880,7 +5197,16 @@ mod up_test {
                 vec![],
                 10,
                 vec![request.clone()],
-                ImpactedBlocks::default(),
+                ImpactedBlocks::new(
+                    ImpactedAddr {
+                        extent_id: 0,
+                        block: 7,
+                    },
+                    ImpactedAddr {
+                        extent_id: 0,
+                        block: 7,
+                    },
+                ),
             );
 
             ds.enqueue(op);
@@ -4921,7 +5247,7 @@ mod up_test {
                 0,
                 0,
                 None,
-                ImpactedBlocks::default(),
+                ImpactedBlocks::Empty,
             );
             ds.enqueue(op);
 
@@ -4988,7 +5314,16 @@ mod up_test {
                     },
                 }],
                 false,
-                ImpactedBlocks::default(),
+                ImpactedBlocks::new(
+                    ImpactedAddr {
+                        extent_id: 0,
+                        block: 7,
+                    },
+                    ImpactedAddr {
+                        extent_id: 0,
+                        block: 7,
+                    },
+                ),
             );
 
             ds.enqueue(op);
@@ -5051,7 +5386,16 @@ mod up_test {
                 vec![],
                 10,
                 vec![request.clone()],
-                ImpactedBlocks::default(),
+                ImpactedBlocks::new(
+                    ImpactedAddr {
+                        extent_id: 0,
+                        block: 7,
+                    },
+                    ImpactedAddr {
+                        extent_id: 0,
+                        block: 7,
+                    },
+                ),
             );
 
             ds.enqueue(op);
@@ -5104,7 +5448,16 @@ mod up_test {
                     },
                 }],
                 false,
-                ImpactedBlocks::default(),
+                ImpactedBlocks::new(
+                    ImpactedAddr {
+                        extent_id: 0,
+                        block: 7,
+                    },
+                    ImpactedAddr {
+                        extent_id: 0,
+                        block: 7,
+                    },
+                ),
             );
 
             ds.enqueue(op);
@@ -5167,7 +5520,16 @@ mod up_test {
                     },
                 }],
                 false,
-                ImpactedBlocks::default(),
+                ImpactedBlocks::new(
+                    ImpactedAddr {
+                        extent_id: 0,
+                        block: 7,
+                    },
+                    ImpactedAddr {
+                        extent_id: 0,
+                        block: 7,
+                    },
+                ),
             );
 
             ds.enqueue(op);
@@ -5209,7 +5571,7 @@ mod up_test {
                 0,
                 0,
                 None,
-                ImpactedBlocks::default(),
+                ImpactedBlocks::Empty,
             );
             ds.enqueue(op);
 
@@ -6400,12 +6762,12 @@ mod up_test {
         assert_eq!(jobs.len(), 3);
 
         // confirm which extents are impacted (in case make_upstairs changes)
-        assert_eq!(jobs[0].impacted_blocks.extents().len(), 1);
-        assert_eq!(jobs[1].impacted_blocks.extents().len(), 2);
-        assert_eq!(jobs[2].impacted_blocks.extents().len(), 1);
+        assert_eq!(jobs[0].impacted_blocks.extents().unwrap().count(), 1);
+        assert_eq!(jobs[1].impacted_blocks.extents().unwrap().count(), 2);
+        assert_eq!(jobs[2].impacted_blocks.extents().unwrap().count(), 1);
         assert_ne!(
-            jobs[0].impacted_blocks.extents()[0],
-            jobs[2].impacted_blocks.extents()[0]
+            jobs[0].impacted_blocks.extents(),
+            jobs[2].impacted_blocks.extents()
         );
 
         // confirm deps
@@ -6487,19 +6849,19 @@ mod up_test {
         assert_eq!(jobs.len(), 5);
 
         // confirm which extents are impacted (in case make_upstairs changes)
-        assert_eq!(jobs[0].impacted_blocks.extents().len(), 1);
-        assert_eq!(jobs[1].impacted_blocks.extents().len(), 2);
-        assert_eq!(jobs[2].impacted_blocks.extents().len(), 1);
-        assert_eq!(jobs[3].impacted_blocks.extents().len(), 2);
-        assert_eq!(jobs[4].impacted_blocks.extents().len(), 1);
+        assert_eq!(jobs[0].impacted_blocks.extents().unwrap().count(), 1);
+        assert_eq!(jobs[1].impacted_blocks.extents().unwrap().count(), 2);
+        assert_eq!(jobs[2].impacted_blocks.extents().unwrap().count(), 1);
+        assert_eq!(jobs[3].impacted_blocks.extents().unwrap().count(), 2);
+        assert_eq!(jobs[4].impacted_blocks.extents().unwrap().count(), 1);
 
         assert_ne!(
-            jobs[0].impacted_blocks.extents()[0],
-            jobs[2].impacted_blocks.extents()[0]
+            jobs[0].impacted_blocks.extents(),
+            jobs[2].impacted_blocks.extents()
         );
         assert_ne!(
-            jobs[4].impacted_blocks.extents()[0],
-            jobs[2].impacted_blocks.extents()[0]
+            jobs[4].impacted_blocks.extents(),
+            jobs[2].impacted_blocks.extents()
         );
 
         assert!(jobs[0].work.deps().is_empty()); // op 0
@@ -6569,13 +6931,13 @@ mod up_test {
         assert_eq!(jobs.len(), 3);
 
         // confirm which extents are impacted (in case make_upstairs changes)
-        assert_eq!(jobs[0].impacted_blocks.extents().len(), 1);
-        assert_eq!(jobs[1].impacted_blocks.extents().len(), 1);
-        assert_eq!(jobs[2].impacted_blocks.extents().len(), 2);
+        assert_eq!(jobs[0].impacted_blocks.extents().unwrap().count(), 1);
+        assert_eq!(jobs[1].impacted_blocks.extents().unwrap().count(), 1);
+        assert_eq!(jobs[2].impacted_blocks.extents().unwrap().count(), 2);
 
         assert_ne!(
-            jobs[0].impacted_blocks.extents()[0],
-            jobs[1].impacted_blocks.extents()[0]
+            jobs[0].impacted_blocks.extents(),
+            jobs[1].impacted_blocks.extents()
         );
 
         assert!(jobs[0].work.deps().is_empty()); // op 0


### PR DESCRIPTION
Switch ImpactedBlocks from bitvec to a range
    
The bitvec implementation of ImpactedBlocks was really slow, allocating kilobytes of bitvecs at a time, and doing kilobytes of bit operatoins to check for conflicts. The replacement I've opted for after talking with Alan is just a simple range; none of our usecases need anything more complex. This eliminates one of the largest sources of Upstairs CPU utilization.
    
If in the future we want a single ImpactedBlocks so support multiple ranges, we should probably just store that as a Vec or binary tree of ranges, but we'll burn that bridge when we come to it. As it is, Upstairs' API doesn't create a scenario where that would be relevant.
    
Also, this commit brings in Proptest to test ImpactedBlocks extremely thorougly! Give that a look, it's pretty neat. As part of that I did also modify crucible_region to expose MIN_SHIFT and MAX_SHIFT so I wouldn't need to re-derive it from MIN_BLOCK_SIZE and MAX_BLOCK_SIZE.
