### PR TITLE
Test live repair using dummy downstairs

### DIFF
--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -19,10 +19,16 @@ pub(crate) mod protocol_test {
     use crucible_common::RegionOptions;
     use crucible_protocol::CrucibleDecoder;
     use crucible_protocol::CrucibleEncoder;
-
     use crucible_protocol::Message;
+
+    use bytes::Bytes;
+    use bytes::BytesMut;
     use futures::SinkExt;
     use futures::StreamExt;
+    use slog::error;
+    use slog::info;
+    use slog::o;
+    use slog::Logger;
     use std::net::SocketAddr;
     use tokio::net::TcpListener;
     use tokio::sync::mpsc;
@@ -31,12 +37,6 @@ pub(crate) mod protocol_test {
     use tokio::task::JoinHandle;
     use tokio_util::codec::FramedRead;
     use tokio_util::codec::FramedWrite;
-
-    use slog::info;
-    use slog::o;
-    use slog::Logger;
-
-    use bytes::BytesMut;
     use uuid::Uuid;
 
     pub struct Downstairs {
@@ -204,6 +204,8 @@ pub(crate) mod protocol_test {
                     session_id,
                     gen,
                 } => {
+                    assert!(*gen == 1);
+
                     info!(self.inner.log, "negotiate packet {:?}", packet);
 
                     // Record the session id the upstairs sent us
@@ -343,7 +345,7 @@ pub(crate) mod protocol_test {
     }
 
     pub struct TestHarness {
-        _log: Logger,
+        log: Logger,
         ds1: Mutex<Option<Arc<ConnectedDownstairs>>>,
         ds2: Arc<ConnectedDownstairs>,
         ds3: Arc<ConnectedDownstairs>,
@@ -429,7 +431,7 @@ pub(crate) mod protocol_test {
             assert!(guest.query_is_active().await.unwrap());
 
             TestHarness {
-                _log: log,
+                log,
                 ds1: Mutex::new(Some(ds1)),
                 ds2,
                 ds3,
@@ -462,6 +464,15 @@ pub(crate) mod protocol_test {
                 encryption_context: None,
             }],
         }
+    }
+
+    /// Filter the first element that matches some predicate out of a list
+    pub fn filter_out<T, P>(l: &mut Vec<T>, pred: P) -> Option<T>
+    where
+        P: FnMut(&T) -> bool,
+    {
+        let idx = l.iter().position(pred);
+        idx.map(|i| l.remove(i))
     }
 
     /// Test that flow control kicks in at 100 jobs, and until the downstairs
@@ -710,5 +721,1000 @@ pub(crate) mod protocol_test {
         }
 
         assert_eq!(ds1_message, ds1_message_second_time.unwrap());
+    }
+
+    /// Test that after giving up on a downstairs, setting it to faulted, and
+    /// letting it reconnect, live repair occurs. Check that each extent is
+    /// repaired with the correct source, and that extent limits are honoured if
+    /// additional IO comes through.
+    #[tokio::test]
+    async fn test_successful_live_repair() {
+        let harness = Arc::new(TestHarness::new().await);
+
+        let (jh1, mut ds1_messages) =
+            harness.ds1().await.spawn_message_receiver().await;
+        let (_jh2, mut ds2_messages) =
+            harness.ds2.spawn_message_receiver().await;
+        let (_jh3, mut ds3_messages) =
+            harness.ds3.spawn_message_receiver().await;
+
+        // Send 1200 jobs. Flow control will kick in at 100 messages, so we need
+        // to be sending read responses while reads are being sent. After 1000
+        // jobs, the Upstairs will set ds1 to faulted, and send it no more work.
+        let mut job_ids = Vec::with_capacity(1200);
+
+        for i in 0..1200 {
+            info!(harness.log, "sending read {}", i);
+
+            {
+                let harness = harness.clone();
+
+                // We must tokio::spawn here because `read` will wait for the
+                // response to come back before returning
+                tokio::spawn(async move {
+                    let buffer = Buffer::new(512);
+                    harness
+                        .guest
+                        .read(Block::new_512(0), buffer)
+                        .await
+                        .unwrap();
+                });
+            }
+
+            if i < 100 {
+                // Before flow control kicks in, assert we're seeing the read
+                // requests
+                assert!(matches!(
+                    ds1_messages.recv().await.unwrap(),
+                    Message::ReadRequest { .. },
+                ));
+            } else {
+                // After flow control kicks in, we shouldn't see any more
+                // messages
+                assert!(matches!(
+                    ds1_messages.try_recv(),
+                    Err(TryRecvError::Empty)
+                ));
+            }
+
+            match ds2_messages.recv().await.unwrap() {
+                Message::ReadRequest { job_id, .. } => {
+                    // Record the job ids of the read requests
+                    job_ids.push(job_id);
+                }
+
+                _ => panic!("saw non read request!"),
+            }
+
+            assert!(matches!(
+                ds3_messages.recv().await.unwrap(),
+                Message::ReadRequest { .. },
+            ));
+
+            // Respond with read responses for downstairs 2 and 3
+            harness
+                .ds2
+                .fw
+                .lock()
+                .await
+                .send(Message::ReadResponse {
+                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
+                    session_id: harness
+                        .ds2
+                        .upstairs_session_id
+                        .lock()
+                        .await
+                        .unwrap(),
+                    job_id: job_ids[i],
+                    responses: Ok(vec![make_blank_read_response()]),
+                })
+                .await
+                .unwrap();
+
+            harness
+                .ds3
+                .fw
+                .lock()
+                .await
+                .send(Message::ReadResponse {
+                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
+                    session_id: harness
+                        .ds3
+                        .upstairs_session_id
+                        .lock()
+                        .await
+                        .unwrap(),
+                    job_id: job_ids[i],
+                    responses: Ok(vec![make_blank_read_response()]),
+                })
+                .await
+                .unwrap();
+        }
+
+        // Confirm that's all the Upstairs sent us (only ds2 and ds3) - with the
+        // flush_timeout set to five minutes, we shouldn't see anything else
+        assert!(matches!(ds2_messages.try_recv(), Err(TryRecvError::Empty)));
+        assert!(matches!(ds3_messages.try_recv(), Err(TryRecvError::Empty)));
+
+        // Flush to clean out skipped jobs
+        {
+            let jh = {
+                let harness = harness.clone();
+
+                // We must tokio::spawn here because `flush` will wait for the
+                // response to come back before returning
+                tokio::spawn(async move {
+                    harness.guest.flush(None).await.unwrap();
+                })
+            };
+
+            let flush_job_id = match ds2_messages.recv().await.unwrap() {
+                Message::Flush { job_id, .. } => job_id,
+
+                _ => panic!("saw non flush ack!"),
+            };
+
+            assert!(matches!(
+                ds3_messages.recv().await.unwrap(),
+                Message::Flush { .. },
+            ));
+
+            harness
+                .ds2
+                .fw
+                .lock()
+                .await
+                .send(Message::FlushAck {
+                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
+                    session_id: harness
+                        .ds2
+                        .upstairs_session_id
+                        .lock()
+                        .await
+                        .unwrap(),
+                    job_id: flush_job_id,
+                    result: Ok(()),
+                })
+                .await
+                .unwrap();
+
+            harness
+                .ds3
+                .fw
+                .lock()
+                .await
+                .send(Message::FlushAck {
+                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
+                    session_id: harness
+                        .ds3
+                        .upstairs_session_id
+                        .lock()
+                        .await
+                        .unwrap(),
+                    job_id: flush_job_id,
+                    result: Ok(()),
+                })
+                .await
+                .unwrap();
+
+            // Wait for the flush to come back
+            jh.await.unwrap();
+        }
+
+        // Send ds1 responses for the jobs it saw
+        for (i, job_id) in job_ids.iter().enumerate().take(100) {
+            match harness
+                .ds1()
+                .await
+                .fw
+                .lock()
+                .await
+                .send(Message::ReadResponse {
+                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
+                    session_id: harness
+                        .ds1()
+                        .await
+                        .upstairs_session_id
+                        .lock()
+                        .await
+                        .unwrap(),
+                    job_id: *job_id,
+                    responses: Ok(vec![make_blank_read_response()]),
+                })
+                .await
+            {
+                Ok(()) => {
+                    info!(
+                        harness.log,
+                        "sent read response for job {} = {}", i, job_id,
+                    );
+                }
+
+                Err(e) => {
+                    // We should be able to send a few, but at some point
+                    // the Upstairs will disconnect us.
+                    error!(
+                        harness.log,
+                        "could not send read response for job {} = {}: {}",
+                        i,
+                        job_id,
+                        e
+                    );
+                    break;
+                }
+            }
+        }
+
+        // Assert the Upstairs isn't sending ds1 more work, because it is
+        // Faulted
+        assert!(matches!(ds1_messages.try_recv(), Err(TryRecvError::Empty)));
+
+        // Reconnect ds1
+        drop(ds1_messages);
+        jh1.abort();
+
+        let ds1 = harness.take_ds1().await;
+        let ds1 = ds1.close();
+        let ds1 = ds1.into_connected_downstairs().await;
+
+        ds1.negotiate_start().await;
+        ds1.negotiate_step_extent_versions_please().await;
+
+        let (_jh1, mut ds1_messages) = ds1.spawn_message_receiver().await;
+
+        // The Upstairs will start sending LiveRepair related work, which may be
+        // out of order. Buffer some here.
+
+        let mut ds1_buffered_messages = vec![];
+        let mut ds2_buffered_messages = vec![];
+        let mut ds3_buffered_messages = vec![];
+
+        for eid in 0..10 {
+            // The Upstairs first sends the close and reopen jobs
+            for _ in 0..2 {
+                ds1_buffered_messages.push(ds1_messages.recv().await.unwrap());
+                ds2_buffered_messages.push(ds2_messages.recv().await.unwrap());
+                ds3_buffered_messages.push(ds3_messages.recv().await.unwrap());
+            }
+
+            assert!(ds1_buffered_messages
+                .iter()
+                .any(|m| matches!(m, Message::ExtentLiveClose { .. })));
+            assert!(ds2_buffered_messages
+                .iter()
+                .any(|m| matches!(m, Message::ExtentLiveFlushClose { .. })));
+            assert!(ds3_buffered_messages
+                .iter()
+                .any(|m| matches!(m, Message::ExtentLiveFlushClose { .. })));
+
+            assert!(ds1_buffered_messages
+                .iter()
+                .any(|m| matches!(m, Message::ExtentLiveReopen { .. })));
+            assert!(ds2_buffered_messages
+                .iter()
+                .any(|m| matches!(m, Message::ExtentLiveReopen { .. })));
+            assert!(ds3_buffered_messages
+                .iter()
+                .any(|m| matches!(m, Message::ExtentLiveReopen { .. })));
+
+            // This is the reopen job id for extent eid
+
+            let reopen_job_id = {
+                let m = ds1_buffered_messages
+                    .iter()
+                    .position(|m| matches!(m, Message::ExtentLiveReopen { .. }))
+                    .unwrap();
+                match ds1_buffered_messages[m] {
+                    Message::ExtentLiveReopen { job_id, .. } => {
+                        job_id
+                    }
+
+                    _ => panic!("ds1_buffered_messages[m] not Message::ExtentLiveReopen"),
+                }
+            };
+
+            // Extent limit is Some(eid), where eid is the current loop
+            // iteration. It marks the extent at and below are clear to receive
+            // IO. Issue some single extent reads and writes to make sure that
+            // extent limit is honoured. Do this only after receiving the two
+            // above messages as that guarantees we are in the repair task and
+            // that extent_limit is set. Make sure reads and writes to the
+            // extent under repair has the ExtentLiveReopen job as a dependency.
+            // Batch up responses to send after the live repair is done,
+            // otherwise flow control will kick in.
+
+            let mut responses = vec![Vec::new(); 3];
+
+            for io_eid in 0usize..10 {
+                // read
+
+                {
+                    let harness = harness.clone();
+                    tokio::spawn(async move {
+                        let buffer = Buffer::new(512);
+                        harness
+                            .guest
+                            .read(Block::new_512(io_eid as u64 * 10), buffer)
+                            .await
+                            .unwrap();
+                    })
+                };
+
+                if io_eid <= eid {
+                    // IO at or below the extent under repair is sent to the
+                    // downstairs under repair.
+                    let m1 = ds1_messages.recv().await.unwrap();
+
+                    match &m1 {
+                        Message::ReadRequest {
+                            upstairs_id,
+                            session_id,
+                            job_id,
+                            dependencies,
+                            ..
+                        } => {
+                            if io_eid == eid {
+                                assert!(dependencies.contains(&reopen_job_id));
+                            }
+
+                            responses[0].push(Message::ReadResponse {
+                                upstairs_id: *upstairs_id,
+                                session_id: *session_id,
+                                job_id: *job_id,
+                                responses: Ok(vec![make_blank_read_response()]),
+                            });
+                        }
+
+                        _ => panic!("saw {:?}", m1),
+                    }
+                } else {
+                    // All IO above this is skipped for the downstairs under
+                    // repair.
+                    assert!(matches!(
+                        ds1_messages.try_recv(),
+                        Err(TryRecvError::Empty)
+                    ));
+                }
+
+                let m2 = ds2_messages.recv().await.unwrap();
+                let m3 = ds3_messages.recv().await.unwrap();
+
+                match &m2 {
+                    Message::ReadRequest {
+                        upstairs_id,
+                        session_id,
+                        job_id,
+                        dependencies,
+                        ..
+                    } => {
+                        if io_eid == eid {
+                            assert!(dependencies.contains(&reopen_job_id));
+                        }
+
+                        responses[1].push(Message::ReadResponse {
+                            upstairs_id: *upstairs_id,
+                            session_id: *session_id,
+                            job_id: *job_id,
+                            responses: Ok(vec![make_blank_read_response()]),
+                        });
+                    }
+
+                    _ => panic!("saw {:?}", m2),
+                }
+
+                match &m3 {
+                    Message::ReadRequest {
+                        upstairs_id,
+                        session_id,
+                        job_id,
+                        dependencies,
+                        ..
+                    } => {
+                        if io_eid == eid {
+                            assert!(dependencies.contains(&reopen_job_id));
+                        }
+
+                        responses[2].push(Message::ReadResponse {
+                            upstairs_id: *upstairs_id,
+                            session_id: *session_id,
+                            job_id: *job_id,
+                            responses: Ok(vec![make_blank_read_response()]),
+                        });
+                    }
+
+                    _ => panic!("saw {:?}", m3),
+                }
+
+                // write
+
+                {
+                    let harness = harness.clone();
+                    tokio::spawn(async move {
+                        let bytes = Bytes::from(vec![1u8; 512]);
+                        harness
+                            .guest
+                            .write(Block::new_512(io_eid as u64 * 10), bytes)
+                            .await
+                            .unwrap();
+                    })
+                };
+
+                if io_eid <= eid {
+                    // IO at or below the extent under repair is sent to the
+                    // downstairs under repair.
+                    let m1 = ds1_messages.recv().await.unwrap();
+
+                    match &m1 {
+                        Message::Write {
+                            upstairs_id,
+                            session_id,
+                            job_id,
+                            dependencies,
+                            ..
+                        } => {
+                            if io_eid == eid {
+                                assert!(dependencies.contains(&reopen_job_id));
+                            }
+
+                            responses[0].push(Message::WriteAck {
+                                upstairs_id: *upstairs_id,
+                                session_id: *session_id,
+                                job_id: *job_id,
+                                result: Ok(()),
+                            });
+                        }
+
+                        _ => panic!("saw {:?}", m1),
+                    }
+                } else {
+                    // All IO above this is skipped for the downstairs under
+                    // repair.
+                    assert!(matches!(
+                        ds1_messages.try_recv(),
+                        Err(TryRecvError::Empty)
+                    ));
+                }
+
+                let m2 = ds2_messages.recv().await.unwrap();
+                let m3 = ds3_messages.recv().await.unwrap();
+
+                match &m2 {
+                    Message::Write {
+                        upstairs_id,
+                        session_id,
+                        job_id,
+                        dependencies,
+                        ..
+                    } => {
+                        if io_eid == eid {
+                            assert!(dependencies.contains(&reopen_job_id));
+                        }
+
+                        responses[1].push(Message::WriteAck {
+                            upstairs_id: *upstairs_id,
+                            session_id: *session_id,
+                            job_id: *job_id,
+                            result: Ok(()),
+                        });
+                    }
+
+                    _ => panic!("saw {:?}", m2),
+                }
+
+                match &m3 {
+                    Message::Write {
+                        upstairs_id,
+                        session_id,
+                        job_id,
+                        dependencies,
+                        ..
+                    } => {
+                        if io_eid == eid {
+                            assert!(dependencies.contains(&reopen_job_id));
+                        }
+
+                        responses[2].push(Message::WriteAck {
+                            upstairs_id: *upstairs_id,
+                            session_id: *session_id,
+                            job_id: *job_id,
+                            result: Ok(()),
+                        });
+                    }
+
+                    _ => panic!("saw {:?}", m3),
+                }
+            }
+
+            // The repair task then waits for the close responses.
+
+            let m1 = filter_out(&mut ds1_buffered_messages, |x| {
+                matches!(x, Message::ExtentLiveClose { .. })
+            })
+            .unwrap();
+            let m2 = filter_out(&mut ds2_buffered_messages, |x| {
+                matches!(x, Message::ExtentLiveFlushClose { .. })
+            })
+            .unwrap();
+            let m3 = filter_out(&mut ds3_buffered_messages, |x| {
+                matches!(x, Message::ExtentLiveFlushClose { .. })
+            })
+            .unwrap();
+
+            match &m1 {
+                Message::ExtentLiveClose {
+                    upstairs_id,
+                    session_id,
+                    job_id,
+                    extent_id,
+                    ..
+                } => {
+                    assert!(*extent_id == eid);
+
+                    // ds1 didn't get the flush, it was set to faulted
+                    let gen = 1;
+                    let flush = 0;
+                    let dirty = false;
+
+                    ds1.fw
+                        .lock()
+                        .await
+                        .send(Message::ExtentLiveCloseAck {
+                            upstairs_id: *upstairs_id,
+                            session_id: *session_id,
+                            job_id: *job_id,
+                            result: Ok((gen, flush, dirty)),
+                        })
+                        .await
+                        .unwrap();
+                }
+
+                _ => panic!("saw {:?}", m1),
+            }
+
+            match &m2 {
+                Message::ExtentLiveFlushClose {
+                    upstairs_id,
+                    session_id,
+                    job_id,
+                    extent_id,
+                    ..
+                } => {
+                    assert!(*extent_id == eid);
+
+                    // ds2 and ds3 did get a flush
+                    let gen = 0;
+                    let flush = 2;
+                    let dirty = false;
+
+                    harness
+                        .ds2
+                        .fw
+                        .lock()
+                        .await
+                        .send(Message::ExtentLiveCloseAck {
+                            upstairs_id: *upstairs_id,
+                            session_id: *session_id,
+                            job_id: *job_id,
+                            result: Ok((gen, flush, dirty)),
+                        })
+                        .await
+                        .unwrap()
+                }
+
+                _ => panic!("saw {:?}", m2),
+            }
+
+            match &m3 {
+                Message::ExtentLiveFlushClose {
+                    upstairs_id,
+                    session_id,
+                    job_id,
+                    extent_id,
+                    ..
+                } => {
+                    assert!(*extent_id == eid);
+
+                    // ds2 and ds3 did get a flush
+                    let gen = 0;
+                    let flush = 2;
+                    let dirty = false;
+
+                    harness
+                        .ds3
+                        .fw
+                        .lock()
+                        .await
+                        .send(Message::ExtentLiveCloseAck {
+                            upstairs_id: *upstairs_id,
+                            session_id: *session_id,
+                            job_id: *job_id,
+                            result: Ok((gen, flush, dirty)),
+                        })
+                        .await
+                        .unwrap()
+                }
+
+                _ => panic!("saw {:?}", m3),
+            }
+
+            // Based on those gen, flush, and dirty values, ds1 should get the
+            // ExtentLiveRepair message, while ds2 and ds3 should get
+            // ExtentLiveNoOp.
+
+            let m1 = ds1_messages.recv().await.unwrap();
+            let m2 = ds2_messages.recv().await.unwrap();
+            let m3 = ds3_messages.recv().await.unwrap();
+
+            match &m1 {
+                Message::ExtentLiveRepair {
+                    upstairs_id,
+                    session_id,
+                    job_id,
+                    extent_id,
+                    source_client_id,
+                    ..
+                } => {
+                    assert!(*source_client_id != 0);
+                    assert!(*extent_id == eid);
+
+                    ds1.fw
+                        .lock()
+                        .await
+                        .send(Message::ExtentLiveRepairAckId {
+                            upstairs_id: *upstairs_id,
+                            session_id: *session_id,
+                            job_id: *job_id,
+                            result: Ok(()),
+                        })
+                        .await
+                        .unwrap();
+                }
+
+                _ => panic!("saw {:?}", m3),
+            }
+
+            match &m2 {
+                Message::ExtentLiveNoOp {
+                    upstairs_id,
+                    session_id,
+                    job_id,
+                    ..
+                } => harness
+                    .ds2
+                    .fw
+                    .lock()
+                    .await
+                    .send(Message::ExtentLiveAckId {
+                        upstairs_id: *upstairs_id,
+                        session_id: *session_id,
+                        job_id: *job_id,
+                        result: Ok(()),
+                    })
+                    .await
+                    .unwrap(),
+
+                _ => panic!("saw {:?}", m2),
+            }
+
+            match &m3 {
+                Message::ExtentLiveNoOp {
+                    upstairs_id,
+                    session_id,
+                    job_id,
+                    ..
+                } => harness
+                    .ds3
+                    .fw
+                    .lock()
+                    .await
+                    .send(Message::ExtentLiveAckId {
+                        upstairs_id: *upstairs_id,
+                        session_id: *session_id,
+                        job_id: *job_id,
+                        result: Ok(()),
+                    })
+                    .await
+                    .unwrap(),
+
+                _ => panic!("saw {:?}", m2),
+            }
+
+            // Now, all downstairs will see ExtentLiveNoop
+
+            let m1 = ds1_messages.recv().await.unwrap();
+            let m2 = ds2_messages.recv().await.unwrap();
+            let m3 = ds3_messages.recv().await.unwrap();
+
+            match &m1 {
+                Message::ExtentLiveNoOp {
+                    upstairs_id,
+                    session_id,
+                    job_id,
+                    ..
+                } => ds1
+                    .fw
+                    .lock()
+                    .await
+                    .send(Message::ExtentLiveAckId {
+                        upstairs_id: *upstairs_id,
+                        session_id: *session_id,
+                        job_id: *job_id,
+                        result: Ok(()),
+                    })
+                    .await
+                    .unwrap(),
+
+                _ => panic!("saw {:?}", m2),
+            }
+
+            match &m2 {
+                Message::ExtentLiveNoOp {
+                    upstairs_id,
+                    session_id,
+                    job_id,
+                    ..
+                } => harness
+                    .ds2
+                    .fw
+                    .lock()
+                    .await
+                    .send(Message::ExtentLiveAckId {
+                        upstairs_id: *upstairs_id,
+                        session_id: *session_id,
+                        job_id: *job_id,
+                        result: Ok(()),
+                    })
+                    .await
+                    .unwrap(),
+
+                _ => panic!("saw {:?}", m2),
+            }
+
+            match &m3 {
+                Message::ExtentLiveNoOp {
+                    upstairs_id,
+                    session_id,
+                    job_id,
+                    ..
+                } => harness
+                    .ds3
+                    .fw
+                    .lock()
+                    .await
+                    .send(Message::ExtentLiveAckId {
+                        upstairs_id: *upstairs_id,
+                        session_id: *session_id,
+                        job_id: *job_id,
+                        result: Ok(()),
+                    })
+                    .await
+                    .unwrap(),
+
+                _ => panic!("saw {:?}", m2),
+            }
+
+            // Finally, processing the ExtentLiveNoOp above means that the
+            // dependencies for the final Reopen are all completed.
+
+            let m1 = filter_out(&mut ds1_buffered_messages, |x| {
+                matches!(x, Message::ExtentLiveReopen { .. })
+            })
+            .unwrap();
+            let m2 = filter_out(&mut ds2_buffered_messages, |x| {
+                matches!(x, Message::ExtentLiveReopen { .. })
+            })
+            .unwrap();
+            let m3 = filter_out(&mut ds3_buffered_messages, |x| {
+                matches!(x, Message::ExtentLiveReopen { .. })
+            })
+            .unwrap();
+
+            match &m1 {
+                Message::ExtentLiveReopen {
+                    upstairs_id,
+                    session_id,
+                    job_id,
+                    extent_id,
+                    ..
+                } => {
+                    assert!(*extent_id == eid);
+
+                    ds1.fw
+                        .lock()
+                        .await
+                        .send(Message::ExtentLiveAckId {
+                            upstairs_id: *upstairs_id,
+                            session_id: *session_id,
+                            job_id: *job_id,
+                            result: Ok(()),
+                        })
+                        .await
+                        .unwrap()
+                }
+
+                _ => panic!("saw {:?}", m2),
+            }
+
+            match &m2 {
+                Message::ExtentLiveReopen {
+                    upstairs_id,
+                    session_id,
+                    job_id,
+                    extent_id,
+                    ..
+                } => {
+                    assert!(*extent_id == eid);
+
+                    harness
+                        .ds2
+                        .fw
+                        .lock()
+                        .await
+                        .send(Message::ExtentLiveAckId {
+                            upstairs_id: *upstairs_id,
+                            session_id: *session_id,
+                            job_id: *job_id,
+                            result: Ok(()),
+                        })
+                        .await
+                        .unwrap()
+                }
+
+                _ => panic!("saw {:?}", m2),
+            }
+
+            match &m3 {
+                Message::ExtentLiveReopen {
+                    upstairs_id,
+                    session_id,
+                    job_id,
+                    extent_id,
+                    ..
+                } => {
+                    assert!(*extent_id == eid);
+
+                    harness
+                        .ds3
+                        .fw
+                        .lock()
+                        .await
+                        .send(Message::ExtentLiveAckId {
+                            upstairs_id: *upstairs_id,
+                            session_id: *session_id,
+                            job_id: *job_id,
+                            result: Ok(()),
+                        })
+                        .await
+                        .unwrap()
+                }
+
+                _ => panic!("saw {:?}", m2),
+            }
+
+            // After those are done, send out the read and write job responses
+            for m in &responses[0] {
+                ds1.fw.lock().await.send(m).await.unwrap();
+            }
+            for m in &responses[1] {
+                harness.ds2.fw.lock().await.send(m).await.unwrap();
+            }
+            for m in &responses[2] {
+                harness.ds3.fw.lock().await.send(m).await.unwrap();
+            }
+        }
+
+        // Expect the live repair to send a final flush
+        {
+            let flush_job_id = match ds1_messages.recv().await.unwrap() {
+                Message::Flush {
+                    job_id,
+                    flush_number: 12,
+                    ..
+                } => job_id,
+
+                _ => panic!("saw non flush!"),
+            };
+
+            assert!(matches!(
+                ds2_messages.recv().await.unwrap(),
+                Message::Flush {
+                    flush_number: 12,
+                    ..
+                },
+            ));
+
+            assert!(matches!(
+                ds3_messages.recv().await.unwrap(),
+                Message::Flush {
+                    flush_number: 12,
+                    ..
+                },
+            ));
+
+            ds1.fw
+                .lock()
+                .await
+                .send(Message::FlushAck {
+                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
+                    session_id: ds1.upstairs_session_id.lock().await.unwrap(),
+                    job_id: flush_job_id,
+                    result: Ok(()),
+                })
+                .await
+                .unwrap();
+
+            harness
+                .ds2
+                .fw
+                .lock()
+                .await
+                .send(Message::FlushAck {
+                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
+                    session_id: harness
+                        .ds2
+                        .upstairs_session_id
+                        .lock()
+                        .await
+                        .unwrap(),
+                    job_id: flush_job_id,
+                    result: Ok(()),
+                })
+                .await
+                .unwrap();
+
+            harness
+                .ds3
+                .fw
+                .lock()
+                .await
+                .send(Message::FlushAck {
+                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
+                    session_id: harness
+                        .ds3
+                        .upstairs_session_id
+                        .lock()
+                        .await
+                        .unwrap(),
+                    job_id: flush_job_id,
+                    result: Ok(()),
+                })
+                .await
+                .unwrap();
+        }
+
+        // Try another read
+        {
+            {
+                let harness = harness.clone();
+
+                // We must tokio::spawn here because `read` will wait for the
+                // response to come back before returning
+                tokio::spawn(async move {
+                    let buffer = Buffer::new(512);
+                    harness
+                        .guest
+                        .read(Block::new_512(0), buffer)
+                        .await
+                        .unwrap();
+                });
+            }
+
+            // All downstairs should see it
+
+            assert!(matches!(
+                ds1_messages.recv().await.unwrap(),
+                Message::ReadRequest { .. },
+            ));
+
+            assert!(matches!(
+                ds2_messages.recv().await.unwrap(),
+                Message::ReadRequest { .. },
+            ));
+
+            assert!(matches!(
+                ds3_messages.recv().await.unwrap(),
+                Message::ReadRequest { .. },
+            ));
+        }
     }
 }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -133,9 +133,9 @@ pub trait BlockIO: Sync {
     /// implemented for those.
     async fn replace_downstairs(
         &self,
-        id: Uuid,
-        old: SocketAddr,
-        new: SocketAddr,
+        _id: Uuid,
+        _old: SocketAddr,
+        _new: SocketAddr,
     ) -> Result<ReplaceResult, CrucibleError> {
         panic!("should never hit here!");
     }
@@ -7309,9 +7309,9 @@ impl Upstairs {
 
     async fn replace_downstairs(
         &self,
-        id: Uuid,
-        old: SocketAddr,
-        new: SocketAddr,
+        _id: Uuid,
+        _old: SocketAddr,
+        _new: SocketAddr,
     ) -> Result<ReplaceResult, CrucibleError> {
         crucible_bail!(GenericError, "write more code!");
     }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -76,6 +76,10 @@ use async_trait::async_trait;
 // before we give up and mark that downstairs faulted.
 const IO_OUTSTANDING_MAX: usize = 1000;
 
+// Max number of submitted IOs between the upstairs and the downstairs, above
+// which flow control kicks in.
+const MAX_ACTIVE_COUNT: usize = 100;
+
 /// The BlockIO trait behaves like a physical NVMe disk (or a virtio virtual
 /// disk): there is no contract about what order operations that are submitted
 /// between flushes are performed in.
@@ -601,7 +605,7 @@ where
 
     let mut active_count = u.downstairs.lock().await.submitted_work(client_id);
     for new_id in new_work.iter() {
-        if active_count >= 100 {
+        if active_count >= MAX_ACTIVE_COUNT {
             // Flow control enacted, stop sending work
             return Ok(true);
         }


### PR DESCRIPTION
Now that Live repair has landed, add a dummy downstairs protocol test for the successful case. Test that extent limit is honoured, and that jobs submitted during live repair always have the proper dependencies.

This is meant as a compliment to the tests in the repair_test module in upstairs/src/live_repair.rs, as those also run through repairs step by step and perform checks as they go.