### PR TITLE
Move active jobs into a separate data structure and optimize `ackable_work`

### DIFF
--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -148,7 +148,8 @@ impl ActiveJobs {
          *
          * - writes have to depend on the last flush completing (because
          *   currently everything has to depend on flushes)
-         * - any overlap of impacted blocks requires a dependency
+         * - any overlap of impacted blocks before the flush requires a
+         *   dependency
          *
          * It's important to remember that jobs may arrive at different
          * Downstairs in different orders but they should still complete in job

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -264,11 +264,3 @@ impl<'a> IntoIterator for &'a ActiveJobs {
         self.jobs.iter()
     }
 }
-
-impl Extend<(u64, DownstairsIO)> for ActiveJobs {
-    fn extend<T: IntoIterator<Item = (u64, DownstairsIO)>>(&mut self, iter: T) {
-        for (job_id, io) in iter {
-            self.insert(job_id, io);
-        }
-    }
-}

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -148,8 +148,7 @@ impl ActiveJobs {
          *
          * - writes have to depend on the last flush completing (because
          *   currently everything has to depend on flushes)
-         * - any overlap of impacted blocks before the flush requires a
-         *   dependency
+         * - any overlap of impacted blocks requires a dependency
          *
          * It's important to remember that jobs may arrive at different
          * Downstairs in different orders but they should still complete in job
@@ -180,7 +179,6 @@ impl ActiveJobs {
             // all writes.
             if job.work.is_flush() {
                 dep.push(*id);
-                break;
             }
 
             // If this job impacts the same blocks as something already active,

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -1,0 +1,222 @@
+// Copyright 2023 Oxide Computer Company
+
+use crucible_common::RegionDefinition;
+
+use crate::{DownstairsIO, ImpactedBlocks};
+use std::collections::BTreeMap;
+
+#[derive(Debug)]
+pub(crate) struct ActiveJobs {
+    jobs: BTreeMap<u64, DownstairsIO>,
+}
+
+impl ActiveJobs {
+    pub fn new() -> Self {
+        Self {
+            jobs: BTreeMap::new(),
+        }
+    }
+
+    /// Looks up a job by ID, returning a reference
+    pub fn get(&self, job_id: &u64) -> Option<&DownstairsIO> {
+        self.jobs.get(job_id)
+    }
+
+    /// Looks up a job by ID, returning a mutable reference
+    pub fn get_mut(&mut self, job_id: &u64) -> Option<&mut DownstairsIO> {
+        self.jobs.get_mut(job_id)
+    }
+
+    /// Returns the total number of active jobs
+    pub fn len(&self) -> usize {
+        self.jobs.len()
+    }
+
+    /// Returns `true` if no jobs are active
+    pub fn is_empty(&self) -> bool {
+        self.jobs.is_empty()
+    }
+
+    /// Returns an iterator over all active jobs
+    pub fn iter_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (&u64, &mut DownstairsIO)> {
+        self.jobs.iter_mut()
+    }
+
+    /// Inserts a new job ID and its associated IO work
+    pub fn insert(
+        &mut self,
+        job_id: u64,
+        io: DownstairsIO,
+    ) -> Option<DownstairsIO> {
+        self.jobs.insert(job_id, io)
+    }
+
+    /// Removes a job by ID, returning its IO work
+    pub fn remove(&mut self, job_id: &u64) -> Option<DownstairsIO> {
+        self.jobs.remove(job_id)
+    }
+
+    /// Returns an iterator over job IDs
+    pub fn keys(&self) -> std::collections::btree_map::Keys<u64, DownstairsIO> {
+        self.jobs.keys()
+    }
+
+    /// Returns an iterator over job values
+    #[cfg(test)]
+    pub fn values(
+        &self,
+    ) -> std::collections::btree_map::Values<u64, DownstairsIO> {
+        self.jobs.values()
+    }
+
+    pub fn iter(&self) -> std::collections::btree_map::Iter<u64, DownstairsIO> {
+        self.jobs.iter()
+    }
+
+    pub fn deps_for_flush(&self) -> Vec<u64> {
+        /*
+         * To build the dependency list for this flush, iterate from the end of
+         * the downstairs work active list in reverse order and check each job
+         * in that list to see if this new flush must depend on it.
+         *
+         * We can safely ignore everything before the last flush, because the
+         * last flush will depend on jobs before it. But this flush must depend
+         * on the last flush - flush and gen numbers downstairs need to be
+         * sequential and the same for each downstairs.
+         *
+         * The downstairs currently assumes that all jobs previous to the last
+         * flush have completed, so the Upstairs must set that flushes depend on
+         * all jobs. It's currently important that flushes depend on everything,
+         * and everything depends on flushes.
+         */
+        let num_jobs = self.len();
+        let mut dep: Vec<u64> = Vec::with_capacity(num_jobs);
+
+        for (id, job) in self.iter().rev() {
+            // Flushes must depend on everything
+            dep.push(*id);
+
+            // Depend on the last flush, but then bail out
+            if job.work.is_flush() {
+                break;
+            }
+        }
+        dep
+    }
+
+    pub fn deps_for_write(
+        &self,
+        impacted_blocks: ImpactedBlocks,
+        _ddef: RegionDefinition,
+    ) -> Vec<u64> {
+        /*
+         * To build the dependency list for this write, iterate from the end
+         * of the downstairs work active list in reverse order and
+         * check each job in that list to see if this new write must
+         * depend on it.
+         *
+         * Construct a list of dependencies for this write based on the
+         * following rules:
+         *
+         * - writes have to depend on the last flush completing (because
+         *   currently everything has to depend on flushes)
+         * - any overlap of impacted blocks requires a dependency
+         *
+         * It's important to remember that jobs may arrive at different
+         * Downstairs in different orders but they should still complete in job
+         * dependency order.
+         *
+         * TODO: any overlap of impacted blocks will create a dependency.
+         * take this an example (this shows three writes, all to the
+         * same block, along with the dependency list for each
+         * write):
+         *
+         *       block
+         * op# | 0 1 2 | deps
+         * ----|-------------
+         *   0 | W     |
+         *   1 | W     | 0
+         *   2 | W     | 0,1
+         *
+         * op 2 depends on both op 1 and op 0. If dependencies are transitive
+         * with an existing job, it would be nice if those were removed from
+         * this job's dependencies.
+         */
+        let num_jobs = self.len();
+        let mut dep: Vec<u64> = Vec::with_capacity(num_jobs);
+
+        // Search backwards in the list of active jobs
+        for (id, job) in self.iter().rev() {
+            // Depend on the last flush - flushes are a barrier for
+            // all writes.
+            if job.work.is_flush() {
+                dep.push(*id);
+                break;
+            }
+
+            // If this job impacts the same blocks as something already active,
+            // create a dependency.
+            if impacted_blocks.conflicts(&job.impacted_blocks) {
+                dep.push(*id);
+            }
+        }
+        dep
+    }
+
+    pub fn deps_for_read(
+        &self,
+        impacted_blocks: ImpactedBlocks,
+        _ddef: RegionDefinition,
+    ) -> Vec<u64> {
+        /*
+         * To build the dependency list for this read, iterate from the end
+         * of the downstairs work active list in reverse order and
+         * check each job in that list to see if this new read must
+         * depend on it.
+         *
+         * Construct a list of dependencies for this read based on the
+         * following rules:
+         *
+         * - reads depend on flushes (because currently everything has to depend
+         *   on flushes)
+         * - any write with an overlap of impacted blocks requires a
+         *   dependency
+         */
+        let num_jobs = self.len();
+        let mut dep: Vec<u64> = Vec::with_capacity(num_jobs);
+
+        // Search backwards in the list of active jobs
+        for (id, job) in self.iter().rev() {
+            if job.work.is_flush() {
+                dep.push(*id);
+                break;
+            } else if (job.work.is_write() | job.work.is_repair())
+                && impacted_blocks.conflicts(&job.impacted_blocks)
+            {
+                // If this is a write or repair and it impacts the same blocks
+                // as something already active, create a dependency.
+                dep.push(*id);
+            }
+        }
+        dep
+    }
+}
+
+impl<'a> IntoIterator for &'a ActiveJobs {
+    type Item = (&'a u64, &'a DownstairsIO);
+    type IntoIter = std::collections::btree_map::Iter<'a, u64, DownstairsIO>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.jobs.iter()
+    }
+}
+
+impl Extend<(u64, DownstairsIO)> for ActiveJobs {
+    fn extend<T: IntoIterator<Item = (u64, DownstairsIO)>>(&mut self, iter: T) {
+        for (job_id, io) in iter {
+            self.insert(job_id, io);
+        }
+    }
+}

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -18,26 +18,31 @@ impl ActiveJobs {
     }
 
     /// Looks up a job by ID, returning a reference
+    #[inline]
     pub fn get(&self, job_id: &u64) -> Option<&DownstairsIO> {
         self.jobs.get(job_id)
     }
 
     /// Looks up a job by ID, returning a mutable reference
+    #[inline]
     pub fn get_mut(&mut self, job_id: &u64) -> Option<&mut DownstairsIO> {
         self.jobs.get_mut(job_id)
     }
 
     /// Returns the total number of active jobs
+    #[inline]
     pub fn len(&self) -> usize {
         self.jobs.len()
     }
 
     /// Returns `true` if no jobs are active
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.jobs.is_empty()
     }
 
     /// Returns an iterator over all active jobs
