### PR TITLE
Undo the last VolumeConstructionRequest changes

### DIFF
--- a/crucible-client-types/src/lib.rs
+++ b/crucible-client-types/src/lib.rs
@@ -11,45 +11,29 @@ use uuid::Uuid;
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum VolumeConstructionRequest {
-    Volume(VcrVolume),
-    Url(VcrUrl),
-    Region(VcrRegion),
-    File(VcrFile),
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
-#[serde(tag = "vcr_type", rename_all = "snake_case")]
-pub struct VcrVolume {
-    pub id: Uuid,
-    pub block_size: u64,
-    pub sub_volumes: Vec<VolumeConstructionRequest>,
-    pub read_only_parent: Option<Box<VolumeConstructionRequest>>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
-#[serde(tag = "vcr_type", rename_all = "snake_case")]
-pub struct VcrUrl {
-    pub id: Uuid,
-    pub block_size: u64,
-    pub url: String,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
-#[serde(tag = "vcr_type", rename_all = "snake_case")]
-pub struct VcrRegion {
-    pub block_size: u64,
-    pub blocks_per_extent: u64,
-    pub extent_count: u32,
-    pub opts: CrucibleOpts,
-    pub gen: u64,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, PartialEq)]
-#[serde(tag = "vcr_type", rename_all = "snake_case")]
-pub struct VcrFile {
-    pub id: Uuid,
-    pub block_size: u64,
-    pub path: String,
+    Volume {
+        id: Uuid,
+        block_size: u64,
+        sub_volumes: Vec<VolumeConstructionRequest>,
+        read_only_parent: Option<Box<VolumeConstructionRequest>>,
+    },
+    Url {
+        id: Uuid,
+        block_size: u64,
+        url: String,
+    },
+    Region {
+        block_size: u64,
+        blocks_per_extent: u64,
+        extent_count: u32,
+        opts: CrucibleOpts,
+        gen: u64,
+    },
+    File {
+        id: Uuid,
+        block_size: u64,
+        path: String,
+    },
 }
 
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -9,9 +9,7 @@ mod test {
     use anyhow::*;
     use base64::{engine, Engine};
     use crucible::{Bytes, *};
-    use crucible_client_types::{
-        VcrRegion, VcrUrl, VcrVolume, VolumeConstructionRequest,
-    };
+    use crucible_client_types::VolumeConstructionRequest;
     use crucible_downstairs::*;
     use crucible_pantry::pantry::Pantry;
     use crucible_pantry_client::Client as CruciblePantryClient;
@@ -309,20 +307,18 @@ mod test {
         let opts = tds.opts();
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(
-                    VcrRegion {
-                        block_size: BLOCK_SIZE as u64,
-                        blocks_per_extent: tds.blocks_per_extent(),
-                        extent_count: tds.extent_count(),
-                        opts,
-                        gen: 1,
-                    },
-                )],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts,
+                    gen: 1,
+                }],
                 read_only_parent: None,
-            });
+            };
 
         let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
@@ -487,20 +483,18 @@ mod test {
 
         // Create volume with read only parent
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(
-                    VcrRegion {
-                        block_size: BLOCK_SIZE as u64,
-                        blocks_per_extent: tds.blocks_per_extent(),
-                        extent_count: tds.extent_count(),
-                        opts,
-                        gen: 1,
-                    },
-                )],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts,
+                    gen: 1,
+                }],
                 read_only_parent: None,
-            });
+            };
 
         let log = csl();
         let mut volume = Volume::construct(vcr, None, log.clone()).await?;
@@ -573,33 +567,29 @@ mod test {
         );
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(
-                    VcrRegion {
-                        block_size: BLOCK_SIZE as u64,
-                        blocks_per_extent: tds.blocks_per_extent(),
-                        extent_count: tds.extent_count(),
-                        opts,
-                        gen: 1,
-                    },
-                )],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts,
+                    gen: 1,
+                }],
                 read_only_parent: Some(Box::new(
-                    VolumeConstructionRequest::Volume(VcrVolume {
+                    VolumeConstructionRequest::Volume {
                         id: Uuid::new_v4(),
                         block_size: BLOCK_SIZE as u64,
-                        sub_volumes: vec![VolumeConstructionRequest::Url(
-                            VcrUrl {
-                                id: Uuid::new_v4(),
-                                block_size: BLOCK_SIZE as u64,
-                                url: server.url("/ff.raw").to_string(),
-                            },
-                        )],
+                        sub_volumes: vec![VolumeConstructionRequest::Url {
+                            id: Uuid::new_v4(),
+                            block_size: BLOCK_SIZE as u64,
+                            url: server.url("/ff.raw").to_string(),
+                        }],
                         read_only_parent: None,
-                    }),
+                    },
                 )),
