### PR TITLE
Switch to building on heliosv2

### DIFF
--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "rbuild"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: rust_toolchain = "1.66"
 #: output_rules = [
 #:	"/out/*",

--- a/.github/buildomat/jobs/build.sh
+++ b/.github/buildomat/jobs/build.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "build"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: rust_toolchain = "1.66"
 #: output_rules = [
 #:	"/work/bins/*",

--- a/.github/buildomat/jobs/test-crudd-benchmark.sh
+++ b/.github/buildomat/jobs/test-crudd-benchmark.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "test-crudd-benchmark"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: output_rules = [
 #:  "/tmp/crudd-speed-battery-results.json",
 #: ]

--- a/.github/buildomat/jobs/test-ds.sh
+++ b/.github/buildomat/jobs/test-ds.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "test-ds"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: output_rules = [
 #:	"/tmp/*.txt",
 #: ]

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "test-live-repair"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: output_rules = [
 #:	"/tmp/*.txt",
 #:	"/tmp/*.log",

--- a/.github/buildomat/jobs/test-memory.sh
+++ b/.github/buildomat/jobs/test-memory.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "test-memory"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: output_rules = [
 #:  "/tmp/test_mem_log.txt",
 #:  "/tmp/dsc/*.txt",

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "test-perf"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: output_rules = [
 #:  "=/tmp/perf*.csv",
 #:  "/tmp/perfout.txt",

--- a/.github/buildomat/jobs/test-region-create.sh
+++ b/.github/buildomat/jobs/test-region-create.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "test-region-create"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: output_rules = [
 #:	"/tmp/region.csv",
 #: ]

--- a/.github/buildomat/jobs/test-repair.sh
+++ b/.github/buildomat/jobs/test-repair.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "test-repair"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: output_rules = [
 #:	"/tmp/*.txt",
 #: ]

--- a/.github/buildomat/jobs/test-up-encrypted.sh
+++ b/.github/buildomat/jobs/test-up-encrypted.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "test-up-encrypted"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: output_rules = [
 #:	"/tmp/test_up/*.txt",
 #: ]

--- a/.github/buildomat/jobs/test-up-unencrypted.sh
+++ b/.github/buildomat/jobs/test-up-unencrypted.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "test-up-unencrypted"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: output_rules = [
 #:	"/tmp/test_up/*.txt",
 #: ]


### PR DESCRIPTION
This is a pre-requisite for moving the rack software on top of heliosv2. Once this is integrated, we can point the omicron pins at the CI artefacts built with the newer helios version. It's going to take a few days to get everything over and build machines updated.