### PR TITLE
target replace does not need a Logger

### DIFF
--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -4463,10 +4463,7 @@ mod test {
             };
 
         info!(log, "Replace VCR now: {:?}", replacement);
-        volume
-            .target_replace(original, replacement, &log)
-            .await
-            .unwrap();
+        volume.target_replace(original, replacement).await.unwrap();
         info!(log, "send read now");
         let buffer = Buffer::new(BLOCK_SIZE * 10);
         volume

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -1463,18 +1463,17 @@ impl Volume {
         &self,
         original: VolumeConstructionRequest,
         replacement: VolumeConstructionRequest,
-        log: &Logger,
     ) -> Result<(), CrucibleError> {
         let (original_target, new_target) =
             Self::compare_vcr_for_target_replacement(
                 original,
                 replacement,
-                log,
+                &self.log,
             )
             .await?;
 
         info!(
-            log,
+            self.log,
             "Volume {}, OK to replace: {original_target} with {new_target}",
             self.uuid
         );
@@ -1494,7 +1493,10 @@ impl Volume {
             Ok(ReplaceResult::Started)
             | Ok(ReplaceResult::StartedAlready)
             | Ok(ReplaceResult::CompletedAlready) => {
-                info!(log, "Replace downstairs underway for {}", self.uuid);
+                info!(
+                    self.log,
+                    "Replace downstairs underway for {}", self.uuid
+                );
                 Ok(())
             }
             Err(e) => {


### PR DESCRIPTION
The volume struct now has a Logger field, so we don't need to include
one with calls to target_replace