### PR TITLE
A bounced agent must reinitialize all SMF config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,7 +754,9 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
+ "slog-term",
  "subprocess",
+ "tempfile",
  "tokio",
  "uuid",
 ]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -27,3 +27,5 @@ expectorate.workspace = true
 openapi-lint.workspace = true
 openapiv3.workspace = true
 subprocess.workspace = true
+tempfile.workspace = true
+slog-term.workspace = true

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1467,7 +1467,9 @@ fn worker(
 
                 if let Err(e) = result {
                     error!(log, "SMF application failure: {:?}", e);
-                    // XXX no fail_rs?! RS is still in requested
+
+                    // There's no fail_rs here: a future `apply_smf` should
+                    // attempt to start the service again.
                 } else {
                     info!(log, "SMF ok!");
 

--- a/agent/src/smf_interface.rs
+++ b/agent/src/smf_interface.rs
@@ -296,6 +296,7 @@ pub struct RealSmfValue<'a> {
 }
 
 impl<'a> RealSmfValue<'a> {
+    #[allow(unused)]
     pub fn new(v: crucible_smf::Value<'a>) -> RealSmfValue<'a> {
         RealSmfValue { v }
     }

--- a/agent/src/smf_interface.rs
+++ b/agent/src/smf_interface.rs
@@ -1,0 +1,761 @@
+// Copyright 2023 Oxide Computer Company
+
+use anyhow::Result;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+/// Interfaces for an implementation to interface with SMF objects.
+
+pub trait SmfInterface {
+    fn instances(
+        &self,
+    ) -> Result<Vec<Box<dyn SmfInstance + '_>>, crucible_smf::ScfError>;
+
+    fn get_instance(
+        &self,
+        name: &str,
+    ) -> Result<Option<Box<dyn SmfInstance + '_>>, crucible_smf::ScfError>;
+
+    fn add_instance(
+        &self,
+        name: &str,
+    ) -> Result<Box<dyn SmfInstance + '_>, crucible_smf::ScfError>;
+
+    #[cfg(test)]
+    fn prune(&self);
+}
+
+pub struct RealSmf<'a> {
+    svc: &'a crucible_smf::Service<'a>,
+}
+
+impl<'a> RealSmf<'a> {
+    pub fn new(svc: &'a crucible_smf::Service<'a>) -> Result<RealSmf<'a>> {
+        Ok(RealSmf { svc })
+    }
+}
+
+impl<'a> SmfInterface for RealSmf<'a> {
+    fn instances(
+        &self,
+    ) -> Result<Vec<Box<dyn SmfInstance + '_>>, crucible_smf::ScfError> {
+        let smf_insts: Vec<crucible_smf::Instance<'_>> = self
+            .svc
+            .instances()?
+            .collect::<Vec<Result<_, _>>>()
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut insts: Vec<Box<dyn SmfInstance>> =
+            Vec::with_capacity(smf_insts.len());
+        for smf_inst in smf_insts {
+            insts.push(Box::new(RealSmfInstance::new(smf_inst)));
+        }
+
+        Ok(insts)
+    }
+
+    fn get_instance(
+        &self,
+        name: &str,
+    ) -> Result<Option<Box<dyn SmfInstance + '_>>, crucible_smf::ScfError> {
+        let inst = self.svc.get_instance(name)?;
+        if let Some(inst) = inst {
+            Ok(Some(Box::new(RealSmfInstance::new(inst))))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn add_instance(
+        &self,
+        name: &str,
+    ) -> Result<Box<dyn SmfInstance + '_>, crucible_smf::ScfError> {
+        let inst = self.svc.add_instance(name)?;
+        Ok(Box::new(RealSmfInstance::new(inst)))
+    }
+
+    #[cfg(test)]
+    fn prune(&self) {
+        todo!()
+    }
+}
+
+pub trait SmfInstance {
+    fn name(&self) -> Result<String, crucible_smf::ScfError>;
+    fn fmri(&self) -> Result<String, crucible_smf::ScfError>;
+    fn states(
+        &self,
+    ) -> Result<
+        (Option<crucible_smf::State>, Option<crucible_smf::State>),
+        crucible_smf::ScfError,
+    >;
+    fn disable(&self, temporary: bool) -> Result<(), crucible_smf::ScfError>;
+    fn enable(&self, temporary: bool) -> Result<(), crucible_smf::ScfError>;
+    fn enabled(&self) -> bool;
+
+    fn get_pg(
+        &self,
+        name: &str,
+    ) -> Result<Option<Box<dyn SmfPropertyGroup + '_>>, crucible_smf::ScfError>;
+    fn add_pg(
+        &self,
+        name: &str,
+        pgtype: &str,
+    ) -> Result<Box<dyn SmfPropertyGroup + '_>, crucible_smf::ScfError>;
+    fn get_snapshot(
+        &self,
+        name: &str,
+    ) -> Result<Option<Box<dyn SmfSnapshot + '_>>, crucible_smf::ScfError>;
+}
+
+pub struct RealSmfInstance<'a> {
+    inst: crucible_smf::Instance<'a>,
+}
+
+impl<'a> RealSmfInstance<'a> {
+    pub fn new(inst: crucible_smf::Instance<'a>) -> RealSmfInstance {
+        RealSmfInstance { inst }
+    }
+}
+
+impl<'a> SmfInstance for RealSmfInstance<'a> {
+    fn name(&self) -> Result<String, crucible_smf::ScfError> {
+        self.inst.name()
+    }
+
+    fn fmri(&self) -> Result<String, crucible_smf::ScfError> {
+        self.inst.fmri()
+    }
+
+    fn states(
+        &self,
+    ) -> Result<
+        (Option<crucible_smf::State>, Option<crucible_smf::State>),
+        crucible_smf::ScfError,
+    > {
+        self.inst.states()
+    }
+
+    fn disable(&self, temporary: bool) -> Result<(), crucible_smf::ScfError> {
+        self.inst.disable(temporary)
+    }
+
+    fn enable(&self, temporary: bool) -> Result<(), crucible_smf::ScfError> {
+        self.inst.enable(temporary)
+    }
+
+    fn enabled(&self) -> bool {
+        unimplemented!();
+    }
+
+    fn get_pg(
+        &self,
+        name: &str,
+    ) -> Result<Option<Box<dyn SmfPropertyGroup + '_>>, crucible_smf::ScfError>
+    {
+        if let Some(pg) = self.inst.get_pg(name)? {
+            Ok(Some(Box::new(RealSmfPropertyGroup::new(pg))))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn add_pg(
+        &self,
+        name: &str,
+        pgtype: &str,
+    ) -> Result<Box<dyn SmfPropertyGroup + '_>, crucible_smf::ScfError> {
+        let pg = self.inst.add_pg(name, pgtype)?;
+        Ok(Box::new(RealSmfPropertyGroup::new(pg)))
+    }
+
+    fn get_snapshot(
+        &self,
+        name: &str,
+    ) -> Result<Option<Box<dyn SmfSnapshot + '_>>, crucible_smf::ScfError> {
+        let snap = self.inst.get_snapshot(name)?;
+        if let Some(snap) = snap {
+            Ok(Some(Box::new(RealSmfSnapshot::new(snap))))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+pub trait SmfSnapshot {
+    fn get_pg(
+        &self,
+        name: &str,
+    ) -> Result<Option<Box<dyn SmfPropertyGroup + '_>>, crucible_smf::ScfError>;
+}
+
+pub struct RealSmfSnapshot<'a> {
+    snap: crucible_smf::Snapshot<'a>,
+}
+
+impl<'a> RealSmfSnapshot<'a> {
+    pub fn new(snap: crucible_smf::Snapshot<'a>) -> RealSmfSnapshot {
+        RealSmfSnapshot { snap }
+    }
+}
+
+impl<'a> SmfSnapshot for RealSmfSnapshot<'a> {
+    fn get_pg(
+        &self,
+        name: &str,
+    ) -> Result<Option<Box<dyn SmfPropertyGroup + '_>>, crucible_smf::ScfError>
+    {
+        if let Some(pg) = self.snap.get_pg(name)? {
+            Ok(Some(Box::new(RealSmfPropertyGroup::new(pg))))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+pub trait SmfPropertyGroup {
+    fn get_property(
+        &self,
+        name: &str,
+    ) -> Result<Option<Box<dyn SmfProperty + '_>>, crucible_smf::ScfError>;
+
+    fn transaction(
+        &self,
+    ) -> Result<Box<dyn SmfTransaction + '_>, crucible_smf::ScfError>;
+}
+
+pub struct RealSmfPropertyGroup<'a> {
+    pg: crucible_smf::PropertyGroup<'a>,
+}
+
+impl<'a> RealSmfPropertyGroup<'a> {
+    pub fn new(pg: crucible_smf::PropertyGroup<'a>) -> RealSmfPropertyGroup {
+        RealSmfPropertyGroup { pg }
+    }
+}
+
+impl<'a> SmfPropertyGroup for RealSmfPropertyGroup<'a> {
+    fn get_property(
+        &self,
+        name: &str,
+    ) -> Result<Option<Box<dyn SmfProperty + '_>>, crucible_smf::ScfError> {
+        let p = self.pg.get_property(name)?;
+        Ok(Some(Box::new(RealSmfProperty::new(p))))
+    }
+
+    fn transaction(
+        &self,
+    ) -> Result<Box<dyn SmfTransaction + '_>, crucible_smf::ScfError> {
+        let t = self.pg.transaction()?;
+        Ok(Box::new(RealSmfTransaction::new(t)))
+    }
+}
+
+pub trait SmfProperty {
+    fn value(
+        &self,
+    ) -> Result<Option<Box<dyn SmfValue + '_>>, crucible_smf::ScfError>;
+}
+
+pub struct RealSmfProperty<'a> {
+    p: Option<crucible_smf::Property<'a>>,
+}
+
+impl<'a> RealSmfProperty<'a> {
+    pub fn new(p: Option<crucible_smf::Property<'a>>) -> RealSmfProperty<'a> {
+        RealSmfProperty { p }
+    }
+}
+
+impl<'a> SmfProperty for RealSmfProperty<'a> {
+    fn value(
+        &self,
+    ) -> Result<Option<Box<dyn SmfValue + '_>>, crucible_smf::ScfError> {
+        match &self.p {
+            Some(p) => {
+                if let Some(v) = p.value()? {
+                    Ok(Some(Box::new(RealSmfValue { v })))
+                } else {
+                    Ok(None)
+                }
+            }
+
+            None => Ok(None),
+        }
+    }
+}
+
+pub trait SmfValue {
+    fn as_string(&self) -> Result<String, crucible_smf::ScfError>;
+}
+
+pub struct RealSmfValue<'a> {
+    v: crucible_smf::Value<'a>,
+}
+
+impl<'a> RealSmfValue<'a> {
+    pub fn new(v: crucible_smf::Value<'a>) -> RealSmfValue<'a> {
+        RealSmfValue { v }
+    }
+}
+
+impl<'a> SmfValue for RealSmfValue<'a> {
+    fn as_string(&self) -> Result<String, crucible_smf::ScfError> {
+        self.v.as_string()
+    }
+}
+
+pub trait SmfTransaction {
+    fn start(&self) -> Result<(), crucible_smf::ScfError>;
+
+    fn property_ensure(
+        &self,
+        name: &str,
+        typ: crucible_smf::scf_type_t,
+        val: &str,
+    ) -> Result<(), crucible_smf::ScfError>;
+
+    fn commit(
+        &self,
+    ) -> Result<crucible_smf::CommitResult, crucible_smf::ScfError>;
+}
+
+pub struct RealSmfTransaction<'a> {
+    t: crucible_smf::Transaction<'a>,
+}
+
+impl<'a> RealSmfTransaction<'a> {
+    pub fn new(t: crucible_smf::Transaction<'a>) -> RealSmfTransaction<'a> {
+        RealSmfTransaction { t }
+    }
+}
+
+impl<'a> SmfTransaction for RealSmfTransaction<'a> {
+    fn start(&self) -> Result<(), crucible_smf::ScfError> {
+        self.t.start()
+    }
+
+    fn property_ensure(
+        &self,
+        name: &str,
+        typ: crucible_smf::scf_type_t,
+        val: &str,
+    ) -> Result<(), crucible_smf::ScfError> {
+        self.t.property_ensure(name, typ, val)
+    }
+
+    fn commit(
+        &self,
+    ) -> Result<crucible_smf::CommitResult, crucible_smf::ScfError> {
+        self.t.commit()
+    }
+}
+
+#[derive(Debug)]
+pub struct MockSmf {
+    scope: String,
+
+    // Instance name -> Mock instance entry
+    config: Mutex<HashMap<String, MockSmfInstance>>,
+}
+
+impl MockSmf {
+    #[cfg(test)]
+    pub fn new(scope: String) -> MockSmf {
+        MockSmf {
+            scope,
+            config: Mutex::new(HashMap::new()),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn config_is_empty(&self) -> bool {
+        self.config.lock().unwrap().is_empty()
+    }
+}
+
+impl PartialEq for MockSmf {
+    fn eq(&self, other: &Self) -> bool {
+        let lhs = self.config.lock().unwrap();
+        let rhs = other.config.lock().unwrap();
+
+        self.scope == other.scope && *lhs == *rhs
+    }
+}
+
+impl SmfInterface for MockSmf {
+    fn instances(
+        &self,
+    ) -> Result<Vec<Box<dyn SmfInstance + '_>>, crucible_smf::ScfError> {
+        let config = self.config.lock().unwrap();
+        let mut instances: Vec<Box<dyn SmfInstance>> = vec![];
+
+        for value in config.values() {
+            instances.push(Box::new(value.clone()));
+        }
+
+        Ok(instances)
+    }
+
+    fn get_instance(
+        &self,
+        name: &str,
+    ) -> Result<Option<Box<dyn SmfInstance + '_>>, crucible_smf::ScfError> {
+        let config = self.config.lock().unwrap();
+        if let Some(value) = config.get(name) {
+            Ok(Some(Box::new(value.clone())))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn add_instance(
+        &self,
+        name: &str,
+    ) -> Result<Box<dyn SmfInstance + '_>, crucible_smf::ScfError> {
+        let mut config = self.config.lock().unwrap();
+
+        config.insert(
+            name.to_string(),
+            MockSmfInstance::new(
+                name.to_string(),
+                format!("{}:{}", self.scope, name),
+            ),
+        );
+
+        drop(config);
+
+        Ok(self.get_instance(name)?.unwrap())
+    }
+
+    /// When testing to see if running `apply_smf` based on the on-disk
+    /// datafile, disabled stuff remains in the current SMF interface and will
+    /// cause PartialEq comparison to fail. Prune that here so that comparison
+    /// can be done.
+    #[cfg(test)]
+    fn prune(&self) {
+        let mut config = self.config.lock().unwrap();
+        let pairs: Vec<(String, MockSmfInstance)> = config.drain().collect();
+        for (key, value) in pairs {
+            if value.inner.lock().unwrap().enabled {
+                config.insert(key, value);
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct MockSmfInstanceInner {
+    enabled: bool,
+    temporary: bool,
+    property_groups: HashMap<String, MockSmfPropertyGroup>,
+}
+
+impl MockSmfInstanceInner {
+    pub fn get_property_group(
+        &self,
+        name: &str,
+    ) -> Option<MockSmfPropertyGroup> {
+        self.property_groups.get(name).cloned()
+    }
+
+    pub fn add_property_group(
+        &mut self,
+        name: &str,
+        pg_type: &str,
+    ) -> MockSmfPropertyGroup {
+        self.property_groups
+            .entry(name.to_string())
+            .or_insert(MockSmfPropertyGroup::new(
+                name.to_string(),
+                pg_type.to_string(),
+            ))
+            .clone()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct MockSmfInstance {
+    name: String,
+    fmri: String,
+    inner: Arc<Mutex<MockSmfInstanceInner>>,
+}
+
+impl MockSmfInstance {
+    pub fn new(name: String, fmri: String) -> MockSmfInstance {
+        MockSmfInstance {
+            name,
+            fmri,
+            inner: Arc::new(Mutex::new(MockSmfInstanceInner::default())),
+        }
+    }
+}
+
+impl PartialEq for MockSmfInstance {
+    fn eq(&self, other: &Self) -> bool {
+        let lhs = self.inner.lock().unwrap();
+        let rhs = other.inner.lock().unwrap();
+
+        self.name == other.name && self.fmri == other.fmri && *lhs == *rhs
+    }
+}
+
+impl SmfInstance for MockSmfInstance {
+    fn name(&self) -> Result<String, crucible_smf::ScfError> {
+        Ok(self.name.clone())
+    }
+
+    fn fmri(&self) -> Result<String, crucible_smf::ScfError> {
+        Ok(self.fmri.clone())
+    }
+
+    fn states(
+        &self,
+    ) -> Result<
+        (Option<crucible_smf::State>, Option<crucible_smf::State>),
+        crucible_smf::ScfError,
+    > {
+        // TODO is this necessary for testing? it's only used for debug print
+        // right now
+        Ok((None, None))
+    }
+
+    fn disable(&self, temporary: bool) -> Result<(), crucible_smf::ScfError> {
+        let mut inner = self.inner.lock().unwrap();
+        inner.enabled = false;
+        inner.temporary = temporary;
+
+        Ok(())
+    }
+
+    fn enable(&self, temporary: bool) -> Result<(), crucible_smf::ScfError> {
+        let mut inner = self.inner.lock().unwrap();
+        inner.enabled = true;
+        inner.temporary = temporary;
+
+        Ok(())
+    }
+
+    fn enabled(&self) -> bool {
+        self.inner.lock().unwrap().enabled
+    }
+
+    fn get_pg(
+        &self,
+        name: &str,
+    ) -> Result<Option<Box<dyn SmfPropertyGroup + '_>>, crucible_smf::ScfError>
+    {
+        let inner = self.inner.lock().unwrap();
+        if let Some(pg) = inner.get_property_group(name) {
+            Ok(Some(Box::new(pg)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn add_pg(
+        &self,
+        name: &str,
+        pgtype: &str,
+    ) -> Result<Box<dyn SmfPropertyGroup + '_>, crucible_smf::ScfError> {
+        let mut inner = self.inner.lock().unwrap();
+        let pg = inner.add_property_group(name, pgtype);
+        Ok(Box::new(pg))
+    }
+
+    fn get_snapshot(
+        &self,
+        _name: &str,
+    ) -> Result<Option<Box<dyn SmfSnapshot + '_>>, crucible_smf::ScfError> {
+        // XXX this probably isn't how it works?
+        let inner = self.inner.lock().unwrap();
+        Ok(Some(Box::new(MockSmfSnapshot::new(
+            inner.property_groups.clone(),
+        ))))
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct MockSmfSnapshot {
+    property_groups: HashMap<String, MockSmfPropertyGroup>,
+}
+
+impl MockSmfSnapshot {
+    pub fn new(
+        property_groups: HashMap<String, MockSmfPropertyGroup>,
+    ) -> MockSmfSnapshot {
+        MockSmfSnapshot { property_groups }
+    }
+}
+
+impl SmfSnapshot for MockSmfSnapshot {
+    fn get_pg(
+        &self,
+        name: &str,
+    ) -> Result<Option<Box<dyn SmfPropertyGroup + '_>>, crucible_smf::ScfError>
+    {
+        if let Some(pg) = self.property_groups.get(name) {
+            Ok(Some(Box::new(pg.clone())))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct MockSmfPropertyGroup {
+    pg_name: String,
+    pgtype: String,
+    properties: Arc<Mutex<HashMap<String, MockSmfProperty>>>,
+}
+
+impl MockSmfPropertyGroup {
+    pub fn new(pg_name: String, pgtype: String) -> MockSmfPropertyGroup {
+        MockSmfPropertyGroup {
+            pg_name,
+            pgtype,
+            properties: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl PartialEq for MockSmfPropertyGroup {
+    fn eq(&self, other: &Self) -> bool {
+        let lhs = self.properties.lock().unwrap();
+        let rhs = other.properties.lock().unwrap();
+
+        self.pg_name == other.pg_name
+            && self.pgtype == other.pgtype
+            && *lhs == *rhs
+    }
+}
+
+impl SmfPropertyGroup for MockSmfPropertyGroup {
+    fn get_property(
+        &self,
+        name: &str,
+    ) -> Result<Option<Box<dyn SmfProperty + '_>>, crucible_smf::ScfError> {
+        let properties = self.properties.lock().unwrap();
+        if let Some(value) = properties.get(name) {
+            Ok(Some(Box::new(value.clone())))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn transaction(
+        &self,
+    ) -> Result<Box<dyn SmfTransaction + '_>, crucible_smf::ScfError> {
+        Ok(Box::new(MockSmfTransaction::new(self.properties.clone())))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MockSmfProperty {
+    name: String,
+    value: Option<String>,
+}
+
+impl MockSmfProperty {
+    // XXX don't store scf_type_t, can't derive Eq
+    pub fn new(
+        name: String,
+        _typ: crucible_smf::scf_type_t,
+        value: Option<String>,
+    ) -> MockSmfProperty {
+        MockSmfProperty { name, value }
+    }
+}
+
+impl SmfProperty for MockSmfProperty {
+    fn value(
+        &self,
+    ) -> Result<Option<Box<dyn SmfValue + '_>>, crucible_smf::ScfError> {
+        if let Some(value) = &self.value {
+            Ok(Some(Box::new(MockSmfValue {
+                value: value.clone(),
+            })))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+pub struct MockSmfValue {
+    value: String,
+}
+
+impl SmfValue for MockSmfValue {
+    fn as_string(&self) -> Result<String, crucible_smf::ScfError> {
+        Ok(self.value.clone())
+    }
+}
+
+pub struct MockSmfTransaction {
+    properties: Arc<Mutex<HashMap<String, MockSmfProperty>>>,
+    ensured: Mutex<HashMap<String, MockSmfProperty>>,
+}
+
+impl MockSmfTransaction {
+    pub fn new(
+        properties: Arc<Mutex<HashMap<String, MockSmfProperty>>>,
+    ) -> MockSmfTransaction {
+        MockSmfTransaction {
+            properties,
+            ensured: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl SmfTransaction for MockSmfTransaction {
+    fn start(&self) -> Result<(), crucible_smf::ScfError> {
+        Ok(())
+    }
+
+    fn property_ensure(
+        &self,
+        name: &str,
+        typ: crucible_smf::scf_type_t,
+        val: &str,
+    ) -> Result<(), crucible_smf::ScfError> {
+        let mut ensured = self.ensured.lock().unwrap();
+
+        if let Some(p) = ensured.get_mut(name) {
+            *p = MockSmfProperty::new(
+                name.to_string(),
+                typ,
+                Some(val.to_string()),
+            );
+        } else {
+            ensured.insert(
+                name.to_string(),
+                MockSmfProperty::new(
+                    name.to_string(),
+                    typ,
+                    Some(val.to_string()),
+                ),
+            );
+        }
+
+        Ok(())
+    }
+
+    fn commit(
+        &self,
+    ) -> Result<crucible_smf::CommitResult, crucible_smf::ScfError> {
+        let ensured = self.ensured.lock().unwrap();
+        let mut properties = self.properties.lock().unwrap();
+
+        for (name, property) in &*ensured {
+            if let Some(p) = properties.get_mut(name) {
+                *p = property.clone();
+            } else {
+                properties.insert(name.clone(), property.clone());
+            }
+        }
+
+        Ok(crucible_smf::CommitResult::Success)
+    }
+}

--- a/agent/src/snapshot_interface.rs
+++ b/agent/src/snapshot_interface.rs
@@ -1,0 +1,283 @@
+// Copyright 2023 Oxide Computer Company
+
+use super::model::*;
+use anyhow::{bail, Result};
+use slog::{error, info, Logger};
+use std::collections::HashSet;
+use std::process::Command;
+use std::sync::Mutex;
+
+use chrono::{TimeZone, Utc};
+
+#[cfg(test)]
+use std::path::PathBuf;
+
+/// A interface for an implementation to interact with ZFS snapshots.
+pub trait SnapshotInterface: Sync + Send {
+    /// Get all snapshots for a dataset.
+    fn get_snapshots_for_dataset(
+        &self,
+        dataset: String,
+    ) -> Result<Vec<Snapshot>>;
+
+    /// Delete a snapshot if it exists. This call should be idempotent.
+    fn delete_snapshot(&self, snapshot_name: String) -> Result<()>;
+
+    /// Create a snapshot. Only used for testing.
+    #[cfg(test)]
+    fn create_snapshot(
+        &self,
+        base_path: PathBuf,
+        region_id: String,
+        snapshot_name: String,
+    );
+}
+
+pub struct ZfsSnapshotInterface {
+    log: Logger,
+}
+
+impl ZfsSnapshotInterface {
+    pub fn new(log: Logger) -> ZfsSnapshotInterface {
+        ZfsSnapshotInterface { log }
+    }
+}
+
+impl SnapshotInterface for ZfsSnapshotInterface {
+    fn get_snapshots_for_dataset(
+        &self,
+        dataset: String,
+    ) -> Result<Vec<Snapshot>> {
+        let cmd = Command::new("zfs")
+            .arg("list")
+            .arg("-t")
+            .arg("snapshot")
+            .arg("-H")
+            .arg("-o")
+            .arg("name")
+            .arg("-r")
+            .arg(&dataset)
+            .output()?;
+
+        let snapshots_stdout = String::from_utf8_lossy(&cmd.stdout);
+        if !cmd.status.success() {
+            let snapshots_stderr = String::from_utf8_lossy(&cmd.stderr);
+
+            error!(
+                self.log,
+                "zfs list snapshot for dataset {:?} list failed: out {:?} err {:?}",
+                dataset,
+                snapshots_stdout,
+                snapshots_stderr,
+            );
+
+            bail!("zfs list snapshots failed!");
+        }
+
+        let mut results = Vec::new();
+
+        let snapshots_list: Vec<&str> = snapshots_stdout
+            .trim_end()
+            .split('\n')
+            .filter(|x| !x.is_empty())
+            .collect();
+
+        for snapshot in snapshots_list {
+            if snapshot == dataset {
+                info!(self.log, "skipping {} matches dataset name", snapshot);
+                continue;
+            }
+            info!(self.log, "snapshot is {}", &snapshot);
+            let parts: Vec<&str> = snapshot.split('@').collect();
+            info!(self.log, "parts is {:?}", &parts);
+            if parts.len() != 2 {
+                // If some non-snapshot-name output snuck in here, then don't
+                // panic! Continue to the next one in the list.
+                error!(self.log, "bad snapshot name {}!", &snapshot);
+                continue;
+            }
+            let snapshot_name = parts[1];
+
+            let cmd = Command::new("zfs")
+                .arg("get")
+                .arg("-pH")
+                .arg("-o")
+                .arg("value")
+                .arg("creation")
+                .arg(snapshot)
+                .output()?;
+
+            let cmd_stdout = {
+                let cmd_stdout = String::from_utf8_lossy(&cmd.stdout);
+
+                // Remove newline
+                let cmd_stdout = cmd_stdout.trim_end().to_string();
+
+                cmd_stdout
+            };
+
+            if !cmd.status.success() {
+                let err = String::from_utf8_lossy(&cmd.stderr);
+
+                error!(
+                    self.log,
+                    "zfs get for snapshot {} failed: out {:?} err {:?}",
+                    snapshot,
+                    cmd_stdout,
+                    err,
+                );
+
+                bail!("zfs get failed!");
+            }
+
+            results.push(Snapshot {
+                name: snapshot_name.to_string(),
+                created: Utc.timestamp_opt(cmd_stdout.parse()?, 0).unwrap(),
+            });
+        }
+
+        Ok(results)
+    }
+
+    fn delete_snapshot(&self, snapshot_name: String) -> Result<()> {
+        // If the snapshot doesn't exist, return Ok - this call should be
+        // idempotent
+        let cmd = Command::new("zfs")
+            .arg("list")
+            .arg(snapshot_name.clone())
+            .output()?;
+
+        if !cmd.status.success() {
+            let out = String::from_utf8_lossy(&cmd.stdout);
+            let err = String::from_utf8_lossy(&cmd.stderr);
+
+            if err.trim_end().ends_with("dataset does not exist") {
+                return Ok(());
+            }
+
+            error!(
+                self.log,
+                "zfs snapshot {:?} list failed: out {:?} err {:?}",
+                snapshot_name,
+                out,
+                err,
+            );
+
+            bail!("zfs snapshot list failure");
+        }
+
+        // Delete it if it exists
+        let cmd = Command::new("zfs")
+            .arg("destroy")
+            .arg(snapshot_name.clone())
+            .output()?;
+
+        if !cmd.status.success() {
+            let err = String::from_utf8_lossy(&cmd.stderr);
+            let out = String::from_utf8_lossy(&cmd.stdout);
+
+            error!(
+                self.log,
+                "zfs snapshot {:?} delete failed: out {:?} err {:?}",
+                snapshot_name,
+                out,
+                err,
+            );
+
+            bail!("zfs snapshot delete failure");
+        }
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn create_snapshot(
+        &self,
+        _base_path: PathBuf,
+        _region_id: String,
+        _snapshot_name: String,
+    ) {
+        unimplemented!();
+    }
+}
+
+pub struct TestSnapshotInterface {
+    log: Logger,
+    snapshots: Mutex<HashSet<String>>,
+}
+
+impl TestSnapshotInterface {
+    #[cfg(test)]
+    pub fn new(log: Logger) -> TestSnapshotInterface {
+        TestSnapshotInterface {
+            log,
+            snapshots: Mutex::new(HashSet::new()),
+        }
+    }
+}
+
+impl SnapshotInterface for TestSnapshotInterface {
+    fn get_snapshots_for_dataset(
+        &self,
+        dataset: String,
+    ) -> Result<Vec<Snapshot>> {
+        let snapshots = self.snapshots.lock().unwrap();
+
+        let snapshots = snapshots
+            .iter()
+            .filter(|x| x.starts_with(&format!("{}@", dataset)))
+            .map(|x| Snapshot {
+                name: x.clone(),
+                created: Utc::now(),
+            })
+            .collect();
+
+        info!(
+            self.log,
+            "dataset {} has snapshots {:?}", dataset, snapshots
+        );
+
+        Ok(snapshots)
+    }
+
+    fn delete_snapshot(&self, snapshot_name: String) -> Result<()> {
+        let mut snapshots = self.snapshots.lock().unwrap();
+        info!(self.log, "deleting snapshot {}", snapshot_name);
+        snapshots.remove(&snapshot_name);
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn create_snapshot(
+        &self,
+        base_path: PathBuf,
+        region_id: String,
+        snapshot_name: String,
+    ) {
+        let mut snapshots = self.snapshots.lock().unwrap();
+
+        info!(
+            self.log,
+            "creating region {} snapshot {}", region_id, snapshot_name
+        );
+        snapshots.insert(format!("{}@{}", region_id, snapshot_name));
+
+        // Create a directory so that the "wait until snapshot is mounted" code
+        // finds what it's looking for.
+        let mut snapshot_path = base_path;
+        snapshot_path.push("regions");
+        snapshot_path.push(region_id.clone());
+        snapshot_path.push(".zfs");
+        snapshot_path.push("snapshot");
+        snapshot_path.push(snapshot_name.clone());
+
+        info!(
+            self.log,
+            "creating region {} snapshot {} dir {:?}",
+            region_id,
+            snapshot_name,
+            snapshot_path
+        );
+        std::fs::create_dir_all(&snapshot_path).unwrap();
+    }
+}

--- a/smf/src/lib.rs
+++ b/smf/src/lib.rs
@@ -20,7 +20,7 @@ mod service;
 pub use service::{Service, Services};
 
 mod instance;
-pub use instance::{Instance, Instances};
+pub use instance::{Instance, Instances, State};
 
 mod snapshot;
 pub use snapshot::{Snapshot, Snapshots};


### PR DESCRIPTION
Inspired by Angela's testing where she disabled and enabled the Pantry to see what would happen, I tried this with the Agent, and saw that the agent would **not** reconfigure running snapshots when bounced. This is due to object state transitioning from Requested to Created, but `apply_smf` only taking action for running snapshots in state Requested. If it was successfully created once, then it will remain in state Created, and when the agent stops and starts again it will 1) read the datafile, and 2) initialize all running snapshot SMF for objects with state Requested.

The fix for this is to take action in `apply_smf` on both Requested and Created states. This is different from how the region/downstairs objects are handled, but importantly the agent doesn't create snapshots like it does for region requests.

There's another bug fix here where it was previously possible to delete a snapshot if the running read-only downstairs corresponding to that snapshot was in state Failed. It's now not possible so we can investigate.

Testing the fix involved creating two general interfaces, one for interacting with SMF and one for interacting with ZFS snapshots. Two implementations of both were created: a real one for use, and a mock one for testing. The test that confirmed the running snapshot bug that this commit fixes is `test_smf_running_snapshot`.