### PR TITLE
Fix LR hang, polish dtrace, make CI test more

### DIFF
--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -82,21 +82,7 @@ mv out/crucible.tar.gz out/crucible-pantry.tar.gz /out/
 # and binaries needed to run the nightly test.
 # This needs the ./out directory created above
 banner nightly
-
-tar cavf out/crucible-nightly.tar.gz \
-    target/release/crutest \
-    target/release/crucible-downstairs \
-    target/release/crucible-hammer \
-    target/release/dsc \
-    target/release/crudd \
-    tools/hammer_loop.sh \
-    tools/test_perf.sh \
-    tools/test_mem.sh \
-    tools/test_reconnect.sh \
-    tools/test_repair.sh \
-    tools/test_restart_repair.sh \
-    tools/test_nightly.sh \
-    tools/crudd-speed-battery.sh
+./tools/make-nightly.sh
 
 banner copy
 mv out/crucible-nightly.tar.gz /out/crucible-nightly.tar.gz

--- a/.github/buildomat/jobs/build.sh
+++ b/.github/buildomat/jobs/build.sh
@@ -27,7 +27,7 @@ for t in crucible-downstairs crucible-hammer crutest dsc; do
 done
 
 mkdir -p /work/scripts
-for s in tools/test_repair.sh tools/test_up.sh tools/test_ds.sh; do
+for s in tools/test_live_repair.sh tools/test_repair.sh tools/test_up.sh tools/test_ds.sh; do
 	cp "$s" /work/scripts/
 done
 

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -40,7 +40,7 @@ echo "BINDIR is $BINDIR"
 echo "bindir contains:"
 ls -ltr "$BINDIR" || true
 
-banner repair
+banner LR
 ptime -m bash "$input/scripts/test_live_repair.sh"
 
 # Save the output files?

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -5,6 +5,7 @@
 #: target = "helios"
 #: output_rules = [
 #:	"/tmp/*.txt",
+#:	"/tmp/*.log",
 #: ]
 #: skip_clone = true
 #:

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -19,6 +19,11 @@ set -o xtrace
 
 pfexec chmod +x "$input"/scripts/* || true
 
+echo "input bins dir contains:"
+ls -ltr "$input"/bins || true
+echo "input script dir contains:"
+ls -ltr "$input"/scripts || true
+
 banner unpack
 mkdir -p /var/tmp/bins
 for t in "$input/bins/"*.gz; do
@@ -29,6 +34,10 @@ for t in "$input/bins/"*.gz; do
 done
 
 export BINDIR=/var/tmp/bins
+
+echo "BINDIR is $BINDIR"
+echo "bindir contains:"
+ls -ltr "$BINDIR" || true
 
 banner repair
 ptime -m bash "$input/scripts/test_live_repair.sh"

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#:
+#: name = "test-live-repair"
+#: variety = "basic"
+#: target = "helios"
+#: output_rules = [
+#:	"/tmp/*.txt",
+#: ]
+#: skip_clone = true
+#:
+#: [dependencies.build]
+#: job = "build"
+
+input="/input/build/work"
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+pfexec chmod +x "$input"/scripts/* || true
+
+banner unpack
+mkdir -p /var/tmp/bins
+for t in "$input/bins/"*.gz; do
+	b=$(basename "$t")
+	b=${b%.gz}
+	gunzip < "$t" > "/var/tmp/bins/$b"
+	chmod +x "/var/tmp/bins/$b"
+done
+
+export BINDIR=/var/tmp/bins
+
+banner repair
+ptime -m bash "$input/scripts/test_live_repair.sh"
+
+# Save the output files?

--- a/tools/dtrace/upstairs_info.d
+++ b/tools/dtrace/upstairs_info.d
@@ -17,13 +17,13 @@ dtrace:::BEGIN
 tick-1s
 /show > 20/
 {
-    printf("   DS STATE 0    DS STATE 1    DS STATE 2");
-    printf("   UPW  DSW");
-    printf("  NEW0 NEW1 NEW2");
-    printf("   IP0  IP1  IP2");
-    printf("    D0   D1   D2");
-    printf("    S0   S1   S2");
-    printf("  E0 E1 E2");
+    printf("%17s %17s %17s", "DS STATE 0", "DS STATE 1", "DS STATE 2");
+    printf("  %4s %4s", "UPW", "DSW");
+    printf("  %4s %4s %4s", "NEW0", "NEW1", "NEW2");
+    printf("  %4s %4s %4s", "IP0", "IP1", "IP2");
+    printf("  %4s %4s %4s", "D0", "D1", "D2");
+    printf("  %4s %4s %4s", "S0", "S1", "S2");
+    printf("  %2s %2s %2s", "E0", "E1", "E2");
     printf("\n");
     show = 0;
 }
@@ -34,9 +34,9 @@ crucible_upstairs*:::up-status
     /*
      * State for the three downstiars
      */
