### PR TITLE
Return info when closing an extent.

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -599,12 +599,13 @@ where
                     flush_number,
                     gen_number
                 );
+
                 match d
                     .region
                     .region_flush_extent(
                         *extent_id,
-                        *flush_number,
                         *gen_number,
+                        *flush_number,
                         *repair_id,
                     )
                     .await
@@ -632,9 +633,12 @@ where
                 info!(d.log, "{} Close extent {}", repair_id, extent_id);
                 match d.region.extents.get_mut(*extent_id) {
                     Some(ext) => {
-                        ext.close().await?;
-                        Message::RepairAckId {
+                        let (gen, flush, dirty) = ext.close().await?;
+                        Message::ExtentCloseAck {
                             repair_id: *repair_id,
+                            gen_number: gen,
+                            flush_number: flush,
+                            dirty,
                         }
                     }
                     None => Message::ExtentError {

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -236,6 +236,17 @@ pub enum Message {
     RepairAckId {
         repair_id: u64,
     },
+    /// The given extent flush repair job ID has finished without error.
+    /// Included are the gen and flush numbers that were committed as
+    /// part of this flush request.  Note that if the extent is not
+    /// dirty, then these numbers may be different than the flush/gen
+    /// that was sent with the original flush
+    ExtentCloseAck {
+        repair_id: u64,
+        gen_number: u64,
+        flush_number: u64,
+        dirty: bool,
+    },
 
     /// A problem with the given extent
     ExtentError {


### PR DESCRIPTION
Another piece of the live repair puzzle.

Updated the extent close command to return the flush, gen, and the dirty bit for the extent just closed.
This behavior will be used by future code to do live repair of a downstairs.

Added some tests for close to verify correct behavior.