### PR TITLE
Add an extent limit to the flush command

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -312,6 +312,7 @@ pub async fn show_work(ds: &mut Downstairs) {
                         flush_number: _flush_number,
                         gen_number: _gen_number,
                         snapshot_details: _,
+                        extent_limit: _,
                     } => {
                         dsw_type = "Flush".to_string();
                         dep_list = dependencies.to_vec();
@@ -567,6 +568,7 @@ where
             flush_number,
             gen_number,
             snapshot_details,
+            extent_limit,
         } => {
             if !is_message_valid(
                 upstairs_connection,
@@ -585,6 +587,7 @@ where
                 flush_number: *flush_number,
                 gen_number: *gen_number,
                 snapshot_details: snapshot_details.clone(),
+                extent_limit: *extent_limit,
             };
 
             let mut d = ad.lock().await;
@@ -1943,6 +1946,7 @@ impl Downstairs {
                 flush_number,
                 gen_number,
                 snapshot_details,
+                extent_limit,
             } => {
                 let result = if self.flush_errors && random() && random() {
                     warn!(self.log, "returning error on flush!");
@@ -1957,6 +1961,7 @@ impl Downstairs {
                             *gen_number,
                             snapshot_details,
                             job_id,
+                            *extent_limit,
                         )
                         .await
                 };
@@ -2614,6 +2619,7 @@ impl Work {
                                     flush_number: _flush_number,
                                     gen_number: _gen_number,
                                     snapshot_details: _,
+                                    extent_limit: _,
                                 } => "Flush",
                                 IOop::Read {
                                     dependencies: _,
@@ -3043,6 +3049,7 @@ mod test {
                         flush_number: 10,
                         gen_number: 0,
                         snapshot_details: None,
+                        extent_limit: None,
                     }
                 } else {
                     IOop::Read {
@@ -3098,6 +3105,7 @@ mod test {
                     flush_number: _,
                     gen_number: _,
                     snapshot_details: _,
+                    extent_limit: _,
                 }
             )
         };
@@ -3605,6 +3613,7 @@ mod test {
             flush_number: 3,
             gen_number: gen,
             snapshot_details: None,
+            extent_limit: None,
         };
         ds.add_work(upstairs_connection, 1001, rio).await?;
 
@@ -4735,7 +4744,7 @@ mod test {
         // import random_data to the region
 
         downstairs_import(&mut region, &random_file_path).await?;
-        region.region_flush(1, 1, &None, 0).await?;
+        region.region_flush(1, 1, &None, 0, None).await?;
 
         // export region to another file
 
@@ -4804,7 +4813,7 @@ mod test {
         // import random_data to the region
 
         downstairs_import(&mut region, &random_file_path).await?;
-        region.region_flush(1, 1, &None, 0).await?;
+        region.region_flush(1, 1, &None, 0, None).await?;
 
         // export region to another file (note: 100 fewer bytes imported than
         // region size still means the whole region is exported)
@@ -4887,7 +4896,7 @@ mod test {
         // import random_data to the region
 
         downstairs_import(&mut region, &random_file_path).await?;
-        region.region_flush(1, 1, &None, 0).await?;
+        region.region_flush(1, 1, &None, 0, None).await?;
 
         // export region to another file (note: 100 more bytes will have caused
         // 10 more extents to be added, but someone running the export command
@@ -4971,7 +4980,7 @@ mod test {
         // import random_data to the region
 
         downstairs_import(&mut region, &random_file_path).await?;
-        region.region_flush(1, 1, &None, 0).await?;
+        region.region_flush(1, 1, &None, 0, None).await?;
 
         // read block by block
         let mut read_data = Vec::with_capacity(total_bytes as usize);

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -233,7 +233,7 @@ async fn main() -> Result<()> {
                  * The region we just created should now have a flush so the
                  * new data and inital flush number is written to disk.
                  */
-                region.region_flush(1, 0, &None, 0).await?;
+                region.region_flush(1, 0, &None, 0, None).await?;
             }
 
             info!(log, "UUID: {:?}", region.def().uuid());

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -370,6 +370,11 @@ pub enum Message {
         flush_number: u64,
         gen_number: u64,
         snapshot_details: Option<SnapshotDetails>,
+        /*
+         * The ending extent where a flush should stop.
+         * This value is unique per downstairs.
+         */
+        extent_limit: Option<usize>,
     },
     FlushAck {
         upstairs_id: Uuid,

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -764,6 +764,7 @@ mod up_test {
             0,
             None,
             ImpactedBlocks::Empty,
+            None,
         );
 
         ds.enqueue(op, ds_done_tx.clone()).await;
@@ -830,6 +831,7 @@ mod up_test {
             0,
             None,
             ImpactedBlocks::Empty,
+            None,
         );
 
         ds.enqueue(op, ds_done_tx.clone()).await;
@@ -896,6 +898,7 @@ mod up_test {
             0,
             None,
             ImpactedBlocks::Empty,
+            None,
         );
 
         ds.enqueue(op, ds_done_tx.clone()).await;
@@ -1765,6 +1768,7 @@ mod up_test {
             0,
             None,
             ImpactedBlocks::Empty,
+            None,
         );
 
         ds.enqueue(op, ds_done_tx.clone()).await;
@@ -1901,6 +1905,7 @@ mod up_test {
             0,
             None,
             ImpactedBlocks::Empty,
+            None,
         );
         ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -2060,6 +2065,7 @@ mod up_test {
             0,
             None,
             ImpactedBlocks::Empty,
+            None,
         );
         ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -2192,6 +2198,7 @@ mod up_test {
             0,
             None,
             ImpactedBlocks::Empty,
+            None,
         );
         ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -4716,6 +4723,7 @@ mod up_test {
                 0,
                 None,
                 ImpactedBlocks::Empty,
+                None,
             );
             ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -4894,8 +4902,16 @@ mod up_test {
 
         let id = ds.next_id();
 
-        let op =
-            create_flush(id, vec![], 10, 0, 0, None, ImpactedBlocks::Empty);
+        let op = create_flush(
+            id,
+            vec![],
+            10,
+            0,
+            0,
+            None,
+            ImpactedBlocks::Empty,
+            None,
+        );
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         if make_in_progress {
@@ -5026,6 +5042,7 @@ mod up_test {
                 0,
                 None,
                 ImpactedBlocks::Empty,
+                None,
             );
             ds.enqueue(op, ds_done_tx.clone()).await;
 


### PR DESCRIPTION
Make an optional extent limit field to the flush command that will tell the downstairs to only flush a subset of extents.

What this option represents is a boundary where extent flushes will go no further.  Any extent less than this value will be issued a flush, any extent at or beyond this value will not be flushed.

The intent here is for use by the online repair process, which is still under development, so there are no actual users of this option as of yet.  When online repair is ready, the repair task will keep track of the "extent limit" and update it
as each extent on a downstairs under repair is repaired (or deemed not to need repair).

If an extent is not "dirty" then no action will be taken (just like a regular flush).