-    printf("%13s", json(copyinstr(arg1), "ok.ds_state[0]"));
-    printf(" %13s", json(copyinstr(arg1), "ok.ds_state[1]"));
-    printf(" %13s", json(copyinstr(arg1), "ok.ds_state[2]"));
+    printf("%17s", json(copyinstr(arg1), "ok.ds_state[0]"));
+    printf(" %17s", json(copyinstr(arg1), "ok.ds_state[1]"));
+    printf(" %17s", json(copyinstr(arg1), "ok.ds_state[2]"));
 
     /*
      * Work queue counts for Upstairs and Downstairs

--- a/tools/dtrace/upstairs_repair.d
+++ b/tools/dtrace/upstairs_repair.d
@@ -17,8 +17,9 @@ dtrace:::BEGIN
 tick-1s
 /show > 20/
 {
-    printf("   DS STATE 0    DS STATE 1    DS STATE 2");
-    printf(" CONF0 CONF1 CONF2 RPAR0 RPAR1 RPAR2");
+    printf("%17s %17s %17s", "DS STATE 0", "DS STATE 1", "DS STATE 2");
+    printf("  %5s %5s %5s %5s %5s %5s",
+        "CONF0", "CONF1", "CONF2", "RPAR0", "RPAR1", "RPAR2");
     printf("\n");
     show = 0;
 }
@@ -29,9 +30,9 @@ crucible_upstairs*:::up-status
     /*
      * State for the three downstiars
      */
