### PR TITLE
Writes have to depend on all in-flight jobs

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1001,6 +1001,7 @@ where
                 .await
                 .in_progress(upstairs_connection, *new_id)
                 .await?;
+
             if let Some(job_id) = job_id {
                 let m = ads
                     .lock()

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1336,7 +1336,7 @@ impl Extent {
                 // we hit the end of the iterator.
                 if cur_block == Some(prev_block + 1) {
                     // Run is continuing
-                    prev_block = prev_block + 1;
+                    prev_block += 1;
                 } else {
                     // Discontinuity or end of iteration.
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -5077,22 +5077,6 @@ impl Upstairs {
          * incorrect read. It's important to search for write dependencies in
          * the list of all active jobs.
          *
-         * Take another example. Again say that a flush was a barrier to
-         * searching for write dependencies:
-         *
-         *       block
-         * op# | 0 1 2 | deps
-         * ----|-------------
-         *   0 | W     |
-         *   1 |   W   |
-         *   2 | FFFFF | 0,1
-         *   3 | W     | 2
-         *   4 |   W   | 2
-         *
-         * Without dependencies between ops 0 and 3, and 1 and 4, there's
-         * nothing that prevents an aggressively parallel downstairs from
-         * executing these writes in the wrong order.
-         *
          * TODO: any overlap of impacted blocks will create a dependency.
          * take this an example (this shows three writes, all to the
          * same block, along with the dependency list for each

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -5056,9 +5056,42 @@ impl Upstairs {
          * Construct a list of dependencies for this write based on the
          * following rules:
          *
-         * - ignore everything that happened before the last flush
          * - writes have to depend on the last flush completing
          * - any overlap of impacted blocks requires a dependency
+         *
+         * It's important to remember that jobs may arrive at different
+         * Downstairs in different orders (they should still complete in job
+         * dependency order!). For example, say that searching for the
+         * dependency of a write stopped at the last flush. Then say that the
+         * following set of jobs were submitted:
+         *
+         *       block
+         * op# | 0 1 2 | deps
+         * ----|-------------
+         *   0 | R R   |
+         *   1 | F F F |
+         *   2 |   W W | 1
+         *
+         * Without any dependencies, a downstairs could choose to perform op 0
+         * at any time, including after the write! This would result in an
+         * incorrect read. It's important to search for write dependencies in
+         * the list of all active jobs.
+         *
+         * Take another example. Again say that a flush was a barrier to
+         * searching for write dependencies:
+         *
+         *       block
+         * op# | 0 1 2 | deps
+         * ----|-------------
+         *   0 | W     |
+         *   1 |   W   |
+         *   2 | FFFFF | 0,1
+         *   3 | W     | 2
+         *   4 |   W   | 2
+         *
+         * Without dependencies between ops 0 and 3, and 1 and 4, there's
+         * nothing that prevents an aggressively parallel downstairs from
+         * executing these writes in the wrong order.
          *
          * TODO: any overlap of impacted blocks will create a dependency.
          * take this an example (this shows three writes, all to the
@@ -5090,11 +5123,10 @@ impl Upstairs {
         {
             let job = &downstairs.ds_active[job_id];
 
-            // Depend on the last flush, then break - flushes are a barrier for
+            // Depend on the last flush - flushes are a barrier for
             // all writes.
             if job.work.is_flush() {
                 dep.push(**job_id);
-                break;
             }
 
             // If this job impacts the same blocks as something already active,

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -5994,7 +5994,7 @@ mod up_test {
         // ----|-------|-----
         //   0 | W     |
         //   1 | FFFFF | 0
-        //   2 | W     | 1
+        //   2 | W     | 0,1
 
         let upstairs = make_upstairs();
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
@@ -6036,9 +6036,12 @@ mod up_test {
             keys.iter().map(|k| ds.ds_active.get(k).unwrap()).collect();
         assert_eq!(jobs.len(), 3);
 
-        assert!(jobs[0].work.deps().is_empty());
-        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]);
-        assert_eq!(jobs[2].work.deps(), &[jobs[1].ds_id]);
+        assert!(jobs[0].work.deps().is_empty()); // write (op 0)
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // flush (op 1)
+        assert_eq!(
+            hashset(jobs[2].work.deps()),
+            hashset(&[jobs[0].ds_id, jobs[1].ds_id]),
+        ); // write (op 2)
     }
 
     #[tokio::test]
@@ -6631,9 +6634,9 @@ mod up_test {
         //   1 | W     | 0
         //   2 |   W   | 0
         //   3 | FFFFF | 0,1,2
-        //   4 | W     | 3
-        //   5 |   W   | 3
-        //   6 |     W | 3
+        //   4 | W     | 0,1,3
+        //   5 |   W   | 0,2,3
+        //   6 |     W | 0,3
         //   7 | FFFFF | 3,4,5,6
 
         let upstairs = make_upstairs();
@@ -6698,13 +6701,24 @@ mod up_test {
         assert_eq!(jobs[2].work.deps(), &vec![jobs[0].ds_id]); // write (op 2)
 
         assert_eq!(
-            hashset(jobs[3].work.deps()), // flush (op 3)
+            hashset(jobs[3].work.deps()),
             hashset(&[jobs[0].ds_id, jobs[1].ds_id, jobs[2].ds_id]),
-        );
+        ); // flush (op 3)
 
-        assert_eq!(jobs[4].work.deps(), &[jobs[3].ds_id]); // write (op 4)
-        assert_eq!(jobs[5].work.deps(), &[jobs[3].ds_id]); // write (op 5)
-        assert_eq!(jobs[6].work.deps(), &[jobs[3].ds_id]); // write (op 6)
+        assert_eq!(
+            hashset(jobs[4].work.deps()),
+            hashset(&[jobs[0].ds_id, jobs[1].ds_id, jobs[3].ds_id]),
+        ); // write (op 4)
+
+        assert_eq!(
+            hashset(jobs[5].work.deps()),
+            hashset(&[jobs[0].ds_id, jobs[2].ds_id, jobs[3].ds_id]),
+        ); // write (op 5)
+
+        assert_eq!(
+            hashset(jobs[6].work.deps()),
+            hashset(&[jobs[0].ds_id, jobs[3].ds_id]),
+        ); // write (op 6)
 
         assert_eq!(
             hashset(jobs[7].work.deps()), // flush (op 7)
@@ -7573,5 +7587,68 @@ mod up_test {
         ds.retire_check(flush);
 
         assert_eq!(ds.ds_active.keys().count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_read_flush_write_hash_mismatch() {
+        // Test that the following job dependency graph is made:
+        //
+        //     |      block     |
+        // op# | 95 96 97 98 99 | deps
+        // ----|----------------|-----
+        //   0 |  R  R          |
+        //   1 | FFFFFFFFFFFFFFF|
+        //   2 |     W  W       |
+
+        let upstairs = make_upstairs();
+        let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
+        upstairs.set_active().await.unwrap();
+
+        // op 0
+        upstairs
+            .submit_read(
+                Block::new_512(95),
+                Buffer::new(512 * 2),
+                None,
+                ds_done_tx.clone(),
+            )
+            .await
+            .unwrap();
+
+        // op 1
+        upstairs
+            .submit_flush(None, None, ds_done_tx.clone())
+            .await
+            .unwrap();
+
+        // op 2
+        upstairs
+            .submit_write(
+                Block::new_512(96),
+                Bytes::from(vec![0xff; 512 * 2]),
+                None,
+                false,
+                ds_done_tx.clone(),
+            )
+            .await
+            .unwrap();
+
+        let ds = upstairs.downstairs.lock().await;
+        let keys: Vec<&u64> = ds.ds_active.keys().sorted().collect();
+        let jobs: Vec<&DownstairsIO> =
+            keys.iter().map(|k| ds.ds_active.get(k).unwrap()).collect();
+        assert_eq!(jobs.len(), 3);
+
+        // assert read has no deps
+        assert!(jobs[0].work.deps().is_empty()); // op 0
+
+        // assert flush has no deps
+        assert!(jobs[1].work.deps().is_empty()); // op 1
+
+        // assert write depends on both the read and flush
+        assert_eq!(
+            hashset(jobs[2].work.deps()),
+            hashset(&[jobs[0].ds_id, jobs[1].ds_id])
+        ); // op 2
     }
 }

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -7598,7 +7598,7 @@ mod up_test {
         // ----|----------------|-----
         //   0 |  R  R          |
         //   1 | FFFFFFFFFFFFFFF|
-        //   2 |     W  W       |
+        //   2 |     W  W       | 0,1
 
         let upstairs = make_upstairs();
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);


### PR DESCRIPTION
`test_repair.sh` found a problem where a read job executed after a write! The current job dependency rules for writes stops searching for jobs that have overlapping blocks if a flush is seen, but this is obviously wrong: jobs may arrive at different Downstairs in different orders, or an aggressively parallel Downstairs could re-order jobs however it wants. We have to construct job dependencies so that even when this happens jobs still complete in the correct order.

When searching for write dependencies, search all in-flight jobs - do not stop looking when a flush is seen. This commit also adds a unit test for the problem that `test_repair.sh` identified.

Also fix a clippy problem in downstairs/src/region.rs.

Fixes #595