### PR TITLE
dsc: note that extent-size is in number of blocks not bytes.

### DIFF
--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -68,7 +68,7 @@ enum Action {
         #[clap(long, action)]
         encrypted: bool,
 
-        /// The extent size for the region
+        /// The extent size for the region (in blocks NOT bytes!)
         #[clap(long, default_value = "100", action)]
         extent_size: u64,
 
@@ -170,7 +170,7 @@ enum Action {
         #[clap(long, action)]
         encrypted: bool,
 
-        /// If creating, the extent size for the region
+        /// If creating, the extent size for the region (in blocks NOT bytes!)
         #[clap(long, default_value = "100", action)]
         extent_size: u64,
 


### PR DESCRIPTION
I've definitely been tripped up over this before and evidently forgot. Pending fully addressing #181, we can at least update the help output.