### PR TITLE
Add build info and version commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,12 +689,13 @@ dependencies = [
 
 [[package]]
 name = "crucible-common"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "nix",
  "rusqlite",
  "rustls-pemfile",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",
@@ -703,6 +704,7 @@ dependencies = [
  "toml 0.7.3",
  "twox-hash",
  "uuid 1.3.0",
+ "vergen",
 ]
 
 [[package]]
@@ -969,6 +971,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "reedline",
  "ringbuffer",
+ "schemars",
  "serde",
  "serde_json",
  "statistical",
@@ -2157,7 +2160,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac8cd24d9f185bb7223958d8c1ff7a961b74b1953fd05dba7cc568a63b3861ec"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.1.7",
 ]
 
 [[package]]
@@ -3435,6 +3438,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.16",
+]
+
+[[package]]
 name = "rustfmt-wrapper"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3498,9 +3510,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.6"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "rusty-fork"
@@ -3726,7 +3738,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.17",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -3884,7 +3896,7 @@ dependencies = [
  "hostname",
  "slog",
  "slog-json",
- "time 0.3.17",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -3910,7 +3922,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "time 0.3.17",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -3923,7 +3935,7 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time 0.3.17",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -4263,9 +4275,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
  "libc",
@@ -4283,9 +4295,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]
@@ -4830,6 +4842,19 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b86a8af1dedf089b1c78338678e4c7492b6045649042d94faf19690499d236"
+dependencies = [
+ "anyhow",
+ "git2",
+ "rustc_version 0.4.0",
+ "rustversion",
+ "time 0.3.20",
+]
 
 [[package]]
 name = "version_check"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "crucible-common"
-version = "0.0.0"
+version = "0.0.1"
 authors = ["Joshua M. Clulow <jmc@oxide.computer>", "Alan Hanson <alan@oxide.computer>"]
 license = "MPL-2.0"
 edition = "2021"
 
 [dependencies]
 anyhow = "1"
+schemars = { version = "0.8.12", features = [ "uuid1" ] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.7"
@@ -18,3 +19,6 @@ rusqlite = { version = "0.29" }
 tokio-rustls = { version = "0.23.4" }
 rustls-pemfile = { version = "1.0.2" }
 nix = { version = "0.26", features = [ "feature", "uio" ] }
+
+[build-dependencies]
+vergen = { version = "8.0", features = ["cargo", "git", "git2", "rustc" ] }

--- a/common/build.rs
+++ b/common/build.rs
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+use vergen::EmitBuilder;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    EmitBuilder::builder()
+        .all_cargo()
+        .all_git()
+        .all_rustc()
+        .emit()
+        .unwrap();
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 Oxide Computer Company
-use std::fs::File;
 use std::fmt;
+use std::fs::File;
 use std::hash::Hasher;
 use std::io::{ErrorKind, Read, Write};
 use std::path::Path;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,5 +1,6 @@
 // Copyright 2021 Oxide Computer Company
 use std::fs::File;
+use std::fmt;
 use std::hash::Hasher;
 use std::io::{ErrorKind, Read, Write};
 use std::path::Path;
@@ -7,6 +8,7 @@ use std::path::Path;
 use ErrorKind::NotFound;
 
 use anyhow::{anyhow, bail, Context, Result};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;
 
@@ -230,4 +232,62 @@ pub fn integrity_hash(args: &[&[u8]]) -> u64 {
         hasher.write(arg);
     }
     hasher.finish()
+}
+
+/// Detailed build information about Crucible.
+#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+pub struct BuildInfo {
+    pub version: String,
+    pub git_sha: String,
+    pub git_commit_timestamp: String,
+    pub git_branch: String,
+    pub rustc_semver: String,
+    pub rustc_channel: String,
+    pub rustc_host_triple: String,
+    pub rustc_commit_sha: String,
+    pub cargo_triple: String,
+    pub debug: bool,
+    pub opt_level: u8,
+}
+
+impl Default for BuildInfo {
+    fn default() -> Self {
+        Self {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            git_sha: env!("VERGEN_GIT_SHA").to_string(),
+            git_commit_timestamp: env!("VERGEN_GIT_COMMIT_TIMESTAMP")
+                .to_string(),
+            git_branch: env!("VERGEN_GIT_BRANCH").to_string(),
+            rustc_semver: env!("VERGEN_RUSTC_SEMVER").to_string(),
+            rustc_channel: env!("VERGEN_RUSTC_CHANNEL").to_string(),
+            rustc_host_triple: env!("VERGEN_RUSTC_HOST_TRIPLE").to_string(),
+            rustc_commit_sha: env!("VERGEN_RUSTC_COMMIT_HASH").to_string(),
+            cargo_triple: env!("VERGEN_CARGO_TARGET_TRIPLE").to_string(),
+            debug: env!("VERGEN_CARGO_DEBUG").parse().unwrap(),
+            opt_level: env!("VERGEN_CARGO_OPT_LEVEL").parse().unwrap(),
+        }
+    }
+}
+
+impl std::fmt::Display for BuildInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Crucible Version: {}\n\
+            Commit SHA: {}\n\
+            Commit timestamp: {}  branch: {}\n\
+            rustc: {} {} {}\n\
+            Cargo: {}  Debug: {} Opt level: {}",
+            self.version,
+            self.git_sha,
+            self.git_commit_timestamp,
+            self.git_branch,
+            self.rustc_semver,
+            self.rustc_channel,
+            self.rustc_host_triple,
+            self.cargo_triple,
+            self.debug,
+            self.opt_level
+        )
+    }
 }