-    printf("%13s", json(copyinstr(arg1), "ok.ds_state[0]"));
-    printf(" %13s", json(copyinstr(arg1), "ok.ds_state[1]"));
-    printf(" %13s", json(copyinstr(arg1), "ok.ds_state[2]"));
+    printf("%17s", json(copyinstr(arg1), "ok.ds_state[0]"));
+    printf(" %17s", json(copyinstr(arg1), "ok.ds_state[1]"));
+    printf(" %17s", json(copyinstr(arg1), "ok.ds_state[2]"));
 
     /*
      * Repair counts for the downstairs
@@ -40,7 +41,7 @@ crucible_upstairs*:::up-status
     printf(" %5s", json(copyinstr(arg1), "ok.ds_confirm[0]"));
     printf(" %5s", json(copyinstr(arg1), "ok.ds_confirm[1]"));
     printf(" %5s", json(copyinstr(arg1), "ok.ds_confirm[2]"));
-    printf(" %4s", json(copyinstr(arg1), "ok.ds_repair[0]"));
+    printf(" %5s", json(copyinstr(arg1), "ok.ds_repair[0]"));
     printf(" %5s", json(copyinstr(arg1), "ok.ds_repair[1]"));
     printf(" %5s", json(copyinstr(arg1), "ok.ds_repair[2]"));
 

--- a/tools/make-nightly.sh
+++ b/tools/make-nightly.sh
@@ -14,14 +14,19 @@ echo "git status:" >> nightly-info.txt
 git status >> nightly-info.txt
 
 tar cavf out/crucible-nightly.tar.gz \
+  target/release/cmon \
+  target/release/crudd \
   target/release/crutest \
   target/release/crucible-downstairs \
   target/release/crucible-hammer \
-  target/release/cmon \
   target/release/dsc \
+  tools/crudd-speed-battery.sh \
+  tools/dtrace/* \
   tools/hammer_loop.sh \
-  tools/test_perf.sh \
+  tools/test_live_repair.sh \
+  tools/test_fail_live_repair.sh \
   tools/test_mem.sh \
+  tools/test_perf.sh \
   tools/test_reconnect.sh \
   tools/test_repair.sh \
   tools/test_restart_repair.sh \

--- a/tools/test_fail_live_repair.sh
+++ b/tools/test_fail_live_repair.sh
@@ -71,7 +71,7 @@ if ! ${dsc} create --cleanup \
     echo "Failed to create downstairs regions"
     exit 1
 fi
-${dsc} start >> "$dsc_test_log" 2>&1 &
+${dsc} start --ds-bin "$cds" >> "$dsc_test_log" 2>&1 &
 dsc_pid=$!
 sleep 5
 if ! ps -p $dsc_pid > /dev/null; then

--- a/tools/test_live_repair.sh
+++ b/tools/test_live_repair.sh
@@ -111,7 +111,7 @@ do
     sleep 5
 
     # Fault a downstairs.
-    curl -X POST http://127.0.0.1:7777/downstairs/fault/"${choice}"
+    curl -s -X POST http://127.0.0.1:7777/downstairs/fault/"${choice}"
 
     # Give the fault time to be noticed
     sleep 5

--- a/tools/test_live_repair.sh
+++ b/tools/test_live_repair.sh
@@ -69,7 +69,7 @@ if ! ${dsc} create --cleanup \
     echo "Failed to create downstairs regions"
     exit 1
 fi
-${dsc} start >> "$dsc_test_log" 2>&1 &
+${dsc} start --ds-bin "$cds" >> "$dsc_test_log" 2>&1 &
 dsc_pid=$!
 sleep 5
 if ! ps -p $dsc_pid > /dev/null; then

--- a/upstairs/src/control.rs
+++ b/upstairs/src/control.rs
@@ -32,7 +32,11 @@ pub(crate) fn build_api() -> ApiDescription<Arc<UpstairsInfo>> {
  * Nexus or Propolis to send Snapshot commands. Also, publish some stats on
  * a `/info` from the Upstairs internal struct.
  */
