### PR TITLE
Add quota to agent created datasets

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -17,7 +17,7 @@ const SERVICE: &str = "oxide/crucible/downstairs";
  * As a safety mechanism to prevent the agent from creating more regions
  * than we have physical space, we using a zfs reservation on each dataset
  * we create.  While not a complete solution, it does help in some
- * situations to avoid allocation of a regions that we don't have the
+ * situations to avoid allocation of a region that we don't have the
  * space for if that region was to fill up.
  * As for how much we reserve, it's the region size itself, plus the
  * amount we need for metadata (currently around 17%) then an additional

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -34,8 +34,8 @@ const SERVICE: &str = "oxide/crucible/downstairs";
  * grown that big however, something is potentially very wrong and we should
  * prevent it from growing any larger and impacting other regions on the disk.
  */
-const METADATA_BUFFER: f64 = 1.25;
-const REGION_QUOTA: u64 = 3;
+const RESERVATION_FACTOR: f64 = 1.25;
+const QUOTA_FACTOR: u64 = 3;
 
 mod datafile;
 mod model;
@@ -857,10 +857,10 @@ fn worker(
                          */
                         let region_size =
                             r.block_size * r.extent_size * r.extent_count;
-                        let reservation = (region_size as f64 * METADATA_BUFFER)
-                            .round()
-                            as u64;
-                        let quota = region_size * REGION_QUOTA;
+                        let reservation =
+                            (region_size as f64 * RESERVATION_FACTOR).round()
+                                as u64;
+                        let quota = region_size * QUOTA_FACTOR;
 
                         info!(
                             log,


### PR DESCRIPTION
This adds a quota and a reservation to crucible datasets created when a region
is created in the crucible agent.  A somewhat arbitrary .25 overhead is reserved
for each region.  17% is the largest possible space the metadata will take, and this
gives us a little room in the unlikely event that all regions are full.

This does not consider snapshot overhead.
 
For issue #605 