### PR TITLE
Check incoming IOs are inside the region.

### DIFF
--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -3,6 +3,8 @@ use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use super::*;
+
 /*
  * Where the unit is blocks, not bytes, make sure to reflect that in the
  * types used.
@@ -180,6 +182,26 @@ impl RegionDefinition {
     pub fn get_encrypted(&self) -> bool {
         self.encrypted
     }
+
+    /*
+     * Validate an IO would fit inside this region
+     */
+    pub fn validate_io(
+        &self,
+        offset: Block,
+        length: usize,
+    ) -> Result<(), CrucibleError> {
+        if offset.shift != self.extent_size.shift {
+            return Err(CrucibleError::BlockSizeMismatch);
+        }
+
+        let final_offset = offset.byte_value() + length as u64;
+
+        if final_offset > self.total_size() {
+            return Err(CrucibleError::OffsetInvalid);
+        }
+        Ok(())
+    }
 }
 
 /**
@@ -283,5 +305,134 @@ impl Default for RegionOptions {
             uuid: Uuid::nil(),
             encrypted: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_basic_region() {
+        /*
+         * Test basic RegionDefinition methods
+         */
+
+        let mut rd = RegionDefinition::default();
+        rd.set_block_size(512);
+        assert_eq!(rd.block_size(), 512);
+
+        rd.set_extent_size(Block::new(4, 9));
+        assert_eq!(rd.extent_size(), Block::new(4, 9));
+
+        rd.set_extent_count(1);
+        assert_eq!(rd.extent_count(), 1);
+
+        assert_eq!(rd.total_size(), 2048);
+    }
+
+    #[test]
+    fn test_region_validate_io() {
+        /*
+         * Test validate io method of RegionDefinition
+         * This is our region, 4 blocks:
+         *   |---|---|---|---|
+         * So, we test various IO sizes to verify how each pass/fail
+         */
+
+        let mut rd = RegionDefinition::default();
+        rd.set_block_size(512);
+        rd.set_extent_size(Block::new(4, 9));
+        rd.set_extent_count(1);
+
+        /*
+         *   Region |---|---|---|---|
+         *   IO     |---|
+         */
+        assert_eq!(rd.validate_io(Block::new(0, 9), 512), Ok(()));
+
+        /*
+         *   Region |---|---|---|---|
+         *   IO         |---|
+         */
+        assert_eq!(rd.validate_io(Block::new(1, 9), 512), Ok(()));
+
+        /*
+         *   Region |---|---|---|---|
+         *   IO             |---|
+         */
+        assert_eq!(rd.validate_io(Block::new(2, 9), 512), Ok(()));
+
+        /*
+         *   Region |---|---|---|---|
+         *   IO                 |---|
+         */
+        assert_eq!(rd.validate_io(Block::new(3, 9), 512), Ok(()));
+
+        /*
+         *   Region |---|---|---|---|
+         *   IO                     |---|
+         */
+        assert!(rd.validate_io(Block::new(4, 9), 512).is_err());
+
+        /*
+         *   Region |---|---|---|---|
+         *   IO     |---|---|
+         */
+        assert_eq!(rd.validate_io(Block::new(0, 9), 1024), Ok(()));
+
+        /*
+         *   Region |---|---|---|---|
+         *   IO         |---|---|
+         */
+        assert_eq!(rd.validate_io(Block::new(1, 9), 1024), Ok(()));
+
+        /*
+         *   Region |---|---|---|---|
+         *   IO             |---|---|
+         */
+        assert_eq!(rd.validate_io(Block::new(2, 9), 1024), Ok(()));
+
+        /*
+         *   Region |---|---|---|---|
+         *   IO                 |---|---|
+         */
+        assert!(rd.validate_io(Block::new(3, 9), 1024).is_err());
+
+        /*
+         *   Region |---|---|---|---|
+         *   IO                     |---|---|
+         */
+        assert!(rd.validate_io(Block::new(4, 9), 1024).is_err());
+
+        /*
+         *   Region |---|---|---|---|
+         *   IO     |---|---|---|
+         */
+        assert_eq!(rd.validate_io(Block::new(0, 9), 1536), Ok(()));
+
+        /*
+         *   Region |---|---|---|---|
+         *   IO         |---|---|---|
+         */
+        assert_eq!(rd.validate_io(Block::new(1, 9), 1536), Ok(()));
+
+        /*
+         *   Region |---|---|---|---|
+         *   IO             |---|---|---|
+         */
+        assert!(rd.validate_io(Block::new(2, 9), 1536).is_err());
+
+        /*
+         *   Region |---|---|---|---|
+         *   IO     |---|---|---|---|
+         */
+        assert_eq!(rd.validate_io(Block::new(0, 9), 2048), Ok(()));
+
+        /*
+         *   Region |---|---|---|---|
+         *   IO         |---|---|---|---|
+         */
+        assert!(rd.validate_io(Block::new(1, 9), 2048).is_err());
     }
 }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -4400,7 +4400,7 @@ impl Upstairs {
          * Build the flush request, and take note of the request ID that
          * will be assigned to this new piece of work.
          */
-        let ddef = self.ddef.lock().await;
+        let ddef = self.ddef.lock().await.get_def().unwrap();
         let fl = create_flush(
             next_id,
             dep,
@@ -4408,7 +4408,7 @@ impl Upstairs {
             gw_id,
             self.get_generation().await,
             snapshot_details,
-            ImpactedBlocks::new(ddef.get_def().unwrap()),
+            ImpactedBlocks::new(ddef),
         );
 
         let mut sub = HashMap::new();
@@ -4462,6 +4462,22 @@ impl Upstairs {
          */
         let mut gw = self.guest.guest_work.lock().await;
         let mut downstairs = self.downstairs.lock().await;
+        let ddef = self.ddef.lock().await.get_def().unwrap();
+
+        /*
+         * Verify IO is in range for our region.  If not give up now and
+         * report error.
+         */
+        match ddef.validate_io(offset, data.len()) {
+            Ok(()) => {}
+            Err(e) => {
+                if let Some(req) = req {
+                    req.send_err(e).await;
+                }
+                return Err(());
+            }
+        }
+
         self.set_flush_need().await;
 
         /*
@@ -4469,11 +4485,10 @@ impl Upstairs {
          * byte offset that translates into. Keep in mind that an offset
          * and length may span two extents, and eventually XXX, two regions.
          */
-        let ddef = self.ddef.lock().await;
         let impacted_blocks = extent_from_offset(
-            ddef.get_def().unwrap(),
+            ddef,
             offset,
-            Block::from_bytes(data.len(), &ddef.get_def().unwrap()),
+            Block::from_bytes(data.len(), &ddef),
         );
 
         /*
@@ -4559,7 +4574,7 @@ impl Upstairs {
             Vec::with_capacity(impacted_blocks.tuples().len());
 
         for (eid, bo) in impacted_blocks.tuples() {
-            let byte_len: usize = ddef.get_def().unwrap().block_size() as usize;
+            let byte_len: usize = ddef.block_size() as usize;
 
             let (sub_data, encryption_context, hash) = if let Some(context) =
                 &self.encryption_context
@@ -4668,6 +4683,21 @@ impl Upstairs {
          */
         let mut gw = self.guest.guest_work.lock().await;
         let mut downstairs = self.downstairs.lock().await;
+        let ddef = self.ddef.lock().await.get_def().unwrap();
+
+        /*
+         * Verify IO is in range for our region
+         */
+        match ddef.validate_io(offset, data.len()) {
+            Ok(()) => {}
+            Err(e) => {
+                if let Some(req) = req {
+                    req.send_err(e).await;
+                }
+                return Err(());
+            }
+        }
+
         self.set_flush_need().await;
 
         /*
@@ -4675,12 +4705,10 @@ impl Upstairs {
          * byte offset that translates into. Keep in mind that an offset
          * and length may span many extents, and eventually, TODO, regions.
          */
-        let ddef_state = self.ddef.lock().await;
-        let ddef = &ddef_state.get_def().unwrap();
         let impacted_blocks = extent_from_offset(
-            *ddef,
+            ddef,
             offset,
-            Block::from_bytes(data.len(), ddef),
+            Block::from_bytes(data.len(), &ddef),
         );
 
         /*


### PR DESCRIPTION
Added a method to the RegionDefinition that allows verification of an IO offset+length to be sure it will be inside the region.

Added tests at both the common/region layer and the integration test layer.