### PR TITLE
Add a quick fill for crutest, fix clippy warnings

### DIFF
--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -241,10 +241,10 @@ impl RegionDefinition {
 
 /**
  * Default for Upstairs to use before it receives the actual values
- * from the downstairs.  XXX I think I can better do this with an Option.
+ * from the downstairs.
  */
-impl RegionDefinition {
-    pub fn default() -> RegionDefinition {
+impl Default for RegionDefinition {
+    fn default() -> RegionDefinition {
         RegionDefinition {
             block_size: 0,
             extent_size: Block::new(0, 9),
@@ -255,6 +255,8 @@ impl RegionDefinition {
             database_write_version: DATABASE_WRITE_VERSION,
         }
     }
+}
+impl RegionDefinition {
     pub fn test_default(
         database_read_version: usize,
         database_write_version: usize,

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -1452,11 +1452,12 @@ async fn fill_sparse_workload(
 
     // Figure out how many extents we have
     let extents = ri.total_blocks / (ri.extent_size.value as usize);
+    let extent_size = ri.extent_size.value as usize;
 
     // Do one write to each extent.
-    for extent in 0..extents {
-        let mut block_index = extent * (ri.extent_size.value as usize);
-        let random_offset = rng.gen_range(0..100);
+    for extent in 0..extent_size {
+        let mut block_index: usize = extent * extent_size;
+        let random_offset: usize = rng.gen_range(0..extent_size);
         block_index += random_offset;
 
         let offset =

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -100,6 +100,11 @@ enum Workload {
     /// Run IO to the upstairs, then replace a downstairs, then run
     /// more IO and verify it all works as expected.
     Replace {
+        /// Before each replacement, do a fill of the region so
+        /// the replace will have to copy the entire region..
+        #[clap(long, action)]
+        fill: bool,
+
         /// The address:port of a running downstairs for replacement
         #[clap(long, action)]
         replacement: SocketAddr,
@@ -598,6 +603,7 @@ async fn main() -> Result<()> {
     // If we are running the replace workload, we need to know the
     // current list of targets the upstairs will be started with.
     let full_target = if let Workload::Replace {
+        fill: _,
         replacement,
         work: _,
     } = opt.workload
@@ -980,6 +986,7 @@ async fn main() -> Result<()> {
                 .await?;
         }
         Workload::Replace {
+            fill,
             replacement: _,
             work,
         } => {
@@ -1002,6 +1009,7 @@ async fn main() -> Result<()> {
                 &mut region_info,
                 full_target,
                 work,
+                fill,
             )
             .await?;
         }
@@ -1433,6 +1441,41 @@ async fn fill_workload(
 }
 
 /*
+ * Do a single random write to every extent, results in every extent being
+ * touched without having to write to every block.
+ */
+async fn fill_sparse_workload(
+    guest: &Arc<Guest>,
+    ri: &mut RegionInfo,
+) -> Result<()> {
+    let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
+
+    // Figure out how many extents we have
+    let extents = ri.total_blocks / (ri.extent_size.value as usize);
+
+    // Do one write to each extent.
+    for extent in 0..extents {
+        let mut block_index = extent * (ri.extent_size.value as usize);
+        let random_offset = rng.gen_range(0..100);
+        block_index += random_offset;
+
+        let offset =
+            Block::new(block_index as u64, ri.block_size.trailing_zeros());
+
+        ri.write_log.update_wc(block_index);
+
+        let vec = fill_vec(block_index, 1, &ri.write_log, ri.block_size);
+        let data = Bytes::from(vec);
+
+        println!("[{extent}/{extents}] Write to block {}", block_index);
+        guest.write(offset, data).await?;
+    }
+
+    guest.flush(None).await?;
+    Ok(())
+}
+
+/*
  * Generic workload.  Do a random R/W/F, but wait for the operation to be
  * ACK'd before sending the next.  Limit the size of the IO to 10 blocks.
  * Read data is verified.
@@ -1682,6 +1725,7 @@ async fn replace_workload(
     ri: &mut RegionInfo,
     full_targets: Vec<SocketAddr>,
     work: usize,
+    fill: bool,
 ) -> Result<()> {
     assert!(full_targets.len() == 4);
 
@@ -1693,6 +1737,9 @@ async fn replace_workload(
     let mut new_ds = 3;
     loop {
         println!("[{c}] Replace loop starts");
+        if fill {
+            fill_sparse_workload(guest, ri).await?;
+        }
         generic_workload(guest, &mut preload_wtq, ri).await?;
 
         println!(


### PR DESCRIPTION
Added a quick fill for crutest that will do one write to every extent in a region.  This can be used to be sure that all extents are dirty/changed without having to write to every single block in a volume.

Fixed clippy warnings for region default