### PR TITLE
Replace a downstairs via a new VCR 

### DIFF
--- a/crucible-client-types/src/lib.rs
+++ b/crucible-client-types/src/lib.rs
@@ -11,29 +11,45 @@ use uuid::Uuid;
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum VolumeConstructionRequest {
-    Volume {
-        id: Uuid,
-        block_size: u64,
-        sub_volumes: Vec<VolumeConstructionRequest>,
-        read_only_parent: Option<Box<VolumeConstructionRequest>>,
-    },
-    Url {
-        id: Uuid,
-        block_size: u64,
-        url: String,
-    },
-    Region {
-        block_size: u64,
-        blocks_per_extent: u64,
-        extent_count: u32,
-        opts: CrucibleOpts,
-        gen: u64,
-    },
-    File {
-        id: Uuid,
-        block_size: u64,
-        path: String,
-    },
+    Volume(VcrVolume),
+    Url(VcrUrl),
+    Region(VcrRegion),
+    File(VcrFile),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
+#[serde(tag = "vcr_type", rename_all = "snake_case")]
+pub struct VcrVolume {
+    pub id: Uuid,
+    pub block_size: u64,
+    pub sub_volumes: Vec<VolumeConstructionRequest>,
+    pub read_only_parent: Option<Box<VolumeConstructionRequest>>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
+#[serde(tag = "vcr_type", rename_all = "snake_case")]
+pub struct VcrUrl {
+    pub id: Uuid,
+    pub block_size: u64,
+    pub url: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
+#[serde(tag = "vcr_type", rename_all = "snake_case")]
+pub struct VcrRegion {
+    pub block_size: u64,
+    pub blocks_per_extent: u64,
+    pub extent_count: u32,
+    pub opts: CrucibleOpts,
+    pub gen: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
+#[serde(tag = "vcr_type", rename_all = "snake_case")]
+pub struct VcrFile {
+    pub id: Uuid,
+    pub block_size: u64,
+    pub path: String,
 }
 
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -9,7 +9,9 @@ mod test {
     use anyhow::*;
     use base64::{engine, Engine};
     use crucible::{Bytes, *};
-    use crucible_client_types::VolumeConstructionRequest;
+    use crucible_client_types::{
+        VcrRegion, VcrUrl, VcrVolume, VolumeConstructionRequest,
+    };
     use crucible_downstairs::*;
     use crucible_pantry::pantry::Pantry;
     use crucible_pantry_client::Client as CruciblePantryClient;
@@ -307,18 +309,20 @@ mod test {
         let opts = tds.opts();
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: tds.blocks_per_extent(),
-                    extent_count: tds.extent_count(),
-                    opts,
-                    gen: 1,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(
+                    VcrRegion {
+                        block_size: BLOCK_SIZE as u64,
+                        blocks_per_extent: tds.blocks_per_extent(),
+                        extent_count: tds.extent_count(),
+                        opts,
+                        gen: 1,
+                    },
+                )],
                 read_only_parent: None,
-            };
+            });
 
         let volume = Arc::new(Volume::construct(vcr, None, None).await?);
 
@@ -484,18 +488,20 @@ mod test {
 
         // Create volume with read only parent
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: tds.blocks_per_extent(),
-                    extent_count: tds.extent_count(),
-                    opts,
-                    gen: 1,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(
+                    VcrRegion {
+                        block_size: BLOCK_SIZE as u64,
+                        blocks_per_extent: tds.blocks_per_extent(),
+                        extent_count: tds.extent_count(),
+                        opts,
+                        gen: 1,
+                    },
+                )],
                 read_only_parent: None,
-            };
+            });
 
         let mut volume = Volume::construct(vcr, None, None).await?;
 
@@ -567,29 +573,33 @@ mod test {
         );
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: tds.blocks_per_extent(),
-                    extent_count: tds.extent_count(),
-                    opts,
-                    gen: 1,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(
+                    VcrRegion {
+                        block_size: BLOCK_SIZE as u64,
+                        blocks_per_extent: tds.blocks_per_extent(),
+                        extent_count: tds.extent_count(),
+                        opts,
+                        gen: 1,
+                    },
+                )],
                 read_only_parent: Some(Box::new(
-                    VolumeConstructionRequest::Volume {
+                    VolumeConstructionRequest::Volume(VcrVolume {
                         id: Uuid::new_v4(),
                         block_size: BLOCK_SIZE as u64,
-                        sub_volumes: vec![VolumeConstructionRequest::Url {
-                            id: Uuid::new_v4(),
-                            block_size: BLOCK_SIZE as u64,
-                            url: server.url("/ff.raw").to_string(),
-                        }],
+                        sub_volumes: vec![VolumeConstructionRequest::Url(
+                            VcrUrl {
+                                id: Uuid::new_v4(),
+                                block_size: BLOCK_SIZE as u64,
+                                url: server.url("/ff.raw").to_string(),
+                            },
+                        )],
                         read_only_parent: None,
-                    },
+                    }),
                 )),
-            };
+            });
 
         let volume = Volume::construct(vcr, None, None).await?;
         volume.activate().await?;
@@ -629,20 +639,20 @@ mod test {
         let opts = tds.opts();
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
                 sub_volumes: vec![],
                 read_only_parent: Some(Box::new(
-                    VolumeConstructionRequest::Region {
+                    VolumeConstructionRequest::Region(VcrRegion {
                         block_size: BLOCK_SIZE as u64,
                         blocks_per_extent: tds.blocks_per_extent(),
                         extent_count: tds.extent_count(),
                         opts,
                         gen: 1,
-                    },
+                    }),
                 )),
-            };
+            });
 
         let volume = Volume::construct(vcr, None, None).await?;
         volume.activate().await?;
@@ -678,18 +688,20 @@ mod test {
         let opts = tds.opts();
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: tds.blocks_per_extent(),
-                    extent_count: tds.extent_count(),
-                    opts,
-                    gen: 1,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(
+                    VcrRegion {
+                        block_size: BLOCK_SIZE as u64,
+                        blocks_per_extent: tds.blocks_per_extent(),
+                        extent_count: tds.extent_count(),
+                        opts,
+                        gen: 1,
+                    },
+                )],
                 read_only_parent: None,
-            };
+            });
 
         let volume = Arc::new(Volume::construct(vcr, None, None).await?);
 
@@ -749,18 +761,20 @@ mod test {
         let opts = tds.opts();
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: tds.blocks_per_extent(),
-                    extent_count: tds.extent_count(),
-                    opts,
-                    gen: 1,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(
+                    VcrRegion {
+                        block_size: BLOCK_SIZE as u64,
+                        blocks_per_extent: tds.blocks_per_extent(),
+                        extent_count: tds.extent_count(),
+                        opts,
+                        gen: 1,
+                    },
+                )],
                 read_only_parent: None,
