### PR TITLE
Use preadv and pwritev downstairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-staticfile",
+ "libc",
  "mime_guess",
  "omicron-common",
  "openapi-lint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ dependencies = [
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
- "memoffset",
+ "memoffset 0.6.5",
  "scopeguard",
 ]
 
@@ -672,6 +672,7 @@ name = "crucible-common"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "nix",
  "rusqlite",
  "rustls-pemfile",
  "serde",
@@ -717,8 +718,8 @@ dependencies = [
  "http",
  "hyper",
  "hyper-staticfile",
- "libc",
  "mime_guess",
+ "nix",
  "omicron-common",
  "openapi-lint",
  "openapiv3",
@@ -2027,6 +2028,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg 1.1.0",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,6 +2131,20 @@ dependencies = [
  "serde_json",
  "slog",
  "uuid 1.3.0",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]
@@ -4351,7 +4375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.6.5",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -17,3 +17,4 @@ twox-hash = "1.6.3"
 rusqlite = { version = "0.28" }
 tokio-rustls = { version = "0.23.4" }
 rustls-pemfile = { version = "1.0.2" }
+nix = { version = "0.26", features = [ "feature", "uio" ] }

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -21,7 +21,7 @@ hex = "0.4"
 http = "0.2.8"
 hyper = { version = "0.14", features = [ "full" ] }
 hyper-staticfile = "0.9"
-libc = "0.2.139"
+nix = { version = "0.26", features = [ "feature", "uio" ] }
 mime_guess = "2.0.4"
 omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -21,6 +21,7 @@ hex = "0.4"
 http = "0.2.8"
 hyper = { version = "0.14", features = [ "full" ] }
 hyper-staticfile = "0.9"
+libc = "0.2.139"
 mime_guess = "2.0.4"
 omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
 oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }


### PR DESCRIPTION
Use preadv and pwritev downstairs to reduce the number of syscalls.

This has a drastic impact in `measure_iops` results:

    $ ministat -w 60 before_iops after_iops
    x before_iops
    + after_iops
    +------------------------------------------------------------+
    |                                   +     +                  |
    |                       +           +     +                  |
    |                      ++           +     +                  |
    |                      ++           +     +              +   |
    |                    x ++           ++    ++             +   |
    |                    x ++*          *+   +*+    +        +   |
    |                 x xx ++*          *+   +*+   ++      + +   |
    |            x  xxx xx +**          *+   +*+   ++      + +   |
    |            x  xxxxxx +**          **+  +*+   ++ *    + ++x |
    |  x x      xx  xxxxxxx+** xx       **+  +**   ++**    + *+x |
    |  x x      xx  xxxxxx****xxx      +**+  +**  ++***+   ++*+x |
    |  x xx     xxx xxxxxx****xxx      +**+  +**  ++***+   ++*+* |
    | xx xxx  x xxx xxx********xx++    ***** +**+ ++****  x++*+*x|
    |xxx xxxxxxxxxx+*x*************x ++******+*** ******* **+****|
    |            |___________M__|___________AM__|_______|        |
    +------------------------------------------------------------+
        N           Min           Max        Median           Avg        Stddev
    x 200      1.379299     953.86163     381.22012     441.21303     253.10804
    + 200       226.427      950.7285     651.68335     624.39467     192.52535
    Difference at 95.0% confidence
            183.182 +/- 44.0738
            41.5177% +/- 9.98923%
            (Student's t, pooled s = 224.866)

    $ ministat -w 60 before_bw after_bw
    x before_bw
    + after_bw
    +------------------------------------------------------------+
    |                                   +     +                  |
    |                       +           +     +                  |
    |                      ++           +     +                  |
    |                      ++           +     +              +   |
    |                    x ++           ++    ++             +   |
    |                    x ++*          *+   +*+    +        +   |
    |                 x xx ++*          *+   +*+   ++      + +   |
    |            x  xxx xx +**          *+   +*+   ++      + +   |
    |            x  xxxxxx +**          **+  +*+   ++ *    + ++x |
    |  x x      xx  xxxxxxx+** xx       **+  +**   ++**    + *+x |
    |  x x      xx  xxxxxx****xxx      +**+  +**  ++***+   ++*+x |
    |  x xx     xxx xxxxxx****xxx      +**+  +**  ++***+   ++*+* |
    | xx xxx  x xxx xxx********xx++    ***** +**+ ++****  x++*+*x|
    |xxx xxxxxxxxxx+*x*************x ++******+*** ******* **+****|
    |            |___________M__|___________AM__|_______|        |
    +------------------------------------------------------------+
        N           Min           Max        Median           Avg        Stddev
    x 200      706.2011     488377.16      195184.7     225901.07     129591.32
    + 200     115930.62        486773     333661.88     319690.07      98572.98
    Difference at 95.0% confidence
            93789 +/- 22565.8
            41.5177% +/- 9.98923%
            (Student's t, pooled s = 115132)

Full measure_iops output will be posted to the PR.