### PR TITLE
Update oximeter dependency to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 [[package]]
 name = "api_identity"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#bd6c62807fbb2ea4fdae0b11c301124936ea41a2"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#4c05962d1c14c52a7067ef8db582e9f76d94e440"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.72"
+version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -434,6 +434,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "camino-tempfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ab15a83d13f75dbd86f082bdefd160b628476ef58d3b900a0ef74e001bb097"
+dependencies = [
+ "camino",
+ "tempfile",
 ]
 
 [[package]]
@@ -1273,7 +1283,7 @@ dependencies = [
 [[package]]
 name = "dropshot"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#7622dc0eac7445e0b39b72140f22cdadca8276c4"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#aca6de3cfc160c6e68946c70cc48634f9a750824"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1318,7 +1328,7 @@ dependencies = [
 [[package]]
 name = "dropshot_endpoint"
 version = "0.9.1-dev"
-source = "git+https://github.com/oxidecomputer/dropshot?branch=main#7622dc0eac7445e0b39b72140f22cdadca8276c4"
+source = "git+https://github.com/oxidecomputer/dropshot?branch=main#aca6de3cfc160c6e68946c70cc48634f9a750824"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1880,7 +1890,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -2050,6 +2060,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
 dependencies = [
+ "schemars",
  "serde",
 ]
 
@@ -2370,10 +2381,11 @@ dependencies = [
 [[package]]
 name = "nexus-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#bd6c62807fbb2ea4fdae0b11c301124936ea41a2"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#4c05962d1c14c52a7067ef8db582e9f76d94e440"
 dependencies = [
  "chrono",
  "futures",
+ "ipnetwork",
  "omicron-common",
  "omicron-passwords",
  "progenitor",
@@ -2510,9 +2522,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg 1.1.0",
  "libm",
@@ -2576,11 +2588,14 @@ dependencies = [
 [[package]]
 name = "omicron-common"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#bd6c62807fbb2ea4fdae0b11c301124936ea41a2"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#4c05962d1c14c52a7067ef8db582e9f76d94e440"
 dependencies = [
  "anyhow",
  "api_identity",
+ "async-trait",
  "backoff",
+ "camino",
+ "camino-tempfile",
  "chrono",
  "dropshot",
  "futures",
@@ -2596,7 +2611,7 @@ dependencies = [
  "reqwest",
  "ring",
  "schemars",
- "semver 1.0.17",
+ "semver 1.0.18",
  "serde",
  "serde_derive",
  "serde_human_bytes",
@@ -2604,7 +2619,7 @@ dependencies = [
  "serde_with",
  "slog",
  "steno",
- "strum 0.24.0",
+ "strum",
  "thiserror",
  "tokio",
  "tokio-postgres",
@@ -2615,7 +2630,7 @@ dependencies = [
 [[package]]
 name = "omicron-passwords"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#bd6c62807fbb2ea4fdae0b11c301124936ea41a2"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#4c05962d1c14c52a7067ef8db582e9f76d94e440"
 dependencies = [
  "argon2",
  "rand 0.8.5",
@@ -2640,7 +2655,7 @@ dependencies = [
  "hex",
  "reqwest",
  "ring",
- "semver 1.0.17",
+ "semver 1.0.18",
  "serde",
  "serde_derive",
  "tar",
@@ -2877,11 +2892,12 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "oximeter"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#bd6c62807fbb2ea4fdae0b11c301124936ea41a2"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#4c05962d1c14c52a7067ef8db582e9f76d94e440"
 dependencies = [
  "bytes",
  "chrono",
  "num-traits",
+ "omicron-common",
  "oximeter-macro-impl",
  "schemars",
  "serde",
@@ -2892,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "oximeter-macro-impl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#bd6c62807fbb2ea4fdae0b11c301124936ea41a2"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#4c05962d1c14c52a7067ef8db582e9f76d94e440"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2902,7 +2918,7 @@ dependencies = [
 [[package]]
 name = "oximeter-producer"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#bd6c62807fbb2ea4fdae0b11c301124936ea41a2"
+source = "git+https://github.com/oxidecomputer/omicron?branch=main#4c05962d1c14c52a7067ef8db582e9f76d94e440"
 dependencies = [
  "chrono",
  "dropshot",
@@ -2981,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "percent-encoding"
@@ -3104,9 +3120,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -3197,7 +3213,7 @@ dependencies = [
 [[package]]
 name = "progenitor"
 version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#2bb38c798f77fdb41c9e3b790cd7939e4ed8f538"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#76716eeaaebfec796c9e7a5bf15d3a69212363bc"
 dependencies = [
  "progenitor-client",
  "progenitor-impl",
@@ -3208,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "progenitor-client"
 version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#2bb38c798f77fdb41c9e3b790cd7939e4ed8f538"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#76716eeaaebfec796c9e7a5bf15d3a69212363bc"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3222,7 +3238,7 @@ dependencies = [
 [[package]]
 name = "progenitor-impl"
 version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#2bb38c798f77fdb41c9e3b790cd7939e4ed8f538"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#76716eeaaebfec796c9e7a5bf15d3a69212363bc"
 dependencies = [
  "getopts",
  "heck",
@@ -3244,7 +3260,7 @@ dependencies = [
 [[package]]
 name = "progenitor-macro"
 version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/progenitor?branch=main#2bb38c798f77fdb41c9e3b790cd7939e4ed8f538"
+source = "git+https://github.com/oxidecomputer/progenitor?branch=main#76716eeaaebfec796c9e7a5bf15d3a69212363bc"
 dependencies = [
  "openapiv3",
  "proc-macro2",
@@ -3512,8 +3528,8 @@ dependencies = [
  "nu-ansi-term 0.49.0",
  "serde",
  "strip-ansi-escapes",
- "strum 0.25.0",
- "strum_macros 0.25.2",
+ "strum",
+ "strum_macros",
  "thiserror",
  "unicode-segmentation",
  "unicode-width",
@@ -3672,7 +3688,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.17",
+ "semver 1.0.18",
 ]
 
 [[package]]
@@ -3865,9 +3881,9 @@ checksum = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 dependencies = [
  "serde",
 ]
@@ -3906,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "serde_human_bytes"
 version = "0.1.0"
-source = "git+http://github.com/oxidecomputer/serde_human_bytes#0a09794501b6208120528c3b457d5f3a8cb17424"
+source = "git+http://github.com/oxidecomputer/serde_human_bytes?branch=main#0a09794501b6208120528c3b457d5f3a8cb17424"
 dependencies = [
  "hex",
  "serde",
@@ -3914,9 +3930,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.100"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -3925,10 +3941,11 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
 dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -4206,6 +4223,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4322,30 +4349,11 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
-dependencies = [
- "strum_macros 0.24.0",
-]
-
-[[package]]
-name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-
-[[package]]
-name = "strum_macros"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
 dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.107",
+ "strum_macros",
 ]
 
 [[package]]
@@ -4606,11 +4614,10 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
- "autocfg 1.1.0",
  "backtrace",
  "bytes",
  "libc",
@@ -4619,7 +4626,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.3",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -4663,7 +4670,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tokio-util",
 ]
@@ -4841,7 +4848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.6.5",
  "static_assertions",
 ]
 
@@ -4854,7 +4861,7 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 [[package]]
 name = "typify"
 version = "0.0.13"
-source = "git+https://github.com/oxidecomputer/typify#43bd5bce4ada2a87152895d2abfc4888154242f3"
+source = "git+https://github.com/oxidecomputer/typify#92bfed8b0ac2937c9c06575044f0b683e266981f"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -4863,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "typify-impl"
 version = "0.0.13"
-source = "git+https://github.com/oxidecomputer/typify#43bd5bce4ada2a87152895d2abfc4888154242f3"
+source = "git+https://github.com/oxidecomputer/typify#92bfed8b0ac2937c9c06575044f0b683e266981f"
 dependencies = [
  "heck",
  "log",
@@ -4880,7 +4887,7 @@ dependencies = [
 [[package]]
 name = "typify-macro"
 version = "0.0.13"
-source = "git+https://github.com/oxidecomputer/typify#43bd5bce4ada2a87152895d2abfc4888154242f3"
+source = "git+https://github.com/oxidecomputer/typify#92bfed8b0ac2937c9c06575044f0b683e266981f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4921,9 +4928,9 @@ checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -5067,9 +5074,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d023da39d1fde5a8a3fe1f3e01ca9632ada0a63e9797de55a879d6e2236277be"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom",
  "serde",

--- a/downstairs/src/stats.rs
+++ b/downstairs/src/stats.rs
@@ -111,13 +111,13 @@ impl Producer for DsStatOuter {
     ) -> Result<Box<dyn Iterator<Item = Sample> + 'static>, MetricsError> {
         let dss = executor::block_on(self.ds_stat_wrap.lock());
 
-        let mut data = Vec::with_capacity(4);
-        let name = dss.stat_name;
-
-        data.push(Sample::new(&name, &dss.up_connect_count));
-        data.push(Sample::new(&name, &dss.flush_count));
-        data.push(Sample::new(&name, &dss.write_count));
-        data.push(Sample::new(&name, &dss.read_count));
+        let name = &dss.stat_name;
+        let data = vec![
+            Sample::new(name, &dss.up_connect_count)?,
+            Sample::new(name, &dss.flush_count)?,
+            Sample::new(name, &dss.write_count)?,
+            Sample::new(name, &dss.read_count)?,
+        ];
 
         // Yield the available samples.
         Ok(Box::new(data.into_iter()))

--- a/upstairs/src/stats.rs
+++ b/upstairs/src/stats.rs
@@ -177,19 +177,19 @@ impl Producer for UpStatOuter {
             tokio::runtime::Handle::current().block_on(self.up_stat_wrap.lock())
         });
 
-        let mut data = Vec::with_capacity(6);
-        let name = ups.stat_name;
-
-        data.push(Sample::new(&name, &ups.activated_count));
-        data.push(Sample::new(&name, &ups.flush_count));
-        data.push(Sample::new(&name, &ups.write_count));
-        data.push(Sample::new(&name, &ups.write_bytes));
-        data.push(Sample::new(&name, &ups.read_count));
-        data.push(Sample::new(&name, &ups.read_bytes));
-        data.push(Sample::new(&name, &ups.flush_close_count));
-        data.push(Sample::new(&name, &ups.extent_repair_count));
-        data.push(Sample::new(&name, &ups.extent_noop_count));
-        data.push(Sample::new(&name, &ups.extent_reopen_count));
+        let name = &ups.stat_name;
+        let data = vec![
+            Sample::new(name, &ups.activated_count)?,
+            Sample::new(name, &ups.flush_count)?,
+            Sample::new(name, &ups.write_count)?,
+            Sample::new(name, &ups.write_bytes)?,
+            Sample::new(name, &ups.read_count)?,
+            Sample::new(name, &ups.read_bytes)?,
+            Sample::new(name, &ups.flush_close_count)?,
+            Sample::new(name, &ups.extent_repair_count)?,
+            Sample::new(name, &ups.extent_noop_count)?,
+            Sample::new(name, &ups.extent_reopen_count)?,
+        ];
 
         // Yield the available samples.
         Ok(Box::new(data.into_iter()))


### PR DESCRIPTION
This will allow downstream consumers to have an updated oximeter dependency in their lockfile and still be able to build the upstairs.