### PR TITLE
crutest use SIGUSR1 to stop tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,6 +970,8 @@ dependencies = [
  "ringbuffer",
  "serde",
  "serde_json",
+ "signal-hook",
+ "signal-hook-tokio",
  "statistical",
  "tokio",
  "tokio-util 0.7.3",

--- a/crutest/Cargo.toml
+++ b/crutest/Cargo.toml
@@ -29,6 +29,8 @@ rand_chacha = "0.3.1"
 reedline = "0.17.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
+signal-hook = "0.3.15"
 statistical = "1.0.0"
 tokio = { version = "1.27.0", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"]}

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -799,7 +799,8 @@ async fn process_cli_command(
                 )))
                 .await
             } else {
-                match generic_workload(guest, count, ri).await {
+                let mut wtq = WhenToQuit::Count { count };
+                match generic_workload(guest, &mut wtq, ri).await {
                     Ok(_) => fw.send(CliMessage::DoneOk).await,
                     Err(e) => {
                         let msg = format!("{}", e);

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -502,8 +502,12 @@ async fn load_write_log(
 // How to determine when a test will stop running.
 // Either by count, or a message over a channel.
 enum WhenToQuit {
-    Count { count: usize },
-    Signal { shutdown_rx: mpsc::Receiver<SignalAction> },
+    Count {
+        count: usize,
+    },
+    Signal {
+        shutdown_rx: mpsc::Receiver<SignalAction>,
+    },
 }
 
 #[derive(Debug)]
@@ -515,7 +519,7 @@ enum SignalAction {
 // When a signal is received, send a message over a channel.
 async fn handle_signals(
     mut signals: Signals,
-    shutdown_tx: mpsc::Sender<SignalAction>
+    shutdown_tx: mpsc::Sender<SignalAction>,
 ) {
     while let Some(signal) = signals.next().await {
         match signal {
@@ -1475,7 +1479,7 @@ async fn generic_workload(
                             bail!("Requested volume verify failed: {:?}", e)
                         }
                     }
-                    _ => {}  // Ignore everything else
+                    _ => {} // Ignore everything else
                 }
             }
         }


### PR DESCRIPTION
Added a simple signal handler for crutest that will receive a signal and, depending on that signal will send a message over a channel.

Currently there are two signals supported , `SIGUSR1` and `SIGUSR2` and only the test command `generic` supports
them.  `SIGUSR1` will send the message over the channel to stop running, and `SIGUSR2` will send the message to verify the volume.

Added a test mode, "continuous", that will run the test indefinitely.

This is inspired by the signal code in `crudd`.  By inspired I mean copied.

All of this allows us to run a test that just sends IO.
We can interrupt it to have it verify the volume (then go back to sending IO)
We can interrupt it and have it stop gracefully.
