### PR TITLE
Widen assert values to u128 to deal with u64::MAX

### DIFF
--- a/upstairs/proptest-regressions/impacted_blocks.txt
+++ b/upstairs/proptest-regressions/impacted_blocks.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc b0180a9c53047e868f53ba06087baac4a57195b36d8a7361e1dc8fde55f01d6b # shrinks to input = _ExtentFromOffsetPanicsWhenNumBlocksOutsideRegionArgs { first_block: 31072609678208356, n_blocks: 18415671464031343260, ddef: RegionDefinition { block_size: 512, extent_size: Block { value: 23965161273, shift: 9 }, extent_count: 538296746, uuid: 00000000-0000-0000-0000-000000000000, encrypted: false, database_read_version: 1, database_write_version: 1 } }

--- a/upstairs/src/impacted_blocks.rs
+++ b/upstairs/src/impacted_blocks.rs
@@ -279,10 +279,11 @@ pub fn extent_from_offset(
     // Second, the offset is actually within the region
     assert!(offset.value < ddef.extent_count() as u64 * extent_size);
 
-    // Third, the last block is also within the region
+    // Third, the last block is also within the region. These are widened to
+    // u128 in order to catch the case where first_block + n_blocks == u64::MAX.
     assert!(
-        offset.value + num_blocks.value
-            <= ddef.extent_count() as u64 * extent_size
+        offset.value as u128 + num_blocks.value as u128
+            <= ddef.extent_count() as u128 * extent_size as u128
     );
 
     let fst = ImpactedAddr {


### PR DESCRIPTION
Cast to u128 in extent_from_offset when performing the "last block is also within the region" assert, as there was a proptest regression where first_block + n_blocks == u64::MAX.

Also committing upstairs/proptest-regressions/impacted_blocks.txt like it suggests :)