### PR TITLE
Only flush extents that might actually be dirty.

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -923,7 +923,7 @@ where
             extent_id,
         } => {
             let msg = {
-                let d = ad.lock().await;
+                let mut d = ad.lock().await;
                 debug!(d.log, "{} Reopen extent {}", repair_id, extent_id);
                 match d.region.reopen_extent(*extent_id).await {
                     Ok(()) => Message::RepairAckId {
@@ -1797,7 +1797,7 @@ pub struct ActiveUpstairs {
  */
 #[derive(Debug)]
 pub struct Downstairs {
-    pub region: Arc<Region>,
+    pub region: Region,
     lossy: bool,        // Test flag, enables pauses and skipped jobs
     read_errors: bool,  // Test flag
     write_errors: bool, // Test flag
@@ -1829,7 +1829,7 @@ impl Downstairs {
             ))),
         };
         Downstairs {
-            region: Arc::new(region),
+            region,
             lossy,
             read_errors,
             write_errors,


### PR DESCRIPTION
This change keeps track at the region level which extents might be dirty. That way, during a flush, it only locks/sends flush commands to those extents.

This makes a big difference for regions with a lot of extents. Right now our write perf goes down the more extents you have, and it's pretty gnarly.

When opening extents, we check the dirty flag. If it's dirty, we add it to the region's dirty flag cache.

When we send a write command to an extent, we unconditionally set the dirty flag cache for that extent. If the extent decides the write is a NOP and doesn't actually mark itself dirty in its metadata, it'll still get flushed. That's fine- it's technically a waste to do, but it's not going to happen a lot and it's minor if it does. So it's not worth the complexity we'd need to perfectly track the dirty state of the extents.

Basically, an incorrect negative is unacceptable, but an incorrect positive is fine.

fixes #872 

I am fairly confident in the logic of this but I'd like an extra confirmation from the other crucible-knowers that I'm not going to end up with a stale cache somehow, so please really make sure the logic of this seems sound. Also feel free to suggest tests if you think our existing test suite doesn't cover some aspect of this.