### PR TITLE
Turn on live-repair test in CI

### DIFF
--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -73,7 +73,9 @@ ptime -m "$BINDIR"/crutest replay \
   -g 1 -c 40 -q | tee /tmp/crutest-replay.log
 
 banner StopDSC
-$input/bins/dsc cmd shutdown
+$BINDIR/dsc cmd shutdown
+
+banner WaitStop
 wait "$dsc_pid"
 
 # Save the output files?

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -40,8 +40,16 @@ echo "BINDIR is $BINDIR"
 echo "bindir contains:"
 ls -ltr "$BINDIR" || true
 
+banner StartDSC
+$input/bins/dsc start --create --cleanup > /tmp/dsc.log 2>&1 &
+dsc_pid=$?
+
 banner LR
-echo "This test is skipped till Alan fixes it"
-# ptime -m bash "$input/scripts/test_live_repair.sh"
+ptime -m "$input"/bin/crutest replay -t 127.0.0.1:8810 \
+ -t 127.0.0.1:8820 -t 127.0.0.1:8830 -g 1 -c 40 -q | tee /tmp/crutest-replay.log
+
+banner StopDSC
+$input/bins/dsc cmd shutdown
+wait "$dsc_pid"
 
 # Save the output files?

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -70,7 +70,7 @@ fi
 banner LR
 ptime -m "$BINDIR"/crutest replay \
   -t 127.0.0.1:8810 -t 127.0.0.1:8820 -t 127.0.0.1:8830 \
-  -g 1 -c 40 -q | tee /tmp/crutest-replay.log
+  -g 1 -c 60 -q > /tmp/crutest-replay.log 2>&1
 
 banner StopDSC
 $BINDIR/dsc cmd shutdown

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -41,9 +41,18 @@ echo "bindir contains:"
 ls -ltr "$BINDIR" || true
 
 banner StartDSC
-$BINDIR/dsc start --downstairs-bin "$BINDIR" \
-  --create --cleanup > /tmp/dsc.log 2>&1 &
+$BINDIR/dsc start --downstairs-bin "$BINDIR"/crucible-downstairs --create --cleanup > /tmp/dsc.log 2>&1 &
 dsc_pid=$?
+
+echo dsc_pid is $dsc_pid
+cat /tmp/dsc.log
+
+if ps -p $dsc_pid; then
+    echo "Found dsc"
+else
+    echo "dsc failed"
+    exit 1
+fi
 
 banner LR
 ptime -m "$BINDIR"/crutest replay \

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -41,8 +41,14 @@ echo "bindir contains:"
 ls -ltr "$BINDIR" || true
 
 banner CreateDS
-echo $BINDIR/dsc create --ds-bin "$BINDIR"/crucible-downstairs --cleanup
-$BINDIR/dsc create --ds-bin "$BINDIR"/crucible-downstairs --cleanup
+echo $BINDIR/dsc create \
+  --ds-bin "$BINDIR"/crucible-downstairs \
+  --region-count 4 \
+  --cleanup
+$BINDIR/dsc create \
+  --ds-bin "$BINDIR"/crucible-downstairs \
+  --region-count 4 \
+  --cleanup
 
 banner StartDS
 $BINDIR/dsc start --ds-bin "$BINDIR"/crucible-downstairs --create --cleanup >> /tmp/dsc.log 2>&1 &
@@ -68,9 +74,10 @@ else
 fi
 
 banner LR
-ptime -m "$BINDIR"/crutest replay \
+ptime -m "$BINDIR"/crutest replace \
   -t 127.0.0.1:8810 -t 127.0.0.1:8820 -t 127.0.0.1:8830 \
-  -g 1 -c 60 -q > /tmp/crutest-replay.log
+  --replacement 127.0.0.1:8840 \
+  -g 1 -c 10 -q > /tmp/crutest-replace.log
 
 banner StopDSC
 $BINDIR/dsc cmd shutdown

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -46,23 +46,24 @@ $BINDIR/dsc create --ds-bin "$BINDIR"/crucible-downstairs --cleanup
 
 banner StartDS
 $BINDIR/dsc start --ds-bin "$BINDIR"/crucible-downstairs --create --cleanup >> /tmp/dsc.log 2>&1 &