-            });
+            };
 
         let volume = Volume::construct(vcr, None, csl()).await?;
         volume.activate().await?;
@@ -639,20 +629,20 @@ mod test {
         let opts = tds.opts();
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
                 sub_volumes: vec![],
                 read_only_parent: Some(Box::new(
-                    VolumeConstructionRequest::Region(VcrRegion {
+                    VolumeConstructionRequest::Region {
                         block_size: BLOCK_SIZE as u64,
                         blocks_per_extent: tds.blocks_per_extent(),
                         extent_count: tds.extent_count(),
                         opts,
                         gen: 1,
-                    }),
+                    },
                 )),
-            });
+            };
 
         let volume = Volume::construct(vcr, None, csl()).await?;
         volume.activate().await?;
@@ -688,20 +678,18 @@ mod test {
         let opts = tds.opts();
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(
-                    VcrRegion {
-                        block_size: BLOCK_SIZE as u64,
-                        blocks_per_extent: tds.blocks_per_extent(),
-                        extent_count: tds.extent_count(),
-                        opts,
-                        gen: 1,
-                    },
-                )],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts,
+                    gen: 1,
+                }],
                 read_only_parent: None,
-            });
+            };
 
         let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
@@ -761,20 +749,18 @@ mod test {
         let opts = tds.opts();
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(
-                    VcrRegion {
-                        block_size: BLOCK_SIZE as u64,
-                        blocks_per_extent: tds.blocks_per_extent(),
-                        extent_count: tds.extent_count(),
-                        opts,
-                        gen: 1,
-                    },
-                )],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts,
+                    gen: 1,
+                }],
                 read_only_parent: None,
-            });
+            };
 
         let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
@@ -836,20 +822,18 @@ mod test {
         let opts = tds.opts();
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(
-                    VcrRegion {
-                        block_size: BLOCK_SIZE as u64,
-                        blocks_per_extent: tds.blocks_per_extent(),
-                        extent_count: tds.extent_count(),
-                        opts,
-                        gen: 1,
-                    },
-                )],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts,
+                    gen: 1,
+                }],
                 read_only_parent: None,
-            });
+            };
 
         let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
@@ -911,30 +895,30 @@ mod test {
         let mut sv = Vec::new();
         let tds1 = TestDownstairsSet::small(false).await?;
         let opts = tds1.opts();
-        sv.push(VolumeConstructionRequest::Region(VcrRegion {
+        sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds1.blocks_per_extent(),
             extent_count: tds1.extent_count(),
             opts,
             gen: 1,
-        }));
+        });
         let tds2 = TestDownstairsSet::small(false).await?;
         let opts = tds2.opts();
-        sv.push(VolumeConstructionRequest::Region(VcrRegion {
+        sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds2.blocks_per_extent(),
             extent_count: tds2.extent_count(),
             opts,
             gen: 1,
-        }));
+        });
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
                 sub_volumes: sv,
                 read_only_parent: None,
-            });
+            };
 
         let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
@@ -997,30 +981,30 @@ mod test {
         let mut sv = Vec::new();
         let tds1 = TestDownstairsSet::small(false).await?;
         let opts = tds1.opts();
-        sv.push(VolumeConstructionRequest::Region(VcrRegion {
+        sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds1.blocks_per_extent(),
             extent_count: tds1.extent_count(),
             opts,
             gen: 1,
-        }));
+        });
         let tds2 = TestDownstairsSet::small(false).await?;
         let opts = tds2.opts();
-        sv.push(VolumeConstructionRequest::Region(VcrRegion {
+        sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds2.blocks_per_extent(),
             extent_count: tds2.extent_count(),
             opts,
             gen: 1,
-        }));
+        });
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
                 sub_volumes: sv,
                 read_only_parent: None,
-            });
+            };
 
         let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
