### PR TITLE
test-live-repair is not finishing, disable for now

### DIFF
--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -41,6 +41,7 @@ echo "bindir contains:"
 ls -ltr "$BINDIR" || true
 
 banner LR
-ptime -m bash "$input/scripts/test_live_repair.sh"
+echo "This test is skipped till Alan fixes it"
+# ptime -m bash "$input/scripts/test_live_repair.sh"
 
 # Save the output files?


### PR DESCRIPTION
Turning off the test-live-repair CI test, as its is not finishing.
I'll figure out why it is broken, fix it, then re-enable it.

Turning it off on main for now while I debug and to allow others CI jobs to pass.