-            };
+            });
 
         let volume = Arc::new(Volume::construct(vcr, None, None).await?);
 
@@ -822,18 +836,20 @@ mod test {
         let opts = tds.opts();
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: tds.blocks_per_extent(),
-                    extent_count: tds.extent_count(),
-                    opts,
-                    gen: 1,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(
+                    VcrRegion {
+                        block_size: BLOCK_SIZE as u64,
+                        blocks_per_extent: tds.blocks_per_extent(),
+                        extent_count: tds.extent_count(),
+                        opts,
+                        gen: 1,
+                    },
+                )],
                 read_only_parent: None,
-            };
+            });
 
         let volume = Arc::new(Volume::construct(vcr, None, None).await?);
 
@@ -895,30 +911,30 @@ mod test {
         let mut sv = Vec::new();
         let tds1 = TestDownstairsSet::small(false).await?;
         let opts = tds1.opts();
-        sv.push(VolumeConstructionRequest::Region {
+        sv.push(VolumeConstructionRequest::Region(VcrRegion {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds1.blocks_per_extent(),
             extent_count: tds1.extent_count(),
             opts,
             gen: 1,
-        });
+        }));
         let tds2 = TestDownstairsSet::small(false).await?;
         let opts = tds2.opts();
-        sv.push(VolumeConstructionRequest::Region {
+        sv.push(VolumeConstructionRequest::Region(VcrRegion {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds2.blocks_per_extent(),
             extent_count: tds2.extent_count(),
             opts,
             gen: 1,
-        });
+        }));
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
                 sub_volumes: sv,
                 read_only_parent: None,
-            };
+            });
 
         let volume = Arc::new(Volume::construct(vcr, None, None).await?);
 
@@ -981,30 +997,30 @@ mod test {
         let mut sv = Vec::new();
         let tds1 = TestDownstairsSet::small(false).await?;
         let opts = tds1.opts();
-        sv.push(VolumeConstructionRequest::Region {
+        sv.push(VolumeConstructionRequest::Region(VcrRegion {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds1.blocks_per_extent(),
             extent_count: tds1.extent_count(),
             opts,
             gen: 1,
-        });
+        }));
         let tds2 = TestDownstairsSet::small(false).await?;
         let opts = tds2.opts();
-        sv.push(VolumeConstructionRequest::Region {
+        sv.push(VolumeConstructionRequest::Region(VcrRegion {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds2.blocks_per_extent(),
             extent_count: tds2.extent_count(),
             opts,
             gen: 1,
-        });
+        }));
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
                 sub_volumes: sv,
                 read_only_parent: None,
-            };
+            });
 
         let volume = Arc::new(Volume::construct(vcr, None, None).await?);
 
@@ -1089,30 +1105,30 @@ mod test {
         let mut sv = Vec::new();
         let tds1 = TestDownstairsSet::small(false).await?;
         let opts = tds1.opts();
-        sv.push(VolumeConstructionRequest::Region {
+        sv.push(VolumeConstructionRequest::Region(VcrRegion {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds1.blocks_per_extent(),
             extent_count: tds1.extent_count(),
             opts,
             gen: 1,
-        });
+        }));
         let tds2 = TestDownstairsSet::small(false).await?;
         let opts = tds2.opts();
-        sv.push(VolumeConstructionRequest::Region {
+        sv.push(VolumeConstructionRequest::Region(VcrRegion {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds2.blocks_per_extent(),
             extent_count: tds2.extent_count(),
             opts,
             gen: 1,
-        });
+        }));
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
                 sub_volumes: sv,
                 read_only_parent: None,
-            };
+            });
 
         let volume = Arc::new(Volume::construct(vcr, None, None).await?);
 
@@ -1666,30 +1682,30 @@ mod test {
         let mut sv = Vec::new();
         let tds1 = TestDownstairsSet::small(false).await?;
         let opts = tds1.opts();
-        sv.push(VolumeConstructionRequest::Region {
+        sv.push(VolumeConstructionRequest::Region(VcrRegion {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds1.blocks_per_extent(),
             extent_count: tds1.extent_count(),
             opts,
             gen: 1,
-        });
+        }));
         let tds2 = TestDownstairsSet::small(false).await?;
         let opts = tds2.opts();
-        sv.push(VolumeConstructionRequest::Region {
+        sv.push(VolumeConstructionRequest::Region(VcrRegion {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds2.blocks_per_extent(),
             extent_count: tds2.extent_count(),
             opts,
             gen: 1,
-        });
+        }));
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
                 sub_volumes: sv,
                 read_only_parent: None,
-            };
+            });
 
         let mut volume = Volume::construct(vcr, None, None).await?;
 
@@ -1791,30 +1807,30 @@ mod test {
         let mut sv = Vec::new();
         let tds1 = TestDownstairsSet::small(false).await?;
         let opts = tds1.opts();
-        sv.push(VolumeConstructionRequest::Region {
+        sv.push(VolumeConstructionRequest::Region(VcrRegion {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds1.blocks_per_extent(),
             extent_count: tds1.extent_count(),
             opts,
             gen: 1,
-        });
+        }));
         let tds2 = TestDownstairsSet::small(false).await?;
         let opts = tds2.opts();
-        sv.push(VolumeConstructionRequest::Region {
+        sv.push(VolumeConstructionRequest::Region(VcrRegion {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds2.blocks_per_extent(),
             extent_count: tds2.extent_count(),
             opts,
             gen: 1,
-        });
+        }));
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
                 sub_volumes: sv,
                 read_only_parent: None,
-            };
+            });
 
         let mut volume = Volume::construct(vcr, None, None).await?;
 
@@ -1900,39 +1916,39 @@ mod test {
         let mut opts = tds.opts();
 
         let vcr_1: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
                 sub_volumes: vec![],
                 read_only_parent: Some(Box::new(
-                    VolumeConstructionRequest::Region {
+                    VolumeConstructionRequest::Region(VcrRegion {
                         block_size: BLOCK_SIZE as u64,
                         blocks_per_extent: tds.blocks_per_extent(),
                         extent_count: tds.extent_count(),
                         opts: opts.clone(),
                         gen: 1,
-                    },
+                    }),
                 )),
-            };
+            });
 
         // Second volume should have a unique UUID
         opts.id = Uuid::new_v4();
 
         let vcr_2: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
                 sub_volumes: vec![],
                 read_only_parent: Some(Box::new(
-                    VolumeConstructionRequest::Region {
+                    VolumeConstructionRequest::Region(VcrRegion {
                         block_size: BLOCK_SIZE as u64,
                         blocks_per_extent: tds.blocks_per_extent(),
                         extent_count: tds.extent_count(),
                         opts,
                         gen: 1,
-                    },
+                    }),
                 )),
-            };
+            });
 
         let volume1 = Volume::construct(vcr_1, None, None).await?;
         volume1.activate().await?;
