### PR TITLE
up_main take a log option, Block on logging by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,12 +676,18 @@ name = "crucible-common"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "atty",
  "nix",
  "rusqlite",
  "rustls-pemfile",
  "schemars",
  "serde",
  "serde_json",
+ "slog",
+ "slog-async",
+ "slog-bunyan",
+ "slog-dtrace",
+ "slog-term",
  "tempfile",
  "thiserror",
  "tokio-rustls",
@@ -3935,9 +3941,9 @@ dependencies = [
 
 [[package]]
 name = "slog-dtrace"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a37d13a54955d22a120656475baa60bb10462646378fadeaad840fc5f7d396c"
+checksum = "ebb79013d51afb48c5159d62068658fa672772be3aeeadee0d2710fb3903f637"
 dependencies = [
  "chrono",
  "serde",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,18 +7,24 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
+atty = "0.2.14"
+nix = { version = "0.26", features = [ "feature", "uio" ] }
+rusqlite = { version = "0.29" }
+rustls-pemfile = { version = "1.0.2" }
 schemars = { version = "0.8.12", features = [ "uuid1" ] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-toml = "0.7"
+slog = "2.7"
+slog-async = "2.7"
+slog-bunyan = "2.4.0"
+slog-dtrace = "0.2.3"
+slog-term = "2.8"
 tempfile = "3"
 thiserror = "1.0"
-uuid = { version = "1.3.2", features = [ "serde", "v4" ] }
-twox-hash = "1.6.3"
-rusqlite = { version = "0.29" }
 tokio-rustls = { version = "0.23.4" }
-rustls-pemfile = { version = "1.0.2" }
-nix = { version = "0.26", features = [ "feature", "uio" ] }
+toml = "0.7"
+twox-hash = "1.6.3"
+uuid = { version = "1.3.2", features = [ "serde", "v4" ] }
 
 [build-dependencies]
 vergen = { version = "8.0", features = ["cargo", "git", "git2", "rustc" ] }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -10,6 +10,7 @@ use ErrorKind::NotFound;
 use anyhow::{anyhow, bail, Context, Result};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use slog::Drain;
 use tempfile::NamedTempFile;
 
 mod region;
@@ -290,4 +291,39 @@ impl std::fmt::Display for BuildInfo {
             self.opt_level
         )
     }
+}
+
+/**
+ * A common logger setup for all to use.
+ */
+pub fn build_logger() -> slog::Logger {
+    let main_drain = if atty::is(atty::Stream::Stdout) {
+        let decorator = slog_term::TermDecorator::new().build();
+        let drain = slog_term::FullFormat::new(decorator).build().fuse();
+        slog_async::Async::new(drain)
+            .overflow_strategy(slog_async::OverflowStrategy::Block)
+            .build_no_guard()
+    } else {
+        let drain = slog_bunyan::with_name("crucible", std::io::stdout())
+            .build()
+            .fuse();
+        slog_async::Async::new(drain)
+            .overflow_strategy(slog_async::OverflowStrategy::Block)
+            .build_no_guard()
+    };
+
+    let (dtrace_drain, probe_reg) = slog_dtrace::Dtrace::new();
+
+    let filtered_main = slog::LevelFilter::new(main_drain, slog::Level::Info);
+
+    let log = slog::Logger::root(
+        slog::Duplicate::new(filtered_main.fuse(), dtrace_drain.fuse()).fuse(),
+        slog::o!(),
+    );
+
+    if let slog_dtrace::ProbeRegistration::Failed(err) = probe_reg {
+        slog::error!(&log, "Error registering slog-dtrace probes: {:?}", err);
+    }
+
+    log
 }

--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -565,7 +565,8 @@ async fn main() -> Result<()> {
     let guest = Arc::new(Guest::new());
 
     let _join_handle =
-        up_main(crucible_opts, opt.gen, None, guest.clone(), None).await?;
+        up_main(crucible_opts, opt.gen, None, guest.clone(), None, None)
+            .await?;
     eprintln!("Crucible runtime is spawned");
 
     // IO time

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -636,7 +636,7 @@ async fn main() -> Result<()> {
     }
 
     let _join_handle =
-        up_main(crucible_opts, opt.gen, None, guest.clone(), pr).await?;
+        up_main(crucible_opts, opt.gen, None, guest.clone(), pr, None).await?;
     println!("Crucible runtime is spawned");
 
     if let Workload::CliServer { listen, port } = opt.workload {

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -15,20 +15,18 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crucible::*;
-use crucible_common::{Block, CrucibleError, MAX_BLOCK_SIZE};
+use crucible_common::{build_logger, Block, CrucibleError, MAX_BLOCK_SIZE};
 
 use anyhow::{bail, Result};
 use bytes::BytesMut;
 use futures::{SinkExt, StreamExt};
 use rand::prelude::*;
-use slog::{error, info, o, warn, Drain, Logger};
-use slog_dtrace::{with_drain, ProbeRegistration};
+use slog::{error, info, o, warn, Logger};
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::time::{sleep_until, Instant};
 use tokio_util::codec::{FramedRead, FramedWrite};
-use usdt::register_probes;
 use uuid::Uuid;
 
 pub mod admin;
@@ -2904,21 +2902,7 @@ pub async fn build_downstairs_for_region(
 ) -> Result<Arc<Mutex<Downstairs>>> {
     let log = match log_request {
         Some(log) => log,
-        None => {
-            // Register DTrace, and setup slog logging to use it.
-            register_probes().unwrap();
-            let decorator = slog_term::TermDecorator::new().build();
-            let drain = slog_term::FullFormat::new(decorator)
-                .build()
-                .filter_level(slog::Level::Info)
-                .fuse();
-            let drain = slog_async::Async::new(drain).build().fuse();
-            let (drain, registration) = with_drain(drain);
-            if let ProbeRegistration::Failed(ref e) = registration {
-                panic!("Failed to register probes: {:#?}", e);
-            }
-            Logger::root(drain.fuse(), o!())
-        }
+        None => build_logger(),
     };
     let region =
         Region::open(data, Default::default(), true, read_only, &log).await?;
@@ -3127,8 +3111,7 @@ mod test {
 
     // Create a simple logger
     fn csl() -> Logger {
-        let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
-        Logger::root(slog_term::FullFormat::new(plain).build().fuse(), o!())
+        build_logger()
     }
 
     fn add_work(

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -2531,8 +2531,7 @@ mod test {
 
     // Create a simple logger
     fn csl() -> Logger {
-        let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
-        Logger::root(slog_term::FullFormat::new(plain).build().fuse(), o!())
+        build_logger()
     }
 
     fn new_region_options() -> crucible_common::RegionOptions {

--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -271,8 +271,7 @@ mod test {
 
     // Create a simple logger
     fn csl() -> Logger {
-        let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
-        Logger::root(slog_term::FullFormat::new(plain).build().fuse(), o!())
+        build_logger()
     }
 
     #[tokio::test]

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -133,9 +133,15 @@ async fn main() -> Result<()> {
         let guest = Arc::new(Guest::new());
 
         let gen: u64 = i as u64 + opt.gen;
-        let _join_handle =
-            up_main(crucible_opts.clone(), gen, None, guest.clone(), None)
-                .await?;
+        let _join_handle = up_main(
+            crucible_opts.clone(),
+            gen,
+            None,
+            guest.clone(),
+            None,
+            None,
+        )
+        .await?;
         println!("Crucible runtime is spawned");
 
         cpfs.push(crucible::CruciblePseudoFile::from(guest)?);

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -2149,7 +2149,7 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None).await?;
+        let _join_handle = up_main(opts, 1, None, gc, None, None).await?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -2193,7 +2193,7 @@ mod test {
         let gc = guest.clone();
 
         // Read-only Upstairs should return errors if writes are attempted.
-        let _join_handle = up_main(opts, 1, None, gc, None).await?;
+        let _join_handle = up_main(opts, 1, None, gc, None, None).await?;
 
         guest.activate().await?;
 
@@ -2227,7 +2227,7 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None).await?;
+        let _join_handle = up_main(opts, 1, None, gc, None, None).await?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -2300,7 +2300,7 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None).await?;
+        let _join_handle = up_main(opts, 1, None, gc, None, None).await?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -2358,7 +2358,7 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None).await?;
+        let _join_handle = up_main(opts, 1, None, gc, None, None).await?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -2417,7 +2417,7 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None).await?;
+        let _join_handle = up_main(opts, 1, None, gc, None, None).await?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -2474,7 +2474,7 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None).await?;
+        let _join_handle = up_main(opts, 1, None, gc, None, None).await?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -2531,7 +2531,7 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None).await?;
+        let _join_handle = up_main(opts, 1, None, gc, None, None).await?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -2586,7 +2586,8 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None).await.unwrap();
+        let _join_handle =
+            up_main(opts, 1, None, gc, None, None).await.unwrap();
 
         guest.activate().await.unwrap();
 
@@ -2622,7 +2623,8 @@ mod test {
         let guest = Arc::new(Guest::new());
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None).await.unwrap();
+        let _join_handle =
+            up_main(opts, 1, None, gc, None, None).await.unwrap();
 
         guest.activate().await.unwrap();
 

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -105,7 +105,8 @@ async fn main() -> Result<()> {
 
     let guest = Arc::new(guest);
     let _join_handle =
-        up_main(crucible_opts, opt.gen, None, guest.clone(), None).await?;
+        up_main(crucible_opts, opt.gen, None, guest.clone(), None, None)
+            .await?;
     println!("Crucible runtime is spawned");
 
     guest.activate().await?;

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -94,7 +94,8 @@ async fn main() -> Result<()> {
     let guest = Arc::new(Guest::new());
 
     let _join_handle =
-        up_main(crucible_opts, opt.gen, None, guest.clone(), None).await?;
+        up_main(crucible_opts, opt.gen, None, guest.clone(), None, None)
+            .await?;
     println!("Crucible runtime is spawned");
 
     // NBD server

--- a/upstairs/src/mend.rs
+++ b/upstairs/src/mend.rs
@@ -378,8 +378,7 @@ mod test {
 
     // Create a simple logger
     fn csl() -> Logger {
-        let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
-        Logger::root(slog_term::FullFormat::new(plain).build().fuse(), o!())
+        build_logger()
     }
 
     #[test]

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -22,8 +22,7 @@ mod up_test {
 
     // Create a simple logger
     fn csl() -> Logger {
-        let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
-        Logger::root(slog_term::FullFormat::new(plain).build().fuse(), o!())
+        build_logger()
     }
 
     fn extent_tuple(eid: u64, offset: u64) -> (u64, Block) {

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -174,6 +174,7 @@ impl Volume {
             Some(region_def),
             guest_clone,
             producer_registry,
+            None,
         )
         .await?;
 


### PR DESCRIPTION
Update up_main to take an option Logger arg and use that instead of creating its own logger.

Made a generic build_logger function (stolen from propolis) that everyone can use.  This build_logger will not drop logging messages if too many are received and instead will force back pressure on whatever is generating the logs.

Part of what we want for: https://github.com/oxidecomputer/crucible/issues/735