### PR TITLE
ACK the write after adding it to the work queue

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -26,7 +26,7 @@ pub const REPAIR_PORT_OFFSET: u16 = 4000;
 
 // Max number of submitted IOs between the upstairs and the downstairs, above
 // which flow control kicks in.
-pub const MAX_ACTIVE_COUNT: usize = 600;
+pub const MAX_ACTIVE_COUNT: usize = 2600;
 
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -80,12 +80,19 @@ enum Action {
         #[clap(long, global = true, default_value = "/tmp/dsc", action)]
         output_dir: PathBuf,
 
+        /// The port_base where the downstairs will listen.
+        /// Note: is used as part of the expected region directory path.
+        #[clap(long, default_value = "8810", action)]
+        port_base: u32,
+
         /// The directory where the downstairs regions will be created.
         /// Either provide once, or "N" times.  One means all downstairs
         /// share the same top level directory (each downstairs has its own
         /// subdirectory).  "N" means we will create "N" downstairs and each
         /// downstairs will get its own region directory.  If using N other
         /// than 3, you must also provide a matching "region-dir" value.
+        /// Note that, for each downstairs, dsc adds a "port" to the
+        /// region directory path.
         #[clap(
             long,
             global = true,
@@ -182,12 +189,19 @@ enum Action {
         #[clap(long, global = true, default_value = "/tmp/dsc", action)]
         output_dir: PathBuf,
 
+        /// The port_base where the downstairs will listen
+        /// Note: is used as part of the expected region directory path.
+        #[clap(long, default_value = "8810", action)]
+        port_base: u32,
+
         /// The directory where the downstairs regions will be created.
         /// Either provide once, or "N" times.  One means all downstairs
         /// share the same top level directory (each downstairs has its own
         /// subdirectory).  "N" means we will create "N" downstairs and each
         /// downstairs will get its own region directory.  If using N other
         /// than 3, you must also provide a matching "region-dir" value.
+        /// Note that, for each downstairs, dsc adds a "port" to the
+        /// region directory path.
         #[clap(
             long,
             global = true,
@@ -1359,6 +1373,7 @@ fn main() -> Result<()> {
             extent_size,
             extent_count,
             output_dir,
+            port_base,
             region_dir,
             region_count,
         } => {
@@ -1371,7 +1386,7 @@ fn main() -> Result<()> {
                 region_dir,
                 notify_tx,
                 true,
-                8810,
+                port_base,
                 region_count,
             )?;
 
@@ -1405,6 +1420,7 @@ fn main() -> Result<()> {
             extent_size,
             extent_count,
             output_dir,
+            port_base,
             region_dir,
             region_count,
         } => {
@@ -1426,7 +1442,7 @@ fn main() -> Result<()> {
                 region_dir,
                 notify_tx,
                 create,
-                8810,
+                port_base,
                 region_count,
             )?;
 

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -416,7 +416,6 @@ pub(crate) mod protocol_test {
                             }
 
                             Some(m) => {
-                                info!(log, "received {:?}", m);
                                 tx.send(m).await.unwrap();
                             }
                         },
@@ -874,8 +873,6 @@ pub(crate) mod protocol_test {
         let mut job_ids = Vec::with_capacity(NUM_JOBS);
 
         for i in 0..NUM_JOBS {
-            info!(harness.log, "sending read {}/{NUM_JOBS}", i);
-
             {
                 let harness = harness.clone();
 
@@ -1070,13 +1067,7 @@ pub(crate) mod protocol_test {
                 })
                 .await
             {
-                Ok(()) => {
-                    info!(
-                        harness.log,
-                        "sent read response for job {} = {}", i, job_id,
-                    );
-                }
-
+                Ok(()) => {}
                 Err(e) => {
                     // We should be able to send a few, but at some point
                     // the Upstairs will disconnect us.
@@ -1902,8 +1893,6 @@ pub(crate) mod protocol_test {
         let mut job_ids = Vec::with_capacity(NUM_JOBS);
 
         for i in 0..NUM_JOBS {
-            info!(harness.log, "sending read {}/{NUM_JOBS}", i);
-
             {
                 let harness = harness.clone();
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -3629,8 +3629,6 @@ impl Downstairs {
 
             ds_done_tx.send(ds_id).await.unwrap();
         } else if is_write {
-            // XXX Check for replay moving things back to NotAcked
-            // Does WriteUnwritten need to be here?
             let job = self.ds_active.get_mut(&ds_id).unwrap();
             assert_eq!(job.ack_status, AckStatus::NotAcked);
             job.ack_status = AckStatus::AckReady;

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -73,7 +73,7 @@ use async_trait::async_trait;
 
 // Max number of outstanding IOs between the upstairs and the downstairs
 // before we give up and mark that downstairs faulted.
-const IO_OUTSTANDING_MAX: usize = 7000;
+const IO_OUTSTANDING_MAX: usize = 97000;
 
 /// The BlockIO trait behaves like a physical NVMe disk (or a virtio virtual
 /// disk): there is no contract about what order operations that are submitted

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -73,7 +73,7 @@ use async_trait::async_trait;
 
 // Max number of outstanding IOs between the upstairs and the downstairs
 // before we give up and mark that downstairs faulted.
-const IO_OUTSTANDING_MAX: usize = 5000;
+const IO_OUTSTANDING_MAX: usize = 7000;
 
 /// The BlockIO trait behaves like a physical NVMe disk (or a virtio virtual
 /// disk): there is no contract about what order operations that are submitted

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -1684,16 +1684,20 @@ pub(crate) mod up_test {
 
         let response = Ok(vec![]);
 
-        assert!(ds
+        let res = ds
             .process_ds_completion(
                 next_id,
                 2,
                 response,
                 &None,
                 UpState::Active,
-                None
+                None,
             )
-            .unwrap());
+            .unwrap();
+
+        // If it's write_unwritten, then this should have returned true,
+        // if it's just a write, then it should be false.
+        assert_eq!(res, is_write_unwritten);
 
         assert!(ds.downstairs_errors.get(&0).is_some());
         assert!(ds.downstairs_errors.get(&1).is_some());
@@ -1945,9 +1949,9 @@ pub(crate) mod up_test {
         .unwrap();
 
         // DS 1, return error.
-        // This will return true because we have now completed all
-        // three IOs (skipped, ok, and error here).
-        assert!(ds
+        // On a write_unwritten, This will return true because we have now
+        // completed all three IOs (skipped, ok, and error here).
+        let res = ds
             .process_ds_completion(
                 next_id,
                 1,
@@ -1956,7 +1960,9 @@ pub(crate) mod up_test {
                 UpState::Active,
                 None,
             )
-            .unwrap());
+            .unwrap();
+
+        assert_eq!(res, is_write_unwritten);
 
         let ack_list = ds.ackable_work();
         assert_eq!(ack_list.len(), 1);
@@ -5603,15 +5609,10 @@ pub(crate) mod up_test {
         assert_eq!(up.ds_state(1).await, DsState::Faulted);
         assert_eq!(up.ds_state(2).await, DsState::Active);
 
-        {
-            // Verify we are not ready to ACK yet.
-            let mut ds = up.downstairs.lock().await;
-            let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
-            assert_eq!(state, AckStatus::NotAcked);
-        }
-        // Three failures, process_ds_operation should return true now.
+        // Three failures, But since this is a write we already have marked
+        // the ACK as ready.
         // Process the operation for client 2
-        assert!(up
+        assert!(!up
             .process_ds_operation(next_id, 2, response, None)
             .await
             .unwrap());
@@ -5619,7 +5620,7 @@ pub(crate) mod up_test {
         assert_eq!(up.ds_state(1).await, DsState::Faulted);
         assert_eq!(up.ds_state(2).await, DsState::Faulted);
 
-        // Verify we can ack this (failed) work
+        // Verify we can still ack this (failed) work
         let mut ds = up.downstairs.lock().await;
         assert_eq!(ds.ackable_work().len(), 1);
     }
@@ -5862,8 +5863,8 @@ pub(crate) mod up_test {
         assert_eq!(up.ds_state(2).await, DsState::Active);
 
         let ok_response = Ok(vec![]);
-        // process_ds_operation should return true after we process this.
-        assert!(up
+        // Because we ACK writes, this op will always return false
+        assert!(!up
             .process_ds_operation(next_id, 2, ok_response, None)
             .await
             .unwrap());

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -3631,9 +3631,14 @@ pub(crate) mod up_test {
         // Now the IO should be replay
         assert!(ds.ds_active.get_mut(&id1).unwrap().replay);
 
-        // State goes back to NotAcked
+        // Write Unwritten State goes back to NotAcked,
+        // Write will remain AckReady
         let state = ds.ds_active.get_mut(&id1).unwrap().ack_status;
-        assert_eq!(state, AckStatus::NotAcked);
+        if is_write_unwritten {
+            assert_eq!(state, AckStatus::NotAcked);
+        } else {
+            assert_eq!(state, AckStatus::AckReady);
+        }
 
         // Re-submit and complete the write
         assert!(ds.in_progress(id1, 1).is_some());


### PR DESCRIPTION
Ack writes after submission to downstairs work queues                               
                                                                                    
Write jobs are marked for ACK after we submit them to the downstairs work           
queue.  This changes the previous behavior where we waited for 2/3 writes           
to be ACK'd back from the downstairs.                                               
                                                                                    
Updated some replay tests to not change the ACK status for writes when a            
replay happens.                                                                     
                                                                                    
As we can absorb much more outstanding IOs with this change, the queue              
depth for downstairs outstanding work as well as the number of active               
jobs we hold in the upstairs before deciding there is a problem has                 
been increased.                                                                     
                                                                                    
The jobs outstanding to a downstairs, MAX_ACTIVE_COUNT, goes from 600 to 2600.      
The total jobs outstanding, IO_OUTSTANDING_MAX, goes from 5000 to 57000.            
Both these numbers probably need more tuning.                                       
                                                                                    
dsc now takes a port_base instead of always starting at 8810.                       
This enables multiple dscs to be running at the same time.                          
                                                                                    
Took some of the log messages out of dummy_downstairs_tests in a hope               
that they would run faster in CI.                                                   