@@ -2125,32 +2141,37 @@ mod test {
         let bottom_layer_opts = test_downstairs_set.opts();
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: top_layer_tds.blocks_per_extent(),
-                    extent_count: top_layer_tds.extent_count(),
-                    opts: top_layer_opts,
-                    gen: 3,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(
+                    VcrRegion {
+                        block_size: BLOCK_SIZE as u64,
+                        blocks_per_extent: top_layer_tds.blocks_per_extent(),
+                        extent_count: top_layer_tds.extent_count(),
+                        opts: top_layer_opts,
+                        gen: 3,
+                    },
+                )],
                 read_only_parent: Some(Box::new(
-                    VolumeConstructionRequest::Volume {
+                    VolumeConstructionRequest::Volume(VcrVolume {
                         id: Uuid::new_v4(),
                         block_size: BLOCK_SIZE as u64,
-                        sub_volumes: vec![VolumeConstructionRequest::Region {
-                            block_size: BLOCK_SIZE as u64,
-                            blocks_per_extent: test_downstairs_set
-                                .blocks_per_extent(),
-                            extent_count: test_downstairs_set.extent_count(),
-                            opts: bottom_layer_opts,
-                            gen: 3,
-                        }],
+                        sub_volumes: vec![VolumeConstructionRequest::Region(
+                            VcrRegion {
+                                block_size: BLOCK_SIZE as u64,
+                                blocks_per_extent: test_downstairs_set
+                                    .blocks_per_extent(),
+                                extent_count: test_downstairs_set
+                                    .extent_count(),
+                                opts: bottom_layer_opts,
+                                gen: 3,
+                            },
+                        )],
                         read_only_parent: None,
-                    },
+                    }),
                 )),
-            };
+            });
 
         let volume = Volume::construct(vcr, None, None).await?;
         volume.activate().await?;
@@ -3347,18 +3368,20 @@ mod test {
         let opts = tds.opts();
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: tds.blocks_per_extent(),
-                    extent_count: tds.extent_count(),
-                    opts: opts.clone(),
-                    gen: 1,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(
+                    VcrRegion {
+                        block_size: BLOCK_SIZE as u64,
+                        blocks_per_extent: tds.blocks_per_extent(),
+                        extent_count: tds.extent_count(),
+                        opts: opts.clone(),
+                        gen: 1,
+                    },
+                )],
                 read_only_parent: None,
-            };
+            });
 
         let client =
             CruciblePantryClient::new(&format!("http://{}", pantry_addr));
@@ -3451,18 +3474,20 @@ mod test {
             .unwrap();
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: tds.blocks_per_extent(),
-                    extent_count: tds.extent_count(),
-                    opts: opts.clone(),
-                    gen: 2,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(
+                    VcrRegion {
+                        block_size: BLOCK_SIZE as u64,
+                        blocks_per_extent: tds.blocks_per_extent(),
+                        extent_count: tds.extent_count(),
+                        opts: opts.clone(),
+                        gen: 2,
+                    },
+                )],
                 read_only_parent: None,
-            };
+            });
         let volume = Volume::construct(vcr, None, None).await.unwrap();
         volume.activate().await.unwrap();
 
@@ -3556,18 +3581,20 @@ mod test {
 
         let volume_id = Uuid::new_v4();
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: tds.blocks_per_extent(),
-                    extent_count: tds.extent_count(),
-                    opts: opts.clone(),
-                    gen: 1,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(
+                    VcrRegion {
+                        block_size: BLOCK_SIZE as u64,
+                        blocks_per_extent: tds.blocks_per_extent(),
+                        extent_count: tds.extent_count(),
+                        opts: opts.clone(),
+                        gen: 1,
+                    },
+                )],
                 read_only_parent: None,
-            };
+            });
 
         // Verify contents are zero on init
         {
@@ -3615,18 +3642,20 @@ mod test {
         // Attach, validate img.raw got imported
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: tds.blocks_per_extent(),
-                    extent_count: tds.extent_count(),
-                    opts,
-                    gen: 3,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(
+                    VcrRegion {
+                        block_size: BLOCK_SIZE as u64,
+                        blocks_per_extent: tds.blocks_per_extent(),
+                        extent_count: tds.extent_count(),
+                        opts,
+                        gen: 3,
+                    },
+                )],
                 read_only_parent: None,
-            };
+            });
         let volume = Volume::construct(vcr, None, None).await.unwrap();
         volume.activate().await.unwrap();
 
@@ -3693,18 +3722,20 @@ mod test {
         // Attach, validate bulk write worked
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: tds.blocks_per_extent(),
-                    extent_count: tds.extent_count(),
-                    opts,
-                    gen: 2,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(
+                    VcrRegion {
+                        block_size: BLOCK_SIZE as u64,
+                        blocks_per_extent: tds.blocks_per_extent(),
+                        extent_count: tds.extent_count(),
+                        opts,
+                        gen: 2,
+                    },
+                )],
                 read_only_parent: None,
-            };
+            });
         let volume = Volume::construct(vcr, None, None).await.unwrap();
         volume.activate().await.unwrap();
 
@@ -3756,18 +3787,20 @@ mod test {
         // Attach, validate bulk write worked
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: tds.blocks_per_extent(),
-                    extent_count: tds.extent_count(),
-                    opts,
-                    gen: 2,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(
+                    VcrRegion {
+                        block_size: BLOCK_SIZE as u64,
+                        blocks_per_extent: tds.blocks_per_extent(),
+                        extent_count: tds.extent_count(),
+                        opts,
+                        gen: 2,
+                    },
+                )],
                 read_only_parent: None,
-            };
+            });
         let volume = Volume::construct(vcr, None, None).await.unwrap();
         volume.activate().await.unwrap();
 
@@ -3821,25 +3854,28 @@ mod test {
 
         let volume_id = Uuid::new_v4();
         let rop_id = Uuid::new_v4();
-        let read_only_parent = Some(Box::new(VolumeConstructionRequest::Url {
-            id: rop_id,
-            block_size: BLOCK_SIZE as u64,
-            url: url.clone(),
-        }));
+        let read_only_parent =
+            Some(Box::new(VolumeConstructionRequest::Url(VcrUrl {
+                id: rop_id,
+                block_size: BLOCK_SIZE as u64,
+                url: url.clone(),
+            })));
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: tds.blocks_per_extent(),
-                    extent_count: tds.extent_count(),
-                    opts: opts.clone(),
-                    gen: 1,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(
+                    VcrRegion {
+                        block_size: BLOCK_SIZE as u64,
+                        blocks_per_extent: tds.blocks_per_extent(),
+                        extent_count: tds.extent_count(),
+                        opts: opts.clone(),
+                        gen: 1,
+                    },
+                )],
                 read_only_parent: read_only_parent.clone(),
