### PR TITLE
eliminate uuid v0.8 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
  "toml",
  "tracing",
  "usdt",
- "uuid 1.3.3",
+ "uuid",
  "version_check",
 ]
 
@@ -719,7 +719,7 @@ dependencies = [
  "slog",
  "subprocess",
  "tokio",
- "uuid 1.3.3",
+ "uuid",
 ]
 
 [[package]]
@@ -744,7 +744,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "uuid 1.3.3",
+ "uuid",
 ]
 
 [[package]]
@@ -769,7 +769,7 @@ dependencies = [
  "tokio-rustls 0.23.4",
  "toml",
  "twox-hash",
- "uuid 1.3.3",
+ "uuid",
  "vergen",
 ]
 
@@ -838,7 +838,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "usdt",
- "uuid 1.3.3",
+ "uuid",
  "version_check",
 ]
 
@@ -857,7 +857,7 @@ dependencies = [
  "tokio",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "uuid 1.3.3",
+ "uuid",
 ]
 
 [[package]]
@@ -887,7 +887,7 @@ dependencies = [
  "slog-term",
  "tempfile",
  "tokio",
- "uuid 1.3.3",
+ "uuid",
 ]
 
 [[package]]
@@ -948,7 +948,7 @@ dependencies = [
  "slog",
  "subprocess",
  "tokio",
- "uuid 1.3.3",
+ "uuid",
 ]
 
 [[package]]
@@ -963,7 +963,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "uuid 1.3.3",
+ "uuid",
 ]
 
 [[package]]
@@ -977,7 +977,7 @@ dependencies = [
  "num_enum",
  "serde",
  "tokio-util 0.7.3",
- "uuid 1.3.3",
+ "uuid",
 ]
 
 [[package]]
@@ -1046,7 +1046,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.3",
  "toml",
- "uuid 1.3.3",
+ "uuid",
 ]
 
 [[package]]
@@ -1246,7 +1246,7 @@ dependencies = [
  "tokio-rustls 0.24.0",
  "toml",
  "usdt",
- "uuid 1.3.3",
+ "uuid",
  "version_check",
 ]
 
@@ -2140,7 +2140,7 @@ dependencies = [
  "rand 0.8.5",
  "statistical",
  "tokio",
- "uuid 1.3.3",
+ "uuid",
 ]
 
 [[package]]
@@ -2271,7 +2271,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "uuid 1.3.3",
+ "uuid",
 ]
 
 [[package]]
@@ -2488,7 +2488,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "toml",
- "uuid 1.3.3",
+ "uuid",
 ]
 
 [[package]]
@@ -2755,7 +2755,7 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror",
- "uuid 1.3.3",
+ "uuid",
 ]
 
 [[package]]
@@ -2785,7 +2785,7 @@ dependencies = [
  "slog-dtrace",
  "thiserror",
  "tokio",
- "uuid 1.3.3",
+ "uuid",
 ]
 
 [[package]]
@@ -3035,7 +3035,7 @@ dependencies = [
  "chrono",
  "fallible-iterator",
  "postgres-protocol",
- "uuid 1.3.3",
+ "uuid",
 ]
 
 [[package]]
@@ -3678,8 +3678,7 @@ dependencies = [
  "schemars_derive",
  "serde",
  "serde_json",
- "uuid 0.8.2",
- "uuid 1.3.3",
+ "uuid",
 ]
 
 [[package]]
@@ -4122,7 +4121,7 @@ dependencies = [
  "slog",
  "thiserror",
  "tokio",
- "uuid 1.3.3",
+ "uuid",
 ]
 
 [[package]]
@@ -4922,12 +4921,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ reqwest = { version = "0.11", features = ["default", "blocking", "json", "stream
 ringbuffer = "0.13"
 rusqlite = { version = "0.29" }
 rustls-pemfile = { version = "1.0.2" }
-schemars = { version = "0.8", features = [ "chrono", "uuid", "uuid1" ] }
+schemars = { version = "0.8", features = [ "chrono", "uuid1" ] }
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 sha2 = "0.10"


### PR DESCRIPTION
I noticed that uuid v0.8.x had crept back into omicron; I believe this was the source:

https://github.com/oxidecomputer/omicron/pull/3320/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e

Note that the `uuid1` and `uuid` (which is equivalent to `uuid08`) features of schemars are meant to be mutually exclusive. Why didn't schemars just support a range of versions for `uuid`? I wish I knew:

https://github.com/GREsau/schemars/pull/142#issuecomment-1132008289