### PR TITLE
Add FMRI-decoding methods to `crucible-smf`

### DIFF
--- a/smf/src/instance.rs
+++ b/smf/src/instance.rs
@@ -139,6 +139,12 @@ impl<'a> Instance<'a> {
         Snapshots::new(self)
     }
 
+    /// Helper function to get the running snapshot for this instance, if one
+    /// exists.
+    pub fn get_running_snapshot(&self) -> Result<Option<Snapshot>> {
+        self.get_snapshot("running")
+    }
+
     pub fn get_snapshot(&self, name: &str) -> Result<Option<Snapshot>> {
         let name = CString::new(name).unwrap();
         let snap = Snapshot::new(self)?;

--- a/smf/src/instance.rs
+++ b/smf/src/instance.rs
@@ -139,8 +139,10 @@ impl<'a> Instance<'a> {
         Snapshots::new(self)
     }
 
-    /// Helper function to get the running snapshot for this instance, if one
-    /// exists.
+    /**
+     * Helper function to get the running snapshot for this instance, if one
+     * exists.
+     */
     pub fn get_running_snapshot(&self) -> Result<Option<Snapshot>> {
         self.get_snapshot("running")
     }

--- a/smf/src/instance.rs
+++ b/smf/src/instance.rs
@@ -142,9 +142,16 @@ impl<'a> Instance<'a> {
     /**
      * Helper function to get the running snapshot for this instance, if one
      * exists.
+     *
+     * # Errors
+     *
+     * Returns [`ScfError::NoRunningSnapshot`] if this instance does not have a
+     * `running` snapshot. May return other errors if querying for the running
+     * snapshot fails.
      */
-    pub fn get_running_snapshot(&self) -> Result<Option<Snapshot>> {
-        self.get_snapshot("running")
+    pub fn get_running_snapshot(&self) -> Result<Snapshot> {
+        let maybe_snapshot = self.get_snapshot("running")?;
+        maybe_snapshot.ok_or(ScfError::NoRunningSnapshot)
     }
 
     pub fn get_snapshot(&self, name: &str) -> Result<Option<Snapshot>> {

--- a/smf/src/lib.rs
+++ b/smf/src/lib.rs
@@ -89,6 +89,8 @@ pub enum ScfError {
     Internal,
     #[error("not running under SMF (environment variable SMF_FMRI not found)")]
     NotRunningUnderSmf,
+    #[error("no running snaphot exists")]
+    NoRunningSnapshot,
     #[error("unknown error ({0})")]
     Unknown(u32),
 }

--- a/smf/src/lib.rs
+++ b/smf/src/lib.rs
@@ -209,7 +209,8 @@ impl Scf {
     /// From within a running service instance, get our own [`Instance`].
     ///
     /// If you are using this to look up the current value of your properties,
-    /// you almost certainly want [`get_self_snapshot()`] instead!
+    /// you almost certainly want to call [`Instance::get_running_snapshot()`]
+    /// on the returned instance.
     ///
     /// This method looks up our own FMRI via the `SMF_FMRI` environment
     /// variable, which is supplied by `smf` to running instances.

--- a/smf/src/lib.rs
+++ b/smf/src/lib.rs
@@ -206,14 +206,15 @@ impl Scf {
         }
     }
 
-    /// From within a running service instance, get our own [`Instance`].
-    ///
-    /// If you are using this to look up the current value of your properties,
-    /// you almost certainly want to call [`Instance::get_running_snapshot()`]
-    /// on the returned instance.
-    ///
-    /// This method looks up our own FMRI via the `SMF_FMRI` environment
-    /// variable, which is supplied by `smf` to running instances.
+    /** From within a running service instance, get our own [`Instance`].
+     *
+     * If you are using this to look up the current value of your properties,
+     * you almost certainly want to call [`Instance::get_running_snapshot()`]
+     * on the returned instance.
+     *
+     * This method looks up our own FMRI via the `SMF_FMRI` environment
+     * variable, which is supplied by `smf` to running instances.
+     */
     pub fn get_self_instance(&self) -> Result<Instance<'_>> {
         let fmri =
             env::var("SMF_FMRI").map_err(|_| ScfError::NotRunningUnderSmf)?;

--- a/smf/src/lib.rs
+++ b/smf/src/lib.rs
@@ -178,17 +178,14 @@ impl Scf {
 
     pub fn get_instance_from_fmri(&self, fmri: &str) -> Result<Instance<'_>> {
         let fmri = CString::new(fmri).unwrap();
-
-        let scope = Scope::new(self)?;
-        let service = Service::new(self)?;
         let instance = Instance::new(self)?;
 
         let ret = unsafe {
             scf_handle_decode_fmri(
                 self.handle.as_ptr(),
                 fmri.as_ptr(),
-                scope.scope.as_ptr(),
-                service.service.as_ptr(),
+                ptr::null_mut(),
+                ptr::null_mut(),
                 instance.instance.as_ptr(),
                 ptr::null_mut(),
                 ptr::null_mut(),

--- a/smf/src/lib.rs
+++ b/smf/src/lib.rs
@@ -87,8 +87,8 @@ pub enum ScfError {
     CallbackFailed,
     #[error("internal error")]
     Internal,
-    #[error("environment variable SMF_FMRI not found")]
-    MissingSmfFmriEnvironmentVariable,
+    #[error("not running under SMF (environment variable SMF_FMRI not found)")]
+    NotRunningUnderSmf,
     #[error("unknown error ({0})")]
     Unknown(u32),
 }
@@ -215,8 +215,8 @@ impl Scf {
     /// This method looks up our own FMRI via the `SMF_FMRI` environment
     /// variable, which is supplied by `smf` to running instances.
     pub fn get_self_instance(&self) -> Result<Instance<'_>> {
-        let fmri = env::var("SMF_FMRI")
-            .map_err(|_| ScfError::MissingSmfFmriEnvironmentVariable)?;
+        let fmri =
+            env::var("SMF_FMRI").map_err(|_| ScfError::NotRunningUnderSmf)?;
 
         self.get_instance_from_fmri(&fmri)
     }

--- a/smf/src/lib.rs
+++ b/smf/src/lib.rs
@@ -202,7 +202,8 @@ impl Scf {
         }
     }
 
-    /** From within a running service instance, get our own [`Instance`].
+    /**
+     * From within a running service instance, get our own [`Instance`].
      *
      * If you are using this to look up the current value of your properties,
      * you almost certainly want to call [`Instance::get_running_snapshot()`]

--- a/smf/src/lib.rs
+++ b/smf/src/lib.rs
@@ -192,10 +192,7 @@ impl Scf {
                 instance.instance.as_ptr(),
                 ptr::null_mut(),
                 ptr::null_mut(),
-                // `fmri` _must_ have an instance, but is allowed to also
-                // specify a propertygroup / property; ignore those if present
-                // via `SCF_DECODE_FMRI_TRUNCATE`.
-                SCF_DECODE_FMRI_REQUIRE_INSTANCE | SCF_DECODE_FMRI_TRUNCATE,
+                SCF_DECODE_FMRI_REQUIRE_INSTANCE | SCF_DECODE_FMRI_EXACT,
             )
         };
 

--- a/smf/src/lib.rs
+++ b/smf/src/lib.rs
@@ -213,7 +213,7 @@ impl Scf {
      * on the returned instance.
      *
      * This method looks up our own FMRI via the `SMF_FMRI` environment
-     * variable, which is supplied by `smf` to running instances.
+     * variable, which is supplied by SMF to running instances.
      */
     pub fn get_self_instance(&self) -> Result<Instance<'_>> {
         let fmri =

--- a/smf/src/scf_sys.rs
+++ b/smf/src/scf_sys.rs
@@ -25,9 +25,11 @@ macro_rules! opaque_handle {
         #[repr(C)]
         pub struct $type_name {
             _data: [u8; 0],
-            // See https://doc.rust-lang.org/nomicon/ffi.html; this marker
-            // guarantees our type does not implement `Send`, `Sync`, or
-            // `Unpin`.
+            /*
+             * See https://doc.rust-lang.org/nomicon/ffi.html; this marker
+             * guarantees our type does not implement `Send`, `Sync`, or
+             * `Unpin`.
+             */
             _marker: PhantomData<(*mut u8, PhantomPinned)>,
         }
         impl Copy for $type_name {}

--- a/smf/src/scf_sys.rs
+++ b/smf/src/scf_sys.rs
@@ -5,6 +5,7 @@
 
 use libc::{size_t, ssize_t};
 use std::os::raw::{c_char, c_int, c_ulong};
+use std::marker::{PhantomData, PhantomPinned};
 
 type scf_version_t = c_ulong;
 
@@ -21,7 +22,14 @@ pub const SMF_AT_NEXT_BOOT: c_int = 0x4;
 
 macro_rules! opaque_handle {
     ($type_name:ident) => {
-        pub enum $type_name {}
+        #[repr(C)]
+        pub struct $type_name {
+            _data: [u8; 0],
+            // See https://doc.rust-lang.org/nomicon/ffi.html; this marker
+            // guarantees our type does not implement `Send`, `Sync`, or
+            // `Unpin`.
+            _marker: PhantomData<(*mut u8, PhantomPinned)>,
+        }
         impl Copy for $type_name {}
         impl Clone for $type_name {
             fn clone(&self) -> $type_name {

--- a/smf/src/scf_sys.rs
+++ b/smf/src/scf_sys.rs
@@ -4,8 +4,8 @@
 #![allow(dead_code)]
 
 use libc::{size_t, ssize_t};
-use std::os::raw::{c_char, c_int, c_ulong};
 use std::marker::{PhantomData, PhantomPinned};
+use std::os::raw::{c_char, c_int, c_ulong};
 
 type scf_version_t = c_ulong;
 
@@ -110,6 +110,11 @@ pub const SCF_LIMIT_MAX_PG_TYPE_LENGTH: u32 = 0xfffff82e;
 pub const SCF_LIMIT_MAX_FMRI_LENGTH: u32 = 0xfffff82d;
 
 pub const SCF_SCOPE_LOCAL: &[u8] = b"localhost\0";
+
+pub(crate) const SCF_DECODE_FMRI_EXACT: c_int = 0x00000001;
+pub(crate) const SCF_DECODE_FMRI_TRUNCATE: c_int = 0x00000002;
+pub(crate) const SCF_DECODE_FMRI_REQUIRE_INSTANCE: c_int = 0x00000004;
+pub(crate) const SCF_DECODE_FMRI_REQUIRE_NO_INSTANCE: c_int = 0x00000008;
 
 #[cfg(target_os = "illumos")]
 #[link(name = "scf")]
@@ -415,6 +420,17 @@ extern "C" {
     pub fn smf_disable_instance(instance: *const c_char, flags: c_int)
         -> c_int;
     pub fn smf_enable_instance(instance: *const c_char, flags: c_int) -> c_int;
+
+    pub fn scf_handle_decode_fmri(
+        handle: *mut scf_handle_t,
+        fmri: *const c_char,
+        out_scope: *mut scf_scope_t,
+        out_service: *mut scf_service_t,
+        out_instance: *mut scf_instance_t,
+        out_pg: *mut scf_propertygroup_t,
+        out_prop: *mut scf_property_t,
+        flags: c_int,
+    ) -> c_int;
 }
 
 #[cfg(not(target_os = "illumos"))]
@@ -915,6 +931,19 @@ mod dummy {
     }
     pub unsafe fn smf_enable_instance(
         instance: *const c_char,
+        flags: c_int,
+    ) -> c_int {
+        unimplemented!()
+    }
+
+    pub unsafe fn scf_handle_decode_fmri(
+        handle: *mut scf_handle_t,
+        fmri: *const c_char,
+        out_scope: *mut scf_scope_t,
+        out_service: *mut scf_service_t,
+        out_instance: *mut scf_instance_t,
+        out_pg: *mut scf_propertygroup_t,
+        out_prop: *mut scf_property_t,
         flags: c_int,
     ) -> c_int {
         unimplemented!()

--- a/smf/src/scf_sys.rs
+++ b/smf/src/scf_sys.rs
@@ -113,10 +113,10 @@ pub const SCF_LIMIT_MAX_FMRI_LENGTH: u32 = 0xfffff82d;
 
 pub const SCF_SCOPE_LOCAL: &[u8] = b"localhost\0";
 
-pub(crate) const SCF_DECODE_FMRI_EXACT: c_int = 0x00000001;
-pub(crate) const SCF_DECODE_FMRI_TRUNCATE: c_int = 0x00000002;
-pub(crate) const SCF_DECODE_FMRI_REQUIRE_INSTANCE: c_int = 0x00000004;
-pub(crate) const SCF_DECODE_FMRI_REQUIRE_NO_INSTANCE: c_int = 0x00000008;
+pub const SCF_DECODE_FMRI_EXACT: c_int = 0x00000001;
+pub const SCF_DECODE_FMRI_TRUNCATE: c_int = 0x00000002;
+pub const SCF_DECODE_FMRI_REQUIRE_INSTANCE: c_int = 0x00000004;
+pub const SCF_DECODE_FMRI_REQUIRE_NO_INSTANCE: c_int = 0x00000008;
 
 #[cfg(target_os = "illumos")]
 #[link(name = "scf")]


### PR DESCRIPTION
This PR adds a high-level wrapper for `scf_handle_decode_fmri()` (`Scf::get_instance_from_fmri(fmri)`), and a couple of utility methods:

* `Scf::get_self_instance()` is for use by running services; it grabs the `SMF_FMRI` environment variable and calls `get_instance_from_fmri` with that value.
* `Instance::get_running_snapshot()` is a trivial wrapper that calls `Instance::get_snapshot("running")` to put the raw string in just one place

It also changes the FFI type definition for opaque pointers based on the guidance from https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs; in particular:

> Notice that it is a really bad idea to use an empty enum as FFI type. The compiler relies on empty enums being uninhabited, so handling values of type &Empty is a huge footgun and can lead to buggy program behavior (by triggering undefined behavior).

`crucible-smf` never constructed a Rust reference to an empty enum, therefore avoiding this class of bugs, but it doesn't hurt to remove the potential to accidentally introduce UB.