### PR TITLE
Wait for ZFS snapshot directory + agent fixes

### DIFF
--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -827,7 +827,10 @@ impl DataFile {
             let parts: Vec<&str> = snapshot.split('@').collect();
             info!(self.log, "parts is {:?}", &parts);
             if parts.len() != 2 {
-                panic!("bad snapshot name");
+                // If some non-snapshot-name output snuck in here, then don't
+                // panic! Continue to the next one in the list.
+                error!(self.log, "bad snapshot name {}!", &snapshot);
+                continue;
             }
             let snapshot_name = parts[1];
 


### PR DESCRIPTION
When `zfs snapshot dataset@name` is called, the ZFS snapshot is not instantaneously mounted to the appropriate .../.zfs/snapshot/<name> path (as long as 172 ms was measured for a zpool with file backed vdevs). There's two fixes that result from this:

1. Use `zfs list -t snapshot ...` to tell if a snapshot exists, not the presence of the mounted snapshot directory

2. Wait for the ZFS snapshot directory to get mounted before starting a read-only downstairs service that points to it. Wait a maximum of 5 seconds before returning an error.

Also bundled in this commit is a fix for an agent bug: it's possible for a snapshot to have a running read-only downstairs that is in the destroyed state (but not deleted yet), and this will prevent the deletion of said snapshot, as the deletion code simply checked for the presence of a running read-only snapshot and not its state. Fix this by matching on the state and allowing deletion.

Also (!) bundled in this commit is another fix for another agent bug: when getting snapshots for a region, if the region wasn't in state Created then the endpoint would return 500. This is wrong, and we can handle more states than !Created. The only state that should return 500 is Failed.

Fixes #827.