-pub async fn start(up: &Arc<Upstairs>, addr: SocketAddr) -> Result<(), String> {
+pub async fn start(
+    up: &Arc<Upstairs>,
+    addr: SocketAddr,
+    ds_done_tx: mpsc::Sender<u64>,
+) -> Result<(), String> {
     /*
      * Setup dropshot
      */
@@ -53,7 +57,7 @@ pub async fn start(up: &Arc<Upstairs>, addr: SocketAddr) -> Result<(), String> {
      * The functions that implement our API endpoints will share this
      * context.
      */
-    let api_context = Arc::new(UpstairsInfo::new(up));
+    let api_context = Arc::new(UpstairsInfo::new(up, ds_done_tx));
 
     /*
      * Set up the server.
@@ -78,14 +82,24 @@ pub struct UpstairsInfo {
      * Upstairs structure that is used to gather all the info stats
      */
     up: Arc<Upstairs>,
+    /**
+     * Notify channel for work completed by the downstairs.
+     */
+    ds_done_tx: mpsc::Sender<u64>,
 }
 
 impl UpstairsInfo {
     /**
      * Return a new UpstairsInfo.
      */
-    pub fn new(up: &Arc<Upstairs>) -> UpstairsInfo {
-        UpstairsInfo { up: up.clone() }
+    pub fn new(
+        up: &Arc<Upstairs>,
+        ds_done_tx: mpsc::Sender<u64>,
+    ) -> UpstairsInfo {
+        UpstairsInfo {
+            up: up.clone(),
+            ds_done_tx,
+        }
     }
 }
 
@@ -226,6 +240,12 @@ async fn fault_downstairs(
      */
     let active = api_context.up.active.lock().await;
     let up_state = active.up_state;
+    if up_state != UpState::Active {
+        return Err(HttpError::for_bad_request(
+            Some(String::from("InvalidState")),
+            format!("Upstairs not active: {:?}", up_state),
+        ));
+    }
     let mut ds = api_context.up.downstairs.lock().await;
     match ds.ds_state[cid as usize] {
         DsState::Active
@@ -253,8 +273,12 @@ async fn fault_downstairs(
 
     /*
      * Move all jobs to skipped for this downstairs.
+     * If this returns true, then we have to notify tasks that
+     * a job was "completed" (aka, skipped).
      */
-    ds.ds_set_faulted(cid);
+    if ds.ds_set_faulted(cid) {
+        let _ = api_context.ds_done_tx.send(0).await;
+    }
 
     Ok(HttpResponseUpdatedNoContent())
 }


### PR DESCRIPTION
Fixed a situation where a LiveRepair could hang if a downstairs that was under repair was faulted.  This also uncovered a path through the control interface that would not correctly fault a downstairs if called at the wrong location.  Both issues are fixed here through correct usage of ds_set_faulted().  gone_too_long() also needed some special treatment.

Fixed DTrace scripts to correctly account for largest possible downstairs state size.

Added the live_repair test to buildomat.  Updated it and the fail_live_repair test to both use the
new `--continuous` option to crutest so we don't have to guess how long to make the workload run.

Updated the script to create a nightly archive to include more things and updated the buildomat CI job to use that script instead of rolling its own list.

Created a new fail while live repairing test.

Here is some new sample DTrace output for a repair
```
alan@atrium:crucible$ pfexec dtrace -Z -s tools/dtrace/upstairs_repair.d
       DS STATE 0        DS STATE 1        DS STATE 2  CONF0 CONF1 CONF2 RPAR0 RPAR1 RPAR2
              new               new               new      0     0     0     0     0     0
           active            active            active      0     0     0     0     0     0
              new               new               new      0     0     0     0     0     0
           active            active            active      0     0     0     0     0     0
           active            active       live_repair      0     0    16     0     0    50
           active            active live_repair_ready      0     0    21     0     0    99
           active            active       live_repair      0     0    41     0     0   172
           active            active       live_repair      0     0    43     0     0   242
           active            active            active      0     0    43     0     0   277
              new               new               new      0     0     0     0     0     0
           active            active            active      0     0     0     0     0     0
              new               new               new      0     0     0     0     0     0
          faulted            active            active      0     0     0     0     0     0
      live_repair            active            active     11     0     0    50     0     0
live_repair_ready            active            active     15     0     0    98     0     0
      live_repair            active            active     30     0     0   172     0     0
      live_repair            active            active     32     0     0   247     0     0
              new               new               new      0     0     0     0     0     0

```
Made dtrace upstairs_info script align better:
```
alan@atrium:crucible$ pfexec dtrace -Z -s tools/dtrace/upstairs_info.d 
           active            active            active     1   25     0    0    0     1    1    1    24   24   24     0    0    0   0  0  0
       DS STATE 0        DS STATE 1        DS STATE 2   UPW  DSW  NEW0 NEW1 NEW2   IP0  IP1  IP2    D0   D1   D2    S0   S1   S2  E0 E1 E2
           active            active       live_repair     3   12   247  247  247     2    2    5    10   10    2     0    0    5   0  0  0
           active            active live_repair_ready     2    9   457  457  456     1    1    0     7    7    0     0    0    9   0  0  0
           active            active       live_repair     4    9   491  491  491     3    3    2     5    5    4     0    0    2   0  0  0
           active            active       live_repair     4   17   727  727  727     3    3    1    13   13    7     0    0    8   0  0  0
           active            active       live_repair     3   13  1103 1103 1103     2    2   10    11   11    2     0    0    1   0  0  0
           active            active            active     1   10  1257 1257 1257     0    0    0     9    9    9     0    0    0   0  0  0
              new               new               new     0    0     0    0    0     0    0    0     0    0    0     0    0    0   0  0  0
           active            active            active     1  601     1    1    1     0    0    0   600  600  600     0    0    0   0  0  0
              new               new               new     0    0     0    0    0     0    0    0     0    0    0     0    0    0   0  0  0
           active            active            active     1   19     0    0    0     1    1    1    18   18   18     0    0    0   0  0  0
           active       live_repair            active     4   45    31   31   31     3    2    3    41   25   41     0   17    0   0  0  0
```