### PR TITLE
remove std::panic::set_hook in upstairs test

### DIFF
--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -353,12 +353,6 @@ pub(crate) mod protocol_test {
 
     impl TestHarness {
         pub async fn new() -> TestHarness {
-            let default_panic = std::panic::take_hook();
-            std::panic::set_hook(Box::new(move |info| {
-                default_panic(info);
-                std::process::exit(1);
-            }));
-
             let log = csl();
 
             let ds1 = Downstairs::new(log.new(o!("downstairs" => 1))).await;


### PR DESCRIPTION
this causes intermittent failures, racing against #[should_panic] tests