### PR TITLE
Add ability for control interface to fault a downstairs.

### DIFF
--- a/openapi/crucible-control.json
+++ b/openapi/crucible-control.json
@@ -5,6 +5,34 @@
     "version": "0.0.0"
   },
   "paths": {
+    "/downstairs/fault/{cid}": {
+      "post": {
+        "operationId": "fault_downstairs",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cid",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/info": {
       "get": {
         "summary": "Fetch the current value for all the stats in the UpstairsStats struct",


### PR DESCRIPTION
This is primarily a test interface to allow us to move a downstairs client (in the upstairs) to `DsState::Faulted` via the control interface.

For the OnlineRepair work, we need a way to trigger this without forcing a downstairs to return error (what I
was doing before this).

I expect this control interface will change in the future to be the mechanism by which we
replace a downstairs.

I added some protection to prevent accidental panics of the upstairs if the client downstairs is not
in the proper state for a transition to faulted, as well as prevent a request from an invalid client ID
from coming in.

The first post works:
```
alan@atrium$ curl -X POST http://127.0.0.1:7777/downstairs/fault/0
```
A second post will return error:
```
alan@atrium$ curl -X POST http://127.0.0.1:7777/downstairs/fault/0
{
  "request_id": "1aa31a1f-2714-4f92-b336-ea1c67d02275",
  "error_code": "InvalidState",
  "message": "downstairs 0 not in Active state"
}
```

Invalid CID will return error also:
```
alan@atrium$ curl -X POST http://127.0.0.1:7777/downstairs/fault/3
{
  "request_id": "d58bc0dc-4050-4de7-8092-54fb78076a95",
  "error_code": "BadInput",
  "message": "Invalid downstairs client id: 3"
}
```