### PR TITLE
Slightly better versioning between upstairs and downstairs

### DIFF
--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -132,32 +132,68 @@ pub struct SnapshotDetails {
     pub snapshot_name: String,
 }
 
+/**
+ * Crucible Upstairs Downstairs message protocol version.
+ * Crude, but its something.  This should be changed whenever there is
+ * any change to the enum Message below.
+ */
+pub const CRUCIBLE_MESSAGE_VERSION: u32 = 2;
+
+/*
+ * If you add or change the Message enum, you must also increment the
+ * CRUCIBLE_MESSAGE_VERSION.  It's just a few lines above you, why not
+ * go do that right now before you forget.
+ */
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[repr(u16)]
 pub enum Message {
     /**
      * Initial negotiation messages
+     * This is the first message that the upstairs sends to the downstairs
+     * as soon as the connection starts.
      */
     HereIAm {
+        // The Message version the upstairs is running.
         version: u32,
+        // The UUID of the region set.
         upstairs_id: Uuid,
+        // The unique UUID just for this running upstairs session
         session_id: Uuid,
+        // Generation number (IGNORED)
         gen: u64,
+        // If we expect the region to be read-only.
         read_only: bool,
+        // If we expect the region to be  encrypted.
         encrypted: bool,
-    },
+        // Additional Message versions this upstairs supports.
+        supported_versions: Vec<u32>,
+    } = 0,
+    /**
+     * This is the first message (when things are good) that the downstairs
+     * will reply to the upstairs with.
+     */
     YesItsMe {
+        // The version the downstairs will be using.
         version: u32,
+        // The IP:Port that repair commands will use to communicate.
         repair_addr: SocketAddr,
-    },
+    } = 1,
 
-    // Reasons to reject the initial negotiation
+    /*
+     * These messages indicate that there is an incompatibility between the
+     * upstairs and the downstairs and what the problem is.
+     */
+    VersionMismatch {
+        // Version of Message this downstairs wanted.
+        version: u32,
+    } = 2,
     ReadOnlyMismatch {
         expected: bool,
-    },
+    } = 3,
     EncryptedMismatch {
         expected: bool,
-    },
+    } = 4,
 
     /**
      * Forcefully tell this downstairs to promote us (an Upstairs) to
@@ -416,6 +452,11 @@ pub enum Message {
      */
     Unknown(u32, BytesMut),
 }
+/*
+ * If you just added or changed the Message enum above, you must also
+ * increment the CRUCIBLE_MESSAGE_VERSION.  Go do that right now before you
+ * forget.
+ */
 
 #[derive(Debug)]
 pub struct CrucibleEncoder {}
@@ -696,6 +737,7 @@ mod tests {
             gen: 123,
             read_only: false,
             encrypted: true,
+            supported_versions: Vec::new(),
         };
         assert_eq!(input, round_trip(&input)?);
         Ok(())
@@ -766,6 +808,7 @@ mod tests {
             gen: 23849183,
             read_only: true,
             encrypted: false,
+            supported_versions: Vec::new(),
         };
         let mut buffer = BytesMut::new();
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -763,12 +763,13 @@ where
      * As the "client", we must begin the negotiation.
      */
     let m = Message::HereIAm {
-        version: 1,
+        version: CRUCIBLE_MESSAGE_VERSION,
         upstairs_id: up.uuid,
         session_id: up.session_id,
         gen: up.get_generation().await,
         read_only: up.read_only,
         encrypted: up.encrypted(),
+        supported_versions: vec![CRUCIBLE_MESSAGE_VERSION],
     };
     fw.send(m).await?;
 
@@ -941,22 +942,40 @@ where
                             up.encrypted(),
                         );
                     }
+                    Some(Message::VersionMismatch { version }) => {
+                        // Upstairs cannot communicate with the downstairs.
+                        up.ds_transition(
+                            up_coms.client_id, DsState::BadVersion
+                        ).await;
+                        bail!(
+                            "downstairs version is {}, ours is {}!",
+                            version,
+                            CRUCIBLE_MESSAGE_VERSION,
+                        );
+                    }
                     Some(Message::YesItsMe { version, repair_addr }) => {
                         if negotiated != 0 {
                             bail!("Got version already!");
                         }
 
                         /*
-                         * XXX Valid version to compare with should come
-                         * from main task. In the future we will also have
-                         * to handle a version mismatch.
+                         * For now, we only match on a single version and
+                         * ignore any additional supported versions.
+                         * In the future, we may support a version that
+                         * is different than ours.
                          */
-                        if version != 1 {
-                            up.ds_transition(
-                                up_coms.client_id,
-                                DsState::BadVersion
-                            ).await;
-                            bail!("expected version 1, got {}", version);
+                        match version {
+                            CRUCIBLE_MESSAGE_VERSION => {}
+                            x => {
+                                up.ds_transition(
+                                    up_coms.client_id,
+                                    DsState::BadVersion
+                                ).await;
+                                bail!("expected version {}, got {}",
+                                    CRUCIBLE_MESSAGE_VERSION,
+                                    x
+                                );
+                            }
                         }
 
                         negotiated = 1;
@@ -5591,6 +5610,15 @@ impl Upstairs {
                 // A move to Disabled can happen at any time we are talking
                 // to a downstairs.
             }
+            DsState::BadVersion => match old_state {
+                DsState::New | DsState::Disconnected => {}
+                _ => {
+                    panic!(
+                        "[{}] {} Invalid transition: {:?} -> {:?}",
+                        client_id, self.uuid, old_state, new_state
+                    );
+                }
+            },
             _ => {
                 panic!(
                     "Make a check for transition {} to {}",


### PR DESCRIPTION
This adds a slight improvement on message version checking between the upstairs and the downstairs.  We now do a little better version checking, and add a field for future use when more versions are supported.

This also makes the first official change of the message version, as several updates since the initial version have taken place, and its time to begin changing the version going forward whenever there is a change in the Message enum.

Added some basic tests to check for the version.