### PR TITLE
Issue extent flushes in parallel

### DIFF
--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -256,6 +256,7 @@ impl Default for RegionDefinition {
         }
     }
 }
+
 impl RegionDefinition {
     pub fn test_default(
         database_read_version: usize,

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 authors = ["Joshua M. Clulow <jmc@oxide.computer>", "Alan Hanson <alan@oxide.computer"]
 license = "MPL-2.0"
 edition = "2021"
+rust-version = "1.70"
 
 [dependencies]
 anyhow.workspace = true

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -59,6 +59,11 @@ pub async fn dump_region(
          * directory index and the value is the ExtentMeta for that region.
          */
         for e in &region.extents {
+            let e = e.lock().await;
+            let e = match &*e {
+                region::ExtentState::Opened(extent) => extent,
+                region::ExtentState::Closed => panic!("dump on closed extent!"),
+            };
             let en = e.number();
 
             /*
@@ -90,7 +95,8 @@ pub async fn dump_region(
                     continue;
                 }
             }
-            let inner = e.inner().await;
+
+            let inner = e.inner.lock().await;
 
             /*
              * Create the ExtentMeta struct for this directory's extent

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -32,6 +32,10 @@ pub struct Extent {
     block_size: u64,
     extent_size: Block,
     iov_max: usize,
+
+    /// Inner contains information about the actual extent file that holds the
+    /// data, the metadata (stored in the database) about that extent, and the
+    /// set of dirty blocks that have been written to since last flush.
     pub inner: Mutex<Inner>,
 }
 

--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -77,14 +77,7 @@ pub async fn repair_main(
             .start();
     let local_addr = server.local_addr();
 
-    tokio::spawn(async move {
-        /*
-         * Wait for the server to stop.  Note that there's not any code to
-         * shut down this server, so we should never get past this
-         * point.
-         */
-        server.await
-    });
+    tokio::spawn(server);
 
     Ok(local_addr)
 }
@@ -337,8 +330,7 @@ mod test {
             Region::create(&dir, new_region_options(), csl()).await?;
         region.extend(3).await?;
 
-        let ext_one = &mut region.extents[1];
-        ext_one.close().await?;
+        region.close_extent(1).await.unwrap();
 
         // Determine the directory and name for expected extent files.
         let extent_dir = extent_dir(&dir, 1);

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -2589,7 +2589,6 @@ mod test {
     async fn integration_test_guest_replace_many_downstairs() -> Result<()> {
         // Test using the guest layer to verify we can replace one
         // downstairs, but not another while the replace is active.
-        const BLOCK_SIZE: usize = 512;
 
         // Spin off three downstairs, build our Crucible struct.
         let tds = TestDownstairsSet::small(false).await?;
@@ -3232,8 +3231,6 @@ mod test {
 
     #[tokio::test]
     async fn test_pantry_import_from_url_ovmf_bad_digest() {
-        const BLOCK_SIZE: usize = 512;
-
         // Spin off three downstairs, build our Crucible struct.
         let tds = TestDownstairsSet::big(false).await.unwrap();
 
@@ -3387,8 +3384,6 @@ mod test {
 
     #[tokio::test]
     async fn test_pantry_snapshot() {
-        const BLOCK_SIZE: usize = 512;
-
         // Spin off three downstairs, build our Crucible struct.
         let tds = TestDownstairsSet::small(false).await.unwrap();
 
@@ -3704,8 +3699,6 @@ mod test {
 
     #[tokio::test]
     async fn test_pantry_bulk_read() {
-        const BLOCK_SIZE: usize = 512;
-
         // Spin off three downstairs, build our Crucible struct.
 
         let tds = TestDownstairsSet::small(false).await.unwrap();
@@ -3788,8 +3781,6 @@ mod test {
 
     #[tokio::test]
     async fn test_pantry_bulk_read_max_chunk_size() {
-        const BLOCK_SIZE: usize = 512;
-
         // Spin off three downstairs, build our Crucible struct.
 
         let tds = TestDownstairsSet::big(false).await.unwrap();
@@ -4104,8 +4095,6 @@ mod test {
     // Test validating a non-block size amount fails
     #[tokio::test]
     async fn test_pantry_validate_fail() {
-        const BLOCK_SIZE: usize = 512;
-
         // Spin off three downstairs, build our Crucible struct.
 
         let tds = TestDownstairsSet::small(false).await.unwrap();

--- a/pantry/src/server.rs
+++ b/pantry/src/server.rs
@@ -373,7 +373,7 @@ pub async fn run_server(
     let local_addr = server.local_addr();
     info!(log, "listen IP: {:?}", local_addr);
 
-    let join_handle = tokio::spawn(async move { server.await });
+    let join_handle = tokio::spawn(server);
 
     Ok((local_addr, join_handle))
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.66"
+channel = "1.70"
 profile = "default"

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -8490,6 +8490,7 @@ async fn test_buffer_len_after_clone() {
     let data = Buffer::from_slice(&[0x99; READ_SIZE]);
     assert_eq!(data.len(), READ_SIZE);
 
+    #[allow(clippy::redundant_clone)]
     let new_buffer = data.clone();
     assert_eq!(new_buffer.len(), READ_SIZE);
     assert_eq!(data.len(), READ_SIZE);

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -264,7 +264,7 @@ impl<T: BlockIO> Seek for CruciblePseudoFile<T> {
     }
 
     fn stream_position(&mut self) -> IOResult<u64> {
-        self.seek(SeekFrom::Current(0))
+        Ok(self.offset)
     }
 }
 


### PR DESCRIPTION
First, move the concept of whether an Extent is opened or closed *out* of Extent by removing the Option around Mutex<Inner>:

    -    inner: Option<Mutex<Inner>>,
    +    pub inner: Mutex<Inner>,

This moves up to Region as a new enum:

    -    pub extents: Vec<Extent>,
    +    pub extents: Vec<Arc<Mutex<ExtentState>>>,

where ExtentState uses the variant to store if the extent is opened or closed:

    +pub enum ExtentState {
    +    Opened(Arc<Extent>),
    +    Closed,
    +}

This is all in service of `fn region_flush` issuing a `tokio::spawn` for each `extent.flush` call, and waiting on each join handle that is returned. This is possible when an `Arc<Extent>` is used because a clone can be passed to each task.

Using an enum in this way is also a little safer: `Region::close_extent` actually consumes the old extent while closing it, meaning that the old Extent no longer hangs around. It does however mean that the downstairs will panic if the ExtentState is not expected: both `get_opened_extent` and `close_extent` panic if the extent in question is closed. `close_extent` also panics if you're trying to close an extent where there's an Arc clone somewhere as part of doing some other work.

Note this work required updating to Rust 1.70 (for `Arc::into_inner`). There's a few unrelated changes due to this.