### PR TITLE
Reduce Vec cloning and &mut Arc

### DIFF
--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -41,7 +41,7 @@ fn build_api() -> ApiDescription<Arc<FileServerContext>> {
 
 /// Returns Ok(listen address) if everything launched ok, Err otherwise
 pub async fn repair_main(
-    ds: &Arc<Mutex<Downstairs>>,
+    ds: &Mutex<Downstairs>,
     addr: SocketAddr,
     log: &Logger,
 ) -> Result<SocketAddr, String> {


### PR DESCRIPTION
We can pass the `Message` by value into `proc_frame`, saving a handful of `to_vec` calls.  In addition, I found a bunch of places where we can pass a `&Mutex<..>` instead of a `&mut Arc<Mutex<..>>` (or `&Arc<Mutex<..>>`), which simplifies a few of the signatures.