### PR TITLE
Add --stable option to crutest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
+ "terminal_size",
 ]
 
 [[package]]
@@ -4039,6 +4040,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c9afddd2cec1c0909f06b00ef33f94ab2cc0578c4a610aa208ddfec8aa2b43a"
+dependencies = [
+ "rustix 0.36.5",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "test-strategy"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4194,7 +4205,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.4",
+ "syn 2.0.10",
 ]
 
 [[package]]

--- a/crutest/Cargo.toml
+++ b/crutest/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1"
 bincode = "1.3.3"
 bytes = "1"
-clap = { version = "4.1", features = ["derive", "env"] }
+clap = { version = "4.1", features = ["derive", "env", "wrap_help"] }
 crossterm = { version = "0.26.1" }
 crucible = { path = "../upstairs" }
 crucible-common = { path = "../common" }

--- a/upstairs/src/block_io.rs
+++ b/upstairs/src/block_io.rs
@@ -119,6 +119,7 @@ impl BlockIO for FileBlockIO {
         Ok(WQCounts {
             up_count: 0,
             ds_count: 0,
+            active_count: 0,
         })
     }
 }
@@ -291,6 +292,7 @@ impl BlockIO for ReqwestBlockIO {
         Ok(WQCounts {
             up_count: 0,
             ds_count: 0,
+            active_count: 0,
         })
     }
 }

--- a/upstairs/src/in_memory.rs
+++ b/upstairs/src/in_memory.rs
@@ -121,6 +121,7 @@ impl BlockIO for InMemoryBlockIO {
         Ok(WQCounts {
             up_count: 0,
             ds_count: 0,
+            active_count: 0,
         })
     }
 }

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -782,6 +782,7 @@ impl BlockIO for Volume {
         let mut wq_counts = WQCounts {
             up_count: 0,
             ds_count: 0,
+            active_count: 0,
         };
 
         for sub_volume in &self.sub_volumes {


### PR DESCRIPTION
The new stable option to crutest will keep crutest running until all downstairs are active and all downstairs jobs are finished and the queue is flushed.  This allows us to be sure that, when crutest ends, all downstairs were online.

To do this, the easiest way was to just and another field to the struct returned by the show_work guest call.

Also, added the wrap_help feature to clap so it would actually wrap the help output.

We can use this to build a live repair test that will wait for all downstairs to be active before quitting.