-            };
+            });
 
         // Verify contents match data on init
         {
@@ -3877,18 +3913,20 @@ mod test {
             CruciblePantryClient::new(&format!("http://{}", pantry_addr));
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: tds.blocks_per_extent(),
-                    extent_count: tds.extent_count(),
-                    opts: opts.clone(),
-                    gen: 2,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(
+                    VcrRegion {
+                        block_size: BLOCK_SIZE as u64,
+                        blocks_per_extent: tds.blocks_per_extent(),
+                        extent_count: tds.extent_count(),
+                        opts: opts.clone(),
+                        gen: 2,
+                    },
+                )],
                 read_only_parent,
-            };
+            });
         client
             .attach(
                 &volume_id.to_string(),
@@ -3927,18 +3965,20 @@ mod test {
         // Drop the read only parent from the volume construction request
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: tds.blocks_per_extent(),
-                    extent_count: tds.extent_count(),
-                    opts,
-                    gen: 3,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(
+                    VcrRegion {
+                        block_size: BLOCK_SIZE as u64,
+                        blocks_per_extent: tds.blocks_per_extent(),
+                        extent_count: tds.extent_count(),
+                        opts,
+                        gen: 3,
+                    },
+                )],
                 read_only_parent: None,
-            };
+            });
 
         // Attach, validate random data got imported
 
@@ -4391,63 +4431,100 @@ mod test {
         client.detach(&volume_id.to_string()).await.unwrap();
     }
 
-    // XXX
-    // Negative tests for volume type mismatches.
-    // Basically, you can have all sorts of differences.
-    // Test where VCR has one field different.
     #[tokio::test]
-    async fn test_volume_replace_alan() {
+    async fn test_volume_replace_vcr() {
+        // Test of a replacement of a downstairs given two
+        // VolumeConstructionRequests.
+        // We create a volume, write some data to it, then replace a downstairs
+        // in that volume.  After replacement, we verify we can read back the
+        // data.
         const BLOCK_SIZE: usize = 512;
         let log = csl();
 
         info!(log, "test_volume_replace of a volume");
-        // Spin off three downstairs, build our Crucible struct.
+        // Make three downstairs
         let tds = TestDownstairsSet::small(false).await.unwrap();
         let opts = tds.opts();
         let volume_id = Uuid::new_v4();
 
+        let mut vcr_r = VcrRegion {
+            block_size: BLOCK_SIZE as u64,
+            blocks_per_extent: tds.blocks_per_extent(),
+            extent_count: tds.extent_count(),
+            opts: opts.clone(),
+            gen: 2,
+        };
+
         let original: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: tds.blocks_per_extent(),
-                    extent_count: tds.extent_count(),
-                    opts: opts.clone(),
-                    gen: 2,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(
+                    vcr_r.clone(),
+                )],
                 read_only_parent: None,
-            };
+            });
 
-        let volume =
-            Volume::construct(original.clone(), None, None).await.unwrap();
+        let volume = Volume::construct(original.clone(), None, None)
+            .await
+            .unwrap();
         volume.activate().await.unwrap();
 
+        // Write data in
+        volume
+            .write(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![0x55; BLOCK_SIZE * 10]),
+            )
+            .await
+            .unwrap();
+
+        // Read parent, verify contents
+        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec().await);
+
+        // Make one new downstairs
         let new_downstairs = tds.new_downstairs().await.unwrap();
-        info!(log, "A New downstairs: {:?}", new_downstairs.address().await);
+        info!(
+            log,
+            "A New downstairs: {:?}",
+            new_downstairs.address().await
+        );
 
         let mut new_opts = tds.opts().clone();
         new_opts.target[0] = new_downstairs.address().await;
-        info!(log, "Old ops: {:?}", opts.target);
-        info!(log, "New ops: {:?}", new_opts.target);
+        info!(log, "Old ops target: {:?}", opts.target);
+        info!(log, "New ops target: {:?}", new_opts.target);
+        vcr_r.gen += 1;
+        vcr_r.opts = new_opts;
 
+        // Our "new" VCR must have a new downstairs in the opts, and have
+        // the generation number be larger than the original.
         let replacement: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume(VcrVolume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region {
-                    block_size: BLOCK_SIZE as u64,
-                    blocks_per_extent: tds.blocks_per_extent(),
-                    extent_count: tds.extent_count(),
-                    opts: new_opts.clone(),
-                    gen: 3,
-                }],
+                sub_volumes: vec![VolumeConstructionRequest::Region(vcr_r)],
                 read_only_parent: None,
-            };
+            });
 
-        info!(log, "replace volume now: {:?}", replacement);
-        let res = Volume::replace(original, replacement, &log).await.unwrap();
-        info!(log, "Test returns: {:?}", res);
+        info!(log, "Replace VCR now: {:?}", replacement);
+        volume
+            .target_replace(original, replacement, &log)
+            .await
+            .unwrap();
+        info!(log, "send read now");
+        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec().await);
     }
 }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -324,7 +324,7 @@ mod test {
                 read_only_parent: None,
             });
 
-        let volume = Arc::new(Volume::construct(vcr, None, None).await?);
+        let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
         volume.activate().await?;
 
@@ -396,7 +396,7 @@ mod test {
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], *buffer.as_vec().await);
 
-        let mut volume = Volume::new(BLOCK_SIZE as u64);
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
         volume
             .add_subvolume_create_guest(
                 opts,
@@ -406,7 +406,6 @@ mod test {
                     extent_count: tds.extent_count(),
                 },
                 1,
-                None,
                 None,
             )
             .await?;
@@ -503,11 +502,12 @@ mod test {
                 read_only_parent: None,
             });
 
-        let mut volume = Volume::construct(vcr, None, None).await?;
+        let log = csl();
+        let mut volume = Volume::construct(vcr, None, log.clone()).await?;
 
         volume
             .add_read_only_parent({
-                let mut volume = Volume::new(BLOCK_SIZE as u64);
+                let mut volume = Volume::new(BLOCK_SIZE as u64, log.clone());
                 volume.add_subvolume(in_memory_data.clone()).await?;
                 Arc::new(volume)
             })
@@ -601,7 +601,7 @@ mod test {
                 )),
             });
 
-        let volume = Volume::construct(vcr, None, None).await?;
+        let volume = Volume::construct(vcr, None, csl()).await?;
         volume.activate().await?;
 
         // Read one block: should be all 0xff
@@ -654,7 +654,7 @@ mod test {
                 )),
             });
 
-        let volume = Volume::construct(vcr, None, None).await?;
+        let volume = Volume::construct(vcr, None, csl()).await?;
         volume.activate().await?;
 
         // Read one block: should be all 0x00
@@ -703,7 +703,7 @@ mod test {
                 read_only_parent: None,
             });
 
-        let volume = Arc::new(Volume::construct(vcr, None, None).await?);
+        let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
         volume.activate().await?;
 