+    #[inline]
     pub fn iter_mut(
         &mut self,
     ) -> impl Iterator<Item = (&u64, &mut DownstairsIO)> {
@@ -45,6 +50,7 @@ impl ActiveJobs {
     }
 
     /// Inserts a new job ID and its associated IO work
+    #[inline]
     pub fn insert(
         &mut self,
         job_id: u64,
@@ -54,23 +60,27 @@ impl ActiveJobs {
     }
 
     /// Removes a job by ID, returning its IO work
+    #[inline]
     pub fn remove(&mut self, job_id: &u64) -> Option<DownstairsIO> {
         self.jobs.remove(job_id)
     }
 
     /// Returns an iterator over job IDs
+    #[inline]
     pub fn keys(&self) -> std::collections::btree_map::Keys<u64, DownstairsIO> {
         self.jobs.keys()
     }
 
     /// Returns an iterator over job values
     #[cfg(test)]
+    #[inline]
     pub fn values(
         &self,
     ) -> std::collections::btree_map::Values<u64, DownstairsIO> {
         self.jobs.values()
     }
 
+    #[inline]
     pub fn iter(&self) -> std::collections::btree_map::Iter<u64, DownstairsIO> {
         self.jobs.iter()
     }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -3518,13 +3518,7 @@ impl Downstairs {
      * Build a list of jobs that are ready to be acked.
      */
     fn ackable_work(&mut self) -> Vec<u64> {
-        let mut ackable = Vec::new();
-        for (ds_id, job) in &self.ds_active {
-            if job.ack_status == AckStatus::AckReady {
-                ackable.push(*ds_id);
-            }
-        }
-        ackable
+        self.ds_active.ackable_work()
     }
 
     /**

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -5486,7 +5486,8 @@ pub mod repair_test {
         let mut ds = up.downstairs.lock().await;
         // Manually move all these jobs to done.
         for job_id in 1000..1003 {
-            let mut job = ds.ds_active.get_mut(&job_id).unwrap();
+            let mut handle = ds.ds_active.get_mut(&job_id).unwrap();
+            let job = handle.job();
             for cid in 0..3 {
                 job.state.insert(cid, IOState::Done);
             }
@@ -5569,7 +5570,8 @@ pub mod repair_test {
         let mut ds = up.downstairs.lock().await;
         // Manually move all these jobs to done.
         for job_id in 1000..1003 {
-            let mut job = ds.ds_active.get_mut(&job_id).unwrap();
+            let mut handle = ds.ds_active.get_mut(&job_id).unwrap();
+            let job = handle.job();
             for cid in 0..3 {
                 job.state.insert(cid, IOState::Done);
             }
@@ -5684,7 +5686,8 @@ pub mod repair_test {
         let mut ds = up.downstairs.lock().await;
         // Manually move all these jobs to done.
         for job_id in 1000..1003 {
-            let mut job = ds.ds_active.get_mut(&job_id).unwrap();
+            let mut handle = ds.ds_active.get_mut(&job_id).unwrap();
+            let job = handle.job();
             for cid in 0..3 {
                 job.state.insert(cid, IOState::Done);
             }
@@ -5837,11 +5840,12 @@ pub mod repair_test {
 
         let mut ds = up.downstairs.lock().await;
         // Manually move this jobs to done.
-        let mut job = ds.ds_active.get_mut(&1000).unwrap();
+        let mut handle = ds.ds_active.get_mut(&1000).unwrap();
+        let job = handle.job();
         for cid in 0..3 {
             job.state.insert(cid, IOState::Done);
         }
-        drop(job);
+        drop(handle);
         drop(ds);
 
         let eid = 0;

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -807,7 +807,7 @@ pub(crate) mod up_test {
         assert_eq!(ds.ackable_work().len(), 1);
         assert_eq!(ds.completed.len(), 0);
 
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
         ds.ack(next_id);
 
@@ -1002,7 +1002,7 @@ pub(crate) mod up_test {
         assert_eq!(ds.ackable_work().len(), 1);
         assert_eq!(ds.completed.len(), 0);
 
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
         ds.ack(next_id);
 
@@ -1086,7 +1086,7 @@ pub(crate) mod up_test {
         assert_eq!(ds.ackable_work().len(), 1);
         assert_eq!(ds.completed.len(), 0);
 
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
         ds.ack(next_id);
 
@@ -1283,7 +1283,7 @@ pub(crate) mod up_test {
             // emulated run in up_ds_listen
 
             let mut ds = upstairs.downstairs.lock().await;
-            let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+            let state = ds.ds_active.get(&next_id).unwrap().ack_status;
             assert_eq!(state, AckStatus::AckReady);
             ds.ack(next_id);
 
@@ -1798,7 +1798,7 @@ pub(crate) mod up_test {
         for ds_id_done in ack_list.iter() {
             assert_eq!(*ds_id_done, next_id);
 
-            let done = ds.ds_active.get_mut(ds_id_done).unwrap();
+            let done = ds.ds_active.get(ds_id_done).unwrap();
             assert_eq!(done.ack_status, AckStatus::AckReady);
 
             assert_eq!(done.guest_id, gw_id);
@@ -1880,7 +1880,7 @@ pub(crate) mod up_test {
         for ds_id_done in ack_list.iter() {
             assert_eq!(*ds_id_done, next_id);
 
-            let done = ds.ds_active.get_mut(ds_id_done).unwrap();
+            let done = ds.ds_active.get(ds_id_done).unwrap();
             assert_eq!(done.ack_status, AckStatus::AckReady);
 
             assert_eq!(done.guest_id, gw_id);
@@ -1980,7 +1980,7 @@ pub(crate) mod up_test {
         for ds_id_done in ack_list.iter() {
             assert_eq!(*ds_id_done, next_id);
 
-            let done = ds.ds_active.get_mut(ds_id_done).unwrap();
+            let done = ds.ds_active.get(ds_id_done).unwrap();
             assert_eq!(done.ack_status, AckStatus::AckReady);
 
             assert_eq!(done.guest_id, gw_id);
@@ -2066,7 +2066,7 @@ pub(crate) mod up_test {
         for ds_id_done in ack_list.iter() {
             assert_eq!(*ds_id_done, next_id);
 
-            let done = ds.ds_active.get_mut(ds_id_done).unwrap();
+            let done = ds.ds_active.get(ds_id_done).unwrap();
             assert_eq!(done.ack_status, AckStatus::AckReady);
 
             assert_eq!(done.guest_id, gw_id);
@@ -2138,7 +2138,7 @@ pub(crate) mod up_test {
         for ds_id_done in ack_list.iter() {
             assert_eq!(*ds_id_done, next_id);
 
-            let done = ds.ds_active.get_mut(ds_id_done).unwrap();
+            let done = ds.ds_active.get(ds_id_done).unwrap();
             assert_eq!(done.ack_status, AckStatus::AckReady);
 
             assert_eq!(done.guest_id, gw_id);
@@ -2227,7 +2227,7 @@ pub(crate) mod up_test {
         for ds_id_done in ack_list.iter() {
             assert_eq!(*ds_id_done, next_id);
 
-            let done = ds.ds_active.get_mut(ds_id_done).unwrap();
+            let done = ds.ds_active.get(ds_id_done).unwrap();
             assert_eq!(done.ack_status, AckStatus::AckReady);
 
             assert_eq!(done.guest_id, gw_id);
@@ -2443,7 +2443,7 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 0);
 
         // The job should still be ack ready
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
 
         // Ack the job to the guest
@@ -2506,7 +2506,7 @@ pub(crate) mod up_test {
             )
             .unwrap());
 
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
 
         // ACK the flush and let retire_check move things along.
@@ -2559,7 +2559,7 @@ pub(crate) mod up_test {
 
         // But, don't send the ack just yet.
         // The job should be ack ready
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
 
         // A flush is required to move work to completed
@@ -2592,7 +2592,7 @@ pub(crate) mod up_test {
             .unwrap();
         }
 
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
 
         // ACK the flush and let retire_check move things along.
@@ -2941,7 +2941,7 @@ pub(crate) mod up_test {
             )
             .unwrap());
 
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
         ds.ack(next_id);
         ds.retire_check(next_id);
@@ -3190,18 +3190,18 @@ pub(crate) mod up_test {
 
         // One completion should allow for an ACK
         assert_eq!(ds.ackable_work().len(), 1);
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
 
         // Be sure the job is not yet in replay
-        assert!(!ds.ds_active.get_mut(&next_id).unwrap().replay);
+        assert!(!ds.ds_active.get(&next_id).unwrap().replay);
         ds.re_new(0);
         // Now the IO should be replay
-        assert!(ds.ds_active.get_mut(&next_id).unwrap().replay);
+        assert!(ds.ds_active.get(&next_id).unwrap().replay);
 
         // The act of taking a downstairs offline should move a read
         // back from AckReady if it was the only completed read.
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::NotAcked);
     }
 
@@ -3240,7 +3240,7 @@ pub(crate) mod up_test {
             )
             .unwrap());
         assert_eq!(ds.ackable_work().len(), 1);
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
 
         // Complete the read on a 2nd downstairs.
@@ -3263,12 +3263,12 @@ pub(crate) mod up_test {
         ds.re_new(0);
 
         // Should still be ok to ACK this IO
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
 
         // Taking the second downstairs offline should revert the ACK.
         ds.re_new(1);
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::NotAcked);
 
         // Redo the read on DS 0, IO should go back to ackable.
@@ -3287,7 +3287,7 @@ pub(crate) mod up_test {
             )
             .unwrap());
         assert_eq!(ds.ackable_work().len(), 1);
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
     }
 
@@ -3326,7 +3326,7 @@ pub(crate) mod up_test {
 
         // Verify the read is now AckReady
         assert_eq!(ds.ackable_work().len(), 1);
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
 
         // Ack the read to the guest.
@@ -3344,7 +3344,7 @@ pub(crate) mod up_test {
         ds.re_new(0);
 
         // Acked IO should remain so.
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::Acked);
 
         // Redo on DS 0, IO should remain acked.
@@ -3362,7 +3362,7 @@ pub(crate) mod up_test {
             )
             .unwrap());
         assert_eq!(ds.ackable_work().len(), 0);
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::Acked);
     }
 
@@ -3426,11 +3426,11 @@ pub(crate) mod up_test {
         ds.ack(next_id);
 
         // Before re re_new, the IO is not replay
-        assert!(!ds.ds_active.get_mut(&next_id).unwrap().replay);
+        assert!(!ds.ds_active.get(&next_id).unwrap().replay);
         // Now, take that downstairs offline
         ds.re_new(0);
         // Now the IO should be replay
-        assert!(ds.ds_active.get_mut(&next_id).unwrap().replay);
+        assert!(ds.ds_active.get(&next_id).unwrap().replay);
 
         // Move it to in-progress.
         ds.in_progress(next_id, 0);
@@ -3458,7 +3458,7 @@ pub(crate) mod up_test {
         // Some final checks.  The replay should behave in every other way
         // like a regular read.
         assert_eq!(ds.ackable_work().len(), 0);
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::Acked);
     }
 
@@ -3539,7 +3539,7 @@ pub(crate) mod up_test {
         // Now, take the second downstairs offline
         ds.re_new(1);
         // Now the IO should be replay
-        assert!(ds.ds_active.get_mut(&next_id).unwrap().replay);
+        assert!(ds.ds_active.get(&next_id).unwrap().replay);
 
         // Move it to in-progress.
         ds.in_progress(next_id, 1);
@@ -3567,7 +3567,7 @@ pub(crate) mod up_test {
         // Some final checks.  The replay should behave in every other way
         // like a regular read.
         assert_eq!(ds.ackable_work().len(), 0);
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::Acked);
     }
 
@@ -3630,19 +3630,19 @@ pub(crate) mod up_test {
             .unwrap());
 
         // Verify AckReady
-        let state = ds.ds_active.get_mut(&id1).unwrap().ack_status;
+        let state = ds.ds_active.get(&id1).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
 
         /* Now, take that downstairs offline */
         // Before re re_new, the IO is not replay
-        assert!(!ds.ds_active.get_mut(&id1).unwrap().replay);
+        assert!(!ds.ds_active.get(&id1).unwrap().replay);
         ds.re_new(1);
         // Now the IO should be replay
-        assert!(ds.ds_active.get_mut(&id1).unwrap().replay);
+        assert!(ds.ds_active.get(&id1).unwrap().replay);
 
         // Write Unwritten State goes back to NotAcked,
         // Write will remain AckReady
-        let state = ds.ds_active.get_mut(&id1).unwrap().ack_status;
+        let state = ds.ds_active.get(&id1).unwrap().ack_status;
         if is_write_unwritten {
             assert_eq!(state, AckStatus::NotAcked);
         } else {
@@ -3663,7 +3663,7 @@ pub(crate) mod up_test {
             .unwrap());
 
         // State should go back to acked.
-        let state = ds.ds_active.get_mut(&id1).unwrap().ack_status;
+        let state = ds.ds_active.get(&id1).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
     }
 
@@ -3737,7 +3737,7 @@ pub(crate) mod up_test {
         ds.re_new(0);
 
         // State should stay acked
-        let state = ds.ds_active.get_mut(&id1).unwrap().ack_status;
+        let state = ds.ds_active.get(&id1).unwrap().ack_status;
         assert_eq!(state, AckStatus::Acked);
 
         // Finish the write all the way out.
@@ -6316,8 +6316,8 @@ pub(crate) mod up_test {
             enqueue_read(&up, request.clone(), false, ds_done_tx.clone()).await;
 
         // Verify the read is all new still
-        let mut ds = up.downstairs.lock().await;
-        let job = ds.ds_active.get_mut(&read_id).unwrap();
+        let ds = up.downstairs.lock().await;
+        let job = ds.ds_active.get(&read_id).unwrap();
 
         assert_eq!(job.state.get(&0).unwrap(), &IOState::New);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::New);
@@ -6355,8 +6355,8 @@ pub(crate) mod up_test {
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 1);
 
         // Verify the read switched from new to skipped
-        let mut ds = up.downstairs.lock().await;
-        let job = ds.ds_active.get_mut(&read_id).unwrap();
+        let ds = up.downstairs.lock().await;
+        let job = ds.ds_active.get(&read_id).unwrap();
 
         assert_eq!(job.state.get(&0).unwrap(), &IOState::New);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::Skipped);
@@ -6423,8 +6423,8 @@ pub(crate) mod up_test {
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 1);
 
         // Verify the read switched from new to skipped
-        let mut ds = up.downstairs.lock().await;
-        let job = ds.ds_active.get_mut(&read_id).unwrap();
+        let ds = up.downstairs.lock().await;
+        let job = ds.ds_active.get(&read_id).unwrap();
 
         assert_eq!(job.state.get(&0).unwrap(), &IOState::InProgress);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::Skipped);
@@ -6476,11 +6476,11 @@ pub(crate) mod up_test {
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 2);
 
         // Verify all IOs are done
-        let mut ds = up.downstairs.lock().await;
+        let ds = up.downstairs.lock().await;
         for cid in 0..3 {
-            let job = ds.ds_active.get_mut(&read_one).unwrap();
+            let job = ds.ds_active.get(&read_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
-            let job = ds.ds_active.get_mut(&write_one).unwrap();
+            let job = ds.ds_active.get(&write_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
         }
         assert_eq!(ds.ds_skipped_jobs[0].len(), 0);
@@ -6514,14 +6514,14 @@ pub(crate) mod up_test {
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 3);
 
         // Verify all IOs are done
-        let mut ds = up.downstairs.lock().await;
+        let ds = up.downstairs.lock().await;
         for cid in 0..3 {
-            let job = ds.ds_active.get_mut(&read_one).unwrap();
+            let job = ds.ds_active.get(&read_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
-            let job = ds.ds_active.get_mut(&write_one).unwrap();
+            let job = ds.ds_active.get(&write_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
         }
-        let job = ds.ds_active.get_mut(&write_fail).unwrap();
+        let job = ds.ds_active.get(&write_fail).unwrap();
         assert_eq!(job.state.get(&0).unwrap(), &IOState::Done);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::Done);
         assert_eq!(
@@ -6579,11 +6579,11 @@ pub(crate) mod up_test {
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 2);
 
         // Verify all IOs are done
-        let mut ds = up.downstairs.lock().await;
+        let ds = up.downstairs.lock().await;
         for cid in 0..3 {
-            let job = ds.ds_active.get_mut(&read_one).unwrap();
+            let job = ds.ds_active.get(&read_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
-            let job = ds.ds_active.get_mut(&write_one).unwrap();
+            let job = ds.ds_active.get(&write_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
         }
         drop(ds);
@@ -6618,17 +6618,17 @@ pub(crate) mod up_test {
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 3);
 
         // Verify all IOs are done
-        let mut ds = up.downstairs.lock().await;
+        let ds = up.downstairs.lock().await;
         for cid in 0..3 {
             // First read, still Done
-            let job = ds.ds_active.get_mut(&read_one).unwrap();
+            let job = ds.ds_active.get(&read_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
             // First write, still Done
-            let job = ds.ds_active.get_mut(&write_one).unwrap();
+            let job = ds.ds_active.get(&write_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
         }
         // The failing write, done on 0,1
-        let job = ds.ds_active.get_mut(&write_fail).unwrap();
+        let job = ds.ds_active.get(&write_fail).unwrap();
         assert_eq!(job.state.get(&0).unwrap(), &IOState::Done);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::Done);
         // The failing write, error on 2
@@ -6638,7 +6638,7 @@ pub(crate) mod up_test {
         );
 
         // The reads that were in progress
-        let job = ds.ds_active.get_mut(&read_two).unwrap();
+        let job = ds.ds_active.get(&read_two).unwrap();
         assert_eq!(job.state.get(&0).unwrap(), &IOState::InProgress);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::InProgress);
         assert_eq!(job.state.get(&2).unwrap(), &IOState::Skipped);
@@ -6677,18 +6677,18 @@ pub(crate) mod up_test {
 
         let flush_one = enqueue_flush(&up, false, ds_done_tx.clone()).await;
 
-        let mut ds = up.downstairs.lock().await;
-        let job = ds.ds_active.get_mut(&write_one).unwrap();
+        let ds = up.downstairs.lock().await;
+        let job = ds.ds_active.get(&write_one).unwrap();
         assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::New);
         assert_eq!(job.state.get(&2).unwrap(), &IOState::New);
 
-        let job = ds.ds_active.get_mut(&read_one).unwrap();
+        let job = ds.ds_active.get(&read_one).unwrap();
         assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::New);
         assert_eq!(job.state.get(&2).unwrap(), &IOState::New);
 
-        let job = ds.ds_active.get_mut(&flush_one).unwrap();
+        let job = ds.ds_active.get(&flush_one).unwrap();
         assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::New);
         assert_eq!(job.state.get(&2).unwrap(), &IOState::New);
@@ -6729,18 +6729,18 @@ pub(crate) mod up_test {
         // Finally, add a flush
         let flush_one = enqueue_flush(&up, true, ds_done_tx.clone()).await;
 
-        let mut ds = up.downstairs.lock().await;
-        let job = ds.ds_active.get_mut(&write_one).unwrap();
+        let ds = up.downstairs.lock().await;
+        let job = ds.ds_active.get(&write_one).unwrap();
         assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::InProgress);
         assert_eq!(job.state.get(&2).unwrap(), &IOState::InProgress);
 
-        let job = ds.ds_active.get_mut(&read_one).unwrap();
+        let job = ds.ds_active.get(&read_one).unwrap();
         assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::InProgress);
         assert_eq!(job.state.get(&2).unwrap(), &IOState::InProgress);
 
-        let job = ds.ds_active.get_mut(&flush_one).unwrap();
+        let job = ds.ds_active.get(&flush_one).unwrap();
         assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::InProgress);
         assert_eq!(job.state.get(&2).unwrap(), &IOState::InProgress);
@@ -6783,13 +6783,13 @@ pub(crate) mod up_test {
         // Verify all IOs are done
         let mut ds = up.downstairs.lock().await;
 
-        let job = ds.ds_active.get_mut(&read_one).unwrap();
+        let job = ds.ds_active.get(&read_one).unwrap();
         assert_eq!(job.state.get(&1).unwrap(), &IOState::Done);
         assert_eq!(job.state.get(&2).unwrap(), &IOState::Done);
-        let job = ds.ds_active.get_mut(&write_one).unwrap();
+        let job = ds.ds_active.get(&write_one).unwrap();
         assert_eq!(job.state.get(&1).unwrap(), &IOState::Done);
         assert_eq!(job.state.get(&2).unwrap(), &IOState::Done);
-        let job = ds.ds_active.get_mut(&flush_one).unwrap();
+        let job = ds.ds_active.get(&flush_one).unwrap();
         assert_eq!(job.state.get(&1).unwrap(), &IOState::Done);
         assert_eq!(job.state.get(&2).unwrap(), &IOState::Done);
 
@@ -6842,18 +6842,18 @@ pub(crate) mod up_test {
         // Finally, add a flush
         let flush_one = enqueue_flush(&up, true, ds_done_tx.clone()).await;
 
-        let mut ds = up.downstairs.lock().await;
-        let job = ds.ds_active.get_mut(&write_one).unwrap();
+        let ds = up.downstairs.lock().await;
+        let job = ds.ds_active.get(&write_one).unwrap();
         assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::InProgress);
         assert_eq!(job.state.get(&2).unwrap(), &IOState::Skipped);
 
-        let job = ds.ds_active.get_mut(&read_one).unwrap();
+        let job = ds.ds_active.get(&read_one).unwrap();
         assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::InProgress);
         assert_eq!(job.state.get(&2).unwrap(), &IOState::Skipped);
 
-        let job = ds.ds_active.get_mut(&flush_one).unwrap();
+        let job = ds.ds_active.get(&flush_one).unwrap();
         assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::InProgress);
         assert_eq!(job.state.get(&2).unwrap(), &IOState::Skipped);
@@ -6887,11 +6887,11 @@ pub(crate) mod up_test {
         // Verify all IOs are done
         let mut ds = up.downstairs.lock().await;
 
-        let job = ds.ds_active.get_mut(&read_one).unwrap();
+        let job = ds.ds_active.get(&read_one).unwrap();
         assert_eq!(job.state.get(&1).unwrap(), &IOState::Done);
-        let job = ds.ds_active.get_mut(&write_one).unwrap();
+        let job = ds.ds_active.get(&write_one).unwrap();
         assert_eq!(job.state.get(&1).unwrap(), &IOState::Done);
-        let job = ds.ds_active.get_mut(&flush_one).unwrap();
+        let job = ds.ds_active.get(&flush_one).unwrap();
         assert_eq!(job.state.get(&1).unwrap(), &IOState::Done);
 
         ds.ack(read_one);
@@ -6940,8 +6940,8 @@ pub(crate) mod up_test {
         let read_one =
             enqueue_read(&up, request.clone(), false, ds_done_tx.clone()).await;
 
-        let mut ds = up.downstairs.lock().await;
-        let job = ds.ds_active.get_mut(&read_one).unwrap();
+        let ds = up.downstairs.lock().await;
+        let job = ds.ds_active.get(&read_one).unwrap();
         assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&2).unwrap(), &IOState::Skipped);
@@ -6989,8 +6989,8 @@ pub(crate) mod up_test {
         // Create a write.
         let write_one = enqueue_write(&up, true, ds_done_tx.clone()).await;
 
-        let mut ds = up.downstairs.lock().await;
-        let job = ds.ds_active.get_mut(&write_one).unwrap();
+        let ds = up.downstairs.lock().await;
+        let job = ds.ds_active.get(&write_one).unwrap();
         assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&2).unwrap(), &IOState::Skipped);
@@ -7038,8 +7038,8 @@ pub(crate) mod up_test {
         // Create a flush.
         let flush_one = enqueue_flush(&up, false, ds_done_tx.clone()).await;
 
-        let mut ds = up.downstairs.lock().await;
-        let job = ds.ds_active.get_mut(&flush_one).unwrap();
+        let ds = up.downstairs.lock().await;
+        let job = ds.ds_active.get(&flush_one).unwrap();
         assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&1).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&2).unwrap(), &IOState::Skipped);

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -7377,7 +7377,7 @@ pub(crate) mod up_test {
         // ----|-------|-----
         //   0 | W     |
         //   1 | FFFFF | 0
-        //   2 | W     | 1
+        //   2 | W     | 0,1
 
         let upstairs = make_upstairs();
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
@@ -7421,7 +7421,10 @@ pub(crate) mod up_test {
 
         assert!(jobs[0].work.deps().is_empty()); // write (op 0)
         assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // flush (op 1)
-        assert_eq!(jobs[2].work.deps(), &[jobs[1].ds_id]); // write (op 2)
+        assert_eq!(
+            hashset(jobs[2].work.deps()),
+            hashset(&[jobs[0].ds_id, jobs[1].ds_id]),
+        ); // write (op 2)
     }
 
     #[tokio::test]
@@ -8014,9 +8017,9 @@ pub(crate) mod up_test {
         //   1 | W     | 0
         //   2 |   W   | 0
         //   3 | FFFFF | 0,1,2
-        //   4 | W     | 3
-        //   5 |   W   | 3
-        //   6 |     W | 3
+        //   4 | W     | 0,1,3
+        //   5 |   W   | 0,2,3
+        //   6 |     W | 0,3
         //   7 | FFFFF | 3,4,5,6
 
         let upstairs = make_upstairs();
@@ -8085,9 +8088,20 @@ pub(crate) mod up_test {
             hashset(&[jobs[0].ds_id, jobs[1].ds_id, jobs[2].ds_id]),
         ); // flush (op 3)
 
-        assert_eq!(jobs[4].work.deps(), &[jobs[3].ds_id]); // write (op 4)
-        assert_eq!(jobs[5].work.deps(), &[jobs[3].ds_id]); // write (op 5)
-        assert_eq!(jobs[6].work.deps(), &[jobs[3].ds_id]); // write (op 6)
+        assert_eq!(
+            hashset(jobs[4].work.deps()),
+            hashset(&[jobs[0].ds_id, jobs[1].ds_id, jobs[3].ds_id]),
+        ); // write (op 4)
+
+        assert_eq!(
+            hashset(jobs[5].work.deps()),
+            hashset(&[jobs[0].ds_id, jobs[2].ds_id, jobs[3].ds_id]),
+        ); // write (op 5)
+
+        assert_eq!(
+            hashset(jobs[6].work.deps()),
+            hashset(&[jobs[0].ds_id, jobs[3].ds_id]),
+        ); // write (op 6)
 
         assert_eq!(
             hashset(jobs[7].work.deps()), // flush (op 7)
@@ -8807,7 +8821,7 @@ pub(crate) mod up_test {
         // ----|----------------|-----
         //   0 |  R  R          |
         //   1 | FFFFFFFFFFFFFFF| 0
-        //   2 |     W  W       | 1
+        //   2 |     W  W       | 0,1
 
         let upstairs = make_upstairs();
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
@@ -8854,7 +8868,10 @@ pub(crate) mod up_test {
         // assert flush depends on the read
         assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // op 1
 
-        // assert write depends on just the flush
-        assert_eq!(jobs[2].work.deps(), &[jobs[1].ds_id]); // op 2
+        // assert write depends on both the read and flush
+        assert_eq!(
+            hashset(jobs[2].work.deps()),
+            hashset(&[jobs[0].ds_id, jobs[1].ds_id])
+        ); // op 2
     }
 }

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -7300,7 +7300,7 @@ pub(crate) mod up_test {
         assert_eq!(jobs.len(), 2);
 
         assert!(jobs[0].work.deps().is_empty());
-        assert_eq!(jobs[1].work.deps(), &vec![jobs[0].ds_id]);
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]);
     }
 
     #[tokio::test]
@@ -7361,7 +7361,7 @@ pub(crate) mod up_test {
         assert_eq!(jobs.len(), 3);
 
         assert!(jobs[0].work.deps().is_empty());
-        assert_eq!(jobs[1].work.deps(), &vec![jobs[0].ds_id]);
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]);
         assert_eq!(
             hashset(jobs[2].work.deps()),
             hashset(&[jobs[0].ds_id, jobs[1].ds_id]),
@@ -7421,7 +7421,7 @@ pub(crate) mod up_test {
 
         assert!(jobs[0].work.deps().is_empty()); // write (op 0)
         assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // flush (op 1)
-        assert_eq!(hashset(jobs[2].work.deps()), hashset(&[jobs[1].ds_id]),); // write (op 2)
+        assert_eq!(jobs[2].work.deps(), &[jobs[1].ds_id]); // write (op 2)
     }
 
     #[tokio::test]
@@ -8077,19 +8077,17 @@ pub(crate) mod up_test {
 
         assert!(jobs[0].work.deps().is_empty()); // flush (op 0)
 
-        assert_eq!(jobs[1].work.deps(), &vec![jobs[0].ds_id]); // write (op 1)
-        assert_eq!(jobs[2].work.deps(), &vec![jobs[0].ds_id]); // write (op 2)
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // write (op 1)
+        assert_eq!(jobs[2].work.deps(), &[jobs[0].ds_id]); // write (op 2)
 
         assert_eq!(
             hashset(jobs[3].work.deps()),
             hashset(&[jobs[0].ds_id, jobs[1].ds_id, jobs[2].ds_id]),
         ); // flush (op 3)
 
-        assert_eq!(hashset(jobs[4].work.deps()), hashset(&[jobs[3].ds_id]),); // write (op 4)
-
-        assert_eq!(hashset(jobs[5].work.deps()), hashset(&[jobs[3].ds_id]),); // write (op 5)
-
-        assert_eq!(hashset(jobs[6].work.deps()), hashset(&[jobs[3].ds_id]),); // write (op 6)
+        assert_eq!(jobs[4].work.deps(), &[jobs[3].ds_id]); // write (op 4)
+        assert_eq!(jobs[5].work.deps(), &[jobs[3].ds_id]); // write (op 5)
+        assert_eq!(jobs[6].work.deps(), &[jobs[3].ds_id]); // write (op 6)
 
         assert_eq!(
             hashset(jobs[7].work.deps()), // flush (op 7)
@@ -8146,7 +8144,7 @@ pub(crate) mod up_test {
         assert_eq!(jobs.len(), 2);
 
         assert!(jobs[0].work.deps().is_empty()); // op 0
-        assert_eq!(jobs[1].work.deps(), &vec![jobs[0].ds_id]); // op 1
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // op 1
     }
 
     #[tokio::test]
@@ -8205,8 +8203,8 @@ pub(crate) mod up_test {
         assert_eq!(jobs.len(), 3);
 
         assert!(jobs[0].work.deps().is_empty()); // op 0
-        assert_eq!(jobs[1].work.deps(), &vec![jobs[0].ds_id]); // op 1
-        assert_eq!(jobs[2].work.deps(), &vec![jobs[1].ds_id]); // op 2
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // op 1
+        assert_eq!(jobs[2].work.deps(), &[jobs[1].ds_id]); // op 2
     }
 
     #[tokio::test]
@@ -8303,13 +8301,13 @@ pub(crate) mod up_test {
         assert_eq!(jobs.len(), 6);
 
         assert!(jobs[0].work.deps().is_empty()); // op 0
-        assert_eq!(jobs[1].work.deps(), &vec![jobs[0].ds_id]); // op 1
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // op 1
 
         assert!(jobs[2].work.deps().is_empty()); // op 2
-        assert_eq!(jobs[3].work.deps(), &vec![jobs[2].ds_id]); // op 3
+        assert_eq!(jobs[3].work.deps(), &[jobs[2].ds_id]); // op 3
 
         assert!(jobs[4].work.deps().is_empty()); // op 4
-        assert_eq!(jobs[5].work.deps(), &vec![jobs[4].ds_id]); // op 5
+        assert_eq!(jobs[5].work.deps(), &[jobs[4].ds_id]); // op 5
     }
 
     #[tokio::test]
@@ -8350,10 +8348,10 @@ pub(crate) mod up_test {
         assert_eq!(jobs.len(), 5);
 
         assert!(jobs[0].work.deps().is_empty()); // op 0
-        assert_eq!(jobs[1].work.deps(), &vec![jobs[0].ds_id]); // op 1
-        assert_eq!(jobs[2].work.deps(), &vec![jobs[1].ds_id]); // op 2
-        assert_eq!(jobs[3].work.deps(), &vec![jobs[2].ds_id]); // op 3
-        assert_eq!(jobs[4].work.deps(), &vec![jobs[3].ds_id]); // op 4
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // op 1
+        assert_eq!(jobs[2].work.deps(), &[jobs[1].ds_id]); // op 2
+        assert_eq!(jobs[3].work.deps(), &[jobs[2].ds_id]); // op 3
+        assert_eq!(jobs[4].work.deps(), &[jobs[3].ds_id]); // op 4
     }
 
     #[tokio::test]
@@ -8394,10 +8392,10 @@ pub(crate) mod up_test {
         assert_eq!(jobs.len(), 5);
 
         assert!(jobs[0].work.deps().is_empty()); // op 0
-        assert_eq!(jobs[1].work.deps(), &vec![jobs[0].ds_id]); // op 1
-        assert_eq!(jobs[2].work.deps(), &vec![jobs[1].ds_id]); // op 2
-        assert_eq!(jobs[3].work.deps(), &vec![jobs[2].ds_id]); // op 3
-        assert_eq!(jobs[4].work.deps(), &vec![jobs[3].ds_id]); // op 4
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // op 1
+        assert_eq!(jobs[2].work.deps(), &[jobs[1].ds_id]); // op 2
+        assert_eq!(jobs[3].work.deps(), &[jobs[2].ds_id]); // op 3
+        assert_eq!(jobs[4].work.deps(), &[jobs[3].ds_id]); // op 4
     }
 
     #[tokio::test]
@@ -8535,8 +8533,8 @@ pub(crate) mod up_test {
 
         // confirm deps
         assert!(jobs[0].work.deps().is_empty()); // op 0
-        assert_eq!(jobs[1].work.deps(), &vec![jobs[0].ds_id]); // op 1
-        assert_eq!(jobs[2].work.deps(), &vec![jobs[1].ds_id]); // op 2
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // op 1
+        assert_eq!(jobs[2].work.deps(), &[jobs[1].ds_id]); // op 2
     }
 
     #[tokio::test]
@@ -8638,8 +8636,8 @@ pub(crate) mod up_test {
         );
 
         assert!(jobs[0].work.deps().is_empty()); // op 0
-        assert_eq!(jobs[1].work.deps(), &vec![jobs[0].ds_id]); // op 1
-        assert_eq!(jobs[2].work.deps(), &vec![jobs[1].ds_id]); // op 2
+        assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // op 1
+        assert_eq!(jobs[2].work.deps(), &[jobs[1].ds_id]); // op 2
         assert_eq!(
             hashset(jobs[3].work.deps()),
             hashset(&[jobs[1].ds_id, jobs[2].ds_id])
@@ -8856,7 +8854,7 @@ pub(crate) mod up_test {
         // assert flush depends on the read
         assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // op 1
 
-        // assert write depends on both the read and flush
-        assert_eq!(hashset(jobs[2].work.deps()), hashset(&[jobs[1].ds_id])); // op 2
+        // assert write depends on just the flush
+        assert_eq!(jobs[2].work.deps(), &[jobs[1].ds_id]); // op 2
     }
 }

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -7377,7 +7377,7 @@ pub(crate) mod up_test {
         // ----|-------|-----
         //   0 | W     |
         //   1 | FFFFF | 0
-        //   2 | W     | 0,1
+        //   2 | W     | 1
 
         let upstairs = make_upstairs();
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
@@ -7421,10 +7421,7 @@ pub(crate) mod up_test {
 
         assert!(jobs[0].work.deps().is_empty()); // write (op 0)
         assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // flush (op 1)
-        assert_eq!(
-            hashset(jobs[2].work.deps()),
-            hashset(&[jobs[0].ds_id, jobs[1].ds_id]),
-        ); // write (op 2)
+        assert_eq!(hashset(jobs[2].work.deps()), hashset(&[jobs[1].ds_id]),); // write (op 2)
     }
 
     #[tokio::test]
@@ -8017,9 +8014,9 @@ pub(crate) mod up_test {
         //   1 | W     | 0
         //   2 |   W   | 0
         //   3 | FFFFF | 0,1,2
-        //   4 | W     | 0,1,3
-        //   5 |   W   | 0,2,3
-        //   6 |     W | 0,3
+        //   4 | W     | 3
+        //   5 |   W   | 3
+        //   6 |     W | 3
         //   7 | FFFFF | 3,4,5,6
 
         let upstairs = make_upstairs();
@@ -8088,20 +8085,11 @@ pub(crate) mod up_test {
             hashset(&[jobs[0].ds_id, jobs[1].ds_id, jobs[2].ds_id]),
         ); // flush (op 3)
 
-        assert_eq!(
-            hashset(jobs[4].work.deps()),
-            hashset(&[jobs[0].ds_id, jobs[1].ds_id, jobs[3].ds_id]),
-        ); // write (op 4)
+        assert_eq!(hashset(jobs[4].work.deps()), hashset(&[jobs[3].ds_id]),); // write (op 4)
 
-        assert_eq!(
-            hashset(jobs[5].work.deps()),
-            hashset(&[jobs[0].ds_id, jobs[2].ds_id, jobs[3].ds_id]),
-        ); // write (op 5)
+        assert_eq!(hashset(jobs[5].work.deps()), hashset(&[jobs[3].ds_id]),); // write (op 5)
 
-        assert_eq!(
-            hashset(jobs[6].work.deps()),
-            hashset(&[jobs[0].ds_id, jobs[3].ds_id]),
-        ); // write (op 6)
+        assert_eq!(hashset(jobs[6].work.deps()), hashset(&[jobs[3].ds_id]),); // write (op 6)
 
         assert_eq!(
             hashset(jobs[7].work.deps()), // flush (op 7)
@@ -8821,7 +8809,7 @@ pub(crate) mod up_test {
         // ----|----------------|-----
         //   0 |  R  R          |
         //   1 | FFFFFFFFFFFFFFF| 0
-        //   2 |     W  W       | 0,1
+        //   2 |     W  W       | 1
 
         let upstairs = make_upstairs();
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
@@ -8869,9 +8857,6 @@ pub(crate) mod up_test {
         assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // op 1
 
         // assert write depends on both the read and flush
-        assert_eq!(
-            hashset(jobs[2].work.deps()),
-            hashset(&[jobs[0].ds_id, jobs[1].ds_id])
-        ); // op 2
+        assert_eq!(hashset(jobs[2].work.deps()), hashset(&[jobs[1].ds_id])); // op 2
     }
 }


### PR DESCRIPTION
This PR does two things:

First, it moves `ds_active` from a `BTreeMap<u64, DownstairsIO>` into an opaque `ActiveJobs` data structure that exposes a very similar API to the user.  This data structure exposes functions like `deps_for_{read,write,flush}`, which gives us room for future optimization.

Dependency tracking remains identical to before, albeit in a new location (this means that #893 remains an issue).

Second, ackable jobs are now tracked in a `BTreeSet<u64>`, inside the new `struct ActiveJobs`.

Here's the motivation: the longest-running tests (`test_successful_live_repair` and `test_error_during_live_repair_no_halt`) are spending a huge amount of time in `ackable_work`, because each call iterates over every single active job:

<img width="956" alt="Screenshot 2023-09-07 at 10 08 36 AM" src="https://github.com/oxidecomputer/crucible/assets/745333/d660d27b-d4fc-474c-b70d-8d67ba0c5019">

However, tracking ackable jobs in a separate set is tricky, because existing code expects to modify a `&mut DownstairsIO` directly (and can therefore change its `ack_status` willy-nilly).

Instead of relying on users to do this right, I changed `ActiveJobs` to never hand out an uncontrolled `&mut DownstairsIO`.  Instead, it provides a new `struct DownstairsIOHandle`.  This handle wraps a `&mut DownstairsIO`, but also guarantees (on drop) that the list of ackable jobs is correctly updated; as such, it borrows from the parent `ActiveJobs`, so this is all checked by the borrow checker.

The result is that `test_successful_live_repair` goes from 33 seconds down to about 21 (in `cargo test --release`).

I've got more advanced optimizations planned, but this seems like a reasonable point to open a PR.