-dsc_pid=$?
 
 # This gives dsc time to fail, as it is known to happen.  If we don't check,
 # then the later test will just hang forever waiting for downstairs that
 # will never show up.
 sleep 5
-echo After 5 seconds, dsc_pid is $dsc_pid
+dsc_pid=$(pgrep dsc);
 
 if [[ "$dsc_pid" -eq 0 ]]; then
     echo "dsc_pid is invalid, exit"
+    cat /tmp/dsc.log || true
     exit 1
 fi
 
-if ps -p $dsc_pid; then
+if ps -p "$dsc_pid"; then
     echo "Found dsc running, continue tests"
 else
     echo "dsc failed"
+    cat /tmp/dsc.log || true
     exit 1
 fi
 

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -25,7 +25,7 @@ ls -ltr "$input"/bins || true
 echo "input script dir contains:"
 ls -ltr "$input"/scripts || true
 
-banner unpack
+banner Unpack
 mkdir -p /var/tmp/bins
 for t in "$input/bins/"*.gz; do
 	b=$(basename "$t")
@@ -54,7 +54,7 @@ sleep 5
 dsc_pid=$(pgrep dsc);
 
 if [[ "$dsc_pid" -eq 0 ]]; then
-    echo "dsc_pid is invalid, exit"
+    echo "dsc_pid is zero, which is bad, exit"
     cat /tmp/dsc.log || true
     exit 1
 fi

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -41,10 +41,21 @@ echo "bindir contains:"
 ls -ltr "$BINDIR" || true
 
 banner StartDSC
+echo $BINDIR/dsc create --downstairs-bin "$BINDIR"/crucible-downstairs --cleanup
+$BINDIR/dsc create --downstairs-bin "$BINDIR"/crucible-downstairs --cleanup
+echo "dsc try 1 done"
+sleep 1
+echo "Try again"
+
 $BINDIR/dsc start --downstairs-bin "$BINDIR"/crucible-downstairs --create --cleanup > /tmp/dsc.log 2>&1 &
 dsc_pid=$?
 
+sleep 5
+ls -l $BINDIR/dsc
+
+
 echo dsc_pid is $dsc_pid
+ls -l /tmp
 cat /tmp/dsc.log
 
 if ps -p $dsc_pid; then

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -70,7 +70,7 @@ fi
 banner LR
 ptime -m "$BINDIR"/crutest replay \
   -t 127.0.0.1:8810 -t 127.0.0.1:8820 -t 127.0.0.1:8830 \
-  -g 1 -c 60 -q > /tmp/crutest-replay.log 2>&1
+  -g 1 -c 60 -q > /tmp/crutest-replay.log
 
 banner StopDSC
 $BINDIR/dsc cmd shutdown

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -40,26 +40,22 @@ echo "BINDIR is $BINDIR"
 echo "bindir contains:"
 ls -ltr "$BINDIR" || true
 
-banner StartDSC
-echo $BINDIR/dsc create --downstairs-bin "$BINDIR"/crucible-downstairs --cleanup
-$BINDIR/dsc create --downstairs-bin "$BINDIR"/crucible-downstairs --cleanup
-echo "dsc try 1 done"
-sleep 1
-echo "Try again"
+banner CreateDS
+echo $BINDIR/dsc create --ds-bin "$BINDIR"/crucible-downstairs --cleanup
+$BINDIR/dsc create --ds-bin "$BINDIR"/crucible-downstairs --cleanup > /tmp/dsc.log 2>&1
 
