### PR TITLE
Make agent and pantry use bunyan format for logs

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::needless_collect)]
 use anyhow::{anyhow, bail, Result};
 use clap::Parser;
-use dropshot::{ConfigLogging, ConfigLoggingLevel};
+use dropshot::{ConfigLogging, ConfigLoggingIfExists, ConfigLoggingLevel};
 use slog::{error, info, o, warn, Logger};
 use std::collections::HashSet;
 use std::io::Write;
@@ -214,8 +214,10 @@ async fn main() -> Result<()> {
             downstairs_prefix,
             snapshot_prefix,
         } => {
-            let log = ConfigLogging::StderrTerminal {
+            let log = ConfigLogging::File {
                 level: ConfigLoggingLevel::Info,
+                path: "/dev/stdout".into(),
+                if_exists: ConfigLoggingIfExists::Append,
             }
             .to_logger(PROG)?;
 

--- a/downstairs/src/stats.rs
+++ b/downstairs/src/stats.rs
@@ -1,7 +1,9 @@
 // Copyright 2021 Oxide Computer Company
 use super::*;
 
-use dropshot::{ConfigDropshot, ConfigLogging, ConfigLoggingLevel};
+use dropshot::{
+    ConfigDropshot, ConfigLogging, ConfigLoggingIfExists, ConfigLoggingLevel,
+};
 use omicron_common::api::internal::nexus::ProducerEndpoint;
 use oximeter::{
     types::{Cumulative, Sample},
@@ -141,8 +143,10 @@ pub async fn ox_stats(
         request_body_max_bytes: 2048,
         tls: None,
     };
-    let logging_config = ConfigLogging::StderrTerminal {
+    let logging_config = ConfigLogging::File {
         level: ConfigLoggingLevel::Error,
+        path: "/dev/stdout".into(),
+        if_exists: ConfigLoggingIfExists::Append,
     };
 
     let server_info = ProducerEndpoint {

--- a/pantry/src/lib.rs
+++ b/pantry/src/lib.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use dropshot::{ConfigLogging, ConfigLoggingLevel};
+use dropshot::{ConfigLogging, ConfigLoggingIfExists, ConfigLoggingLevel};
 use slog::{o, Logger};
 
 pub const PROG: &str = "crucible-pantry";
@@ -12,8 +12,10 @@ pub mod pantry;
 pub mod server;
 
 pub async fn initialize_pantry() -> Result<(Logger, Arc<pantry::Pantry>)> {
-    let log = ConfigLogging::StderrTerminal {
+    let log = ConfigLogging::File {
         level: ConfigLoggingLevel::Info,
+        path: "/dev/stdout".into(),
+        if_exists: ConfigLoggingIfExists::Append,
     }
     .to_logger(PROG)?;
 


### PR DESCRIPTION
Update agent any pantry to use the `ConfigLogging::File` for logging to be consistent with the rest of the control plane.

In answer to: https://github.com/oxidecomputer/crucible/issues/729
