### PR TITLE
Updates test_restart_repair.sh and dsc

### DIFF
--- a/dsc/src/client.rs
+++ b/dsc/src/client.rs
@@ -17,12 +17,12 @@ pub enum ClientCommand {
     },
     /// Disable auto restart on all downstairs
     DisableRestartAll,
-    /// Disable restart on the given client ID
+    /// Enable automatic restart of the given client ID
     EnableRestart {
         #[clap(long, short, action)]
         cid: u32,
     },
-    /// Enable random stopping of downstairs
+    /// Enable the random stopping of any downstairs
     EnableRandomStop,
     /// Set the minimum random stop time (in seconds)
     EnableRandomMin {


### PR DESCRIPTION
Fixed incorrect help string in dsc cmd

Updated tools/test_restart_repair.sh to use the dsc tool instead of the downstairs_daemon.sh.

Once this goes in, we can remove `downstairs_daemon.sh` as this was the last user of it.