### PR TITLE
WITHOUT ROWID

### DIFF
--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -755,8 +755,11 @@ impl Extent {
             // until we call flush and remove context rows where the integrity
             // hash does not match what was actually flushed to disk.
 
-            // in WITHOUT ROWID mode, SQLite arranges the tables on-disk ordered by the
-            // primary key. since we're always doing operations on contiguous ranges of blocks, this is great for us. The only catch is that you can actually see worse performance with large rows (not a problem for us).
+            // in WITHOUT ROWID mode, SQLite arranges the tables on-disk ordered
+            // by the primary key. since we're always doing operations on
+            // contiguous ranges of blocks, this is great for us. The only catch
+            // is that you can actually see worse performance with large rows
+            // (not a problem for us).
             //
             // From https://www.sqlite.org/withoutrowid.html:
             // > WITHOUT ROWID tables work best when individual rows are not too
@@ -766,14 +769,14 @@ impl Extent {
             // > not contain more than about 50 bytes each for a 1KiB page size
             // > or about 200 bytes each for 4KiB page size.
             //
-            // The default SQLite page size is 4KiB, per https://sqlite.org/pgszchng2016.html
+            // The default SQLite page size is 4KiB, per
+            // https://sqlite.org/pgszchng2016.html
             //
             // The primary key is also a uniqueness constraint. Because the
             // on_disk_hash is a hash of the data AFTER encryption, we only need
             // (block, on_disk_hash). A duplicate write with a different
             // encryption context necessarily results in a different on disk
-            // hash. Likewise for a write with a different nonce, or a different
-            // nonce.
+            // hash.
             metadb.execute(
                 "CREATE TABLE block_context (
                     block INTEGER,

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -154,11 +154,9 @@ impl Inner {
         block: u64,
         count: u64,
     ) -> Result<Vec<Vec<DownstairsBlockContext>>> {
-        // NOTE: "ORDER BY RANDOM()" would be a good --lossy addition here
         let stmt =
             "SELECT block, hash, nonce, tag, on_disk_hash FROM block_context \
-             WHERE block BETWEEN ?1 AND ?2 \
-             ORDER BY ROWID ASC";
+             WHERE block BETWEEN ?1 AND ?2";
         let mut stmt = self.metadb.prepare_cached(stmt)?;
 
         let stmt_iter =
@@ -757,6 +755,25 @@ impl Extent {
             // until we call flush and remove context rows where the integrity
             // hash does not match what was actually flushed to disk.
 
+            // in WITHOUT ROWID mode, SQLite arranges the tables on-disk ordered by the
+            // primary key. since we're always doing operations on contiguous ranges of blocks, this is great for us. The only catch is that you can actually see worse performance with large rows (not a problem for us).
+            //
+            // From https://www.sqlite.org/withoutrowid.html:
+            // > WITHOUT ROWID tables work best when individual rows are not too
+            // > large. A good rule-of-thumb is that the average size of a
+            // > single row in a WITHOUT ROWID table should be less than about
+            // > 1/20th the size of a database page. That means that rows should
+            // > not contain more than about 50 bytes each for a 1KiB page size
+            // > or about 200 bytes each for 4KiB page size.
+            //
+            // The default SQLite page size is 4KiB, per https://sqlite.org/pgszchng2016.html
+            //
+            // The primary key is also a uniqueness constraint. Because the
+            // on_disk_hash is a hash of the data AFTER encryption, we only need
+            // (block, on_disk_hash). A duplicate write with a different
+            // encryption context necessarily results in a different on disk
+            // hash. Likewise for a write with a different nonce, or a different
+            // nonce.
             metadb.execute(
                 "CREATE TABLE block_context (
                     block INTEGER,
@@ -764,13 +781,8 @@ impl Extent {
                     nonce BLOB,
                     tag BLOB,
                     on_disk_hash INTEGER,
-                    PRIMARY KEY (block, hash, nonce, tag, on_disk_hash)
-                )",
-                [],
-            )?;
-            metadb.execute(
-                "CREATE UNIQUE INDEX block_context_rows_unencrypted ON block_context
-                    (block, hash, on_disk_hash)",
+                    PRIMARY KEY (block, on_disk_hash)
+                ) WITHOUT ROWID",
                 [],
             )?;
 

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -164,10 +164,10 @@ impl Inner {
         let stmt_iter =
             stmt.query_map(params![block, block + count - 1], |row| {
                 let block_index: u64 = row.get(0)?;
-                let hash: Vec<u8> = row.get(1)?;
+                let hash: i64 = row.get(1)?;
                 let nonce: Option<Vec<u8>> = row.get(2)?;
                 let tag: Option<Vec<u8>> = row.get(3)?;
-                let on_disk_hash: Vec<u8> = row.get(4)?;
+                let on_disk_hash: i64 = row.get(4)?;
 
                 Ok((block_index, hash, nonce, tag, on_disk_hash))
             })?;
@@ -188,11 +188,11 @@ impl Inner {
 
             let ctx = DownstairsBlockContext {
                 block_context: BlockContext {
-                    hash: u64::from_le_bytes(hash[..].try_into()?),
+                    hash: hash as u64,
                     encryption_context,
                 },
                 block: block_index,
-                on_disk_hash: u64::from_le_bytes(on_disk_hash[..].try_into()?),
+                on_disk_hash: on_disk_hash as u64,
             };
 
             results[(ctx.block - block) as usize].push(ctx);
@@ -225,10 +225,10 @@ impl Inner {
 
         let rows_affected = tx.prepare_cached(stmt)?.execute(params![
             block_context.block,
-            block_context.block_context.hash.to_le_bytes(),
+            block_context.block_context.hash as i64,
             nonce,
             tag,
-            block_context.on_disk_hash.to_le_bytes(),
+            block_context.on_disk_hash as i64,
         ])?;
 
         // We avoid INSERTing duplicate rows, so this should always be 0 or 1.
@@ -272,7 +272,7 @@ impl Inner {
             let mut stmt = tx.prepare_cached(stmt)?;
             for (block, on_disk_hash) in extent_block_indexes_and_hashes {
                 let _rows_affected =
-                    stmt.execute(params![block, on_disk_hash.to_le_bytes()])?;
+                    stmt.execute(params![block, on_disk_hash as i64])?;
             }
         }
         tx.commit()?;
@@ -760,10 +760,10 @@ impl Extent {
             metadb.execute(
                 "CREATE TABLE block_context (
                     block INTEGER,
-                    hash BLOB NOT NULL,
+                    hash INTEGER,
                     nonce BLOB,
                     tag BLOB,
-                    on_disk_hash BLOB NOT NULL,
+                    on_disk_hash INTEGER,
                     PRIMARY KEY (block, hash, nonce, tag, on_disk_hash)
                 )",
                 [],


### PR DESCRIPTION
Here's the WITHOUT ROWID changes per https://github.com/oxidecomputer/crucible/issues/764 https://github.com/oxidecomputer/crucible/issues/763

Note that as a side effect of this, the contexts/hashes will not be sent to upstairs in the order that they were written, it'll be basically random per the hashing function. This doesn't matter for any blocks read after a flush since there will only be one context anyway. This shouldn't matter for any blocks read before a flush because upstairs already scans thru all contexts and picks the whichever one matches.

So yeah in theory this adds some computational overhead to upstairs for finding the right context since its a random distribution as to how far thru the contexts it needs to scan before finding the right one instead of usually being the first one in the list. But (especially given we're tightening down the flush interval significantly anyway), I think you won't see those context lists get big enough for it to matter.

Also we can revert the integer hashes change if y'all hate that one. it helps with perf a little bit and I like what it does to the code but its on the margins