### PR TITLE
`offset_mod` shouldn't be randomized

### DIFF
--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -2085,10 +2085,9 @@ async fn perf_workload(
     let es = ri.extent_size.value;
     let ec = ri.total_blocks as u64 / es;
 
-    // To make a random block offset modulus, we take the total
-    // block number and subtract the IO size in blocks.
-    let offset_mod =
-        rng.gen::<u64>() % (ri.total_blocks - blocks_per_io) as u64;
+    // To make a random block offset, we take the total block count and subtract
+    // the IO size in blocks (so that we don't overspill the region)
+    let offset_mod = (ri.total_blocks - blocks_per_io) as u64;
 
     for _ in 0..write_loop {
         let mut wtime = Vec::with_capacity(count);


### PR DESCRIPTION
When running `crutest` repeatedly, I noticed that my results varied wildly between runs.

I believe this is because of bad randomization in selecting random write blocks.

Right now, we randomly select a modulus:
```rust
    // To make a random block offset modulus, we take the total
    // block number and subtract the IO size in blocks.
    let offset_mod =
        rng.gen::<u64>() % (ri.total_blocks - blocks_per_io) as u64;
```

Then, we use that modulus to randomly select an offset location for a random read / write:
```rust
            for write_buffer in write_buffers.iter().take(io_depth) {
                let offset: u64 = rng.gen::<u64>() % offset_mod;
                let future = guest.write_to_byte_offset(
                    offset * ri.block_size,
                    write_buffer.clone(),
                );
                write_futures.push(future);
            }
```

This means that if the (randomly selected) modulus is small, then all of our writes will be concentrated in one region; if it's large, then they will be scattered across the entire volume.  I would expect this to have a performance impact, and sure enough, I see a strong correlation between `offset_mod` and the `rwrite` `IOPS` reported by `crutest`:

![out](https://github.com/oxidecomputer/crucible/assets/745333/1132a044-44e5-4785-9917-d260229c9b8b)

The fix is simple: don't randomly select the modulus, so we always scatter writes across the entire region.

This gives much more repeatable performance:
```
    TEST SECONDS COUNT DPTH    IOPS    MEAN     P95     P99      MAX    ES    EC
 rwrites    7.22 30000    1 4157.49 0.00024 0.00032 0.00065  0.01211 16384   640
 rwrites    7.19 30000    1 4172.10 0.00024 0.00031 0.00065  0.01739 16384   640
 rwrites    7.22 30000    1 4154.58 0.00024 0.00032 0.00061  0.02106 16384   640
 rwrites    7.18 30000    1 4175.45 0.00024 0.00032 0.00071  0.01231 16384   640
 rwrites    7.21 30000    1 4163.22 0.00024 0.00032 0.00068  0.01223 16384   640
 rwrites    7.18 30000    1 4181.12 0.00024 0.00032 0.00057  0.01722 16384   640
 rwrites    7.18 30000    1 4177.07 0.00024 0.00032 0.00067  0.01240 16384   640
 rwrites    7.21 30000    1 4163.54 0.00024 0.00032 0.00069  0.01224 16384   640
 rwrites    7.20 30000    1 4164.03 0.00024 0.00032 0.00062  0.01226 16384   640
 rwrites    7.17 30000    1 4184.23 0.00024 0.00032 0.00060  0.01943 16384   640
 rwrites    7.23 30000    1 4147.52 0.00024 0.00032 0.00062  0.01321 16384   640
 rwrites    7.19 30000    1 4174.33 0.00024 0.00032 0.00062  0.01227 16384   640
 rwrites    7.18 30000    1 4178.16 0.00024 0.00031 0.00060  0.01277 16384   640
 rwrites    7.24 30000    1 4145.08 0.00024 0.00032 0.00065  0.01973 16384   640
 rwrites    7.21 30000    1 4159.93 0.00024 0.00031 0.00062  0.02120 16384   640
```
(each of these was a separate `crutest` run with `--write-loops=1`)