### PR TITLE
Reduce sqlite page cache size to 64KiB

### DIFF
--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -490,6 +490,14 @@ fn open_sqlite_connection<P: AsRef<Path>>(path: &P) -> Result<Connection> {
     metadb.pragma_update(None, "journal_mode", "WAL")?;
     metadb.pragma_update(None, "synchronous", "FULL")?;
 
+    // 16 page * 4KiB page size = 64KiB cache size
+    // Value chosen somewhat arbitrarily as a guess at a good starting point.
+    // the default is a 2000KiB cache size which was way too large, and we did
+    // not see any performance changes moving to a 64KiB cache size. But, this
+    // value may be something we want to reduce further, tune, or scale with
+    // extent size.
+    metadb.pragma_update(None, "cache_size", 16)?;
+
     // rusqlite provides an LRU Cache (a cache which, when full, evicts the
     // least-recently-used value). This caches prepared statements, allowing
     // us to nullify the cost of parsing and compiling frequently used


### PR DESCRIPTION
Down from 2000KiB. Drastically improves memory usage scaling with number of extents.

After filling a disk with 1024 extents, downstairs used 2.5GiB of ram before this change, and 350MiB of ram after this change.

I tested perf using this commit + my changes in #875 with pgbench insertions and basic fio rand/seq read/write.

Here's what it looks like with a 2000KiB page cache size (before):

```
less flushes

pgbench
propolis worker count: 8
block size: 512
extent size: 32MiB
extent count: 1024
sqlite cache size: 2000KiB

pgbench (14.8, server 15.3)
starting vacuum...end.
transaction type: insert.sql
scaling factor: 50
query mode: simple
number of clients: 50
number of threads: 8
duration: 30 s
number of transactions actually processed: 464734
latency average = 3.227 ms
initial connection time = 16.953 ms
tps = 15496.214025 (without initial connection time)
pgbench (14.8, server 15.3)
starting vacuum...end.
transaction type: insert.sql
scaling factor: 50
query mode: simple
number of clients: 50
number of threads: 8
duration: 30 s
number of transactions actually processed: 494686
latency average = 3.031 ms
initial connection time = 17.752 ms
tps = 16494.823773 (without initial connection time)
pgbench (14.8, server 15.3)
starting vacuum...end.
transaction type: insert.sql
scaling factor: 50
query mode: simple
number of clients: 50
number of threads: 8
duration: 30 s
number of transactions actually processed: 496831
latency average = 3.018 ms
initial connection time = 18.947 ms
tps = 16567.105177 (without initial connection time)


[root@nixos:~]# fio perf.fio
randread-16K: (g=0): rw=randread, bs=(R) 16.0KiB-16.0KiB, (W) 16.0KiB-16.0KiB, (T) 16.0KiB-16.0KiB, ioengine=libaio, iodepth=25
randread-4M: (g=1): rw=randread, bs=(R) 4096KiB-4096KiB, (W) 4096KiB-4096KiB, (T) 4096KiB-4096KiB, ioengine=libaio, iodepth=25
randwrite-16K: (g=2): rw=randwrite, bs=(R) 16.0KiB-16.0KiB, (W) 16.0KiB-16.0KiB, (T) 16.0KiB-16.0KiB, ioengine=libaio, iodepth=25
randwrite-4M: (g=3): rw=randwrite, bs=(R) 4096KiB-4096KiB, (W) 4096KiB-4096KiB, (T) 4096KiB-4096KiB, ioengine=libaio, iodepth=25
read-16K: (g=4): rw=read, bs=(R) 16.0KiB-16.0KiB, (W) 16.0KiB-16.0KiB, (T) 16.0KiB-16.0KiB, ioengine=libaio, iodepth=25
read-4M: (g=5): rw=read, bs=(R) 4096KiB-4096KiB, (W) 4096KiB-4096KiB, (T) 4096KiB-4096KiB, ioengine=libaio, iodepth=25
write-16K: (g=6): rw=write, bs=(R) 16.0KiB-16.0KiB, (W) 16.0KiB-16.0KiB, (T) 16.0KiB-16.0KiB, ioengine=libaio, iodepth=25
write-4M: (g=7): rw=write, bs=(R) 4096KiB-4096KiB, (W) 4096KiB-4096KiB, (T) 4096KiB-4096KiB, ioengine=libaio, iodepth=25
fio-3.33
Starting 8 processes
Jobs: 1 (f=1): [_(7),W(1)][56.7%][w=116MiB/s][w=29 IOPS][eta 03m:08s]
randread-16K: (groupid=0, jobs=1): err= 0: pid=1143: Fri Aug 18 07:48:07 2023
  read: IOPS=3246, BW=50.7MiB/s (53.2MB/s)(1522MiB/30008msec)
    slat (usec): min=18, max=210, avg=23.70, stdev= 7.94
    clat (usec): min=930, max=18590, avg=7665.43, stdev=1246.60
     lat (usec): min=1044, max=18611, avg=7689.12, stdev=1246.56
    clat percentiles (usec):
     |  1.00th=[ 6259],  5.00th=[ 6652], 10.00th=[ 6849], 20.00th=[ 7046],
     | 30.00th=[ 7242], 40.00th=[ 7373], 50.00th=[ 7570], 60.00th=[ 7701],
     | 70.00th=[ 7832], 80.00th=[ 8029], 90.00th=[ 8291], 95.00th=[ 8455],
     | 99.00th=[16319], 99.50th=[16909], 99.90th=[17695], 99.95th=[17957],
     | 99.99th=[18220]
   bw (  KiB/s): min=50981, max=53935, per=100.00%, avg=52006.56, stdev=496.68, samples=59
   iops        : min= 3186, max= 3370, avg=3250.03, stdev=30.98, samples=59
  lat (usec)   : 1000=0.01%
  lat (msec)   : 2=0.01%, 4=0.01%, 10=98.43%, 20=1.56%
  cpu          : usr=1.11%, sys=22.05%, ctx=96990, majf=0, minf=110
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=100.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwts: total=97426,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=25
randread-4M: (groupid=1, jobs=1): err= 0: pid=1146: Fri Aug 18 07:48:07 2023
  read: IOPS=25, BW=101MiB/s (106MB/s)(3144MiB/31018msec)
    slat (usec): min=113, max=1530, avg=269.67, stdev=135.98
    clat (msec): min=51, max=1959, avg=984.64, stdev=146.13
     lat (msec): min=52, max=1959, avg=984.91, stdev=146.06
    clat percentiles (msec):
     |  1.00th=[  313],  5.00th=[  894], 10.00th=[  936], 20.00th=[  961],
     | 30.00th=[  969], 40.00th=[  986], 50.00th=[  995], 60.00th=[  995],
     | 70.00th=[ 1003], 80.00th=[ 1011], 90.00th=[ 1028], 95.00th=[ 1036],
     | 99.00th=[ 1687], 99.50th=[ 1838], 99.90th=[ 1955], 99.95th=[ 1955],
     | 99.99th=[ 1955]
   bw (  KiB/s): min=32833, max=123126, per=99.04%, avg=102801.05, stdev=10628.60, samples=60
   iops        : min=    8, max=   30, avg=25.05, stdev= 2.59, samples=60
  lat (msec)   : 100=0.25%, 250=0.51%, 500=0.89%, 750=0.89%, 1000=62.60%
  lat (msec)   : 2000=34.86%
  cpu          : usr=0.07%, sys=0.92%, ctx=787, majf=0, minf=25611
  IO depths    : 1=0.1%, 2=0.3%, 4=0.5%, 8=1.0%, 16=98.1%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=99.9%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwts: total=786,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=25
randwrite-16K: (groupid=2, jobs=1): err= 0: pid=1148: Fri Aug 18 07:48:07 2023
  write: IOPS=1273, BW=19.9MiB/s (20.9MB/s)(597MiB/30012msec); 0 zone resets
    slat (usec): min=18, max=5228, avg=28.07, stdev=42.49
    clat (usec): min=1317, max=176754, avg=19594.51, stdev=17029.24
     lat (usec): min=1440, max=176777, avg=19622.57, stdev=17030.51
    clat percentiles (msec):
     |  1.00th=[   11],  5.00th=[   12], 10.00th=[   12], 20.00th=[   12],
     | 30.00th=[   13], 40.00th=[   13], 50.00th=[   13], 60.00th=[   15],
     | 70.00th=[   19], 80.00th=[   22], 90.00th=[   34], 95.00th=[   51],
     | 99.00th=[  104], 99.50th=[  123], 99.90th=[  157], 99.95th=[  161],
     | 99.99th=[  167]
   bw (  KiB/s): min= 8480, max=29755, per=100.00%, avg=20541.88, stdev=6684.71, samples=57
   iops        : min=  530, max= 1859, avg=1283.56, stdev=417.69, samples=57
  lat (msec)   : 2=0.01%, 4=0.01%, 10=0.36%, 20=73.88%, 50=20.75%
  lat (msec)   : 100=3.87%, 250=1.13%
  cpu          : usr=0.76%, sys=9.68%, ctx=37871, majf=0, minf=11
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=100.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwts: total=0,38211,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=25
randwrite-4M: (groupid=3, jobs=1): err= 0: pid=1152: Fri Aug 18 07:48:07 2023
  write: IOPS=41, BW=168MiB/s (176MB/s)(5136MiB/30632msec); 0 zone resets
    slat (usec): min=178, max=986, avg=318.30, stdev=75.26
    clat (msec): min=63, max=1265, avg=595.51, stdev=74.31
     lat (msec): min=63, max=1265, avg=595.83, stdev=74.31
    clat percentiles (msec):
     |  1.00th=[  401],  5.00th=[  558], 10.00th=[  558], 20.00th=[  567],
     | 30.00th=[  575], 40.00th=[  584], 50.00th=[  584], 60.00th=[  592],
     | 70.00th=[  600], 80.00th=[  625], 90.00th=[  642], 95.00th=[  659],
     | 99.00th=[  953], 99.50th=[ 1083], 99.90th=[ 1250], 99.95th=[ 1267],
     | 99.99th=[ 1267]
   bw (  KiB/s): min=139543, max=188793, per=100.00%, avg=171884.43, stdev=8032.05, samples=60
   iops        : min=   34, max=   46, avg=41.90, stdev= 1.96, samples=60
  lat (msec)   : 100=0.16%, 250=0.39%, 500=0.86%, 750=96.96%, 1000=0.86%
  lat (msec)   : 2000=0.78%
  cpu          : usr=0.71%, sys=1.10%, ctx=1284, majf=0, minf=10
  IO depths    : 1=0.1%, 2=0.2%, 4=0.3%, 8=0.6%, 16=98.8%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=99.9%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwts: total=0,1284,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=25
read-16K: (groupid=4, jobs=1): err= 0: pid=1156: Fri Aug 18 07:48:07 2023
  read: IOPS=3316, BW=51.8MiB/s (54.3MB/s)(1555MiB/30016msec)
    slat (usec): min=18, max=195, avg=23.27, stdev= 7.77
    clat (usec): min=872, max=23302, avg=7504.68, stdev=1261.58
     lat (usec): min=1067, max=23323, avg=7527.95, stdev=1261.46
    clat percentiles (usec):
     |  1.00th=[ 6128],  5.00th=[ 6521], 10.00th=[ 6652], 20.00th=[ 6915],
     | 30.00th=[ 7111], 40.00th=[ 7242], 50.00th=[ 7373], 60.00th=[ 7504],
     | 70.00th=[ 7635], 80.00th=[ 7832], 90.00th=[ 8094], 95.00th=[ 8291],
     | 99.00th=[16450], 99.50th=[16909], 99.90th=[17695], 99.95th=[17957],
     | 99.99th=[20055]
   bw (  KiB/s): min=52200, max=55006, per=100.00%, avg=53163.10, stdev=512.80, samples=59
   iops        : min= 3262, max= 3437, avg=3322.19, stdev=31.93, samples=59
  lat (usec)   : 1000=0.01%
  lat (msec)   : 2=0.01%, 4=0.01%, 10=98.48%, 20=1.50%, 50=0.01%
  cpu          : usr=0.96%, sys=22.24%, ctx=99094, majf=0, minf=112
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=100.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwts: total=99539,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=25
read-4M: (groupid=5, jobs=1): err= 0: pid=1158: Fri Aug 18 07:48:07 2023
  read: IOPS=24, BW=99.2MiB/s (104MB/s)(3076MiB/31001msec)
    slat (usec): min=112, max=1308, avg=260.28, stdev=130.44
    clat (msec): min=47, max=1945, avg=1005.89, stdev=143.17
     lat (msec): min=48, max=1945, avg=1006.15, stdev=143.10
    clat percentiles (msec):
     |  1.00th=[  351],  5.00th=[  953], 10.00th=[  969], 20.00th=[  978],
     | 30.00th=[  986], 40.00th=[  995], 50.00th=[ 1003], 60.00th=[ 1011],
     | 70.00th=[ 1028], 80.00th=[ 1036], 90.00th=[ 1045], 95.00th=[ 1062],
     | 99.00th=[ 1687], 99.50th=[ 1838], 99.90th=[ 1938], 99.95th=[ 1938],
     | 99.99th=[ 1938]
   bw (  KiB/s): min=82084, max=114917, per=99.81%, avg=101415.50, stdev=5681.72, samples=60
   iops        : min=   20, max=   28, avg=24.70, stdev= 1.38, samples=60
  lat (msec)   : 50=0.13%, 100=0.13%, 250=0.39%, 500=0.91%, 750=0.78%
  lat (msec)   : 1000=42.13%, 2000=55.53%
  cpu          : usr=0.03%, sys=0.93%, ctx=770, majf=0, minf=25612
  IO depths    : 1=0.1%, 2=0.3%, 4=0.5%, 8=1.0%, 16=98.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=99.9%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwts: total=769,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=25
write-16K: (groupid=6, jobs=1): err= 0: pid=1160: Fri Aug 18 07:48:07 2023
  write: IOPS=2713, BW=42.4MiB/s (44.5MB/s)(1274MiB/30038msec); 0 zone resets
    slat (usec): min=18, max=207, avg=25.19, stdev= 7.81
    clat (usec): min=1097, max=82037, avg=9176.87, stdev=6561.89
     lat (usec): min=1186, max=82059, avg=9202.06, stdev=6561.86
    clat percentiles (usec):
     |  1.00th=[ 6194],  5.00th=[ 6718], 10.00th=[ 7308], 20.00th=[ 7701],
     | 30.00th=[ 7898], 40.00th=[ 8029], 50.00th=[ 8160], 60.00th=[ 8291],
     | 70.00th=[ 8455], 80.00th=[ 8717], 90.00th=[ 9503], 95.00th=[10421],
     | 99.00th=[54789], 99.50th=[62653], 99.90th=[69731], 99.95th=[70779],
     | 99.99th=[80217]
   bw (  KiB/s): min=37675, max=47134, per=100.00%, avg=43504.56, stdev=1840.93, samples=59
   iops        : min= 2354, max= 2945, avg=2718.69, stdev=115.00, samples=59
  lat (msec)   : 2=0.01%, 4=0.01%, 10=93.33%, 20=4.64%, 50=0.80%
  lat (msec)   : 100=1.23%
  cpu          : usr=1.21%, sys=18.97%, ctx=81023, majf=0, minf=11
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=100.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwts: total=0,81509,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=25
write-4M: (groupid=7, jobs=1): err= 0: pid=1164: Fri Aug 18 07:48:07 2023
  write: IOPS=38, BW=154MiB/s (162MB/s)(4728MiB/30660msec); 0 zone resets
    slat (usec): min=187, max=943, avg=317.38, stdev=68.19
    clat (msec): min=42, max=1277, avg=647.51, stdev=93.63
     lat (msec): min=42, max=1277, avg=647.83, stdev=93.63
    clat percentiles (msec):
     |  1.00th=[  309],  5.00th=[  575], 10.00th=[  584], 20.00th=[  600],
     | 30.00th=[  609], 40.00th=[  617], 50.00th=[  634], 60.00th=[  651],
     | 70.00th=[  684], 80.00th=[  709], 90.00th=[  735], 95.00th=[  760],
     | 99.00th=[ 1028], 99.50th=[ 1167], 99.90th=[ 1250], 99.95th=[ 1284],
     | 99.99th=[ 1284]
   bw (  KiB/s): min=131072, max=180224, per=100.00%, avg=157931.42, stdev=9682.31, samples=60
   iops        : min=   32, max=   44, avg=38.05, stdev= 2.40, samples=60
  lat (msec)   : 50=0.17%, 100=0.17%, 250=0.34%, 500=1.10%, 750=92.39%
  lat (msec)   : 1000=4.74%, 2000=1.10%
  cpu          : usr=0.77%, sys=0.86%, ctx=1183, majf=0, minf=11
  IO depths    : 1=0.1%, 2=0.2%, 4=0.3%, 8=0.7%, 16=98.7%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=99.9%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwts: total=0,1182,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=25

Run status group 0 (all jobs):
   READ: bw=50.7MiB/s (53.2MB/s), 50.7MiB/s-50.7MiB/s (53.2MB/s-53.2MB/s), io=1522MiB (1596MB), run=30008-30008msec

Run status group 1 (all jobs):
   READ: bw=101MiB/s (106MB/s), 101MiB/s-101MiB/s (106MB/s-106MB/s), io=3144MiB (3297MB), run=31018-31018msec

Run status group 2 (all jobs):
  WRITE: bw=19.9MiB/s (20.9MB/s), 19.9MiB/s-19.9MiB/s (20.9MB/s-20.9MB/s), io=597MiB (626MB), run=30012-30012msec

Run status group 3 (all jobs):
  WRITE: bw=168MiB/s (176MB/s), 168MiB/s-168MiB/s (176MB/s-176MB/s), io=5136MiB (5385MB), run=30632-30632msec

Run status group 4 (all jobs):
   READ: bw=51.8MiB/s (54.3MB/s), 51.8MiB/s-51.8MiB/s (54.3MB/s-54.3MB/s), io=1555MiB (1631MB), run=30016-30016msec

Run status group 5 (all jobs):
   READ: bw=99.2MiB/s (104MB/s), 99.2MiB/s-99.2MiB/s (104MB/s-104MB/s), io=3076MiB (3225MB), run=31001-31001msec

Run status group 6 (all jobs):
  WRITE: bw=42.4MiB/s (44.5MB/s), 42.4MiB/s-42.4MiB/s (44.5MB/s-44.5MB/s), io=1274MiB (1335MB), run=30038-30038msec

Run status group 7 (all jobs):
  WRITE: bw=154MiB/s (162MB/s), 154MiB/s-154MiB/s (162MB/s-162MB/s), io=4728MiB (4958MB), run=30660-30660msec

Disk stats (read/write):
  nvme0n1: ios=204171/130444, merge=253/341, ticks=8255008/7989525, in_queue=16244533, util=99.36%
```


Here's results with a 64KiB page size (after):

```
less flushes

pgbench
propolis worker count: 8
block size: 512
extent size: 32MiB
extent count: 1024
sqlite cache size: 64KiB


  848     4 root        50   0  317M  269M R   0.4  0.0  4:04.16 /persist/vi/crucible/target/release/crucible-downstairs run -p 8820 -d /cru2/ds
  849     2 root        51   0  313M  264M R   0.4  0.0  3:59.95 /persist/vi/crucible/target/release/crucible-downstairs run -p 8830 -d /cru3/ds
  850   123 root        50   0  316M  268M R   0.4  0.0  3:59.93 /persist/vi/crucible/target/release/crucible-downstairs run -p 8810 -d /cru1/ds


pgbench (14.8, server 15.3)
starting vacuum...end.
transaction type: insert.sql
scaling factor: 50
query mode: simple
number of clients: 50
number of threads: 8
duration: 30 s
number of transactions actually processed: 491170
latency average = 3.053 ms
initial connection time = 17.964 ms
tps = 16377.431628 (without initial connection time)
pgbench (14.8, server 15.3)
starting vacuum...end.
transaction type: insert.sql
scaling factor: 50
query mode: simple
number of clients: 50
number of threads: 8
duration: 30 s
number of transactions actually processed: 492138
latency average = 3.047 ms
initial connection time = 16.343 ms
tps = 16408.843327 (without initial connection time)
pgbench (14.8, server 15.3)
starting vacuum...end.
transaction type: insert.sql
scaling factor: 50
query mode: simple
number of clients: 50
number of threads: 8
duration: 30 s
number of transactions actually processed: 491733
latency average = 3.050 ms
initial connection time = 16.362 ms
tps = 16394.500219 (without initial connection time)


[root@nixos:~]# fio perf.fio
randread-16K: (g=0): rw=randread, bs=(R) 16.0KiB-16.0KiB, (W) 16.0KiB-16.0KiB, (T) 16.0KiB-16.0KiB, ioengine=libaio, iodepth=25
randread-4M: (g=1): rw=randread, bs=(R) 4096KiB-4096KiB, (W) 4096KiB-4096KiB, (T) 4096KiB-4096KiB, ioengine=libaio, iodepth=25
randwrite-16K: (g=2): rw=randwrite, bs=(R) 16.0KiB-16.0KiB, (W) 16.0KiB-16.0KiB, (T) 16.0KiB-16.0KiB, ioengine=libaio, iodepth=25
randwrite-4M: (g=3): rw=randwrite, bs=(R) 4096KiB-4096KiB, (W) 4096KiB-4096KiB, (T) 4096KiB-4096KiB, ioengine=libaio, iodepth=25
read-16K: (g=4): rw=read, bs=(R) 16.0KiB-16.0KiB, (W) 16.0KiB-16.0KiB, (T) 16.0KiB-16.0KiB, ioengine=libaio, iodepth=25
read-4M: (g=5): rw=read, bs=(R) 4096KiB-4096KiB, (W) 4096KiB-4096KiB, (T) 4096KiB-4096KiB, ioengine=libaio, iodepth=25
write-16K: (g=6): rw=write, bs=(R) 16.0KiB-16.0KiB, (W) 16.0KiB-16.0KiB, (T) 16.0KiB-16.0KiB, ioengine=libaio, iodepth=25
write-4M: (g=7): rw=write, bs=(R) 4096KiB-4096KiB, (W) 4096KiB-4096KiB, (T) 4096KiB-4096KiB, ioengine=libaio, iodepth=25
fio-3.33
Starting 8 processes
Jobs: 1 (f=1): [_(7),W(1)][56.3%][w=96.0MiB/s][w=24 IOPS][eta 03m:10s]
randread-16K: (groupid=0, jobs=1): err= 0: pid=1098: Fri Aug 18 08:01:20 2023
  read: IOPS=3324, BW=51.9MiB/s (54.5MB/s)(1559MiB/30007msec)
    slat (usec): min=18, max=224, avg=24.19, stdev= 9.90
    clat (usec): min=977, max=18641, avg=7484.91, stdev=1309.05
     lat (usec): min=1072, max=18664, avg=7509.11, stdev=1308.89
    clat percentiles (usec):
     |  1.00th=[ 5735],  5.00th=[ 6194], 10.00th=[ 6456], 20.00th=[ 6783],
     | 30.00th=[ 7046], 40.00th=[ 7242], 50.00th=[ 7439], 60.00th=[ 7570],
     | 70.00th=[ 7767], 80.00th=[ 7898], 90.00th=[ 8160], 95.00th=[ 8455],
     | 99.00th=[16319], 99.50th=[16909], 99.90th=[17695], 99.95th=[17957],
     | 99.99th=[18220]
   bw (  KiB/s): min=51815, max=57071, per=100.00%, avg=53249.53, stdev=938.23, samples=59
   iops        : min= 3238, max= 3566, avg=3327.66, stdev=58.61, samples=59
  lat (usec)   : 1000=0.01%
  lat (msec)   : 2=0.01%, 4=0.01%, 10=98.47%, 20=1.52%
  cpu          : usr=1.21%, sys=21.10%, ctx=99146, majf=0, minf=109
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=100.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwts: total=99754,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=25
randread-4M: (groupid=1, jobs=1): err= 0: pid=1102: Fri Aug 18 08:01:20 2023
  read: IOPS=25, BW=101MiB/s (106MB/s)(3144MiB/31020msec)
    slat (usec): min=115, max=1297, avg=262.30, stdev=129.96
    clat (msec): min=57, max=1920, avg=984.74, stdev=143.43
     lat (msec): min=58, max=1920, avg=985.00, stdev=143.36
    clat percentiles (msec):
     |  1.00th=[  313],  5.00th=[  911], 10.00th=[  927], 20.00th=[  953],
     | 30.00th=[  969], 40.00th=[  978], 50.00th=[  995], 60.00th=[ 1003],
     | 70.00th=[ 1011], 80.00th=[ 1020], 90.00th=[ 1028], 95.00th=[ 1053],
     | 99.00th=[ 1653], 99.50th=[ 1787], 99.90th=[ 1921], 99.95th=[ 1921],
     | 99.99th=[ 1921]
   bw (  KiB/s): min=90292, max=114917, per=99.94%, avg=103724.10, stdev=5385.37, samples=60
   iops        : min=   22, max=   28, avg=25.28, stdev= 1.32, samples=60
  lat (msec)   : 100=0.25%, 250=0.51%, 500=0.89%, 750=0.89%, 1000=58.27%
  lat (msec)   : 2000=39.19%
  cpu          : usr=0.05%, sys=0.91%, ctx=788, majf=0, minf=25610
  IO depths    : 1=0.1%, 2=0.3%, 4=0.5%, 8=1.0%, 16=98.1%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=99.9%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwts: total=786,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=25
randwrite-16K: (groupid=2, jobs=1): err= 0: pid=1104: Fri Aug 18 08:01:20 2023
  write: IOPS=1318, BW=20.6MiB/s (21.6MB/s)(618MiB/30013msec); 0 zone resets
    slat (usec): min=18, max=1997, avg=28.09, stdev=19.01
    clat (usec): min=1359, max=147283, avg=18918.25, stdev=13628.00
     lat (usec): min=1421, max=147305, avg=18946.34, stdev=13628.95
    clat percentiles (msec):
     |  1.00th=[   11],  5.00th=[   12], 10.00th=[   12], 20.00th=[   13],
     | 30.00th=[   13], 40.00th=[   13], 50.00th=[   14], 60.00th=[   16],
     | 70.00th=[   19], 80.00th=[   22], 90.00th=[   30], 95.00th=[   40],
     | 99.00th=[   90], 99.50th=[   99], 99.90th=[  134], 99.95th=[  136],
     | 99.99th=[  146]
   bw (  KiB/s): min=11318, max=28736, per=99.90%, avg=21077.19, stdev=5435.48, samples=59
   iops        : min=  707, max= 1796, avg=1317.02, stdev=339.77, samples=59
  lat (msec)   : 2=0.01%, 4=0.01%, 10=0.13%, 20=77.52%, 50=18.38%
  lat (msec)   : 100=3.59%, 250=0.36%
  cpu          : usr=0.99%, sys=9.33%, ctx=39254, majf=0, minf=10
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=100.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwts: total=0,39576,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=25
randwrite-4M: (groupid=3, jobs=1): err= 0: pid=1109: Fri Aug 18 08:01:20 2023
  write: IOPS=39, BW=159MiB/s (166MB/s)(4868MiB/30672msec); 0 zone resets
    slat (usec): min=177, max=776, avg=329.98, stdev=77.44
    clat (msec): min=47, max=1280, avg=629.09, stdev=81.11
     lat (msec): min=47, max=1281, avg=629.42, stdev=81.11
    clat percentiles (msec):
     |  1.00th=[  342],  5.00th=[  584], 10.00th=[  592], 20.00th=[  600],
     | 30.00th=[  609], 40.00th=[  617], 50.00th=[  617], 60.00th=[  625],
     | 70.00th=[  642], 80.00th=[  667], 90.00th=[  684], 95.00th=[  701],
     | 99.00th=[  944], 99.50th=[ 1150], 99.90th=[ 1267], 99.95th=[ 1284],
     | 99.99th=[ 1284]
   bw (  KiB/s): min=139264, max=180585, per=100.00%, avg=162805.55, stdev=8938.76, samples=60
   iops        : min=   34, max=   44, avg=39.68, stdev= 2.19, samples=60
  lat (msec)   : 50=0.08%, 100=0.16%, 250=0.49%, 500=0.90%, 750=96.63%
  lat (msec)   : 1000=0.90%, 2000=0.82%
  cpu          : usr=0.73%, sys=1.01%, ctx=1216, majf=0, minf=9
  IO depths    : 1=0.1%, 2=0.2%, 4=0.3%, 8=0.7%, 16=98.8%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=99.9%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwts: total=0,1217,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=25
read-16K: (groupid=4, jobs=1): err= 0: pid=1113: Fri Aug 18 08:01:20 2023
  read: IOPS=3312, BW=51.8MiB/s (54.3MB/s)(1553MiB/30008msec)
    slat (usec): min=18, max=191, avg=23.65, stdev= 8.92
    clat (usec): min=1140, max=22420, avg=7513.56, stdev=1290.71
     lat (usec): min=1188, max=22440, avg=7537.21, stdev=1290.63
    clat percentiles (usec):
     |  1.00th=[ 5800],  5.00th=[ 6259], 10.00th=[ 6521], 20.00th=[ 6915],
     | 30.00th=[ 7111], 40.00th=[ 7308], 50.00th=[ 7439], 60.00th=[ 7570],
     | 70.00th=[ 7767], 80.00th=[ 7898], 90.00th=[ 8094], 95.00th=[ 8356],
     | 99.00th=[16319], 99.50th=[16909], 99.90th=[17695], 99.95th=[17957],
     | 99.99th=[21627]
   bw (  KiB/s): min=51687, max=53931, per=100.00%, avg=53055.34, stdev=425.31, samples=59
   iops        : min= 3230, max= 3370, avg=3315.54, stdev=26.54, samples=59
  lat (msec)   : 2=0.01%, 4=0.01%, 10=98.46%, 20=1.50%, 50=0.02%
  cpu          : usr=1.09%, sys=21.00%, ctx=98843, majf=0, minf=111
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=100.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwts: total=99389,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=25
read-4M: (groupid=5, jobs=1): err= 0: pid=1115: Fri Aug 18 08:01:20 2023
  read: IOPS=24, BW=98.2MiB/s (103MB/s)(3044MiB/30984msec)
    slat (usec): min=117, max=1182, avg=239.01, stdev=124.91
    clat (msec): min=53, max=26981, avg=1015.96, stdev=4420.51
     lat (msec): min=54, max=26981, avg=1016.20, stdev=4420.51
    clat percentiles (msec):
     |  1.00th=[  101],  5.00th=[  109], 10.00th=[  113], 20.00th=[  116],
     | 30.00th=[  120], 40.00th=[  123], 50.00th=[  126], 60.00th=[  129],
     | 70.00th=[  133], 80.00th=[  144], 90.00th=[  978], 95.00th=[ 1028],
     | 99.00th=[17113], 99.50th=[17113], 99.90th=[17113], 99.95th=[17113],
     | 99.99th=[17113]
   bw (  KiB/s): min=81920, max=106709, per=99.71%, avg=100310.07, stdev=5759.53, samples=60
   iops        : min=   20, max=   26, avg=24.45, stdev= 1.41, samples=60
  lat (msec)   : 100=0.53%, 250=80.55%, 500=0.92%, 750=0.92%, 1000=10.38%
  lat (msec)   : 2000=3.81%, >=2000=2.89%
  cpu          : usr=0.08%, sys=0.80%, ctx=764, majf=0, minf=25611
  IO depths    : 1=0.1%, 2=0.3%, 4=0.5%, 8=1.1%, 16=98.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=99.9%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwts: total=761,0,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=25
write-16K: (groupid=6, jobs=1): err= 0: pid=1119: Fri Aug 18 08:01:20 2023
  write: IOPS=2729, BW=42.6MiB/s (44.7MB/s)(1280MiB/30009msec); 0 zone resets
    slat (usec): min=18, max=286, avg=25.26, stdev= 8.30
    clat (usec): min=1209, max=72132, avg=9124.14, stdev=6452.99
     lat (usec): min=1302, max=72153, avg=9149.40, stdev=6453.11
    clat percentiles (usec):
     |  1.00th=[ 6259],  5.00th=[ 6783], 10.00th=[ 7308], 20.00th=[ 7635],
     | 30.00th=[ 7832], 40.00th=[ 7963], 50.00th=[ 8094], 60.00th=[ 8225],
     | 70.00th=[ 8455], 80.00th=[ 8717], 90.00th=[ 9503], 95.00th=[10421],
     | 99.00th=[51643], 99.50th=[60031], 99.90th=[69731], 99.95th=[70779],
     | 99.99th=[71828]
   bw (  KiB/s): min=36809, max=46909, per=100.00%, avg=43728.61, stdev=1866.06, samples=59
   iops        : min= 2300, max= 2931, avg=2732.73, stdev=116.60, samples=59
  lat (msec)   : 2=0.01%, 4=0.01%, 10=93.44%, 20=4.48%, 50=0.97%
  lat (msec)   : 100=1.09%
  cpu          : usr=1.49%, sys=18.33%, ctx=81372, majf=0, minf=10
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=100.0%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwts: total=0,81897,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=25
write-4M: (groupid=7, jobs=1): err= 0: pid=1123: Fri Aug 18 08:01:20 2023
  write: IOPS=38, BW=153MiB/s (160MB/s)(4688MiB/30727msec); 0 zone resets
    slat (usec): min=151, max=650, avg=314.71, stdev=65.74
    clat (msec): min=35, max=1381, avg=654.47, stdev=100.58
     lat (msec): min=35, max=1381, avg=654.78, stdev=100.58
    clat percentiles (msec):
     |  1.00th=[  271],  5.00th=[  575], 10.00th=[  584], 20.00th=[  609],
     | 30.00th=[  625], 40.00th=[  625], 50.00th=[  634], 60.00th=[  651],
     | 70.00th=[  684], 80.00th=[  726], 90.00th=[  743], 95.00th=[  760],
     | 99.00th=[ 1028], 99.50th=[ 1250], 99.90th=[ 1351], 99.95th=[ 1385],
     | 99.99th=[ 1385]
   bw (  KiB/s): min= 8175, max=180224, per=98.63%, avg=154083.20, stdev=21690.53, samples=61
   iops        : min=    1, max=   44, avg=37.34, stdev= 5.40, samples=61
  lat (msec)   : 50=0.09%, 100=0.26%, 250=0.60%, 500=0.60%, 750=89.93%
  lat (msec)   : 1000=7.42%, 2000=1.11%
  cpu          : usr=0.62%, sys=0.96%, ctx=1173, majf=0, minf=10
  IO depths    : 1=0.1%, 2=0.2%, 4=0.3%, 8=0.7%, 16=98.7%, 32=0.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=99.9%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwts: total=0,1172,0,0 short=0,0,0,0 dropped=0,0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=25

Run status group 0 (all jobs):
   READ: bw=51.9MiB/s (54.5MB/s), 51.9MiB/s-51.9MiB/s (54.5MB/s-54.5MB/s), io=1559MiB (1634MB), run=30007-30007msec

Run status group 1 (all jobs):
   READ: bw=101MiB/s (106MB/s), 101MiB/s-101MiB/s (106MB/s-106MB/s), io=3144MiB (3297MB), run=31020-31020msec

Run status group 2 (all jobs):
  WRITE: bw=20.6MiB/s (21.6MB/s), 20.6MiB/s-20.6MiB/s (21.6MB/s-21.6MB/s), io=618MiB (648MB), run=30013-30013msec

Run status group 3 (all jobs):
  WRITE: bw=159MiB/s (166MB/s), 159MiB/s-159MiB/s (166MB/s-166MB/s), io=4868MiB (5104MB), run=30672-30672msec

Run status group 4 (all jobs):
   READ: bw=51.8MiB/s (54.3MB/s), 51.8MiB/s-51.8MiB/s (54.3MB/s-54.3MB/s), io=1553MiB (1628MB), run=30008-30008msec

Run status group 5 (all jobs):
   READ: bw=98.2MiB/s (103MB/s), 98.2MiB/s-98.2MiB/s (103MB/s-103MB/s), io=3044MiB (3192MB), run=30984-30984msec

Run status group 6 (all jobs):
  WRITE: bw=42.6MiB/s (44.7MB/s), 42.6MiB/s-42.6MiB/s (44.7MB/s-44.7MB/s), io=1280MiB (1342MB), run=30009-30009msec

Run status group 7 (all jobs):
  WRITE: bw=153MiB/s (160MB/s), 153MiB/s-153MiB/s (160MB/s-160MB/s), io=4688MiB (4916MB), run=30727-30727msec

Disk stats (read/write):
  nvme0n1: ios=205874/131669, merge=146/334, ticks=7967507/7873988, in_queue=15841495, util=99.40%
```

These numbers are very similar.