### PR TITLE
Panic on Write/Flush error, fewer flow control messages.

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1590,10 +1590,9 @@ where
                         "[{}] exits pm_task, this downstairs faulted",
                         client_id
                     );
-                    bail!(
-                        "[{}] exits pm_task, this downstairs faulted",
-                        client_id
-                    );
+                    // Until OnlineRepair is actually supported, we are
+                    // doing more harm than good by remaining up.
+                    panic!("[{}] received Write/WU/Flush error ", client_id);
                 }
 
                 if up_c.ds_deactivate(client_id).await {
@@ -1756,16 +1755,8 @@ where
                 }
             }
             _ = sleep_until(more_work_interval), if more_work => {
-                warn!(up.log, "[{}] flow control sending more work",
-                    up_coms.client_id
-                );
-
-                let more = io_send(up, &mut fw, up_coms.client_id).await?;
-
-                if more {
-                    more_work = true;
-                } else {
-                    more_work = false;
+                more_work = io_send(up, &mut fw, up_coms.client_id).await?;
+                if !more_work {
                     warn!(up.log, "[{}] flow control end ", up_coms.client_id);
                 }
 


### PR DESCRIPTION
Turn back on (for now) a panic when we get a write or flush error from a downstairs.  This panic will be removed once the OnlineRepair work is completed.

Turned off the message about flow control continues.  We have a start and an end message, no need to spam the "its still on" message.