### PR TITLE
Add OnlineRepairReady state for a downstairs

### DIFF
--- a/openapi/crucible-control.json
+++ b/openapi/crucible-control.json
@@ -174,6 +174,7 @@
           "failed_repair",
           "active",
           "faulted",
+          "online_repair_ready",
           "online_repair",
           "migrating",
           "offline",


### PR DESCRIPTION
This just adds a new state for a downstairs to be in.  When we have decided we will repair a downstairs, but not yet
started the actual online repair yet, a downstairs can sit parked here. 

This is no functional change to anything yet, but will be used in the coming OnlineRepair PR.