### PR TITLE
change crucible-pantry to crucible_pantry

### DIFF
--- a/pantry/smf/manifest.xml
+++ b/pantry/smf/manifest.xml
@@ -3,7 +3,7 @@
 
 <service_bundle type='manifest' name='oxide-crucible-pantry'>
 
-<service name='system/illumos/crucible-pantry' type='service' version='1'>
+<service name='system/illumos/crucible_pantry' type='service' version='1'>
   <create_default_instance enabled='false' />
 
   <!-- Run once we hit multi-user, so that the network and file systems have
@@ -14,7 +14,7 @@
   </dependency>
 
   <exec_method type='method' name='start'
-    exec='/opt/oxide/crucible-pantry/bin/crucible-pantry run
+    exec='/opt/oxide/crucible_pantry/bin/crucible-pantry run
       -l %{config/listen}'
     timeout_seconds='30'
     />


### PR DESCRIPTION
PR #583 changed how the pantry service name was constructed, but these changes are required to match 1) where the tar extracts to and 2) the service name the sled agent tries to start.