@@ -1105,30 +1089,30 @@ mod test {
         let mut sv = Vec::new();
         let tds1 = TestDownstairsSet::small(false).await?;
         let opts = tds1.opts();
-        sv.push(VolumeConstructionRequest::Region(VcrRegion {
+        sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds1.blocks_per_extent(),
             extent_count: tds1.extent_count(),
             opts,
             gen: 1,
-        }));
+        });
         let tds2 = TestDownstairsSet::small(false).await?;
         let opts = tds2.opts();
-        sv.push(VolumeConstructionRequest::Region(VcrRegion {
+        sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds2.blocks_per_extent(),
             extent_count: tds2.extent_count(),
             opts,
             gen: 1,
-        }));
+        });
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
                 sub_volumes: sv,
                 read_only_parent: None,
-            });
+            };
 
         let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
@@ -1677,30 +1661,30 @@ mod test {
         let mut sv = Vec::new();
         let tds1 = TestDownstairsSet::small(false).await?;
         let opts = tds1.opts();
-        sv.push(VolumeConstructionRequest::Region(VcrRegion {
+        sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds1.blocks_per_extent(),
             extent_count: tds1.extent_count(),
             opts,
             gen: 1,
-        }));
+        });
         let tds2 = TestDownstairsSet::small(false).await?;
         let opts = tds2.opts();
-        sv.push(VolumeConstructionRequest::Region(VcrRegion {
+        sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds2.blocks_per_extent(),
             extent_count: tds2.extent_count(),
             opts,
             gen: 1,
-        }));
+        });
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
                 sub_volumes: sv,
                 read_only_parent: None,
-            });
+            };
 
         let log = csl();
         let mut volume = Volume::construct(vcr, None, log.clone()).await?;
@@ -1803,30 +1787,30 @@ mod test {
         let mut sv = Vec::new();
         let tds1 = TestDownstairsSet::small(false).await?;
         let opts = tds1.opts();
-        sv.push(VolumeConstructionRequest::Region(VcrRegion {
+        sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds1.blocks_per_extent(),
             extent_count: tds1.extent_count(),
             opts,
             gen: 1,
-        }));
+        });
         let tds2 = TestDownstairsSet::small(false).await?;
         let opts = tds2.opts();
-        sv.push(VolumeConstructionRequest::Region(VcrRegion {
+        sv.push(VolumeConstructionRequest::Region {
             block_size: BLOCK_SIZE as u64,
             blocks_per_extent: tds2.blocks_per_extent(),
             extent_count: tds2.extent_count(),
             opts,
             gen: 1,
-        }));
+        });
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
                 sub_volumes: sv,
                 read_only_parent: None,
-            });
+            };
 
         let log = csl();
         let mut volume = Volume::construct(vcr, None, log.clone()).await?;
@@ -1913,39 +1897,39 @@ mod test {
         let mut opts = tds.opts();
 
         let vcr_1: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
                 sub_volumes: vec![],
                 read_only_parent: Some(Box::new(
-                    VolumeConstructionRequest::Region(VcrRegion {
+                    VolumeConstructionRequest::Region {
                         block_size: BLOCK_SIZE as u64,
                         blocks_per_extent: tds.blocks_per_extent(),
                         extent_count: tds.extent_count(),
                         opts: opts.clone(),
                         gen: 1,
-                    }),
+                    },
                 )),
-            });
+            };
 
         // Second volume should have a unique UUID
         opts.id = Uuid::new_v4();
 
         let vcr_2: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
                 sub_volumes: vec![],
                 read_only_parent: Some(Box::new(
-                    VolumeConstructionRequest::Region(VcrRegion {
+                    VolumeConstructionRequest::Region {
                         block_size: BLOCK_SIZE as u64,
                         blocks_per_extent: tds.blocks_per_extent(),
                         extent_count: tds.extent_count(),
                         opts,
                         gen: 1,
-                    }),
+                    },
                 )),
-            });
+            };
 
         let log = csl();
         let volume1 = Volume::construct(vcr_1, None, log.clone()).await?;
