### PR TITLE
Allow dsc more than three downstairs.

### DIFF
--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -81,10 +81,11 @@ enum Action {
         output_dir: PathBuf,
 
         /// The directory where the downstairs regions will be created.
-        /// Either provide once, or three times.  One means all downstairs
+        /// Either provide once, or "N" times.  One means all downstairs
         /// share the same top level directory (each downstairs has its own
-        /// subdirectory).  Three means each downstairs will get its own
-        /// region directory.
+        /// subdirectory).  "N" means we will create "N" downstairs and each
+        /// downstairs will get its own region directory.  If using N other
+        /// than 3, you must also provide a matching "region-dir" value.
         #[clap(
             long,
             global = true,
@@ -182,10 +183,11 @@ enum Action {
         output_dir: PathBuf,
 
         /// The directory where the downstairs regions will be created.
-        /// Either provide once, or three times.  One means all downstairs
+        /// Either provide once, or "N" times.  One means all downstairs
         /// share the same top level directory (each downstairs has its own
-        /// subdirectory).  Three means each downstairs will get its own
-        /// region directory.
+        /// subdirectory).  "N" means we will create "N" downstairs and each
+        /// downstairs will get its own region directory.  If using N other
+        /// than 3, you must also provide a matching "region-dir" value.
         #[clap(
             long,
             global = true,
@@ -299,7 +301,7 @@ impl DscInfo {
         }
 
         // There should either be one region dir in the vec, or as many
-        // directories as the region_count requested..
+        // directories as the region_count.
         // If there is one directory, then the downstairs will all share it.
         // If there are more, then each downstairs will get its own
         // directory.
@@ -360,9 +362,9 @@ impl DscInfo {
         }
 
         // If we only have one region directory, then use that for all
-        // three downstairs.  If we have three, then each downstairs can
-        // have its own.
-        //
+        // downstairs.  If we have provided more than one region directory
+        // (and a matching region_count) then each downstairs will have
+        // its own region directory.
         let mut rv = Vec::new();
 
         if region_dir.len() == 1 {
@@ -1774,8 +1776,8 @@ mod test {
 
     #[tokio::test]
     async fn restart_region_four_bad() {
-        // Test a restart with four region directories when their only
-        // exist three
+        // Test a restart with four region directories when only three
+        // actually exist.
         let (ds_bin, _ds_path) = temp_file_path();
 
         let dir = tempdir().unwrap().as_ref().to_path_buf();

--- a/tools/test_dsc.sh
+++ b/tools/test_dsc.sh
@@ -69,18 +69,18 @@ res=0
 outfile="/tmp/test_dsc.txt"
 echo "" > $outfile
 
+# Region directories
 r1="/var/tmp/test_dsc_r1"
-if [[ -d ${r1} ]]; then
-    rm -rf ${r1}
-fi
 r2="/var/tmp/test_dsc_r2"
-if [[ -d ${r2} ]]; then
-    rm -rf ${r2}
-fi
 r3="/var/tmp/test_dsc_r3"
-if [[ -d ${r3} ]]; then
-    rm -rf ${r3}
-fi
+r4="/var/tmp/test_dsc_r4"
+
+for rd in $r1 $r2 $r3 $r4; do
+    if [[ -d ${rd} ]]; then
+        rm -rf ${rd}
+    fi
+done
+
 # test with three different directories
 echo "$dsc" create --ds-bin "$downstairs" --extent-count 5 \
     --extent-size 5 --output-dir "$testdir" \
@@ -95,7 +95,7 @@ echo "$dsc" create --ds-bin "$downstairs" --extent-count 5 \
     --region-dir "$r3" \
     | tee "$outfile"
 if [[ $? -ne 0 ]]; then
-    echo "Failed to create multi dir region" | tee -a "$fail_log"
+    echo "Failed to create three directory region set" | tee -a "$fail_log"
     (( res += 1 ))
 fi
 
@@ -111,6 +111,41 @@ done
 
 # Cleanup after above test
 rm -rf ${testdir} ${r1} ${r2} ${r3}
+
+# test with four different directories
+echo "$dsc" create --ds-bin "$downstairs" --extent-count 5 \
+    --extent-size 5 --output-dir "$testdir" \
+    --region-count 4 \
+    --region-dir "$r1" \
+    --region-dir "$r2" \
+    --region-dir "$r3" \
+    --region-dir "$r4" | tee "$outfile"
+
+"$dsc" create --ds-bin "$downstairs" --extent-count 5 \
+    --extent-size 5 --output-dir "$testdir" \
+    --region-count 4 \
+    --region-dir "$r1" \
+    --region-dir "$r2" \
+    --region-dir "$r3" \
+    --region-dir "$r4" \
+    | tee "$outfile"
+if [[ $? -ne 0 ]]; then
+    echo "Failed to create four directory region set" | tee -a "$fail_log"
+    (( res += 1 ))
+fi
+
+# Assuming the default port of 8810 here
+for rdirs in "$r1"/8810 "$r2"/8820 "$r3"/8830 "$r4"/8840
+do
+    if [[ ! -d "$rdirs" ]]; then
+        echo "Failed to create $rdirs region" | tee -a "$fail_log"
+        (( res += 1 ))
+
+    fi
+done
+
+# Cleanup after above test
+rm -rf ${testdir} ${r1} ${r2} ${r3} ${r4}
 
 echo "$dsc" create --ds-bin "$downstairs" --extent-count 5 \
     --extent-size 5 --output-dir "$testdir" \


### PR DESCRIPTION
Updated the dsc tool to be able to create and start more than just three downstairs.  
Updated the dsc test to check and allow for more than three.

This will pave the way for test support for replacement of a downstairs.  By allowing dsc
to create and start additional downstairs processes, we can automate replacing one
downstairs with another.