### PR TITLE
Update values for flow control and gone_too_long

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -24,6 +24,10 @@ pub mod x509;
 
 pub const REPAIR_PORT_OFFSET: u16 = 4000;
 
+// Max number of submitted IOs between the upstairs and the downstairs, above
+// which flow control kicks in.
+pub const MAX_ACTIVE_COUNT: usize = 600;
+
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(
     thiserror::Error,

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1572,8 +1572,9 @@ where
     // Create the log for this task to use.
     let log = ads.lock().await.log.new(o!("task" => "main".to_string()));
 
-    // XXX flow control size to double what Upstairs has for upper limit?
-    let (_job_channel_tx, job_channel_rx) = channel(200);
+    // Give our work queue a little more space than we expect the upstairs
+    // to ever send us.
+    let (_job_channel_tx, job_channel_rx) = channel(MAX_ACTIVE_COUNT + 50);
     let job_channel_tx = Arc::new(Mutex::new(_job_channel_tx));
 
     /*
@@ -1605,7 +1606,8 @@ where
         })
     };
 
-    let (message_channel_tx, mut message_channel_rx) = channel(200);
+    let (message_channel_tx, mut message_channel_rx) =
+        channel(MAX_ACTIVE_COUNT + 50);
     let pf_task = {
         let mut adc = ads.clone();
         let tx = job_channel_tx.clone();

--- a/tools/dtrace/downstairs_count.d
+++ b/tools/dtrace/downstairs_count.d
@@ -87,7 +87,7 @@ tick-1s
     show = 0;
 }
 
-tick-2s
+tick-1s
 {
     printa("%@4u %@4u %@4u %@4u %@5u %@5u %@5u %@5u %@5u",
         @sf_start, @sf_done, @sw_start, @sw_done, @sr_start, @sr_done,

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -73,11 +73,7 @@ use async_trait::async_trait;
 
 // Max number of outstanding IOs between the upstairs and the downstairs
 // before we give up and mark that downstairs faulted.
-const IO_OUTSTANDING_MAX: usize = 1000;
-
-// Max number of submitted IOs between the upstairs and the downstairs, above
-// which flow control kicks in.
-const MAX_ACTIVE_COUNT: usize = 100;
+const IO_OUTSTANDING_MAX: usize = 5000;
 
 /// The BlockIO trait behaves like a physical NVMe disk (or a virtio virtual
 /// disk): there is no contract about what order operations that are submitted
@@ -574,10 +570,10 @@ async fn process_message(
  * of new work that it needs to do. It will then iterate through those
  * work items and send them over the wire to this tasks waiting downstairs.
  *
- * V1 flow control, if we have more than X (where X = 100 for now, as we
- * don't know the best value yet, XXX) jobs submitted that we don't have
- * ACKs for, then stop sending more work and let the receive side catch up.
- * We return true if we have more work to do, false if we are all caught up.
+ * V2 flow control, if we have more than X (where X = MAX_ACTIVE_COUNT) for
+ * jobs submitted that we don't have ACKs for, then stop sending more work
+ * and let the receive side catch up.  We return true if we have more work
+ * to do, false if we are all caught up.
  */
 #[instrument(skip(fw))]
 async fn io_send<WT>(
@@ -626,10 +622,10 @@ where
         if active_count >= MAX_ACTIVE_COUNT {
             // Flow control enacted, stop sending work -- and requeue all of
             // our remaining work to assure it isn't dropped
-            u.downstairs
-                .lock()
-                .await
-                .requeue_work(client_id, &new_work[ndx..]);
+            let mut ds = u.downstairs.lock().await;
+            ds.requeue_work(client_id, &new_work[ndx..]);
+            ds.flow_control[client_id as usize] += 1;
+            drop(ds);
             return Ok(true);
         }
 
@@ -1839,7 +1835,8 @@ where
      * a result of a message we sent).  This channel is how this task
      * communicates that there is a message to handle.
      */
-    let (pm_task_tx, mut pm_task_rx) = mpsc::channel::<Message>(100);
+    let (pm_task_tx, mut pm_task_rx) =
+        mpsc::channel::<Message>(MAX_ACTIVE_COUNT + 50);
 
     info!(up.log, "[{}] Starts cmd_loop", up_coms.client_id);
     let pm_task = {
@@ -2887,9 +2884,14 @@ struct Downstairs {
     connected: Vec<usize>,
 
     /**
-     * Count of downstairs replacements XXX Not yet used
+     * Count of downstairs replacements
      */
     replaced: Vec<usize>,
+
+    /**
+     * Count of times a downstairs has had flow control turned on
+     */
+    flow_control: Vec<usize>,
 }
 
 impl Downstairs {
@@ -2924,6 +2926,7 @@ impl Downstairs {
             repair_min_id: None,
             connected: vec![0; 3],
             replaced: vec![0; 3],
+            flow_control: vec![0; 3],
         }
     }
 
@@ -2960,7 +2963,16 @@ impl Downstairs {
      * has no work to do, so return None.
      */
     fn in_progress(&mut self, ds_id: u64, client_id: u8) -> Option<IOop> {
-        let job = self.ds_active.get_mut(&ds_id).unwrap();
+        let job = match self.ds_active.get_mut(&ds_id) {
+            Some(job) => job,
+            None => {
+                // This job, that we thought was good, is not.  As we don't
+                // keep the lock when gathering job IDs to work on, it is
+                // possible to have a out of date work list.
+                warn!(self.log, "[{client_id}] Job {ds_id} not on active list");
+                return None;
+            }
+        };
 
         // If current state is Skipped, then we have nothing to do here.
         if job.state[&client_id] == IOState::Skipped {
@@ -5137,6 +5149,9 @@ impl Upstairs {
         let ds_live_repair_aborted = ds.live_repair_aborted.clone();
         let ds_connected = ds.connected.clone();
         let ds_replaced = ds.replaced.clone();
+        let ds_flow_control = ds.flow_control.clone();
+        let ds_extents_repaired = ds.extents_repaired.clone();
+        let ds_extents_confirmed = ds.extents_confirmed.clone();
 
         cdt::up__status!(|| {
             let arg = Arg {
@@ -5150,6 +5165,9 @@ impl Upstairs {
                 ds_live_repair_aborted,
                 ds_connected,
                 ds_replaced,
+                ds_flow_control,
+                ds_extents_repaired,
+                ds_extents_confirmed,
             };
             (msg, arg)
         });
@@ -9436,7 +9454,7 @@ async fn send_work(t: &[Target], val: u64, log: &Logger) {
     for (client_id, d_client) in t.iter().enumerate() {
         let res = d_client.ds_work_tx.try_send(val);
         if let Err(e) = res {
-            warn!(
+            debug!(
                 log,
                 "{:?} Failed to notify client {} of work {}", e, client_id, val,
             );
@@ -9874,6 +9892,9 @@ pub struct Arg {
     ds_live_repair_aborted: Vec<usize>,
     ds_connected: Vec<usize>,
     ds_replaced: Vec<usize>,
+    ds_flow_control: Vec<usize>,
+    ds_extents_repaired: Vec<usize>,
+    ds_extents_confirmed: Vec<usize>,
 }
 
 /**
@@ -9957,7 +9978,7 @@ async fn up_listen(
 
     up.stat_update("start").await;
     let mut flush_check = deadline_secs(flush_timeout);
-    let mut stat_update_interval = deadline_secs(5.0);
+    let mut stat_update_interval = deadline_secs(1.0);
     let mut repair_check_interval = deadline_secs(60.0);
     let mut repair_check = false;
     loop {
@@ -10076,7 +10097,7 @@ async fn up_listen(
             }
             _ = sleep_until(stat_update_interval) => {
                 up.stat_update("loop").await;
-                stat_update_interval = deadline_secs(5.0);
+                stat_update_interval = deadline_secs(1.0);
             }
         }
     }
@@ -10134,7 +10155,7 @@ pub async fn up_main(
      * Use this channel to indicate in the upstairs that all downstairs
      * operations for a specific request have completed.
      */
-    let (ds_done_tx, ds_done_rx) = mpsc::channel(500); // XXX 500?
+    let (ds_done_tx, ds_done_rx) = mpsc::channel(MAX_ACTIVE_COUNT + 50);
 
     /*
      * spawn a task to listen for ds completed work which will then


### PR DESCRIPTION
New settings for the constants that control how much work we send to a downstairs, and how many IOs we build up before we disconnect from a downstairs.
`IO_OUTSTANDING_MAX: usize = 5000;`
`MAX_ACTIVE_COUNT: usize = 600;`

Moved the max active count to a common place so the downstairs could use it.

Update a few places that just had hard coded message queue depths that would not work with the new constants.

Other things not related to the above changes.
Updated in_progress() to not assume all job IDs it receives will be valid, and return None if it encounters an ID that is no longer valid.

Added per downstairs counters for when we enabled flow control. 
Put the live repair counters with the rest of the DTrace counters.

Fixed and renamed the fast_fill option, It looping over wrong value.

I tested this a bunch on an actual gimlet, but no propolis/omicron in the loop.
I used a disk for each region:

```
/target/release/dsc start --create --cleanup --extent-size 16384 --extent-count 1600 --block-size=4096 \
  --region-dir /oxp_0ca797a6-f467-4296-bc27-e7590c8330c2/dsc/region/  \
  --region-dir /oxp_627cda87-085b-44af-a70e-d067599c3fe2/dsc/region/ \
  --region-dir /oxp_9f5a50c7-08ce-41f7-8efd-5d1323a1f070/dsc/region/ \
  --region-dir /oxp_d2e09ee0-b7ff-479c-ab50-0cdb5ec76503/dsc/region --region-count 4
```

With the above changes, the upstairs can now send `--io-depth 64` workloads using both `crutest` and
`measure-iops` and still keep up.  Previous runs would pretty quickly hit flow-control and then soon
after, send a downstairs to faulted.

Here is some example dtrace output showing the work queues for each downstairs taking
jobs and moving them through.  Each line is at a 1 second interval:
```
DS STATE 0        DS STATE 1        DS STATE 2   UPW  DSW  NEW0 NEW1 NEW2   IP0  IP1  IP2    D0   D1   D2    S0   S1   S2  E0 E1 E2
    active            active            active   100  256     0    0    0   256  100   99     0  156  157     0    0    0   0  0  0
    active            active            active    36  128     0    0    0    11   92   36   117   36   92     0    0    0   0  0  0
    active            active            active    45 1025     0    0    0   257   45   44   768  980  981     0    0    0   0  0  0
    active            active            active   108  256     0   43    0   128   65   99   128  148  157     0    0    0   0  0  0
    active            active            active    12  256     0    0    0     8   12   47   248  244  209     0    0    0   0  0  0
    active            active            active    54  186     0   10    8   115   44   46    71  132  132     0    0    0   0  0  0
    active            active            active   129 1021     0    0    0     0  129  129  1021  892  892     0    0    0   0  0  0
    active            active            active     1 1153     0    0    0   129    1    0  1024 1152 1153     0    0    0   0  0  0
    active            active            active   112  256    47    0    0    65  114  104   144  142  152     0    0    0   0  0  0
    active            active            active   106  384     0    0    0   106  106  107   278  278  277     0    0    0   0  0  0
    active            active            active    22  256     0    0    0    58   22   16   198  234  240     0    0    0   0  0  0
    active            active            active   129 1025     0    0    0     0  129  129  1025  896  896     0    0    0   0  0  0
    active            active            active   117 1281     0   45   59   257   66   58  1024 1170 1164     0    0    0   0  0  0
    active            active            active     1  213     0    0    0    12    1    1   201  212  212     0    0    0   0  0  0
    active            active            active     3  256     0    0    0    93    3    0   163  253  256     0    0    0   0  0  0
    active            active            active    53  256     0    0    0   151   53   51   105  203  205     0    0    0   0  0  0
    active            active            active   121  128     0    0    0     0  121  128   128    7    0     0    0    0   0  0  0
    active            active            active    94 1153     0    0    0   257   93   94   896 1060 1059     0    0    0   0  0  0
```

The old threshold of 100 outstanding IOs would never stand up to this workload.

I believe we can get further tuning to possibly improve things more, but this is moving in the
right direction.