### PR TITLE
Make consume_req cancel safe

### DIFF
--- a/upstairs/src/block_req.rs
+++ b/upstairs/src/block_req.rs
@@ -70,7 +70,7 @@ impl BlockReqWaiter {
     }
 
     #[allow(dead_code)]
-    pub async fn try_wait(&mut self) -> Option<Result<(), CrucibleError>> {
+    pub fn try_wait(&mut self) -> Option<Result<(), CrucibleError>> {
         match self.recv.try_recv() {
             Ok(v) => Some(v),
             Err(e) => match e {


### PR DESCRIPTION
John helpfully audited our Crucible code for cancel safety of futures used in tokio::select! arms, and found that consume_req was not safe to cancel. This commit makes consume_req cancel safe by splitting out the work into a non-async function: either consume_req is cancelled trying to acquire all the necessary locks, or it runs to completion.

There were a few async functions that were not required to be async, so this commit also changes those.