### PR TITLE
Fix dump output alignment for blocks

### DIFF
--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -493,9 +493,14 @@ fn show_extent(
     }
     println!();
     println!();
+    // Width for BLOCKS column
+    let max_block =
+        blocks_per_extent * cmp_extent as u64 + blocks_per_extent - 1;
+    // Get the max possible width for a single block
+    let block_width = std::cmp::max(3, max_block.to_string().len());
 
     // Print the header
-    print!("{0:5} ", "BLOCK");
+    print!("{:>0width$} ", "BLOCK", width = block_width);
     for (index, _) in region_dir.iter().enumerate() {
         print!(" {0:^2}", format!("D{}", index));
     }
@@ -580,7 +585,7 @@ fn show_extent(
         // Now that we have collected all the results, print them
         let real_block = (blocks_per_extent * cmp_extent as u64) + block;
         if !only_show_differences || different {
-            print!("{:5} ", real_block);
+            print!("{:0width$} ", real_block, width = block_width);
 
             for column in data_columns.iter().take(dir_count) {
                 print!("  {}", column);


### PR DESCRIPTION
Fix alignment issue with dump output when looking at a specific extent with large block numbers.
Before it would max out at 5 for printing the block, which made the column headers out of
alignment.  Now we take the space needed do display the block number as use that to
align the header.

Before:
```
final:crucible$ ./target/release/crucible-downstairs dump -d /var/tmp/dsc/region/8810/ -d /var/tmp/dsc/region/8820 -e 29
           Extent 29
GEN             0        0
FLUSH_ID        0        0
DIRTY

BLOCK  D0 D1  C0 C1 DIFF
29003219   A  A   A  A
29003220   A  A   A  A
29003221   A  A   A  A
29003222   A  A   A  A
29003223   A  A   A  A
29003224   A  A   A  A
29003225   A  A   A  A
29003226   A  A   A  A
...
```

After:
```
final:pflush$ ./target/release/crucible-downstairs dump -d /var/tmp/dsc/region/8810/ -d /var/tmp/dsc/region/8820 -e 29
           Extent 29
GEN             0        0
FLUSH_ID        0        0
DIRTY

   BLOCK  D0 D1  C0 C1 DIFF
29003219   A  A   A  A
29003220   A  A   A  A
29003221   A  A   A  A
29003222   A  A   A  A
29003223   A  A   A  A
29003224   A  A   A  A
29003225   A  A   A  A
29003226   A  A   A  A
...
```
