### PR TITLE
Accept a length for pantry validation requests

### DIFF
--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -3768,96 +3768,9 @@ mod test {
 
         let tds = TestDownstairsSet::small(false).await.unwrap();
 
-        // Start a pantry, get the client for it, then use it to bulk_write in
-        // data
+        // Start a pantry, get the client for it
         let (_pantry, volume_id, client) =
             get_pantry_and_client_for_tds(&tds).await;
-
-        // parallel bulk write in a bunch of random data in a random order
-
-        const THREADS: usize = 10;
-        const CHUNK_SIZE: usize = 512;
-
-        let total_size = tds.blocks_per_extent() as usize
-            * tds.extent_count() as usize
-            * BLOCK_SIZE;
-
-        assert_eq!(total_size % CHUNK_SIZE, 0);
-        assert_eq!((total_size / CHUNK_SIZE) % THREADS, 0);
-
-        let mut handles = Vec::with_capacity(THREADS);
-        let mut senders = Vec::with_capacity(THREADS);
-
-        for _i in 0..THREADS {
-            let (tx, mut rx) = mpsc::channel(100);
-            let client = client.clone();
-
-            handles.push(tokio::spawn(async move {
-                while let Some((offset, base64_encoded_data)) = rx.recv().await
-                {
-                    client
-                        .bulk_write(
-                            &volume_id.to_string(),
-                            &crucible_pantry_client::types::BulkWriteRequest {
-                                offset,
-                                base64_encoded_data,
-                            },
-                        )
-                        .await
-                        .unwrap();
-                }
-            }));
-
-            senders.push(tx);
-        }
-
-        for i in 0..(total_size / CHUNK_SIZE) {
-            let mut data = vec![0u8; CHUNK_SIZE];
-            rand::thread_rng().fill(&mut data[..]);
-            let base64_encoded_data =
-                engine::general_purpose::STANDARD.encode(&data);
-
-            senders[i % THREADS]
-                .send(((i * CHUNK_SIZE) as u64, base64_encoded_data))
-                .await
-                .unwrap();
-        }
-
-        for sender in senders {
-            drop(sender);
-        }
-
-        for handle in handles {
-            handle.await.unwrap();
-        }
-
-        // then, bulk read it out
-        let mut buffer = Vec::with_capacity(total_size);
-
-        for i in 0..(total_size / CHUNK_SIZE) {
-            let response = client
-                .bulk_read(
-                    &volume_id.to_string(),
-                    &crucible_pantry_client::types::BulkReadRequest {
-                        offset: (i * CHUNK_SIZE) as u64,
-                        size: CHUNK_SIZE as u32,
-                    },
-                )
-                .await
-                .unwrap();
-
-            let mut data = engine::general_purpose::STANDARD
-                .decode(&response.base64_encoded_data)
-                .unwrap();
-
-            buffer.append(&mut data);
-        }
-
-        // sha256 here, then send digest to validate function
-        // only send half the bytes to the hasher
-        let mut hasher = sha2::Sha256::new();
-        hasher.update(&buffer.to_vec()[0..100]);
-        let digest = hex::encode(hasher.finalize());
 
         let response = client
             .validate(
@@ -3865,7 +3778,7 @@ mod test {
                 &crucible_pantry_client::types::ValidateRequest {
                     expected_digest:
                         crucible_pantry_client::types::ExpectedDigest::Sha256(
-                            digest.to_string(),
+                            "wrong size".to_string(),
                         ),
 
                     // validate 100 bytes!

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -3605,6 +3605,9 @@ mod test {
                         crucible_pantry_client::types::ExpectedDigest::Sha256(
                             digest.to_string(),
                         ),
+
+                    // validate the whole volume's contents
+                    size_to_validate: None,
                 },
             )
             .await
@@ -3621,6 +3624,268 @@ mod test {
 
         let response = client.job_result_ok(&response.job_id).await.unwrap();
         assert!(response.job_result_ok);
+
+        client.detach(&volume_id.to_string()).await.unwrap();
+    }
+
+    // Test validating a subset of the beginning of the volume
+    #[tokio::test]
+    async fn test_pantry_validate_subset() {
+        const BLOCK_SIZE: usize = 512;
+
+        // Spin off three downstairs, build our Crucible struct.
+
+        let tds = TestDownstairsSet::small(false).await.unwrap();
+
+        // Start a pantry, get the client for it, then use it to bulk_write in
+        // data
+        let (_pantry, volume_id, client) =
+            get_pantry_and_client_for_tds(&tds).await;
+
+        // parallel bulk write in a bunch of random data in a random order
+
+        const THREADS: usize = 10;
+        const CHUNK_SIZE: usize = 512;
+
+        let total_size = tds.blocks_per_extent() as usize
+            * tds.extent_count() as usize
+            * BLOCK_SIZE;
+
+        assert_eq!(total_size % CHUNK_SIZE, 0);
+        assert_eq!((total_size / CHUNK_SIZE) % THREADS, 0);
+
+        let mut handles = Vec::with_capacity(THREADS);
+        let mut senders = Vec::with_capacity(THREADS);
+
+        for _i in 0..THREADS {
+            let (tx, mut rx) = mpsc::channel(100);
+            let client = client.clone();
+
+            handles.push(tokio::spawn(async move {
+                while let Some((offset, base64_encoded_data)) = rx.recv().await
+                {
+                    client
+                        .bulk_write(
+                            &volume_id.to_string(),
+                            &crucible_pantry_client::types::BulkWriteRequest {
+                                offset,
+                                base64_encoded_data,
+                            },
+                        )
+                        .await
+                        .unwrap();
+                }
+            }));
+
+            senders.push(tx);
+        }
+
+        for i in 0..(total_size / CHUNK_SIZE) {
+            let mut data = vec![0u8; CHUNK_SIZE];
+            rand::thread_rng().fill(&mut data[..]);
+            let base64_encoded_data =
+                engine::general_purpose::STANDARD.encode(&data);
+
+            senders[i % THREADS]
+                .send(((i * CHUNK_SIZE) as u64, base64_encoded_data))
+                .await
+                .unwrap();
+        }
+
+        for sender in senders {
+            drop(sender);
+        }
+
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        // then, bulk read it out
+        let mut buffer = Vec::with_capacity(total_size);
+
+        for i in 0..(total_size / CHUNK_SIZE) {
+            let response = client
+                .bulk_read(
+                    &volume_id.to_string(),
+                    &crucible_pantry_client::types::BulkReadRequest {
+                        offset: (i * CHUNK_SIZE) as u64,
+                        size: CHUNK_SIZE as u32,
+                    },
+                )
+                .await
+                .unwrap();
+
+            let mut data = engine::general_purpose::STANDARD
+                .decode(&response.base64_encoded_data)
+                .unwrap();
+
+            buffer.append(&mut data);
+        }
+
+        // sha256 here, then send digest to validate function
+        // only send half the bytes to the hasher
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(&buffer.to_vec()[0..(total_size / 2)]);
+        let digest = hex::encode(hasher.finalize());
+
+        let response = client
+            .validate(
+                &volume_id.to_string(),
+                &crucible_pantry_client::types::ValidateRequest {
+                    expected_digest:
+                        crucible_pantry_client::types::ExpectedDigest::Sha256(
+                            digest.to_string(),
+                        ),
+
+                    // validate half the volume
+                    size_to_validate: Some(total_size as u32 / 2),
+                },
+            )
+            .await
+            .unwrap();
+
+        while !client
+            .is_job_finished(&response.job_id)
+            .await
+            .unwrap()
+            .job_is_finished
+        {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+
+        let response = client.job_result_ok(&response.job_id).await.unwrap();
+        assert!(response.job_result_ok);
+
+        client.detach(&volume_id.to_string()).await.unwrap();
+    }
+
+    // Test validating a non-block size amount fails
+    #[tokio::test]
+    async fn test_pantry_validate_fail() {
+        const BLOCK_SIZE: usize = 512;
+
+        // Spin off three downstairs, build our Crucible struct.
+
+        let tds = TestDownstairsSet::small(false).await.unwrap();
+
+        // Start a pantry, get the client for it, then use it to bulk_write in
+        // data
+        let (_pantry, volume_id, client) =
+            get_pantry_and_client_for_tds(&tds).await;
+
+        // parallel bulk write in a bunch of random data in a random order
+
+        const THREADS: usize = 10;
+        const CHUNK_SIZE: usize = 512;
+
+        let total_size = tds.blocks_per_extent() as usize
+            * tds.extent_count() as usize
+            * BLOCK_SIZE;
+
+        assert_eq!(total_size % CHUNK_SIZE, 0);
+        assert_eq!((total_size / CHUNK_SIZE) % THREADS, 0);
+
+        let mut handles = Vec::with_capacity(THREADS);
+        let mut senders = Vec::with_capacity(THREADS);
+
+        for _i in 0..THREADS {
+            let (tx, mut rx) = mpsc::channel(100);
+            let client = client.clone();
+
+            handles.push(tokio::spawn(async move {
+                while let Some((offset, base64_encoded_data)) = rx.recv().await
+                {
+                    client
+                        .bulk_write(
+                            &volume_id.to_string(),
+                            &crucible_pantry_client::types::BulkWriteRequest {
+                                offset,
+                                base64_encoded_data,
+                            },
+                        )
+                        .await
+                        .unwrap();
+                }
+            }));
+
+            senders.push(tx);
+        }
+
+        for i in 0..(total_size / CHUNK_SIZE) {
+            let mut data = vec![0u8; CHUNK_SIZE];
+            rand::thread_rng().fill(&mut data[..]);
+            let base64_encoded_data =
+                engine::general_purpose::STANDARD.encode(&data);
+
+            senders[i % THREADS]
+                .send(((i * CHUNK_SIZE) as u64, base64_encoded_data))
+                .await
+                .unwrap();
+        }
+
+        for sender in senders {
+            drop(sender);
+        }
+
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        // then, bulk read it out
+        let mut buffer = Vec::with_capacity(total_size);
+
+        for i in 0..(total_size / CHUNK_SIZE) {
+            let response = client
+                .bulk_read(
+                    &volume_id.to_string(),
+                    &crucible_pantry_client::types::BulkReadRequest {
+                        offset: (i * CHUNK_SIZE) as u64,
+                        size: CHUNK_SIZE as u32,
+                    },
+                )
+                .await
+                .unwrap();
+
+            let mut data = engine::general_purpose::STANDARD
+                .decode(&response.base64_encoded_data)
+                .unwrap();
+
+            buffer.append(&mut data);
+        }
+
+        // sha256 here, then send digest to validate function
+        // only send half the bytes to the hasher
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(&buffer.to_vec()[0..100]);
+        let digest = hex::encode(hasher.finalize());
+
+        let response = client
+            .validate(
+                &volume_id.to_string(),
+                &crucible_pantry_client::types::ValidateRequest {
+                    expected_digest:
+                        crucible_pantry_client::types::ExpectedDigest::Sha256(
+                            digest.to_string(),
+                        ),
+
+                    // validate 100 bytes!
+                    size_to_validate: Some(100),
+                },
+            )
+            .await
+            .unwrap();
+
+        while !client
+            .is_job_finished(&response.job_id)
+            .await
+            .unwrap()
+            .job_is_finished
+        {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+
+        let response = client.job_result_ok(&response.job_id).await.unwrap();
+        assert!(!response.job_result_ok);
 
         client.detach(&volume_id.to_string()).await.unwrap();
     }

--- a/openapi/crucible-pantry.json
+++ b/openapi/crucible-pantry.json
@@ -634,6 +634,12 @@
         "properties": {
           "expected_digest": {
             "$ref": "#/components/schemas/ExpectedDigest"
+          },
+          "size_to_validate": {
+            "nullable": true,
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
           }
         },
         "required": [

--- a/pantry/src/server.rs
+++ b/pantry/src/server.rs
@@ -278,6 +278,10 @@ async fn scrub(
 #[derive(Deserialize, JsonSchema)]
 struct ValidateRequest {
     pub expected_digest: ExpectedDigest,
+
+    // Size to validate in bytes, starting from offset 0. If not specified, the
+    // total volume size is used.
+    pub size_to_validate: Option<usize>,
 }
 
 #[derive(Serialize, JsonSchema)]
@@ -300,7 +304,7 @@ async fn validate(
     let pantry = rc.context();
 
     let job_id = pantry
-        .validate(path.id.clone(), body.expected_digest)
+        .validate(path.id.clone(), body.expected_digest, body.size_to_validate)
         .await
         .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
 


### PR DESCRIPTION
When the user is uploading a file to a disk, they may specify that the disk's size is larger than the file size. In that case, an unbounded validation request's digest would not match the file's digest because the pantry would be hashing all the blocks of zeros after the user's uploaded bits.

Change the validation request to accept a size to validate in bytes.