@@ -776,7 +776,7 @@ mod test {
                 read_only_parent: None,
             });
 
-        let volume = Arc::new(Volume::construct(vcr, None, None).await?);
+        let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
         volume.activate().await?;
 
@@ -851,7 +851,7 @@ mod test {
                 read_only_parent: None,
             });
 
-        let volume = Arc::new(Volume::construct(vcr, None, None).await?);
+        let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
         volume.activate().await?;
 
@@ -936,7 +936,7 @@ mod test {
                 read_only_parent: None,
             });
 
-        let volume = Arc::new(Volume::construct(vcr, None, None).await?);
+        let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
         volume.activate().await?;
 
@@ -1022,7 +1022,7 @@ mod test {
                 read_only_parent: None,
             });
 
-        let volume = Arc::new(Volume::construct(vcr, None, None).await?);
+        let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
         volume.activate().await?;
         let full_volume_size = BLOCK_SIZE * 20;
@@ -1130,7 +1130,7 @@ mod test {
                 read_only_parent: None,
             });
 
-        let volume = Arc::new(Volume::construct(vcr, None, None).await?);
+        let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
         volume.activate().await?;
         let full_volume_size = BLOCK_SIZE * 20;
@@ -1229,7 +1229,7 @@ mod test {
 
         assert_eq!(vec![11; BLOCK_SIZE * 5], *buffer.as_vec().await);
 
-        let mut volume = Volume::new(BLOCK_SIZE as u64);
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
         volume
             .add_subvolume_create_guest(
                 opts,
@@ -1239,7 +1239,6 @@ mod test {
                     extent_count: tds.extent_count(),
                 },
                 1,
-                None,
                 None,
             )
             .await?;
@@ -1310,7 +1309,7 @@ mod test {
             )
             .await?;
 
-        let mut volume = Volume::new(BLOCK_SIZE as u64);
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
         volume
             .add_subvolume_create_guest(
                 opts,
@@ -1320,7 +1319,6 @@ mod test {
                     extent_count: tds.extent_count(),
                 },
                 1,
-                None,
                 None,
             )
             .await?;
@@ -1338,7 +1336,7 @@ mod test {
 
         // Call the scrubber.  This should replace all data from the
         // RO parent into the main volume.
-        volume.scrub(&csl(), None, None).await.unwrap();
+        volume.scrub(None, None).await.unwrap();
 
         // Now, try a write_unwritten, this should not change our
         // data as the scrubber has finished.
@@ -1394,7 +1392,7 @@ mod test {
             )
             .await?;
 
-        let mut volume = Volume::new(BLOCK_SIZE as u64);
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
         volume
             .add_subvolume_create_guest(
                 opts,
@@ -1404,7 +1402,6 @@ mod test {
                     extent_count: tds.extent_count(),
                 },
                 1,
-                None,
                 None,
             )
             .await?;
@@ -1430,7 +1427,7 @@ mod test {
 
         // Call the scrubber.  This should replace all data from the
         // RO parent into the main volume.
-        volume.scrub(&csl(), None, None).await.unwrap();
+        volume.scrub(None, None).await.unwrap();
 
         // Now, try a write_unwritten, this should not change our
         // unwritten data as the scrubber has finished.
@@ -1499,7 +1496,7 @@ mod test {
             )
             .await?;
 
-        let mut volume = Volume::new(BLOCK_SIZE as u64);
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
         volume
             .add_subvolume_create_guest(
                 opts,
@@ -1509,7 +1506,6 @@ mod test {
                     extent_count: tds.extent_count(),
                 },
                 1,
-                None,
                 None,
             )
             .await?;
@@ -1536,7 +1532,7 @@ mod test {
         // Call the scrubber.  This should replace all data from the
         // RO parent into the main volume except where new writes have
         // landed
-        volume.scrub(&csl(), None, None).await.unwrap();
+        volume.scrub(None, None).await.unwrap();
 
         // Read and verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -1595,7 +1591,7 @@ mod test {
             )
             .await?;
 
-        let mut volume = Volume::new(BLOCK_SIZE as u64);
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
         volume
             .add_subvolume_create_guest(
                 opts,
@@ -1605,7 +1601,6 @@ mod test {
                     extent_count: tds.extent_count(),
                 },
                 1,
-                None,
                 None,
             )
             .await?;
@@ -1630,7 +1625,7 @@ mod test {
             .await?;
 
         // Call the scrubber.  This should do nothing
-        volume.scrub(&csl(), None, None).await.unwrap();
+        volume.scrub(None, None).await.unwrap();
 
         // Read and verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -1707,11 +1702,12 @@ mod test {
                 read_only_parent: None,
             });
 
-        let mut volume = Volume::construct(vcr, None, None).await?;
+        let log = csl();
+        let mut volume = Volume::construct(vcr, None, log.clone()).await?;
 
         volume
             .add_read_only_parent({
-                let mut volume = Volume::new(BLOCK_SIZE as u64);
+                let mut volume = Volume::new(BLOCK_SIZE as u64, log.clone());
                 volume.add_subvolume(in_memory_data).await?;
                 Arc::new(volume)
             })
@@ -1745,7 +1741,7 @@ mod test {
             .await?;
 
         // Call the scrubber
-        volume.scrub(&csl(), None, None).await.unwrap();
+        volume.scrub(None, None).await.unwrap();
 
         // Read full volume
         let buffer = Buffer::new(BLOCK_SIZE * 20);
@@ -1832,11 +1828,12 @@ mod test {
                 read_only_parent: None,
             });
 
-        let mut volume = Volume::construct(vcr, None, None).await?;
+        let log = csl();
+        let mut volume = Volume::construct(vcr, None, log.clone()).await?;
 
         volume
             .add_read_only_parent({
-                let mut volume = Volume::new(BLOCK_SIZE as u64);
+                let mut volume = Volume::new(BLOCK_SIZE as u64, log.clone());
                 volume.add_subvolume(in_memory_data).await?;
                 Arc::new(volume)
             })
@@ -1881,7 +1878,7 @@ mod test {
             .await?;
 
         // Call the scrubber
-        volume.scrub(&csl(), None, None).await.unwrap();
+        volume.scrub(None, None).await.unwrap();
 
         // Read full volume
         let buffer = Buffer::new(BLOCK_SIZE * 20);
@@ -1950,10 +1947,11 @@ mod test {
                 )),
             });
 
-        let volume1 = Volume::construct(vcr_1, None, None).await?;
+        let log = csl();
+        let volume1 = Volume::construct(vcr_1, None, log.clone()).await?;
         volume1.activate().await?;
 
-        let volume2 = Volume::construct(vcr_2, None, None).await?;
+        let volume2 = Volume::construct(vcr_2, None, log.clone()).await?;
         volume2.activate().await?;
 
         // Read one block: should be all 0x00
