### PR TITLE
Add picture for downstairs states, remove Verifying

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4194,7 +4194,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.4",
+ "syn 2.0.10",
 ]
 
 [[package]]

--- a/openapi/crucible-control.json
+++ b/openapi/crucible-control.json
@@ -169,7 +169,6 @@
           "wait_quorum",
           "bad_region",
           "disconnected",
-          "verifying",
           "repair",
           "failed_repair",
           "active",

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -6549,9 +6549,76 @@ impl FlushInfo {
 }
 
 /*
- * States a downstairs can be in.
- * XXX This very much still under development. Most of these are place
- * holders and the final set of states will change.
+ * States of a downstairs (from the upstairs point of view).
+ *
+ * This shows the different states a downstairs can be in (from the point of
+ * view of the upstairs.
+ *
+ * Double line paths can only be taken if an upstairs is active and goes to
+ * deactivated.
+ *
+ *                       │
+ *                       ▼
+ *                       │
+ *                  ┌────┴──────┐
+ *   ┌───────┐      │           ╞═════◄══════════════════╗
+ *   │  Bad  │      │    New    ╞═════◄════════════════╗ ║
+ *   │Version├──◄───┤           ├─────◄──────┐         ║ ║
+ *   └───────┘      └────┬───┬──┘            │         ║ ║
+ *                       ▼   └───►───┐       │         ║ ║
+ *                  ┌────┴──────┐    │       │         ║ ║
+ *                  │   Wait    │    │       │         ║ ║
+ *                  │  Active   ├─►┐ │       │         ║ ║
+ *                  └────┬──────┘  │ │  ┌────┴───────┐ ║ ║
+ *   ┌───────┐      ┌────┴──────┐  │ └──┤            │ ║ ║
+ *   │  Bad  │      │   Wait    │  └────┤Disconnected│ ║ ║
+ *   │Region ├──◄───┤  Quorum   ├──►────┤            │ ║ ║
+ *   └───────┘      └────┬──────┘       └────┬───────┘ ║ ║
+ *               ........▼..........         │         ║ ║
+ *  ┌─────────┐  :  ┌────┴──────┐  :         ▲         ║ ║
+ *  │ Failed  │  :  │  Repair   │  :         │       ╔═╝ ║
+ *  │ Repair  ├─◄───┤           ├──►─────────┘       ║   ║
+ *  └─────────┘  :  └────┬──────┘  :                 ║   ║
+ *  Not Active   :       │         :                 ▲   ▲  Not Active
+ *  .............. . . . │. . . . ...................║...║............
+ *  Active               ▼                           ║   ║  Active
+ *                  ┌────┴──────┐         ┌──────────╨┐  ║
+ *              ┌─►─┤  Active   ├─────►───┤Deactivated│  ║
+ *              │   │           │  ┌──────┤           ├─◄──────┐
+ *              │   └─┬───┬───┬─┘  │      └───────────┘  ║     │
+ *              │     ▼   ▼   ▲    ▲                     ║     │
+ *              │     │   │   │    │                     ║     │
+ *              │     │   │   │    │                     ║     │
+ *              │     │   │   ▲  ┌─┘                     ║     │
+ *              │     │   │ ┌─┴──┴──┐                    ║     │
+ *              │     │   │ │Replay │                    ║     │
+ *              │     │   │ │       ├─►─┐                ║     │
+ *              │     │   │ └─┬──┬──┘   │                ║     │
+ *              │     │   ▼   ▼  ▲      │                ║     │
+ *              │     │   │   │  │      │                ▲     │
+ *              │     │ ┌─┴───┴──┴──┐   │   ┌────────────╨──┐  │
+ *              │     │ │  Offline  │   └─►─┤   Faulted     │  │
+ *              │     │ │           ├─────►─┤               │  │
+ *              │     │ └───────────┘       └─┬─┬───────┬─┬─┘  │
+ *              │     │                       ▲ ▲       ▼ ▲    ▲
+ *              │     └───────────►───────────┘ │       │ │    │
+ *              │                               │       │ │    │
+ *              │                      ┌────────┴─┐   ┌─┴─┴────┴─┐
+ *              └──────────────────────┤   Live   ├─◄─┤  Live    │
+ *                                     │  Repair  │   │  Repair  │
+ *                                     │          │   │  Ready   │
+ *                                     └──────────┘   └──────────┘
+ *
+ *
+ *      The downstairs state can go to Disabled from any other state, as that
+ *      transition happens when a message is received from the actual
+ *      downstairs on the other side of the connection..
+ *      The only path back at that point is for the Upstairs (who will self
+ *      deactivate when it detects this) is to go back to New and through
+ *      the reconcile process.
+ *      ┌───────────┐
+ *      │ Disabled  │
+ *      └───────────┘
  */
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -6583,10 +6650,6 @@ enum DsState {
      * downstairs has to go back through the whole negotiation process.
      */
     Disconnected,
-    /*
-     * Comparing downstairs for consistency.
-     */
-    Verifying,
     /*
      * Initial startup, downstairs are repairing from each other.
      */
@@ -6660,9 +6723,6 @@ impl fmt::Display for DsState {
             }
             DsState::Disconnected => {
                 write!(f, "Disconnected")
-            }
-            DsState::Verifying => {
-                write!(f, "Verifying")
             }
             DsState::Repair => {
                 write!(f, "Repair")

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -6549,9 +6549,9 @@ impl FlushInfo {
 }
 
 /*
- * States of a downstairs (from the upstairs point of view).
+ * States of a downstairs
  *
- * This shows the different states a downstairs can be in (from the point of
+ * This shows the different states a downstairs can be in from the point of
  * view of the upstairs.
  *
  * Double line paths can only be taken if an upstairs is active and goes to


### PR DESCRIPTION
Added a pretty picture of downstairs states.

Removed the `Verifying` state, as we don't use that and there are no plans to do so.