@@ -2136,37 +2120,32 @@ mod test {
         let bottom_layer_opts = test_downstairs_set.opts();
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: Uuid::new_v4(),
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(
-                    VcrRegion {
-                        block_size: BLOCK_SIZE as u64,
-                        blocks_per_extent: top_layer_tds.blocks_per_extent(),
-                        extent_count: top_layer_tds.extent_count(),
-                        opts: top_layer_opts,
-                        gen: 3,
-                    },
-                )],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: top_layer_tds.blocks_per_extent(),
+                    extent_count: top_layer_tds.extent_count(),
+                    opts: top_layer_opts,
+                    gen: 3,
+                }],
                 read_only_parent: Some(Box::new(
-                    VolumeConstructionRequest::Volume(VcrVolume {
+                    VolumeConstructionRequest::Volume {
                         id: Uuid::new_v4(),
                         block_size: BLOCK_SIZE as u64,
-                        sub_volumes: vec![VolumeConstructionRequest::Region(
-                            VcrRegion {
-                                block_size: BLOCK_SIZE as u64,
-                                blocks_per_extent: test_downstairs_set
-                                    .blocks_per_extent(),
-                                extent_count: test_downstairs_set
-                                    .extent_count(),
-                                opts: bottom_layer_opts,
-                                gen: 3,
-                            },
-                        )],
+                        sub_volumes: vec![VolumeConstructionRequest::Region {
+                            block_size: BLOCK_SIZE as u64,
+                            blocks_per_extent: test_downstairs_set
+                                .blocks_per_extent(),
+                            extent_count: test_downstairs_set.extent_count(),
+                            opts: bottom_layer_opts,
+                            gen: 3,
+                        }],
                         read_only_parent: None,
-                    }),
+                    },
                 )),
-            });
+            };
 
         let volume = Volume::construct(vcr, None, csl()).await?;
         volume.activate().await?;
@@ -3355,20 +3334,18 @@ mod test {
         let opts = tds.opts();
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(
-                    VcrRegion {
-                        block_size: BLOCK_SIZE as u64,
-                        blocks_per_extent: tds.blocks_per_extent(),
-                        extent_count: tds.extent_count(),
-                        opts: opts.clone(),
-                        gen: 1,
-                    },
-                )],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts: opts.clone(),
+                    gen: 1,
+                }],
                 read_only_parent: None,
-            });
+            };
 
         let client =
             CruciblePantryClient::new(&format!("http://{}", pantry_addr));
@@ -3461,20 +3438,18 @@ mod test {
             .unwrap();
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(
-                    VcrRegion {
-                        block_size: BLOCK_SIZE as u64,
-                        blocks_per_extent: tds.blocks_per_extent(),
-                        extent_count: tds.extent_count(),
-                        opts: opts.clone(),
-                        gen: 2,
-                    },
-                )],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts: opts.clone(),
+                    gen: 2,
+                }],
                 read_only_parent: None,
-            });
+            };
         let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
@@ -3569,20 +3544,18 @@ mod test {
 
         let volume_id = Uuid::new_v4();
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(
-                    VcrRegion {
-                        block_size: BLOCK_SIZE as u64,
-                        blocks_per_extent: tds.blocks_per_extent(),
-                        extent_count: tds.extent_count(),
-                        opts: opts.clone(),
-                        gen: 1,
-                    },
-                )],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts: opts.clone(),
+                    gen: 1,
+                }],
                 read_only_parent: None,
-            });
+            };
 
         // Verify contents are zero on init
         {
@@ -3631,20 +3604,18 @@ mod test {
         // Attach, validate img.raw got imported
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(
-                    VcrRegion {
-                        block_size: BLOCK_SIZE as u64,
-                        blocks_per_extent: tds.blocks_per_extent(),
-                        extent_count: tds.extent_count(),
-                        opts,
-                        gen: 3,
-                    },
-                )],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts,
+                    gen: 3,
+                }],
                 read_only_parent: None,
-            });
+            };
         let volume = Volume::construct(vcr, None, log.clone()).await.unwrap();
         volume.activate().await.unwrap();
 
@@ -3711,20 +3682,18 @@ mod test {
         // Attach, validate bulk write worked
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(
-                    VcrRegion {
-                        block_size: BLOCK_SIZE as u64,
-                        blocks_per_extent: tds.blocks_per_extent(),
-                        extent_count: tds.extent_count(),
-                        opts,
-                        gen: 2,
-                    },
-                )],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts,
+                    gen: 2,
+                }],
                 read_only_parent: None,
-            });
+            };
         let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
@@ -3776,20 +3745,18 @@ mod test {
         // Attach, validate bulk write worked
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(
-                    VcrRegion {
-                        block_size: BLOCK_SIZE as u64,
-                        blocks_per_extent: tds.blocks_per_extent(),
-                        extent_count: tds.extent_count(),
-                        opts,
-                        gen: 2,
-                    },
-                )],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts,
+                    gen: 2,
+                }],
                 read_only_parent: None,