-$BINDIR/dsc start --downstairs-bin "$BINDIR"/crucible-downstairs --create --cleanup > /tmp/dsc.log 2>&1 &
+banner StartDS
+$BINDIR/dsc start --ds-bin "$BINDIR"/crucible-downstairs --create --cleanup >> /tmp/dsc.log 2>&1 &
 dsc_pid=$?
 
+# This gives dsc time to fail, as it is known to happen.  If we don't check,
+# then the later test will just hang forever waiting for downstairs that
+# will never show up.
 sleep 5
-ls -l $BINDIR/dsc
-
-
 echo dsc_pid is $dsc_pid
-ls -l /tmp
-cat /tmp/dsc.log
 
 if ps -p $dsc_pid; then
-    echo "Found dsc"
+    echo "Found dsc running, continue tests"
 else
     echo "dsc failed"
     exit 1

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -41,12 +41,14 @@ echo "bindir contains:"
 ls -ltr "$BINDIR" || true
 
 banner StartDSC
-$input/bins/dsc start --create --cleanup > /tmp/dsc.log 2>&1 &
+$BINDIR/dsc start --downstairs-bin "$BINDIR" \
+  --create --cleanup > /tmp/dsc.log 2>&1 &
 dsc_pid=$?
 
 banner LR
-ptime -m "$input"/bin/crutest replay -t 127.0.0.1:8810 \
- -t 127.0.0.1:8820 -t 127.0.0.1:8830 -g 1 -c 40 -q | tee /tmp/crutest-replay.log
+ptime -m "$BINDIR"/crutest replay \
+  -t 127.0.0.1:8810 -t 127.0.0.1:8820 -t 127.0.0.1:8830 \
+  -g 1 -c 40 -q | tee /tmp/crutest-replay.log
 
 banner StopDSC
 $input/bins/dsc cmd shutdown

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -51,7 +51,9 @@ $BINDIR/dsc create \
   --cleanup
 
 banner StartDS
-$BINDIR/dsc start --ds-bin "$BINDIR"/crucible-downstairs --create --cleanup >> /tmp/dsc.log 2>&1 &
+$BINDIR/dsc start \
+  --ds-bin "$BINDIR"/crucible-downstairs \
+  --region-count 4 >> /tmp/dsc.log 2>&1 &
 
 # This gives dsc time to fail, as it is known to happen.  If we don't check,
 # then the later test will just hang forever waiting for downstairs that

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -42,7 +42,7 @@ ls -ltr "$BINDIR" || true
 
 banner CreateDS
 echo $BINDIR/dsc create --ds-bin "$BINDIR"/crucible-downstairs --cleanup
-$BINDIR/dsc create --ds-bin "$BINDIR"/crucible-downstairs --cleanup > /tmp/dsc.log 2>&1
+$BINDIR/dsc create --ds-bin "$BINDIR"/crucible-downstairs --cleanup
 
 banner StartDS
 $BINDIR/dsc start --ds-bin "$BINDIR"/crucible-downstairs --create --cleanup >> /tmp/dsc.log 2>&1 &
@@ -52,7 +52,12 @@ dsc_pid=$?
 # then the later test will just hang forever waiting for downstairs that
 # will never show up.
 sleep 5
-echo dsc_pid is $dsc_pid
+echo After 5 seconds, dsc_pid is $dsc_pid
+
+if [[ "$dsc_pid" -eq 0 ]]; then
+    echo "dsc_pid is invalid, exit"
+    exit 1
+fi
 
 if ps -p $dsc_pid; then
     echo "Found dsc running, continue tests"

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -9576,8 +9576,8 @@ async fn gone_too_long(up: &Arc<Upstairs>, ds_done_tx: mpsc::Sender<u64>) {
                     warn!(
                         up.log,
                         "[up] downstairs {} failed, too many outstanding jobs {}",
-                        work_count,
                         cid,
+                        work_count,
                     );
                     if ds.ds_set_faulted(cid) {
                         notify_guest = true;


### PR DESCRIPTION
This enables a new live-repair test using crutest and dsc instead of some massive bash script.  
bash script shame was too great after the last demo Friday.