### PR TITLE
Only rehash if a write may have failed

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -419,13 +419,13 @@ pub mod cdt {
     fn extent__flush__collect__hashes__start(
         job_id: u64,
         extent_id: u32,
-        extent_size: u64,
+        num_dirty: u64,
     ) {
     }
     fn extent__flush__collect__hashes__done(
         job_id: u64,
         extent_id: u32,
-        extent_size: u64,
+        num_rehashed: u64,
     ) {
     }
     fn extent__flush__sqlite__insert__start(

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -4840,8 +4840,6 @@ mod test {
             *a_buf = 9;
         }
 
-        region.region_flush(1, 0, &None, 0, None).await?;
-
         // read data into File, compare what was written to buffer
         let mut read_from_files: Vec<u8> = Vec::with_capacity(total_size);
 

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1232,7 +1232,7 @@ impl Extent {
             (job_id, self.number, writes.len() as u64)
         });
 
-        let mut hashes_to_write = vec![];
+        let mut hashes_to_write = Vec::with_capacity(writes.len());
         for write in writes {
             if writes_to_skip.contains(&write.offset.value) {
                 hashes_to_write.push(None);

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1316,10 +1316,10 @@ impl Extent {
         // Write any remaining data
         batched_pwritev.perform_writes()?;
 
-        // At this point, we know that the on-disk values for any written blocks
+        // At this point, we know that the written data for the target blocks
         // must match the integrity hashes calculated above (and stored to
-        // SQLite).  We can therefore store hash values for many dirty blocks,
-        // allowing us to skip rehashing during a flush operation.
+        // SQLite).  We can therefore store pre-computed hash values for these
+        // dirty blocks, allowing us to skip rehashing during a flush operation.
         for (write, hash) in writes.iter().zip(&hashes_to_write) {
             if let Some(h) = hash {
                 // This overwrites the `None` value written above!


### PR DESCRIPTION
Previously, we always rehashed data during a `flush` operation, which required reading it back from disk and computing an integrity hash.

However, if a block was successfully written, then we already know what its hash value will be (since we computed it earlier)!  We _only_ need to read + rehash if we failed to write the data, because if we failed to write the data, then the on-disk bytes are in an unknown state.

This PR tracks dirty blocks as a map from `block -> Option<u64>`, so that if the hash is known, it won't be recomputed during a flush operation.

It shows a small but noticeable (1-3%) performance increase when running `pgbench`:

<img width="581" alt="Screenshot 2023-08-29 at 11 48 39 AM" src="https://github.com/oxidecomputer/crucible/assets/745333/15462624-54de-4782-8a49-0a92e103a46e">

