### PR TITLE
New dtrace counters for upstairs state of downstairs connections

### DIFF
--- a/tools/dtrace/README.md
+++ b/tools/dtrace/README.md
@@ -312,6 +312,45 @@ DS 0 STATE   DS 1 STATE   DS 2 STATE   UPW  DSW  NEW0 NEW1 NEW2   IP0  IP1  IP2 
     active       active       active     9 2175     1    1  576     8    8  100  2166 2166 1499     0    0    0   0  0  0
 ```
 
+## upstairs_count.d
+This is a dtrace script similar to the upstairs_info, but here we are
+printing various upstairs counters.
+If the upstairs is not yet running, add the -Z flag to dtrace so it will
+wait to find the matching probe.
+```
+pfexec dtrace -s upstairs_count.d
+```
+
+You start crucible, then run the above script.  Output should start appearing
+within a few seconds.
+
+The output has several columns.  The first three will list the state of each
+of the three downstairs.  Following that the remaining columns all indicate
+various internal counters.  The upstairs records values for these counters
+at an interval defined in the up_listen() function.
+
+The remaining columns 4-15 are all groups of three where there is a counter
+for each downstairs client.
+
+`CON` The number of times the upstairs has connected to downstairs.
+`LRC` The number of times this downstairs has completed a LiveRepair.
+`LRA` The number of times this downstiars aborted a LiveRepair.
+`REP` The number of times this downstairs was replaced. 
+
+Here is an example of how it might look:
+```
+alan@cat:crucible$ pfexec dtrace -s upstairs_count.d
+       DS STATE 0        DS STATE 1        DS STATE 2  CON0 CON1 CON2 LRC0 LRC1 LRC2 LRA0 LRA1 LRA2 REP0 REP1 REP2
+              new               new               new     1    1    1    0    0    0    0    0    0    0    0    0
+              new               new               new     1    1    0    0    0    0    0    0    0    0    0    0
+      wait_quorum       wait_quorum               new     1    1    0    0    0    0    0    0    0    0    0    0
+           repair            repair            repair     1    1    1    0    0    0    0    0    0    0    0    0
+           repair            repair            repair     1    1    1    0    0    0    0    0    0    0    0    0
+```
+## upstairs_raw.d
+This is a dtrace script that just dumps the `Arg` structure in json format.
+The output of this can be sent to other commands for additional processing.
+
 ## tracegw.d
 This is a dtrace example script for counting IOs into and out of
 crucible from the guest.

--- a/tools/dtrace/upstairs_count.d
+++ b/tools/dtrace/upstairs_count.d
@@ -1,0 +1,58 @@
+/*
+ * Display internal Upstairs live repair status.
+ */
+#pragma D option quiet
+#pragma D option strsize=1k
+/*
+ * Print the header right away
+ */
+dtrace:::BEGIN
+{
+    show = 21;
+}
+
+/*
+ * Every second, check and see if we have printed enough that it is
+ * time to print the header again
+ */
+tick-1s
+/show > 20/
+{
+    printf("%17s %17s %17s", "DS STATE 0", "DS STATE 1", "DS STATE 2");
+    printf("  %4s %4s %4s %4s %4s %4s",
+        "CON0", "CON1", "CON2", "LRC0", "LRC1", "LRC2");
+    printf(" %4s %4s %4s %4s %4s %4s",
+        "LRA0", "LRA1", "LRA2", "REP0", "REP1", "REP2");
+    printf("\n");
+    show = 0;
+}
+
+crucible_upstairs*:::up-status
+{
+    show = show + 1;
+    /*
+     * State for the three downstiars
+     */
+    printf("%17s", json(copyinstr(arg1), "ok.ds_state[0]"));
+    printf(" %17s", json(copyinstr(arg1), "ok.ds_state[1]"));
+    printf(" %17s", json(copyinstr(arg1), "ok.ds_state[2]"));
+
+    /*
+     * Repair counts for the downstairs
+     */
+    printf(" ");
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_connected[0]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_connected[1]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_connected[2]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_live_repair_completed[0]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_live_repair_completed[1]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_live_repair_completed[2]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_live_repair_aborted[0]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_live_repair_aborted[1]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_live_repair_aborted[2]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_replaced[0]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_replaced[1]"));
+    printf(" %4s", json(copyinstr(arg1), "ok.ds_replaced[2]"));
+
+    printf("\n");
+}

--- a/tools/dtrace/upstairs_raw.d
+++ b/tools/dtrace/upstairs_raw.d
@@ -1,0 +1,12 @@
+/*
+ * Dump the dtrace up-status in json format
+ * This can be used to pipe to other command that
+ * can display whatever fields of the structure you wish.
+ */
+#pragma D option quiet
+#pragma D option strsize=1k
+crucible_upstairs*:::up-status
+{
+    trace(json(copyinstr(arg1), "ok"));
+    printf("\n");
+}


### PR DESCRIPTION
Added a DTrace counter each time the upstairs connects to a respective downstairs.  
Added a (future) counter for downstairs replacements.

Updated stat collection to have its own interval instead of being tied to the flush_timeout interval 
(which was too short for it). Removed the unused show_work_interval.

Added some additional DTrace example scripts showing usage of these new counters.  
Updated README.md in dtrace directory.

New dtrace script prints like this:
```
       DS STATE 0        DS STATE 1        DS STATE 2  CON0 CON1 CON2 LRC0 LRC1 LRC2 LRA0 LRA1 LRA2 REP0 REP1 REP2
      wait_active       wait_active       wait_active     2    2    2    0    0    0    0    0    0    0    0    0
      wait_active       wait_active       wait_active     2    2    2    0    0    0    0    0    0    0    0    0
      wait_active       wait_active       wait_active     2    2    2    0    0    0    0    0    0    0    0    0
      wait_active       wait_active       wait_active     2    2    2    0    0    0    0    0    0    0    0    0
              new               new               new     1    1    1    0    0    0    0    0    0    0    0    0
              new               new               new     1    1    1    0    0    0    0    0    0    0    0    0
              new               new               new     1    1    0    0    0    0    0    0    0    0    0    0
      wait_quorum       wait_quorum               new     1    1    0    0    0    0    0    0    0    0    0    0
           repair            repair            repair     1    1    1    0    0    0    0    0    0    0    0    0
           repair            repair            repair     1    1    1    0    0    0    0    0    0    0    0    0
```

Also added a "raw" example, you can pipe this output to whatever you want:
```
alan@atrium:crucible$ pfexec dtrace -Z -s tools/dtrace/upstairs_raw.d 
{"up_count":0,"ds_count":0,"ds_state":["new","new","new"],"ds_io_count":{"new":[0,0,0],"in_progress":[0,0,0],"done":[0,0,0],"skipped":[0,0,0],"error":[0,0,0]},"ds_repair":[0,0,0],"ds_confirm":[0,0,0],"ds_live_repair_completed":[0,0,0],"ds_live_repair_aborted":[0,0,0],"ds_connected":[0,0,0],"ds_replaced":[0,0,0]}
```

Like so:
```
alan@atrium:crucible$ pfexec dtrace -Z -s tools/dtrace/upstairs_raw.d  | jq '.ds_connected'
[
  1,
  1,
  1
]
```