### PR TITLE
Give up on a downstairs

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -5544,6 +5544,7 @@ impl Upstairs {
                     | DsState::Repair
                     | DsState::OnlineRepair
                     | DsState::OnlineRepairReady
+                    | DsState::Offline
                     | DsState::Replay => {} /* Okay */
                     _ => {
                         panic!(

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -8494,10 +8494,13 @@ async fn gone_too_long(up: &Arc<Upstairs>) {
             | DsState::OnlineRepair
             | DsState::Offline
             | DsState::Replay => {
-                if ds.total_live_work(cid) > IO_OUTSTANDING_MAX {
+                let work_count = ds.total_live_work(cid);
+                if work_count > IO_OUTSTANDING_MAX {
                     warn!(
                         up.log,
-                        "[up] downstairs {} is too far behind, -> failed", cid,
+                        "[up] downstairs {} failed, too many outstanding jobs {}",
+                        work_count,
+                        cid,
                     );
                     ds.ds_set_faulted(cid);
                     up.ds_transition_with_lock(


### PR DESCRIPTION
# Giving up on a downstairs

At present, crucible never gives up on a downstairs, and will queue IOs forever.
This is a first pass attempt at giving up on a downstairs, so we don't eat all available
ram on the system while holding IOs.

We do this by watching the outstanding IOs for each downstairs and, if we have too 
many IOs not completed, mark the downstairs as faulted.  This results in all IOs to
that downstairs being "skipped" and requires repair or restart of the upstairs to
allow that downstairs to be part of the region set again.

Too many is currently defined as 1000, and that will probably be tuned further.