### PR TITLE
Retry pantry requests

### DIFF
--- a/pantry/src/pantry.rs
+++ b/pantry/src/pantry.rs
@@ -96,12 +96,12 @@ impl PantryEntry {
     ) -> Result<()> {
         // Construct a reqwest client that
         //
-        // 1) times out after 5 seconds if a connection can't be made
+        // 1) times out after 10 seconds if a connection can't be made
         // 2) times out if the connection + chunk download takes over 60 seconds
         //
         // Now, `MAX_CHUNK_SIZE / 60s ~= 8.5kb/s`. If the connection you're downloading from is
         // that slow, then the pantry won't work, sorry!
-        let connect_timeout = std::time::Duration::from_secs(5);
+        let connect_timeout = std::time::Duration::from_secs(10);
         let total_timeout =
             std::time::Duration::from_secs(60) + connect_timeout;
         let client = reqwest::ClientBuilder::new()

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -263,7 +263,7 @@ pub(crate) mod protocol_test {
                         if let Err(e) =
                             self.fw.lock().await.send(Message::Imok).await
                         {
-                            error!(log, "negotiate_start could not send on fw due to {}", e);
+                            error!(self.inner.log, "negotiate_start could not send on fw due to {}", e);
                         }
 
                         continue;
@@ -304,7 +304,7 @@ pub(crate) mod protocol_test {
                         if let Err(e) =
                             self.fw.lock().await.send(Message::Imok).await
                         {
-                            error!(log, "negotiate_start could not send on fw due to {}", e);
+                            error!(self.inner.log, "negotiate_start could not send on fw due to {}", e);
                         }
 
                         continue;

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -265,6 +265,7 @@ pub(crate) mod protocol_test {
                         {
                             error!(self.inner.log, "negotiate_start could not send on fw due to {}", e);
                         }
+                        info!(self.inner.log, "responded to ping");
 
                         continue;
                     }
@@ -306,6 +307,7 @@ pub(crate) mod protocol_test {
                         {
                             error!(self.inner.log, "negotiate_start could not send on fw due to {}", e);
                         }
+                        info!(self.inner.log, "responded to ping");
 
                         continue;
                     }
@@ -409,6 +411,7 @@ pub(crate) mod protocol_test {
                                 {
                                     error!(log, "spawn_message_receiver could not send on fw due to {}", e);
                                 }
+                                info!(log, "responded to ping");
                             }
 
                             Some(m) => {

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -191,6 +191,7 @@ pub(crate) mod protocol_test {
                 .transpose()
                 .unwrap()
                 .unwrap();
+
             match &packet {
                 Message::HereIAm {
                     version,
@@ -213,6 +214,7 @@ pub(crate) mod protocol_test {
                         .await
                         .unwrap();
                 }
+
                 x => bail!("wrong packet {:?}", x),
             }
 
@@ -228,6 +230,7 @@ pub(crate) mod protocol_test {
                     .transpose()
                     .unwrap()
                     .unwrap();
+
                 match &packet {
                     Message::PromoteToActive {
                         upstairs_id,
@@ -254,8 +257,15 @@ pub(crate) mod protocol_test {
                             .unwrap();
                         break;
                     }
+
                     Message::Ruok => {
-                        // A ping snuck in, ignore it
+                        // Respond to pings right away
+                        if let Err(e) =
+                            self.fw.lock().await.send(Message::Imok).await
+                        {
+                            error!(log, "negotiate_start could not send on fw due to {}", e);
+                        }
+
                         continue;
                     }
 
@@ -273,6 +283,7 @@ pub(crate) mod protocol_test {
                     .transpose()
                     .unwrap()
                     .unwrap();
+
                 match &packet {
                     Message::RegionInfoPlease => {
                         info!(self.inner.log, "negotiate packet {:?}", packet);
@@ -287,7 +298,15 @@ pub(crate) mod protocol_test {
                             .unwrap();
                         break Ok(());
                     }
+
                     Message::Ruok => {
+                        // Respond to pings right away
+                        if let Err(e) =
+                            self.fw.lock().await.send(Message::Imok).await
+                        {
+                            error!(log, "negotiate_start could not send on fw due to {}", e);
+                        }
+
                         continue;
                     }
 
@@ -379,6 +398,7 @@ pub(crate) mod protocol_test {
                         Ok(v) => match v {
                             None => {
                                 // disconnection, bail
+                                error!(log, "spawn_message_receiver saw disconnect, bailing");
                                 return;
                             }
 
@@ -831,8 +851,6 @@ pub(crate) mod protocol_test {
     /// letting it reconnect, live repair occurs. Check that each extent is
     /// repaired with the correct source, and that extent limits are honoured if
     /// additional IO comes through.
-    /// XXX Turning this test off until we can figure out why it fails, but
-    /// only in buildomat.
     #[tokio::test]
     async fn test_successful_live_repair() -> Result<()> {
         let harness = Arc::new(TestHarness::new().await?);

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2067,8 +2067,6 @@ where
                 return Ok(());
             }
             _ = sleep_until(ping_interval) => {
-                info!(up.log, "[{}] sending ping", up_coms.client_id);
-
                 /*
                  * To keep things alive, initiate a ping any time we have
                  * been idle for (TBD) seconds.

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2067,6 +2067,8 @@ where
                 return Ok(());
             }
             _ = sleep_until(ping_interval) => {
+                info!(up.log, "[{}] sending ping", up_coms.client_id);
+
                 /*
                  * To keep things alive, initiate a ping any time we have
                  * been idle for (TBD) seconds.


### PR DESCRIPTION
Retry pantry requests in the face of network weather (if there is a timeout, 503, or 429).

Also, provide a Logger in PantryEntry, and log when a job fails.