### PR TITLE
Use try_send for ds_work_tx channel, ping dtrace probe

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -255,6 +255,7 @@ pub async fn join_all<'a>(
 mod cdt {
     use crate::Arg;
     fn up__status(_: String, arg: Arg) {}
+    fn ds__ping__sent(_: u64, _: u64) {}
     fn volume__read__start(_: u32, _: Uuid) {}
     fn volume__write__start(_: u32, _: Uuid) {}
     fn volume__writeunwritten__start(_: u32, _: Uuid) {}
@@ -1549,6 +1550,7 @@ where
     let mut more_work_interval = deadline_secs(1);
     let mut ping_interval = deadline_secs(10);
     let mut timeout_deadline = deadline_secs(50);
+    let mut ping_count = 0;
 
     /*
      * We create a task that handles messages from the downstairs (usually
@@ -1784,6 +1786,8 @@ where
                  * been idle for (TBD) seconds.
                  */
                 fw.send(Message::Ruok).await?;
+                ping_count += 1;
+                cdt::ds__ping__sent!(|| (ping_count, up_coms.client_id as u64));
 
                 if up.lossy {
                     /*
@@ -2244,6 +2248,7 @@ async fn looper(
 ) {
     let mut firstgo = true;
     let mut connected = false;
+    let mut notify = 0;
 
     let log = up.log.new(o!("looper" => up_coms.client_id.to_string()));
     'outer: loop {
@@ -2269,7 +2274,10 @@ async fn looper(
         /*
          * Set a connect timeout, and connect to the target:
          */
-        info!(log, "[{1}] connecting to {0}", target, up_coms.client_id);
+        if notify == 0 {
+            info!(log, "[{1}] connecting to {0}", target, up_coms.client_id);
+        }
+        notify = (notify + 1) % 10;
         let deadline = tokio::time::sleep_until(deadline_secs(10));
         tokio::pin!(deadline);
         let tcp = sock.connect(target);
@@ -8289,13 +8297,13 @@ struct Condition {
  * Send work to all the targets.
  * If a send fails, report an error.
  */
-async fn send_work(t: &[Target], val: u64) {
+async fn send_work(t: &[Target], val: u64, log: &Logger) {
     for (client_id, d_client) in t.iter().enumerate() {
-        let res = d_client.ds_work_tx.send(val).await;
+        let res = d_client.ds_work_tx.try_send(val);
         if let Err(e) = res {
-            println!(
-                "ERROR {:#?} Failed to notify client {} of work {}",
-                e, client_id, val,
+            warn!(
+                log,
+                "{:?} Failed to notify client {} of work {}", e, client_id, val,
             );
         }
     }
@@ -8477,7 +8485,7 @@ async fn process_new_io(
                 return;
             }
 
-            send_work(dst, *lastcast).await;
+            send_work(dst, *lastcast, &up.log).await;
             *lastcast += 1;
         }
         BlockOp::Read { offset, data } => {
@@ -8488,7 +8496,7 @@ async fn process_new_io(
             {
                 return;
             }
-            send_work(dst, *lastcast).await;
+            send_work(dst, *lastcast, &up.log).await;
             *lastcast += 1;
         }
         BlockOp::Write { offset, data } => {
@@ -8499,7 +8507,7 @@ async fn process_new_io(
             {
                 return;
             }
-            send_work(dst, *lastcast).await;
+            send_work(dst, *lastcast, &up.log).await;
             *lastcast += 1;
         }
         BlockOp::WriteUnwritten { offset, data } => {
@@ -8510,7 +8518,7 @@ async fn process_new_io(
             {
                 return;
             }
-            send_work(dst, *lastcast).await;
+            send_work(dst, *lastcast, &up.log).await;
             *lastcast += 1;
         }
         BlockOp::Flush { snapshot_details } => {
@@ -8534,7 +8542,7 @@ async fn process_new_io(
                 return;
             }
 
-            send_work(dst, *lastcast).await;
+            send_work(dst, *lastcast, &up.log).await;
             *lastcast += 1;
         }
         // Query ops
@@ -8623,7 +8631,7 @@ async fn process_new_io(
                 req.send_err(CrucibleError::UpstairsInactive).await;
                 return;
             }
-            send_work(dst, *lastcast).await;
+            send_work(dst, *lastcast, &up.log).await;
             *lastcast += 1;
         }
     }
@@ -8802,7 +8810,7 @@ async fn up_listen(
                         error!(up.log, "flush send failed:{:?}", e);
                         // XXX What to do here?
                     } else {
-                        send_work(&dst, 1).await;
+                        send_work(&dst, 1, &up.log).await;
                     }
                 }
                 /*


### PR DESCRIPTION
For sending work to downstairs client tasks, use try_send() instead of send().  This allows a full queue to not block all IOs to all downstairs.  This situation should only happen if a downstairs has gone away.

Passed the logger into send_work() so we can log a message using that instead of a printf.

Added a dtrace probe point every time the upstairs sends a ping to a downstairs.  Useful to verify that a task is still making progress when things look stuck from the outside.

This is a fix for https://github.com/oxidecomputer/crucible/issues/662