### PR TITLE
Test update for fast write ack and gather errors on test failure

### DIFF
--- a/tools/test_reconnect.sh
+++ b/tools/test_reconnect.sh
@@ -81,11 +81,11 @@ do
     echo "New loop starts now $(date)" >> "$test_log"
     "$crucible_test" generic "${args[@]}" -c 15000 \
             -q -g "$gen" --verify-out alan \
+            --range \
             --verify-in alan \
             --retry-activate >> "$test_log" 2>&1
     result=$?
     if [[ $result -ne 0 ]]; then
-        touch /var/tmp/ds_test/up 2> /dev/null
         (( err += 1 ))
         duration=$SECONDS
         printf "[%03d] Error $result after %d:%02d\n" "$i" \

--- a/tools/test_repair_perf.sh
+++ b/tools/test_repair_perf.sh
@@ -72,8 +72,8 @@ function repair_round() {
     # Do one IO to each block, verify.
     gen=1
     echo "$(date) fill" >> "$test_log"
-    echo "$ct" fill "${args[@]}" -q -g "$gen" --verify-out alan >> "$test_log"
-    "$ct" fill "${args[@]}" -q -g "$gen" --verify-out alan >> "$test_log" 2>&1
+    echo "$ct" fill "${args[@]}" --stable -g "$gen" --verify-out alan >> "$test_log"
+    "$ct" fill "${args[@]}" --stable -g "$gen" --verify-out alan >> "$test_log" 2>&1
     if [[ $? -ne 0 ]]; then
         echo "Error in initial fill"
         stop_test

--- a/tools/test_restart_repair.sh
+++ b/tools/test_restart_repair.sh
@@ -138,8 +138,8 @@ gen=1
 # Send something to the region so our old region files have data.
 echo "$(date) pre-fill" >> "$test_log"
 echo "$(date) run pre-fill of our region" | tee -a "$loop_log"
-echo "$ct" fill "${args[@]}" -q -g "$gen" >> "$test_log"
-"$ct" fill "${args[@]}" -q -g "$gen" >> "$test_log" 2>&1
+echo "$ct" fill "${args[@]}" --stable -g "$gen" >> "$test_log"
+"$ct" fill "${args[@]}" --stable -g "$gen" >> "$test_log" 2>&1
 if [[ $? -ne 0 ]]; then
     echo "Error in initial pre-fill"
     ctrl_c
@@ -170,8 +170,8 @@ bring_all_downstairs_online
 # different data in current vs. old region directories.
 echo "$(date) Run a second fill test" >> "$test_log"
 echo "$(date) Run a second fill test" | tee -a "$loop_log"
-echo "$ct" fill "${args[@]}" -q -g "$gen" --verify-out alan >> "$test_log"
-"$ct" fill "${args[@]}" -q -g "$gen" --verify-out alan >> "$test_log" 2>&1
+echo "$ct" fill "${args[@]}" --stable -g "$gen" --verify-out alan >> "$test_log"
+"$ct" fill "${args[@]}" --stable -g "$gen" --verify-out alan >> "$test_log" 2>&1
 if [[ $? -ne 0 ]]; then
     echo "Error in initial fill"
     ctrl_c

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -277,8 +277,8 @@ fi
 
 echo ""
 echo ""
-echo "$ct" "$tt" -g "$gen" -q "${args[@]}"
-if ! "$ct" verify -g "$gen" -q "${args[@]}"; then
+echo "$ct" "$tt" --range -g "$gen" -q "${args[@]}"
+if ! "$ct" verify --range -g "$gen" -q "${args[@]}"; then
     (( res += 1 ))
     echo ""
     echo "Failed repair test part 2"


### PR DESCRIPTION
Updated a few tests, including tools/test_up.sh  to accept a range of valid write counters where a write after a flush might not make it to disk before the test stops.  This fixes issues #896

Added some additional code to test-live-repair buildomat job to gather info in the event of failure.