--- a/crutest/Cargo.toml
+++ b/crutest/Cargo.toml
@@ -27,6 +27,7 @@ ringbuffer = "0.12"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 reedline = "0.17.0"
+schemars = { version = "0.8.12", features = [ "uuid1" ] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 statistical = "1.0.0"

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -21,6 +21,7 @@ mod stats;
 pub use stats::*;
 
 use crucible::*;
+use crucible_protocol::CRUCIBLE_MESSAGE_VERSION;
 
 /*
  * The various tests this program supports.
@@ -84,6 +85,7 @@ enum Workload {
     Repair,
     Span,
     Verify,
+    Version,
 }
 
 #[derive(Debug, Parser)]
@@ -509,6 +511,17 @@ async fn main() -> Result<()> {
 
     let opt = opts()?;
 
+    // If we just want the version, print that and exit.
+    if let Workload::Version = opt.workload {
+        let info = crucible_common::BuildInfo::default();
+        println!("{}", info);
+        println!(
+            "Upstairs <-> Downstairs Message Version: {}",
+            CRUCIBLE_MESSAGE_VERSION
+        );
+        return Ok(());
+    }
+
     if opt.workload == Workload::Verify && opt.verify_in.is_none() {
         bail!("Verify requires verify_in file");
     }
@@ -657,6 +670,12 @@ async fn main() -> Result<()> {
             println!("Run burst test (demo in a loop)");
             burst_workload(&guest, 460, 190, &mut region_info, &opt.verify_out)
                 .await?;
+        }
+        Workload::Cli { .. } => {
+            panic!("This case handled above");
+        }
+        Workload::CliServer { .. } => {
+            panic!("This case handled above");
         }
         Workload::Deactivate => {
             /*
@@ -886,8 +905,8 @@ async fn main() -> Result<()> {
                 }
             }
         }
-        c => {
-            panic!("Unsupported cmd {:?}", c);
+        Workload::Version => {
+            panic!("This case handled above");
         }
     }
 

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -672,10 +672,10 @@ async fn main() -> Result<()> {
                 .await?;
         }
         Workload::Cli { .. } => {
-            panic!("This case handled above");
+            unreachable!("This case handled above");
         }
         Workload::CliServer { .. } => {
-            panic!("This case handled above");
+            unreachable!("This case handled above");
         }
         Workload::Deactivate => {
             /*

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -3004,8 +3004,7 @@ pub async fn start_downstairs(
     info!(log, "Crucible Version: {}", info);
     info!(
         log,
-	"Upstairs <-> Downstairs Message Version: {}",
-	CRUCIBLE_MESSAGE_VERSION
+        "Upstairs <-> Downstairs Message Version: {}", CRUCIBLE_MESSAGE_VERSION
     );
 
     info!(log, "Using address: {:?}", local_addr);

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -3000,6 +3000,14 @@ pub async fn start_downstairs(
         let mut ds = d.lock().await;
         ds.address = Some(local_addr);
     }
+    let info = crucible_common::BuildInfo::default();
+    info!(log, "Crucible Version: {}", info);
+    info!(
+        log,
+	"Upstairs <-> Downstairs Message Version: {}",
+	CRUCIBLE_MESSAGE_VERSION
+    );
+
     info!(log, "Using address: {:?}", local_addr);
 
     let repair_address = match address {

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 
 use crucible_downstairs::admin::*;
 use crucible_downstairs::*;
+use crucible_protocol::CRUCIBLE_MESSAGE_VERSION;
 
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -181,6 +182,7 @@ enum Args {
         #[clap(long, default_value = "127.0.0.1:4567", action)]
         bind_addr: SocketAddr,
     },
+    Version,
 }
 
 #[tokio::main]
@@ -387,6 +389,15 @@ async fn main() -> Result<()> {
             }
 
             run_dropshot(bind_addr, &log).await
+        }
+        Args::Version => {
+            let info = crucible_common::BuildInfo::default();
+            println!("Crucible Version: {}", info);
+            println!(
+                "Upstairs <-> Downstairs Message Version: {}",
+                CRUCIBLE_MESSAGE_VERSION
+            );
+            Ok(())
         }
     }
 }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -8893,8 +8893,7 @@ pub async fn up_main(
     info!(log, "Crucible Version: {:#?}", info);
     info!(
         log,
-        "Upstairs <-> Downstairs Message Version: {}",
-        CRUCIBLE_MESSAGE_VERSION
+        "Upstairs <-> Downstairs Message Version: {}", CRUCIBLE_MESSAGE_VERSION
     );
 
     /*

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -8889,6 +8889,13 @@ pub async fn up_main(
     }
     let log = Logger::root(drain.fuse(), o!());
     info!(log, "Upstairs starts");
+    let info = crucible_common::BuildInfo::default();
+    info!(log, "Crucible Version: {:#?}", info);
+    info!(
+        log,
+        "Upstairs <-> Downstairs Message Version: {}",
+        CRUCIBLE_MESSAGE_VERSION
+    );
 
     /*
      * Build the Upstairs struct that we use to share data between


### PR DESCRIPTION
Added build info information to upstairs and downstairs binaries.
Added version commands to the downstairs and crutest that will display the current
build info and upstairs <-> downstairs message version.

Log the build and message version info when upstairs or downstairs starts up.

# Example output
Version commands crutest:
```
final:version$ ./target/release/crutest version
Crucible Version: 0.0.1
Commit SHA: 9985a4c6ef4c1df98988b28783b174093529c477
Commit timestamp: 2023-04-28T15:01:02.000000000Z  branch: main
rustc: 1.66.1 stable x86_64-apple-darwin
Cargo: x86_64-apple-darwin  Debug: false Opt level: 3
Upstairs <-> Downstairs Message Version: 2
```

Version command for crucible-downstairs
```
final:version$ ./target/release/crucible-downstairs version
Crucible Version: Crucible Version: 0.0.1
Commit SHA: 9985a4c6ef4c1df98988b28783b174093529c477
Commit timestamp: 2023-04-28T15:01:02.000000000Z  branch: main
rustc: 1.66.1 stable x86_64-apple-darwin
Cargo: x86_64-apple-darwin  Debug: false Opt level: 3
Upstairs <-> Downstairs Message Version: 2
```

When upstairs starts, it will now log version info:
```
final:version$ ./target/release/crutest one -t 127.0.0.1:8810 -t 127.0.0.1:8820 -t 127.0.0.1:8830 -q
May 01 17:34:49.633 INFO Upstairs starts
May 01 17:34:49.633 INFO Crucible Version: BuildInfo {
    version: "0.0.1",
    git_sha: "9985a4c6ef4c1df98988b28783b174093529c477",
    git_commit_timestamp: "2023-04-28T15:01:02.000000000Z",
    git_branch: "main",
    rustc_semver: "1.66.1",
    rustc_channel: "stable",
    rustc_host_triple: "x86_64-apple-darwin",
    rustc_commit_sha: "90743e7298aca107ddaa0c202a4d3604e29bfeb6",
    cargo_triple: "x86_64-apple-darwin",
    debug: false,
    opt_level: 3,
}
May 01 17:34:49.633 INFO Upstairs <-> Downstairs Message Version: 2
May 01 17:34:49.633 INFO Crucible stats registered with UUID: c8673341-06a2-4185-a4ca-b5ca76f7624c
Crucible runtime is spawned
May 01 17:34:49.633 INFO Crucible c8673341-06a2-4185-a4ca-b5ca76f7624c has session id: 0cb0b065-f5f0-4ac7-8d80-53137ccc3371
The guest has requested activation with gen:0
May 01 17:34:49.633 INFO up_listen starts, task: up_listen
May 01 17:34:49.634 INFO Wait for all three downstairs to come online
May 01 17:34:49.634 INFO Flush timeout: 5
May 01 17:34:49.634 INFO c8673341-06a2-4185-a4ca-b5ca76f7624c active request set
May 01 17:34:49.634 INFO Set desired generation to :0
May 01 17:34:49.634 INFO [2] connecting to 127.0.0.1:8830, looper: 2
May 01 17:34:49.634 INFO [0] connecting to 127.0.0.1:8810, looper: 0
May 01 17:34:49.640 INFO [1] connecting to 127.0.0.1:8820, looper: 1
```

When downstairs start up, it prints this:
```
May 01 17:18:02.555 INFO Opened existing region file "/var/tmp/dsc/region/8810/region.json"
May 01 17:18:02.583 INFO UUID: 12345678-0000-0000-0000-000000008810
May 01 17:18:02.583 INFO Blocks per extent:100 Total Extents: 15
May 01 17:18:02.583 INFO Crucible Version: Crucible Version: 0.0.1
Commit SHA: 9985a4c6ef4c1df98988b28783b174093529c477
Commit timestamp: 2023-04-28T15:01:02.000000000Z  branch: main
rustc: 1.66.1 stable x86_64-apple-darwin
Cargo: x86_64-apple-darwin  Debug: false Opt level: 3, task: main
May 01 17:18:02.583 INFO Upstairs <-> Downstairs Message Version: 2, task: main
May 01 17:18:02.583 INFO Using address: 0.0.0.0:8810, task: main
May 01 17:18:02.583 INFO Repair listens on 0.0.0.0:12810, task: repair
May 01 17:18:02.584 INFO listening, local_addr: 0.0.0.0:12810, task: repair
May 01 17:18:02.584 INFO Using repair address: 0.0.0.0:12810, task: main
May 01 17:18:02.584 INFO No SSL acceptor configured, task: main
May 01 17:18:02.584 INFO listening on 0.0.0.0:8810, task: main
```