### PR TITLE
Increase flush_timeout for some tests, collect cores

### DIFF
--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -62,7 +62,7 @@ banner rbuild
 ptime -m cargo build --verbose --release --all-features
 
 banner rtest
-ptime -m cargo test --verbose --jobs 5 -- --test-threads=5
+ptime -m cargo test --verbose --jobs 2 -- --test-threads=2
 
 banner output
 mkdir -p /work/rbins

--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -62,7 +62,7 @@ banner rbuild
 ptime -m cargo build --verbose --release --all-features
 
 banner rtest
-ptime -m cargo test --verbose
+ptime -m cargo test --verbose --jobs 5 -- --test-threads=5
 
 banner output
 mkdir -p /work/rbins

--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -62,7 +62,7 @@ banner rbuild
 ptime -m cargo build --verbose --release --all-features
 
 banner rtest
-ptime -m cargo test --verbose --jobs 2 -- --test-threads=2
+ptime -m cargo test --verbose --jobs 1 -- --test-threads=1
 
 banner output
 mkdir -p /work/rbins

--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -62,7 +62,7 @@ banner rbuild
 ptime -m cargo build --verbose --release --all-features
 
 banner rtest
-ptime -m cargo test --verbose --jobs 1 -- --test-threads=1
+ptime -m cargo test --verbose
 
 banner output
 mkdir -p /work/rbins

--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -8,6 +8,8 @@
 #:	"/out/*",
 #:	"/work/rbins/*",
 #:	"/work/scripts/*",
+#:	"/tmp/core.*",
+#:	"/tmp/*.log",
 #: ]
 #:
 #: [[publish]]
@@ -47,6 +49,14 @@ set -o xtrace
 
 cargo --version
 rustc --version
+
+banner cores
+pfexec coreadm -i /tmp/core.%f.%p
+pfexec coreadm -g /tmp/core.%f.%p
+pfexec coreadm -e global
+pfexec coreadm -e log
+pfexec coreadm -e proc-setid
+pfexec coreadm -e global-setid
 
 banner rbuild
 ptime -m cargo build --verbose --release --all-features

--- a/.github/buildomat/jobs/build.sh
+++ b/.github/buildomat/jobs/build.sh
@@ -48,4 +48,4 @@ echo in_work_bins
 ls -l /work/bins
 
 banner test
-ptime -m cargo test --verbose --jobs 2 -- --test-threads=2
+ptime -m cargo test --verbose --jobs 1 -- --test-threads=1

--- a/.github/buildomat/jobs/build.sh
+++ b/.github/buildomat/jobs/build.sh
@@ -48,4 +48,4 @@ echo in_work_bins
 ls -l /work/bins
 
 banner test
-ptime -m cargo test --verbose
+ptime -m cargo test --verbose --jobs 5 -- --test-threads=5

--- a/.github/buildomat/jobs/build.sh
+++ b/.github/buildomat/jobs/build.sh
@@ -7,6 +7,8 @@
 #: output_rules = [
 #:	"/work/bins/*",
 #:	"/work/scripts/*",
+#:	"/tmp/core.*",
+#:	"/tmp/*.log",
 #: ]
 #:
 
@@ -16,6 +18,14 @@ set -o xtrace
 
 cargo --version
 rustc --version
+
+banner cores
+pfexec coreadm -i /tmp/core.%f.%p
+pfexec coreadm -g /tmp/core.%f.%p
+pfexec coreadm -e global
+pfexec coreadm -e log
+pfexec coreadm -e proc-setid
+pfexec coreadm -e global-setid
 
 banner build
 ptime -m cargo build --verbose

--- a/.github/buildomat/jobs/build.sh
+++ b/.github/buildomat/jobs/build.sh
@@ -48,4 +48,4 @@ echo in_work_bins
 ls -l /work/bins
 
 banner test
-ptime -m cargo test --verbose --jobs 1 -- --test-threads=1
+ptime -m cargo test --verbose

--- a/.github/buildomat/jobs/build.sh
+++ b/.github/buildomat/jobs/build.sh
@@ -48,4 +48,4 @@ echo in_work_bins
 ls -l /work/bins
 
 banner test
-ptime -m cargo test --verbose --jobs 5 -- --test-threads=5
+ptime -m cargo test --verbose --jobs 2 -- --test-threads=2

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -397,7 +397,7 @@ pub(crate) mod protocol_test {
             let crucible_opts = CrucibleOpts {
                 id: Uuid::new_v4(),
                 target: vec![ds1.local_addr, ds2.local_addr, ds3.local_addr],
-                flush_timeout: Some(600.0),
+                flush_timeout: Some(86400.0),
 
                 ..Default::default()
             };
@@ -511,7 +511,7 @@ pub(crate) mod protocol_test {
     /// downstairs responds with a read response for a certain job, then more
     /// work is sent.
     #[tokio::test]
-    async fn _test_flow_control() {
+    async fn test_flow_control() {
         let harness = Arc::new(TestHarness::new().await);
 
         let (_jh1, mut ds1_messages) =
@@ -556,7 +556,7 @@ pub(crate) mod protocol_test {
         }
 
         // Confirm that's all the Upstairs sent us - with the flush_timeout set
-        // to five minutes, we shouldn't see anything else
+        // to 24 hours, we shouldn't see anything else
 
         assert!(matches!(ds1_messages.try_recv(), Err(TryRecvError::Empty)));
         assert!(matches!(ds2_messages.try_recv(), Err(TryRecvError::Empty)));
@@ -761,8 +761,8 @@ pub(crate) mod protocol_test {
     /// additional IO comes through.
     /// XXX Turning this test off until we can figure out why it fails, but
     /// only in buildomat.
-    // #[tokio::test]
-    async fn _test_successful_live_repair() {
+    #[tokio::test]
+    async fn test_successful_live_repair() {
         let harness = Arc::new(TestHarness::new().await);
 
         let (jh1, mut ds1_messages) =
@@ -879,7 +879,7 @@ pub(crate) mod protocol_test {
         }
 
         // Confirm that's all the Upstairs sent us (only ds2 and ds3) - with the
-        // flush_timeout set to five minutes, we shouldn't see anything else
+        // flush_timeout set to 24 hours, we shouldn't see anything else
         assert!(matches!(ds2_messages.try_recv(), Err(TryRecvError::Empty)));
         assert!(matches!(ds3_messages.try_recv(), Err(TryRecvError::Empty)));
 


### PR DESCRIPTION
This is pulling out the the fix I found in my other CI debugging PR.

Updated the flush_timeout to be 24 hours for tests that don't want to get a flush ever.
Added core collection to the build jobs to catch any cores from cargo test (or other tests) that fail.