### PR TITLE
Reorder select arms so pings can't be starved out

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1903,13 +1903,28 @@ where
         tokio::select! {
             /*
              * We set biased so the loop will:
-             * First make sure the pm task is still running.
-             * Second, get and look at messages received from the downstairs.
-             *   Some messages we can handle right here, but ACKs from
-             *   messages we sent are passed on to the pm task.
              *
-             * By handling messages from the downstairs before sending
-             * new work, we help to avoid overwhelming the downstairs.
+             * 1. First make sure the pm task is still running.
+             *
+             * 2. Get and look at messages received from the downstairs. Some
+             *    messages we can handle right here, but ACKs from messages we
+             *    sent are passed on to the pm task.
+             *
+             * 3. Send a ping if the timeout has been reached. If the downstairs
+             *    responds, then the #2 select branch will bump the deadlines.
+             *
+             * 4. Timeout the downstairs if it has been too long.
+             *
+             * 5. Check for changes to the work hashmap, and send messages to
+             *    the downstairs if new work is available.
+             *
+             * 6. Check for (and possibly send) more work if #5 triggered flow
+             *    control.
+             *
+             * By handling messages from the downstairs before sending new work,
+             * we help to avoid overwhelming the downstairs. By sending a ping
+             * before checking for new work, we avoid a scenario where too much
+             * new work would result in pings not being sent.
              */
             biased;
             e = &mut pm_task => {
@@ -2030,42 +2045,6 @@ where
                     }
                 }
             }
-            _ = up_coms.ds_work_rx.recv() => {
-                /*
-                 * A change here indicates the work hashmap has changed
-                 * and we should go look for new work to do. It is possible
-                 * that there is no new work but we won't know until we
-                 * check.
-                 */
-                let more =
-                    io_send(up, &mut fw, up_coms.client_id).await?;
-
-                if more && !more_work {
-                    warn!(up.log, "[{}] flow control start ",
-                        up_coms.client_id
-                    );
-
-                    more_work = true;
-                    more_work_interval = deadline_secs(1.0);
-                }
-            }
-            _ = sleep_until(more_work_interval), if more_work => {
-                more_work = io_send(up, &mut fw, up_coms.client_id).await?;
-                if !more_work {
-                    warn!(up.log, "[{}] flow control end ", up_coms.client_id);
-                }
-
-                more_work_interval = deadline_secs(1.0);
-            }
-            /*
-             * Don't wait more than 50 seconds to hear from the other side.
-             * TODO: 50 is too long, but what is the correct value?
-             */
-            _ = sleep_until(timeout_deadline) => {
-                warn!(up.log, "[{}] Downstairs not responding, take offline",
-                    up_coms.client_id);
-                return Ok(());
-            }
             _ = sleep_until(ping_interval) => {
                 /*
                  * To keep things alive, initiate a ping any time we have
@@ -2100,6 +2079,41 @@ where
                 }
 
                 ping_interval = deadline_secs(10.0);
+            }
+            /*
+             * Don't wait more than 50 seconds to hear from the other side.
+             * TODO: 50 is too long, but what is the correct value?
+             */
+            _ = sleep_until(timeout_deadline) => {
+                warn!(up.log, "[{}] Downstairs not responding, take offline",
+                    up_coms.client_id);
+                return Ok(());
+            }
+            _ = up_coms.ds_work_rx.recv() => {
+                /*
+                 * A change here indicates the work hashmap has changed and we
+                 * should go look for new work to do. It is possible that there
+                 * is no new work but we won't know until we check.
+                 */
+                let more =
+                    io_send(up, &mut fw, up_coms.client_id).await?;
+
+                if more && !more_work {
+                    warn!(up.log, "[{}] flow control start ",
+                        up_coms.client_id
+                    );
+
+                    more_work = true;
+                    more_work_interval = deadline_secs(1.0);
+                }
+            }
+            _ = sleep_until(more_work_interval), if more_work => {
+                more_work = io_send(up, &mut fw, up_coms.client_id).await?;
+                if !more_work {
+                    warn!(up.log, "[{}] flow control end ", up_coms.client_id);
+                }
+
+                more_work_interval = deadline_secs(1.0);
             }
         }
     }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -3437,7 +3437,9 @@ impl Downstairs {
 
         info!(
             self.log,
-            "[{}] changed {} to fault skipped", client_id, number_jobs_skipped
+            "[{}] changed {} jobs to fault skipped",
+            client_id,
+            number_jobs_skipped
         );
 
         for ds_id in retire_check {


### PR DESCRIPTION
If the Guest submits a boatload of work, then the current `tokio::select` biased ordering will cause pings to not be sent. If a Downstairs is *not* responding at all (like the dummy downstairs in `test_successful_live_repair`) while this is going on, then the ping and timeout deadlines are not being pushed. This results in the Upstairs kicking out the Downstairs, causing this test to fail.

Reorder the select branches so that this situation can't occur.