### PR TITLE
online repair, part one

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1954,7 +1954,7 @@ impl Downstairs {
                 dependencies: _,
                 extent,
             } => {
-                println!("Closing extent {}", extent);
+                info!(self.log, "Closing extent {}", extent);
                 let result = if !self.is_active(job.upstairs_connection) {
                     error!(self.log, "Upstairs inactive error");
                     Err(CrucibleError::UpstairsInactive)
@@ -1979,7 +1979,7 @@ impl Downstairs {
                 source_downstairs: _,
                 repair_downstairs: _,
             } => {
-                println!("Flush then Closing extent {}", extent);
+                info!(self.log, "Flush then Closing extent {}", extent);
                 let result = if !self.is_active(job.upstairs_connection) {
                     error!(self.log, "Upstairs inactive error");
                     Err(CrucibleError::UpstairsInactive)
@@ -2019,11 +2019,12 @@ impl Downstairs {
             }
             IOop::ExtentLiveRepair {
                 dependencies: _,
-                extent: _,
+                extent,
                 source_downstairs: _,
                 source_repair_address: _,
                 repair_downstairs: _,
             } => {
+                info!(self.log, "TODO: write code to repair extent {}", extent);
                 // TODO: Implement the actual repair
                 Ok(Some(Message::ExtentLiveAckId {
                     upstairs_id: job.upstairs_connection.upstairs_id,
@@ -2266,7 +2267,8 @@ impl Downstairs {
                         .get(&currently_active_upstairs_uuids[0])
                         .unwrap();
 
-                    println!(
+                    warn!(
+                        self.log,
                         "Attempting RW takeover from {:?} to {:?}",
                         active_upstairs.upstairs_connection,
                         upstairs_connection,

--- a/tools/dtrace/upstairs_info.d
+++ b/tools/dtrace/upstairs_info.d
@@ -17,7 +17,7 @@ dtrace:::BEGIN
 tick-1s
 /show > 20/
 {
-    printf("  DS STATE 0   DS STATE 1   DS STATE 2");
+    printf("   DS STATE 0    DS STATE 1    DS STATE 2");
     printf("   UPW  DSW");
     printf("  NEW0 NEW1 NEW2");
     printf("   IP0  IP1  IP2");
@@ -34,9 +34,9 @@ crucible_upstairs*:::up-status
     /*
      * State for the three downstiars
      */
-    printf("%12s", json(copyinstr(arg1), "ok.ds_state[0]"));
-    printf(" %12s", json(copyinstr(arg1), "ok.ds_state[1]"));
-    printf(" %12s", json(copyinstr(arg1), "ok.ds_state[2]"));
+    printf("%13s", json(copyinstr(arg1), "ok.ds_state[0]"));
+    printf(" %13s", json(copyinstr(arg1), "ok.ds_state[1]"));
+    printf(" %13s", json(copyinstr(arg1), "ok.ds_state[2]"));
 
     /*
      * Work queue counts for Upstairs and Downstairs

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -593,11 +593,7 @@ where
                     })
                     .await?
                 } else {
-                    // We need to maybe send this job to the downstairs as
-                    // a no-op so dependencies for this job are met.  Or, maybe
-                    // we can move this job to "Skipped" right here?  That
-                    // seems like it's going to special case too much.
-                    // So, yeah, back to a new "noop" command idea.
+                    // TODO: Send the IOop::NoOp command here.
                 }
             }
             IOop::ExtentLiveRepair {
@@ -737,9 +733,9 @@ where
             }
             DsState::OnlineRepair => {
                 /*
-                 * Write more code here, when a downstairs is being repaired
-                 * and disconnects, we have to basically move it back to
-                 * the beginning of the line and start over, I think.
+                 * TODO: Write more code here, when a downstairs is being
+                 * repaired and disconnects, we have to basically move it back
+                 * to the beginning of the line and start over, I think.
                  * Any outstanding jobs need to be discarded, all extents
                  * that were closed need to re-open, and then the repair
                  * starts over from the beginning.  Something like that.
@@ -1516,7 +1512,11 @@ where
             }
             DsState::OnlineRepair => {
                 drop(ds);
-                // Start some task here to handle the requests
+                // TODO: Repair doing something.
+                // For repair to actually do something, there must be a
+                // responsible task started to coordinate it.  Either do
+                // that here, or signal to an existing task that it must
+                // drive the repair.
                 info!(
                     up.log,
                     "[{}] {} Enter Online Repair mode",
@@ -3625,10 +3625,12 @@ impl Downstairs {
                             extent: _,
                         }
                         | IOop::ExtentLiveNoOp { dependencies: _ } => {
-                            // Errors during repair, this is a mess, we
-                            // need to unwind this whole repair and start
-                            // over?  Or just hang?  Retry forever?  Notify
-                            // nexus?
+                            // TODO: Figure out a plan on how to handle
+                            // errors during repair.  We must invalidate
+                            // any jobs dependent on the repair success as
+                            // well as throw out the whole repair and start
+                            // over as we can no longer trust results from
+                            // the downstairs under repair.
                             panic!(
                                 "Error in repair {:?}, Write more code!",
                                 job

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -7522,7 +7522,7 @@ mod up_test {
         assert_eq!(jobs[0].ds_id, read);
         assert!(matches!(jobs[0].work, IOop::Read { .. }));
 
-        // complete and ack the read, then do another flush. this should retire
+        // complete and ack the read, then do another flush. This should retire
         // everything.
         for client_id in 0..3 {
             ds.in_progress(read, client_id);


### PR DESCRIPTION
This is the first piece of probably several to support repairing a downstairs while IO could be coming
from the guest.  This PR does not introduce the ability to repair a failed downstairs, but does provide 
the types and some of the framework that will be use to support it.

This PR should introduce no different in run time behavior of the upstairs or the downstairs.  If a
downstairs fails, it will remain in purgatory until the upstairs disconnects.

For Crucible Upstairs -> Crucible Downstairs we now have these new `Message` types
`Message::ExtentLiveClose` Close an extent, return the gen/flush/dirty info for that extent.
`Message::ExtentLiveFlushClose` Flush and close an extent, return the gen/flush/dirty info for that extent.
`Message::ExtentLiveRepair` Copy an extent from one downstairs to another.
`Message::ExtentLiveReopen` Reopen a closed extent.
`Message::ExtentLiveNoOp` Take no action other than to complete a specific job_id.

For downstairs -> upstairs we now have:
`ExtentLiveCloseAck` Returns status and the extents gen/flush/dirty at the time of close.
`ExtentLiveAckId` Returns status for a ExtentLive job.

Because repair jobs will be mixed with regular IO, we also need new `IOop` types.  These types will
flow alongside the current read/write/flush types that already exits.  
The new types are: 
`IOop::ExtentClose`. Close the given extent.
`IOop::ExtentFlushCLose` Flush and close the given extent.
`IOop::ExtentLiveRepair` Copy an extent from one downstairs to another.
`IOop::ExtentLiveReopen` Reopen a closed extent.
`IOop::ExtentLiveNoOp` Take no action other than to complete a specific job_id.

Some basic support has been added to the upstairs work queue to take `IOop` types and turn them
into the corresponding `Message::ExtentLive..` types.

Most of the support in the downstairs has been added to both take `Message::ExtentLive..` types
off the wire and then convert them into `IOop` types and put them on the work queue.
Most of the support for the downstairs to do the work of the new `IOop` types has been added and
verified via tests.  The `Message::ExtentLiveRepair` and `IOop::LiveRepair` are the places where
work is still pending.

There are several TODOs added as well.
 
Many new tests have been added to verify the new functionality of these pieces in isolation.
None of the new `Message/IOop`s are currently callable during normal operation of the upstairs or 
downstairs.