### PR TITLE
Update tokio-rustls to 0.24.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
  "tempfile",
  "test-strategy",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls",
  "tokio-test",
  "tokio-util",
  "toml",
@@ -822,7 +822,7 @@ dependencies = [
  "slog-term",
  "tempfile",
  "thiserror",
- "tokio-rustls 0.23.4",
+ "tokio-rustls",
  "toml",
  "twox-hash",
  "uuid",
@@ -888,7 +888,7 @@ dependencies = [
  "slog-term",
  "tempfile",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls",
  "tokio-util",
  "toml",
  "tracing",
@@ -1293,7 +1293,7 @@ dependencies = [
  "paste",
  "percent-encoding",
  "proc-macro2",
- "rustls 0.21.3",
+ "rustls",
  "rustls-pemfile",
  "schemars",
  "serde",
@@ -1307,7 +1307,7 @@ dependencies = [
  "slog-json",
  "slog-term",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "toml",
  "usdt",
  "uuid",
@@ -1895,9 +1895,9 @@ checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
 dependencies = [
  "http",
  "hyper",
- "rustls 0.21.3",
+ "rustls",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -3597,14 +3597,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.3",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -3719,21 +3719,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b19faa85ecb5197342b54f987b142fb3e30d0c90da40f80ef4fa9a726e6676ed"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
@@ -3752,9 +3740,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.1"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",
@@ -4682,22 +4670,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls 0.20.8",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.3",
+ "rustls",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ tempfile = "3"
 test-strategy = "0.3.1"
 thiserror = "1"
 tokio = { version = "1.29", features = ["full"] }
-tokio-rustls = { version = "0.23.4" }
+tokio-rustls = { version = "0.24.1" }
 tokio-test = "*"
 tokio-util = { version = "0.7", features = ["codec"]}
 toml = "0.7"

--- a/common/src/x509.rs
+++ b/common/src/x509.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 Oxide Computer Company
 use std::fs::File;
 use std::io::{self, BufReader};
+use std::sync::Arc;
 
 // Reference tokio-rustls repo examples/server/src/main.rs
 use rustls_pemfile::{certs, rsa_private_keys};
@@ -25,9 +26,6 @@ pub fn load_rsa_keys(path: &str) -> io::Result<Vec<PrivateKey>> {
 
 #[derive(thiserror::Error, Debug)]
 pub enum TLSContextError {
-    #[error("PKI error")]
-    PKIError(#[from] tokio_rustls::webpki::Error),
-
     #[error("IO error")]
     IOError(#[from] std::io::Error),
 
@@ -64,7 +62,7 @@ impl TLSContext {
         Ok(ClientConfig::builder()
             .with_safe_defaults()
             .with_root_certificates(self.root_cert_store.clone())
-            .with_single_cert(self.certs.clone(), self.keys[0].clone())?)
+            .with_client_auth_cert(self.certs.clone(), self.keys[0].clone())?)
     }
 
     pub fn get_server_config(&self) -> Result<ServerConfig, TLSContextError> {
@@ -73,7 +71,7 @@ impl TLSContext {
 
         Ok(ServerConfig::builder()
             .with_safe_defaults()
-            .with_client_cert_verifier(client_cert_verifier)
+            .with_client_cert_verifier(Arc::new(client_cert_verifier))
             .with_single_cert(self.certs.clone(), self.keys[0].clone())?)
     }
 }


### PR DESCRIPTION
This supersedes #724.  The existing tokio-rustls depends on `webpki`, which has a [pending GHSA](https://github.com/advisories/GHSA-8qv2-5vq6-g2g7).  Updating into 0.24.x means we can drop the webpki dependency (once `reqwest` is updated too)