-            });
+            };
         let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
@@ -3843,28 +3810,25 @@ mod test {
 
         let volume_id = Uuid::new_v4();
         let rop_id = Uuid::new_v4();
-        let read_only_parent =
-            Some(Box::new(VolumeConstructionRequest::Url(VcrUrl {
-                id: rop_id,
-                block_size: BLOCK_SIZE as u64,
-                url: url.clone(),
-            })));
+        let read_only_parent = Some(Box::new(VolumeConstructionRequest::Url {
+            id: rop_id,
+            block_size: BLOCK_SIZE as u64,
+            url: url.clone(),
+        }));
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(
-                    VcrRegion {
-                        block_size: BLOCK_SIZE as u64,
-                        blocks_per_extent: tds.blocks_per_extent(),
-                        extent_count: tds.extent_count(),
-                        opts: opts.clone(),
-                        gen: 1,
-                    },
-                )],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts: opts.clone(),
+                    gen: 1,
+                }],
                 read_only_parent: read_only_parent.clone(),
-            });
+            };
 
         // Verify contents match data on init
         {
@@ -3902,20 +3866,18 @@ mod test {
             CruciblePantryClient::new(&format!("http://{}", pantry_addr));
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(
-                    VcrRegion {
-                        block_size: BLOCK_SIZE as u64,
-                        blocks_per_extent: tds.blocks_per_extent(),
-                        extent_count: tds.extent_count(),
-                        opts: opts.clone(),
-                        gen: 2,
-                    },
-                )],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts: opts.clone(),
+                    gen: 2,
+                }],
                 read_only_parent,
-            });
+            };
         client
             .attach(
                 &volume_id.to_string(),
@@ -3954,20 +3916,18 @@ mod test {
         // Drop the read only parent from the volume construction request
 
         let vcr: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(
-                    VcrRegion {
-                        block_size: BLOCK_SIZE as u64,
-                        blocks_per_extent: tds.blocks_per_extent(),
-                        extent_count: tds.extent_count(),
-                        opts,
-                        gen: 3,
-                    },
-                )],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts,
+                    gen: 3,
+                }],
                 read_only_parent: None,
-            });
+            };
 
         // Attach, validate random data got imported
 
@@ -4436,23 +4396,19 @@ mod test {
         let opts = tds.opts();
         let volume_id = Uuid::new_v4();
 
-        let mut vcr_r = VcrRegion {
-            block_size: BLOCK_SIZE as u64,
-            blocks_per_extent: tds.blocks_per_extent(),
-            extent_count: tds.extent_count(),
-            opts: opts.clone(),
-            gen: 2,
-        };
-
         let original: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(
-                    vcr_r.clone(),
-                )],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts: opts.clone(),
+                    gen: 2,
+                }],
                 read_only_parent: None,
-            });
+            };
 
         let volume = Volume::construct(original.clone(), None, log.clone())
             .await
@@ -4489,18 +4445,22 @@ mod test {
         new_opts.target[0] = new_downstairs.address().await;
         info!(log, "Old ops target: {:?}", opts.target);
         info!(log, "New ops target: {:?}", new_opts.target);
-        vcr_r.gen += 1;
-        vcr_r.opts = new_opts;
 
         // Our "new" VCR must have a new downstairs in the opts, and have
         // the generation number be larger than the original.
         let replacement: VolumeConstructionRequest =
-            VolumeConstructionRequest::Volume(VcrVolume {
+            VolumeConstructionRequest::Volume {
                 id: volume_id,
                 block_size: BLOCK_SIZE as u64,
-                sub_volumes: vec![VolumeConstructionRequest::Region(vcr_r)],
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts: new_opts.clone(),
+                    gen: 3,
+                }],
                 read_only_parent: None,
-            });
+            };
 
         info!(log, "Replace VCR now: {:?}", replacement);
         volume


### PR DESCRIPTION
To change the VCR, we have to support transitioning from the current version to the new version, as the VCR is a string field in the database.  The recent VCR changes to support downstairs replacement were not required for functionality.  As we don't want to make the changes on Omicron side to support VCR changes yet, we can transition the VCR back to what it was but still support the new functionality for downstairs replacement.