### PR TITLE
Set open file resource limit to the max

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-staticfile",
+ "libc",
  "mime_guess",
  "nix",
  "omicron-common",

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -21,6 +21,7 @@ hex.workspace = true
 http.workspace = true
 hyper-staticfile.workspace = true
 hyper.workspace = true
+libc.workspace = true
 mime_guess.workspace = true
 nix.workspace = true
 omicron-common.workspace = true


### PR DESCRIPTION
When opening or creating a Region, set the maximum number of open files to the supported max. On my Ubuntu workstation, this showed:

    raising number of open files limit to from 1024 to 524288

On a Helios machine, this showed:

    current number of open files limit 65536 is already the maximum