@@ -1993,7 +1991,7 @@ mod test {
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();
 
-        let mut volume = Volume::new(BLOCK_SIZE as u64);
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
         volume
             .add_subvolume_create_guest(
                 opts,
@@ -2003,7 +2001,6 @@ mod test {
                     extent_count: tds.extent_count(),
                 },
                 1,
-                None,
                 None,
             )
             .await?;
@@ -2027,7 +2024,7 @@ mod test {
             .await?;
 
         // Call the scrubber.  This should do nothing
-        volume.scrub(&csl(), None, None).await.unwrap();
+        volume.scrub(None, None).await.unwrap();
 
         // Read and verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
@@ -2056,7 +2053,7 @@ mod test {
         // read-only.
         let mut test_downstairs_set = TestDownstairsSet::small(false).await?;
 
-        let mut volume = Volume::new(BLOCK_SIZE as u64);
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
         volume
             .add_subvolume_create_guest(
                 test_downstairs_set.opts(),
@@ -2066,7 +2063,6 @@ mod test {
                     extent_count: test_downstairs_set.extent_count(),
                 },
                 1,
-                None,
                 None,
             )
             .await?;
@@ -2095,7 +2091,7 @@ mod test {
 
         // Validate that this now accepts reads and flushes, but rejects writes
         {
-            let mut volume = Volume::new(BLOCK_SIZE as u64);
+            let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
             volume
                 .add_subvolume_create_guest(
                     test_downstairs_set.opts(),
@@ -2106,7 +2102,6 @@ mod test {
                         extent_count: test_downstairs_set.extent_count(),
                     },
                     2,
-                    None,
                     None,
                 )
                 .await?;
@@ -2173,7 +2168,7 @@ mod test {
                 )),
             });
 
-        let volume = Volume::construct(vcr, None, None).await?;
+        let volume = Volume::construct(vcr, None, csl()).await?;
         volume.activate().await?;
 
         // Validate that source blocks originally come from the read-only parent
@@ -2229,7 +2224,7 @@ mod test {
         // boot three downstairs, write some data to them
         let test_downstairs_set = TestDownstairsSet::small(false).await?;
 
-        let mut volume = Volume::new(BLOCK_SIZE as u64);
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
         volume
             .add_subvolume_create_guest(
                 test_downstairs_set.opts(),
@@ -2239,7 +2234,6 @@ mod test {
                     extent_count: test_downstairs_set.extent_count(),
                 },
                 1,
-                None,
                 None,
             )
             .await?;
@@ -2321,7 +2315,7 @@ mod test {
         // Create three downstairs.
         let test_downstairs_set = TestDownstairsSet::small(false).await?;
 
-        let mut volume = Volume::new(BLOCK_SIZE as u64);
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
         volume
             .add_subvolume_create_guest(
                 test_downstairs_set.opts(),
@@ -2331,7 +2325,6 @@ mod test {
                     extent_count: test_downstairs_set.extent_count(),
                 },
                 1,
-                None,
                 None,
             )
             .await?;
@@ -2366,7 +2359,7 @@ mod test {
         // Create three downstairs.
         let test_downstairs_set = TestDownstairsSet::small(false).await?;
 
-        let mut volume = Volume::new(BLOCK_SIZE as u64);
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
         volume
             .add_subvolume_create_guest(
                 test_downstairs_set.opts(),
@@ -2376,7 +2369,6 @@ mod test {
                     extent_count: test_downstairs_set.extent_count(),
                 },
                 1,
-                None,
                 None,
             )
             .await?;
@@ -2406,7 +2398,7 @@ mod test {
         // Create three downstairs.
         let test_downstairs_set = TestDownstairsSet::small(false).await?;
 
-        let mut volume = Volume::new(BLOCK_SIZE as u64);
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
         volume
             .add_subvolume_create_guest(
                 test_downstairs_set.opts(),
@@ -2416,7 +2408,6 @@ mod test {
                     extent_count: test_downstairs_set.extent_count(),
                 },
                 1,
-                None,
                 None,
             )
             .await?;
@@ -2461,7 +2452,7 @@ mod test {
         // Create three downstairs.
         let test_downstairs_set = TestDownstairsSet::small(false).await?;
 
-        let mut volume = Volume::new(BLOCK_SIZE as u64);
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
         volume
             .add_subvolume_create_guest(
                 test_downstairs_set.opts(),
@@ -2471,7 +2462,6 @@ mod test {
                     extent_count: test_downstairs_set.extent_count(),
                 },
                 1,
-                None,
                 None,
             )
             .await?;
@@ -2513,7 +2503,7 @@ mod test {
         // boot three downstairs, write some data to them
         let test_downstairs_set = TestDownstairsSet::big(false).await?;
 
-        let mut volume = Volume::new(BLOCK_SIZE as u64);
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
         volume
             .add_subvolume_create_guest(
                 test_downstairs_set.opts(),
@@ -2523,7 +2513,6 @@ mod test {
                     extent_count: test_downstairs_set.extent_count(),
                 },
                 1,
-                None,
                 None,
             )
             .await?;
@@ -2595,7 +2584,7 @@ mod test {
             test_downstairs_set.downstairs3_address().await,
         ];
 
-        let mut new_volume = Volume::new(BLOCK_SIZE as u64);
+        let mut new_volume = Volume::new(BLOCK_SIZE as u64, csl());
         new_volume
             .add_subvolume_create_guest(
                 opts,
@@ -2605,7 +2594,6 @@ mod test {
                     extent_count: test_downstairs_set.extent_count(),
                 },
                 2,
-                None,
                 None,
             )
             .await?;
@@ -2641,7 +2629,7 @@ mod test {
         // Create three problematic downstairs.
         let test_downstairs_set = TestDownstairsSet::problem().await?;
 
-        let mut volume = Volume::new(BLOCK_SIZE as u64);
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
         volume
             .add_subvolume_create_guest(
                 test_downstairs_set.opts(),
@@ -2651,7 +2639,6 @@ mod test {
                     extent_count: test_downstairs_set.extent_count(),
                 },
                 1,
-                None,
                 None,
             )
             .await?;
@@ -3488,7 +3475,7 @@ mod test {
                 )],
                 read_only_parent: None,
             });
-        let volume = Volume::construct(vcr, None, None).await.unwrap();
+        let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
         let buffer = Buffer::new(bytes.len());
@@ -3558,6 +3545,7 @@ mod test {
     #[tokio::test]
     async fn test_pantry_import_from_local_server() {
         const BLOCK_SIZE: usize = 512;
+        let log = csl();
 
         let server = Server::run();
         server.expect(
@@ -3598,8 +3586,9 @@ mod test {
 
         // Verify contents are zero on init
         {
-            let volume =
-                Volume::construct(vcr.clone(), None, None).await.unwrap();
+            let volume = Volume::construct(vcr.clone(), None, log.clone())
+                .await
+                .unwrap();
             volume.activate().await.unwrap();
 
             let buffer = Buffer::new(5120);
@@ -3656,7 +3645,7 @@ mod test {
                 )],
                 read_only_parent: None,
             });
-        let volume = Volume::construct(vcr, None, None).await.unwrap();
+        let volume = Volume::construct(vcr, None, log.clone()).await.unwrap();
         volume.activate().await.unwrap();
 
         let buffer = Buffer::new(5120);
@@ -3736,7 +3725,7 @@ mod test {
                 )],
                 read_only_parent: None,
             });
-        let volume = Volume::construct(vcr, None, None).await.unwrap();
+        let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
         let buffer = Buffer::new(5120);
@@ -3801,7 +3790,7 @@ mod test {
                 )],
                 read_only_parent: None,
             });
-        let volume = Volume::construct(vcr, None, None).await.unwrap();
+        let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
         let buffer =
@@ -3879,7 +3868,7 @@ mod test {
 
         // Verify contents match data on init
         {
-            let volume = Volume::construct(vcr, None, None).await.unwrap();
+            let volume = Volume::construct(vcr, None, csl()).await.unwrap();
             volume.activate().await.unwrap();
 
             let buffer = Buffer::new(data.len());
@@ -3982,7 +3971,7 @@ mod test {
 
         // Attach, validate random data got imported
 
-        let volume = Volume::construct(vcr, None, Some(log)).await.unwrap();
+        let volume = Volume::construct(vcr, None, log.clone()).await.unwrap();
         volume.activate().await.unwrap();
 
         let buffer = Buffer::new(data.len());
@@ -4465,7 +4454,7 @@ mod test {
                 read_only_parent: None,
             });
 
-        let volume = Volume::construct(original.clone(), None, None)
+        let volume = Volume::construct(original.clone(), None, log.clone())
             .await
             .unwrap();
         volume.activate().await.unwrap();

--- a/pantry/src/pantry.rs
+++ b/pantry/src/pantry.rs
@@ -271,8 +271,8 @@ impl PantryEntry {
         Ok(response.clone())
     }
 
-    pub async fn scrub(&self, log: &Logger) -> Result<()> {
-        self.volume.scrub(log, None, None).await?;
+    pub async fn scrub(&self) -> Result<()> {
+        self.volume.scrub(None, None).await?;
         Ok(())
     }
 
@@ -405,7 +405,7 @@ impl Pantry {
         let volume = Volume::construct(
             volume_construction_request.clone(),
             None,
-            Some(self.log.clone()),
+            self.log.clone(),
         )
         .await?;
 
@@ -564,9 +564,8 @@ impl Pantry {
     pub async fn scrub(&self, volume_id: String) -> Result<String, HttpError> {
         let entry = self.entry(volume_id).await?;
         let entry = entry.clone();
-        let log = self.log.clone();
 
-        let join_handle = tokio::spawn(async move { entry.scrub(&log).await });
+        let join_handle = tokio::spawn(async move { entry.scrub().await });
 
         let mut jobs = self.jobs.lock().await;
         let job_id = Uuid::new_v4().to_string();

--- a/tools/make-nightly.sh
+++ b/tools/make-nightly.sh
@@ -17,6 +17,7 @@ tar cavf out/crucible-nightly.tar.gz \
   target/release/cmon \
   target/release/crudd \
   target/release/crutest \
+  target/release/crucible-agent \
   target/release/crucible-downstairs \
   target/release/crucible-hammer \
   target/release/dsc \

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -9453,10 +9453,7 @@ impl BlockIO for Guest {
             result: data.clone(),
         };
 
-        println!("Send replace message somewhere");
         self.send(sw).await.wait().await?;
-
-        println!("wait for replace message somewhere");
         let result = data.lock().await;
         Ok(*result)
     }

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -1396,25 +1396,28 @@ impl Volume {
         replacement: VolumeConstructionRequest,
         log: &Logger,
     ) -> Result<(), CrucibleError> {
-        let (original_target, new_target) =
-            match Self::compare_vcr_for_update(original, replacement, log)
-                .await
-            {
-                Ok(Some((o, n))) => (o, n),
-                Ok(None) => {
-                    crucible_bail!(
-                        ReplaceRequestInvalid,
-                        "VCR replacement does not differ on targets",
-                    )
-                }
-                Err(e) => {
-                    crucible_bail!(
-                        ReplaceRequestInvalid,
-                        "VCR replacement invalid: {}",
-                        e
-                    )
-                }
-            };
+        let (original_target, new_target) = match Self::compare_vcr_for_update(
+            original,
+            replacement,
+            log,
+        )
+        .await
+        {
+            Ok(Some((o, n))) => (o, n),
+            Ok(None) => {
+                crucible_bail!(
+                    ReplaceRequestInvalid,
+                    "VCR replacement does not differ on targets",
+                )
+            }
+            Err(e) => {
+                crucible_bail!(
+                    ReplaceRequestInvalid,
+                    "VCR replacement invalid: {}",
+                    e
+                )
+            }
+        };
 
         info!(
             log,
@@ -3317,10 +3320,9 @@ mod test {
 
         let log = csl();
         // This should return OK, but not have any targets.
-        let res =
-            Volume::compare_vcr_for_update(original, replacement, &log)
-                .await
-                .unwrap();
+        let res = Volume::compare_vcr_for_update(original, replacement, &log)
+            .await
+            .unwrap();
 
         assert!(res.is_none());
     }
@@ -3367,13 +3369,9 @@ mod test {
             });
 
         let log = csl();
-        assert!(Volume::compare_vcr_for_update(
-            original,
-            replacement,
-            &log
-        )
-        .await
-        .is_err());
+        assert!(Volume::compare_vcr_for_update(original, replacement, &log)
+            .await
+            .is_err());
     }
 
     #[tokio::test]
@@ -3418,13 +3416,9 @@ mod test {
             });
 
         let log = csl();
-        assert!(Volume::compare_vcr_for_update(
-            original,
-            replacement,
-            &log
-        )
-        .await
-        .is_err());
+        assert!(Volume::compare_vcr_for_update(original, replacement, &log)
+            .await
+            .is_err());
     }
 
     #[tokio::test]
@@ -3479,13 +3473,9 @@ mod test {
             });
 
         let log = csl();
-        assert!(Volume::compare_vcr_for_update(
-            original,
-            replacement,
-            &log
-        )
-        .await
-        .is_err());
+        assert!(Volume::compare_vcr_for_update(original, replacement, &log)
+            .await
+            .is_err());
     }
 
     #[tokio::test]
@@ -3532,13 +3522,9 @@ mod test {
             });
 
         let log = csl();
-        assert!(Volume::compare_vcr_for_update(
-            original,
-            replacement,
-            &log
-        )
-        .await
-        .is_err());
+        assert!(Volume::compare_vcr_for_update(original, replacement, &log)
+            .await
+            .is_err());
     }
 
     #[tokio::test]
@@ -3585,13 +3571,9 @@ mod test {
             });
 
         let log = csl();
