### PR TITLE
Remember a summary of completed jobs

### DIFF
--- a/openapi/crucible-control.json
+++ b/openapi/crucible-control.json
@@ -138,22 +138,16 @@
           "Acked"
         ]
       },
-      "DownstairsJobState": {
-        "description": "The Possible states of a job on a downstairs (from the point of view of the upstairs).",
-        "type": "string",
-        "enum": [
-          "New",
-          "InProgress",
-          "Done",
-          "Skipped",
-          "Error",
-          "Unknown"
-        ]
-      },
       "DownstairsWork": {
         "description": "`DownstairsWork` holds the information gathered from the downstairs",
         "type": "object",
         "properties": {
+          "completed": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkSummary"
+            }
+          },
           "jobs": {
             "type": "array",
             "items": {
@@ -162,6 +156,7 @@
           }
         },
         "required": [
+          "completed",
           "jobs"
         ]
       },
@@ -252,6 +247,31 @@
               "$ref": "#/components/schemas/DsState"
             }
           },
+          "extent_limit": {
+            "type": "array",
+            "items": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            }
+          },
+          "extents_confirmed": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            }
+          },
+          "extents_repaired": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            }
+          },
           "repair_done": {
             "type": "integer",
             "format": "uint",
@@ -274,6 +294,9 @@
         "required": [
           "ds_jobs",
           "ds_state",
+          "extent_limit",
+          "extents_confirmed",
+          "extents_repaired",
           "repair_done",
           "repair_needed",
           "state",
@@ -281,7 +304,7 @@
         ]
       },
       "WorkSummary": {
-        "description": "A summary of information from each job the downstairs has in its queue.",
+        "description": "A summary of information from a DownstairsIO struct.",
         "type": "object",
         "properties": {
           "ack_status": {
@@ -314,7 +337,7 @@
           "state": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DownstairsJobState"
+              "type": "string"
             }
           }
         },


### PR DESCRIPTION
The upstairs now keeps track of a summary of the last eight jobs it has removed from its downstairs work queue. These jobs are ones where all three downstairs have returned a result and we have ACK'd back to the guest and are removing the job from the active list.

The control "jobs" endpoint will also display the summary info for the last 8 jobs.

The code to summarize a DownstairsIO has been moved into the objects that do the summarization.
By doing this, we can use it to record a summary of a completed job without having to include large
things, like the data buffers, but still give us enough information to be useful.

In addition, I snuck in a few fields to the Downstairs struct
```
    extents_repaired: Vec<usize>,
    extents_confirmed: Vec<usize>,
    extent_limit: Vec<Option<usize>>,
```

These are not currently used for anything, but will be with the coming OnlineRepair work.