### PR TITLE
Make flushes a dependancy barrier to writes

### DIFF
--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -148,7 +148,8 @@ impl ActiveJobs {
          *
          * - writes have to depend on the last flush completing (because
          *   currently everything has to depend on flushes)
-         * - any overlap of impacted blocks requires a dependency
+         * - any overlap of impacted blocks before the flush requires a
+         *   dependency
          *
          * It's important to remember that jobs may arrive at different
          * Downstairs in different orders but they should still complete in job
@@ -179,6 +180,7 @@ impl ActiveJobs {
             // all writes.
             if job.work.is_flush() {
                 dep.push(*id);
+                break;
             }
 
             // If this job impacts the same blocks as something already active,


### PR DESCRIPTION
This PR is staged on top of #908 and should be rebased once that one is merged; until then, only look at the final commit (e5adcba657d9669fa5ebca3953304dc92878ab20) or look at the [diff](https://github.com/oxidecomputer/crucible/compare/mkeeter:active-jobs-optimization...mkeeter:crucible:write-flush-break)

This PR changes `deps_for_write` to stop checking dependencies when it encounters the first `flush`, and updates unit tests accordingly.  Flushes depend on _everything_ (ever since #658), so this is safe.  This didn't used to be safe – in fact, we had a `break` in this position earlier, but had to remove it (in #648).

This is a significant win for the `crutest` `rwrite` benchmark.  Running on a Gimlet, I see a 10-12% speedup for `rwrites`:
```
    TEST SECONDS COUNT DPTH    IOPS    MEAN     P95     P99      MAX    ES    EC
 rwrites    6.04 30000    1 4968.51 0.00020 0.00029 0.00044  0.01652 16384   640
 rwrites    6.08 30000    1 4935.92 0.00020 0.00029 0.00051  0.01466 16384   640
 rwrites    6.34 30000    1 4734.38 0.00021 0.00032 0.00067  0.01469 16384  1280
 rwrites    6.51 30000    1 4608.46 0.00022 0.00032 0.00069  0.01945 16384  1280

    TEST SECONDS COUNT DPTH    IOPS    MEAN     P95     P99      MAX    ES    EC
  rreads    6.72 30000    1 4463.29 0.00022 0.00026 0.00030  0.01548 16384   640
  rreads    6.68 30000    1 4492.61 0.00022 0.00026 0.00030  0.01548 16384   640
  rreads    6.84 30000    1 4384.87 0.00023 0.00027 0.00031  0.01300 16384  1280
  rreads    6.71 30000    1 4473.39 0.00023 0.00026 0.00030  0.01525 16384  1280
```
compared with `main`:
```
    TEST SECONDS COUNT DPTH    IOPS    MEAN     P95     P99      MAX    ES    EC
 rwrites    7.23 30000    1 4149.00 0.00024 0.00031 0.00066  0.03090 16384   640
 rwrites    7.06 30000    1 4247.18 0.00024 0.00031 0.00063  0.01267 16384   640
 rwrites    7.83 30000    1 3830.61 0.00026 0.00037 0.00085  0.01707 16384  1280
 rwrites    7.77 30000    1 3859.72 0.00026 0.00036 0.00091  0.02224 16384  1280

    TEST SECONDS COUNT DPTH    IOPS    MEAN     P95     P99      MAX    ES    EC
  rreads    7.05 30000    1 4256.52 0.00023 0.00028 0.00032  0.01472 16384   640
  rreads    7.02 30000    1 4274.78 0.00023 0.00028 0.00032  0.01472 16384   640
  rreads    7.23 30000    1 4149.40 0.00024 0.00028 0.00033  0.01420 16384  1280
  rreads    7.13 30000    1 4210.47 0.00024 0.00028 0.00033  0.01429 16384  1280
```
(this is running `tools/test_perf.sh` with small modifications to put the 3 downstairs on separate U.2 drives)

The downside to this optimization is that it speeds up write submission to the upstairs, so we end up with a deeper write queue.  Here's the result of `tools/dtrace/upstairs_info.d` when running the above test:
```
       DS STATE 0        DS STATE 1        DS STATE 2   UPW  DSW  NEW0 NEW1 NEW2   IP0  IP1  IP2    D0   D1   D2    S0   S1   S2  E0 E1 E2
              new               new               new     0    0     0    0    0     0    0    0     0    0    0     0    0    0   0  0  0
           active            active            active     0    0     0    0    0     0    0    0     0    0    0     0    0    0   0  0  0
           active            active            active     0    0     0    0    0     0    0    0     0    0    0     0    0    0   0  0  0
           active            active            active     1 2731     0    0    0  1684 1691 1717  1047 1040 1014     0    0    0   0  0  0
           active            active            active     2 5376   652  544  609  2600 2600 2600  2124 2232 2167     0    0    0   0  0  0
           active            active            active     1 5158  1423 1395 1402  2600 2600 2600  1135 1163 1156     0    0    0   0  0  0
           active            active            active     2 7348  2514 2402 2353  2600 2599 2600  2234 2347 2395     0    0    0   0  0  0
           active            active            active     2 6766  3128 3002 2904  2599 2599 2600  1039 1165 1262     0    0    0   0  0  0
           active            active            active     2 6610  3683 3547 3442  2599 2599 2600   328  464  568     0    0    0   0  0  0
           active            active            active     2 5870  2271 2087 2029  1371 1472 1421  2228 2311 2420     0    0    0   0  0  0
           active            active            active     1 1374     0    0    0  1374 1294 1235     0   80  139     0    0    0   0  0  0
           active            active            active     0    0     0    0    0     0    0    0     0    0    0     0    0    0   0  0  0
```
versus on `main`:
```
       DS STATE 0        DS STATE 1        DS STATE 2   UPW  DSW  NEW0 NEW1 NEW2   IP0  IP1  IP2    D0   D1   D2    S0   S1   S2  E0 E1 E2
              new               new               new     0    0     0    0    0     0    0    0     0    0    0     0    0    0   0  0  0
           active            active            active     0    0     0    0    0     0    0    0     0    0    0     0    0    0   0  0  0
           active            active            active     0    0     0    0    0     0    0    0     0    0    0     0    0    0   0  0  0
           active            active            active     0 2314     0    0    0   679  660  718  1635 1654 1596     0    0    0   0  0  0
           active            active            active     1 2040     1    1    0  1263 1259 1291   776  780  749     0    0    0   0  0  0
           active            active            active     0 1968     0    0    0  1438 1447 1508   530  521  460     0    0    0   0  0  0
           active            active            active     1 1940     1    1    1  1497 1461 1531   442  478  408     0    0    0   0  0  0
           active            active            active     1 2070     1    1    1  1342 1271 1400   727  798  669     0    0    0   0  0  0
           active            active            active     0 2120     0    0    0  1372 1194 1457   748  926  663     0    0    0   0  0  0
           active            active            active     0 2062     0    0    0  1436 1212 1486   626  850  576     0    0    0   0  0  0
           active            active            active     0    0     0    0    0     0    0    0     0    0    0     0    0    0   0  0  0
```

Iterating through every item in `ds_active` (instead of breaking out of the loop at the first flush) was effectively acting as backpressure, since each new item required `O(ds_active.len())` operations.  With that backpressure removed, writes are faster but the queue becomes deeper.

I think this is still worth doing; if we want backpressure, we should do it intentionally and not accidentally!

Marking this as a draft until #908 is merged and this is rebased, to prevent accidental merging.