-        assert!(Volume::compare_vcr_for_update(
-            original,
-            replacement,
-            &log
-        )
-        .await
-        .is_err());
+        assert!(Volume::compare_vcr_for_update(original, replacement, &log)
+            .await
+            .is_err());
     }
 
     #[tokio::test]
@@ -3638,13 +3620,9 @@ mod test {
             });
 
         let log = csl();
-        assert!(Volume::compare_vcr_for_update(
-            original,
-            replacement,
-            &log
-        )
-        .await
-        .is_err());
+        assert!(Volume::compare_vcr_for_update(original, replacement, &log)
+            .await
+            .is_err());
     }
 
     // This is a wrapper function to test changing CrucibleOpts structures.

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -1210,6 +1210,10 @@ impl Volume {
         }
 
         // Presently, we only support one sub_volume for replacement.
+        // If support for multiple sub_volumes is added, then this following
+        // section will need to be updated to loop over the sub_volume Vec and
+        // find the specific one with a difference, while verifying that all
+        // other sub_volumes are no different.
         if n_volume.sub_volumes.len() != 1 {
             crucible_bail!(
                 ReplaceRequestInvalid,

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -1397,7 +1397,7 @@ impl Volume {
         log: &Logger,
     ) -> Result<(), CrucibleError> {
         let (original_target, new_target) =
-            match Self::compare_vcr_for_replacement(original, replacement, log)
+            match Self::compare_vcr_for_update(original, replacement, log)
                 .await
             {
                 Ok(Some((o, n))) => (o, n),
@@ -3093,7 +3093,7 @@ mod test {
         let log = csl();
         info!(log, "Test replacement of CID {cid}");
         let Some((old_t, new_t)) =
-            Volume::compare_vcr_for_replacement(original, replacement, &log)
+            Volume::compare_vcr_for_update(original, replacement, &log)
                 .await
                 .unwrap()
             else {
@@ -3160,7 +3160,7 @@ mod test {
 
         let log = csl();
         let Some((old_t, new_t)) =
-            Volume::compare_vcr_for_replacement(original, replacement, &log)
+            Volume::compare_vcr_for_update(original, replacement, &log)
                 .await
                 .unwrap()
             else {
@@ -3226,7 +3226,7 @@ mod test {
 
         let log = csl();
         let Some((old_t, new_t)) =
-            Volume::compare_vcr_for_replacement(original, replacement, &log)
+            Volume::compare_vcr_for_update(original, replacement, &log)
                 .await
                 .unwrap()
             else {
@@ -3266,7 +3266,7 @@ mod test {
 
         let log = csl();
 
-        assert!(Volume::compare_vcr_for_replacement(
+        assert!(Volume::compare_vcr_for_update(
             original.clone(),
             original,
             &log
@@ -3318,7 +3318,7 @@ mod test {
         let log = csl();
         // This should return OK, but not have any targets.
         let res =
-            Volume::compare_vcr_for_replacement(original, replacement, &log)
+            Volume::compare_vcr_for_update(original, replacement, &log)
                 .await
                 .unwrap();
 
@@ -3367,7 +3367,7 @@ mod test {
             });
 
         let log = csl();
-        assert!(Volume::compare_vcr_for_replacement(
+        assert!(Volume::compare_vcr_for_update(
             original,
             replacement,
             &log
@@ -3418,7 +3418,7 @@ mod test {
             });
 
         let log = csl();
-        assert!(Volume::compare_vcr_for_replacement(
+        assert!(Volume::compare_vcr_for_update(
             original,
             replacement,
             &log
@@ -3479,7 +3479,7 @@ mod test {
             });
 
         let log = csl();
-        assert!(Volume::compare_vcr_for_replacement(
+        assert!(Volume::compare_vcr_for_update(
             original,
             replacement,
             &log
@@ -3532,7 +3532,7 @@ mod test {
             });
 
         let log = csl();
-        assert!(Volume::compare_vcr_for_replacement(
+        assert!(Volume::compare_vcr_for_update(
             original,
             replacement,
             &log
@@ -3585,7 +3585,7 @@ mod test {
             });
 
         let log = csl();
-        assert!(Volume::compare_vcr_for_replacement(
+        assert!(Volume::compare_vcr_for_update(
             original,
             replacement,
             &log
@@ -3638,7 +3638,7 @@ mod test {
             });
 
         let log = csl();
-        assert!(Volume::compare_vcr_for_replacement(
+        assert!(Volume::compare_vcr_for_update(
             original,
             replacement,
             &log
@@ -3650,7 +3650,7 @@ mod test {
     // This is a wrapper function to test changing CrucibleOpts structures.
     // We create two Volumes with the provided information, and use o_opts
     // for one Volume and n_opts for the other.  We return the result of
-    // the compare_vcr_for_replacement function.
+    // the compare_vcr_for_update function.
     async fn test_volume_replace_opts(
         id: Uuid,
         block_size: u64,
@@ -3690,7 +3690,7 @@ mod test {
             });
 
         let log = csl();
-        Volume::compare_vcr_for_replacement(original, replacement, &log).await
+        Volume::compare_vcr_for_update(original, replacement, &log).await
     }
 
     #[tokio::test]

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -1143,7 +1143,7 @@ impl Volume {
             VolumeConstructionRequest::Url { .. } => {
                 crucible_bail!(
                     ReplaceRequestInvalid,
-                    "Replacement URL VCR invalid "
+                    "Replacement URL VCR invalid"
                 )
             }
 


### PR DESCRIPTION
This adds support for replacing a crucible downstairs from the Volume layer by submitting a current and
new `VolumeConstructionRequest` (VCR).  If the new VCR matches the current with only a few allowed differences
 (gen, a single new target) then the guest layer `replace_downstairs` is called with the old and new downstairs targets.

To make this code a little more readable, new structure types were created for each of the enums in the `VolumeConstructionRequest`, and the `VolumeConstructionRequest` now uses the new types.
These changes can be seen in `crucible-client-types/src/lib.rs`, and that's probably a good place to start.

A bunch of new tests were created to verify the old/new VCRs only differ in the required ways, and any other
differences are blocked.

The meat of the changes here are the new `compare_vcr_for_replacement()` call that compares two VCRs and, if it
finds them to match enough, returns the old and new target downstairs.  This can then be passed on to the
existing `replace_downstairs()` call that will tell the upstairs to perform the replacement.

There is a fair chunk of code that is just testing all the possible differences that two VCRs might have, which is sadly
like 85% the same for each test.  I'm happy to take suggestions on how to turn that into less code if possible, but
trying to keep a balance such that it is pretty clear as to what the test was doing.