### PR TITLE
Fast dependency checking

### DIFF
--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -183,6 +183,8 @@ impl RegionDefinition {
     }
 
     pub fn set_block_size(&mut self, bs: u64) {
+        // TODO(matt) this is also stored in self.extent_size.shift, which seems
+        // like bad duplication of state.
         self.block_size = bs;
     }
 

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -5712,7 +5712,7 @@ mod test {
 
         // Add one job, id 1000
         let rio = IOop::Read {
-            dependencies: vec![],
+            dependencies: Vec::new(),
             requests: vec![ReadRequest {
                 eid: 0,
                 offset: Block::new_512(1),
@@ -5807,7 +5807,7 @@ mod test {
 
         // Add one job, id 1000
         let rio = IOop::Read {
-            dependencies: vec![],
+            dependencies: Vec::new(),
             requests: vec![ReadRequest {
                 eid: 0,
                 offset: Block::new_512(1),
@@ -5902,7 +5902,7 @@ mod test {
 
         // Add one job, id 1000
         let rio = IOop::Read {
-            dependencies: vec![],
+            dependencies: Vec::new(),
             requests: vec![ReadRequest {
                 eid: 0,
                 offset: Block::new_512(1),

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -148,7 +148,8 @@ impl ActiveJobs {
          *
          * - writes have to depend on the last flush completing (because
          *   currently everything has to depend on flushes)
-         * - any overlap of impacted blocks requires a dependency
+         * - any overlap of impacted blocks before the flush requires a
+         *   dependency
          *
          * It's important to remember that jobs may arrive at different
          * Downstairs in different orders but they should still complete in job
@@ -179,6 +180,7 @@ impl ActiveJobs {
             // all writes.
             if job.work.is_flush() {
                 dep.push(*id);
+                break;
             }
 
             // If this job impacts the same blocks as something already active,

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -297,9 +297,34 @@ impl Dependencies {
     pub fn take(self) -> Vec<u64> {
         self.0
     }
-    #[cfg(test)]
+    /// Creates a new, empty set of dependencies
+    ///
+    /// Using this outside of unit tests is forbidden, since that would let you
+    /// violate the rule that dependencies must be tracked; however, we can't
+    /// make it private because `Dependencies::empty` is called by unit tests
+    /// outside of this crate.
+    //TODO(matt) do some feature magic to hide this
     pub fn empty() -> Self {
         Self(vec![])
+    }
+    /// Converts from a `Vec` to a dependency list
+    ///
+    /// This must only be called at API boundaries, and should not be used to
+    /// build new sets of dependencies willy-nilly.
+    pub fn from_vec(v: Vec<u64>) -> Self {
+        Self(v)
+    }
+    pub fn iter(&self) -> impl Iterator<Item = &u64> {
+        self.0.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Dependencies {
+    type Item = &'a u64;
+    type IntoIter = std::slice::Iter<'a, u64>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
     }
 }
 

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -392,18 +392,29 @@ impl BlockMap {
         // new range:          |============|
         // result:               |--------|
 
-        let mut split_start = None;
-        let mut split_end = None;
-        for (start, (end, _set)) in self.iter_overlapping(r.clone()) {
-            if r.start >= *start && r.start < *end {
-                assert!(split_start.is_none());
-                split_start = Some(*start);
+        let split_start = if let Some((start, (end, _))) =
+            self.addr_to_jobs.range(..r.start).rev().next()
+        {
+            if r.start < *end {
+                Some(*start)
+            } else {
+                None
             }
-            if r.end >= *start && r.end < *end {
-                assert!(split_end.is_none());
-                split_end = Some(*start);
+        } else {
+            None
+        };
+
+        let mut split_end = if let Some((start, (end, _))) =
+            self.addr_to_jobs.range(..r.end).rev().next()
+        {
+            if r.end < *end {
+                Some(*start)
+            } else {
+                None
             }
-        }
+        } else {
+            None
+        };
 
         // Now, we apply those splits
         if let Some(s) = split_start {

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -74,7 +74,8 @@ impl ActiveJobs {
             | IOop::Flush { .. }
             | IOop::ExtentLiveNoOp { .. }
             | IOop::ExtentFlushClose { .. }
-            | IOop::ExtentLiveReopen { .. } => true,
+            | IOop::ExtentLiveReopen { .. }
+            | IOop::ExtentLiveRepair { .. } => true,
             IOop::Read { .. } => false,
             _ => panic!("unexpected io work {:?}", io.work),
         };
@@ -83,7 +84,7 @@ impl ActiveJobs {
             (IOop::Flush { .. }, ImpactedBlocks::InclusiveRange(..)) => {
                 panic!("cannot have flush with impacted blocks")
             }
-            (_, ImpactedBlocks::Empty) => 0..0, // TODO is this avlid?
+            (_, ImpactedBlocks::Empty) => 0..0, // TODO is this valid?
             (_, ImpactedBlocks::InclusiveRange(..)) => {
                 self.to_lba_range(io.impacted_blocks)
             }

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -180,6 +180,16 @@ impl ActiveJobs {
     pub fn ackable_work(&self) -> Vec<u64> {
         self.ackable.iter().cloned().collect()
     }
+
+    #[cfg(test)]
+    pub fn get_extents_for(&self, job: u64) -> std::ops::RangeInclusive<u64> {
+        let r = self.block_to_active.job_to_range.get(&job).unwrap();
+        r.start.extent_id..=(if r.end.block == 0 {
+            r.end.extent_id - 1
+        } else {
+            r.end.extent_id
+        })
+    }
 }
 
 impl<'a> IntoIterator for &'a ActiveJobs {

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -395,8 +395,6 @@ impl BlockToActive {
     }
 
     fn merge_adjacent_sections(&mut self, r: std::ops::Range<u64>) {
-        println!();
-        println!("running with range {r:?}");
         let mut pos = self
             .lba_to_jobs
             .range(..r.start)
@@ -404,7 +402,6 @@ impl BlockToActive {
             .next()
             .map(|(start, _)| *start)
             .unwrap_or(r.start);
-        println!("starting loop at {pos} with {:?}", self.lba_to_jobs);
         while pos < r.end {
             let (end, value) = self.lba_to_jobs.get(&pos).unwrap();
             let end = *end;
@@ -418,11 +415,9 @@ impl BlockToActive {
                     // Leave pos at the existing position, so that we can
                     // continue merging later blocks
                 } else {
-                    println!("  not merging");
                     pos = end;
                 }
             } else {
-                println!("  assigning to {end}");
                 pos = end;
             }
             pos = self

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -277,9 +277,14 @@ impl BlockToActive {
     fn check_range(&self, r: std::ops::Range<u64>, blocking: bool) -> Vec<u64> {
         let mut out = BTreeSet::new();
         for (_start, (_end, set)) in self.iter_overlapping(r) {
-            out.extend(set.blocking.iter().cloned());
             if blocking {
-                out.extend(set.nonblocking.iter().cloned());
+                if set.nonblocking.is_empty() {
+                    out.extend(set.blocking.iter().cloned());
+                } else {
+                    out.extend(set.nonblocking.iter().cloned());
+                }
+            } else {
+                out.extend(set.blocking.iter().cloned());
             }
         }
         out.into_iter().collect()
@@ -530,9 +535,15 @@ mod test {
             let mut out = BTreeSet::new();
             for i in r {
                 if let Some(s) = self.0.get(&i) {
-                    out.extend(s.blocking.iter().cloned());
+                    // TODO: refactor this into a DependencySet function?
                     if blocking {
-                        out.extend(s.nonblocking.iter().cloned());
+                        if s.nonblocking.is_empty() {
+                            out.extend(s.blocking.iter().cloned());
+                        } else {
+                            out.extend(s.nonblocking.iter().cloned());
+                        }
+                    } else {
+                        out.extend(s.blocking.iter().cloned());
                     }
                 }
             }

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -398,6 +398,9 @@ impl BlockToActive {
     }
 
     fn merge_adjacent_sections(&mut self, r: std::ops::Range<ImpactedAddr>) {
+        // Pick a start position that's right below our modified range if
+        // possible; otherwise, pick the first value in the map (or return if
+        // the entire map is empty).
         let Some(mut pos) = self
             .addr_to_jobs
             .range(..r.start)

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -392,29 +392,14 @@ impl BlockMap {
         // new range:          |============|
         // result:               |--------|
 
-        let split_start = if let Some((start, (end, _))) =
-            self.addr_to_jobs.range(..r.start).rev().next()
+        let find_split_for = |v| match self.addr_to_jobs.range(..v).rev().next()
         {
-            if r.start < *end {
-                Some(*start)
-            } else {
-                None
-            }
-        } else {
-            None
+            Some((start, (end, _))) if v < *end => Some(*start),
+            _ => None,
         };
 
-        let mut split_end = if let Some((start, (end, _))) =
-            self.addr_to_jobs.range(..r.end).rev().next()
-        {
-            if r.end < *end {
-                Some(*start)
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+        let split_start = find_split_for(r.start);
+        let mut split_end = find_split_for(r.end);
 
         // Now, we apply those splits
         if let Some(s) = split_start {

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -585,15 +585,10 @@ impl DependencySet {
 
     fn insert_blocking(&mut self, job: u64) {
         if let Some(prev) = self.blocking {
-            // Skip backfilling older jobs
-            if job < prev {
-                return;
-            }
+            assert!(job > prev);
         }
         if let Some(prev) = self.nonblocking.last() {
-            if job < *prev {
-                return;
-            }
+            assert!(job > *prev);
         }
         self.blocking = Some(job);
         self.nonblocking.clear();
@@ -610,10 +605,8 @@ impl DependencySet {
     }
 
     fn remove(&mut self, job: u64) {
-        if let Some(v) = self.blocking {
-            if v == job {
-                self.blocking = None;
-            }
+        if self.blocking == Some(job) {
+            self.blocking = None;
         }
         self.nonblocking.retain(|&v| v != job);
     }

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -806,6 +806,7 @@ mod test {
             dut.remove_job(order[2]);
             assert!(dut.addr_to_jobs.is_empty());
             assert!(dut.job_to_range.is_empty());
+            dut.self_check();
         }
 
         #[test]

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -562,16 +562,14 @@ mod test {
         }
     }
 
-    // write, write, write, read
-    // each write is a range + bool
-    // read is a range
     proptest! {
         #[test]
         fn test_active_jobs_insert(
             a_start in 0u64..100, a_size in 1u64..50, a_type in any::<bool>(),
             b_start in 0u64..100, b_size in 1u64..50, b_type in any::<bool>(),
             c_start in 0u64..100, c_size in 1u64..50, c_type in any::<bool>(),
-            read_start in 0u64..100, read_size in 1u64..50, read_type in any::<bool>(),
+            read_start in 0u64..100, read_size in 1u64..50,
+            read_type in any::<bool>(),
         ) {
             let mut dut = BlockToActive::new();
             dut.insert_range(a_start..(a_start + a_size), 1000, a_type);
@@ -583,8 +581,10 @@ mod test {
             oracle.insert_range(b_start..(b_start + b_size), 1001, b_type);
             oracle.insert_range(c_start..(c_start + c_size), 1002, c_type);
 
-            let read_dut = dut.check_range(read_start..(read_start + read_size), read_type);
-            let read_oracle = oracle.check_range(read_start..(read_start + read_size), read_type);
+            let read_dut = dut.check_range(
+                read_start..(read_start + read_size), read_type);
+            let read_oracle = oracle.check_range(
+                read_start..(read_start + read_size), read_type);
             assert_eq!(read_dut, read_oracle);
         }
 
@@ -594,7 +594,8 @@ mod test {
             b_start in 0u64..100, b_size in 1u64..50, b_type in any::<bool>(),
             c_start in 0u64..100, c_size in 1u64..50, c_type in any::<bool>(),
             remove in 0usize..3,
-            read_start in 0u64..100, read_size in 1u64..50, read_type in any::<bool>()
+            read_start in 0u64..100, read_size in 1u64..50,
+            read_type in any::<bool>()
         ) {
             let mut dut = BlockToActive::new();
             dut.insert_range(a_start..(a_start + a_size), 1000, a_type);
@@ -606,11 +607,13 @@ mod test {
             oracle.insert_range(b_start..(b_start + b_size), 1001, b_type);
             oracle.insert_range(c_start..(c_start + c_size), 1002, c_type);
 
-            dut.remove_job( 1000 + remove as u64);
-            oracle.remove_job( 1000 + remove as u64);
+            dut.remove_job(1000 + remove as u64);
+            oracle.remove_job(1000 + remove as u64);
 
-            let read_dut = dut.check_range(read_start..(read_start + read_size), read_type);
-            let read_oracle = oracle.check_range(read_start..(read_start + read_size), read_type);
+            let read_dut = dut.check_range(
+                read_start..(read_start + read_size), read_type);
+            let read_oracle = oracle.check_range(
+                read_start..(read_start + read_size), read_type);
             assert_eq!(read_dut, read_oracle);
         }
     }

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -468,7 +468,9 @@ impl DependencySet {
             }
         }
         for prev in &self.nonblocking {
-            assert!(job > *prev);
+            if job < *prev {
+                break;
+            }
         }
         self.blocking = Some(job);
         self.nonblocking.clear();

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -1167,10 +1167,12 @@ pub(crate) mod protocol_test {
             // IO. Issue some single extent reads and writes to make sure that
             // extent limit is honoured. Do this only after receiving the two
             // above messages as that guarantees we are in the repair task and
-            // that extent_limit is set. Make sure the first read and write to
-            // the extent under repair has the ExtentLiveReopen job as a
-            // dependency. Batch up responses to send after the live repair is
-            // done, otherwise flow control will kick in.
+            // that extent_limit is set. Make sure that the first read to the
+            // extent under repair has the the ExtentLiveReopen job as a
+            // dependency, and that later writes have that read as their
+            // dependency (which works because the read already depended on the
+            // ExtentLiveReopen job). Batch up responses to send after the live
+            // repair is done, otherwise flow control will kick in.
 
             let mut responses = vec![Vec::new(); 3];
 

--- a/upstairs/src/impacted_blocks.rs
+++ b/upstairs/src/impacted_blocks.rs
@@ -296,15 +296,15 @@ pub fn extent_from_offset(
 
 pub fn extent_to_impacted_blocks(
     ddef: &RegionDefinition,
-    eid: u32,
+    eid: u64,
 ) -> ImpactedBlocks {
-    assert!(eid < ddef.extent_count());
+    assert!(eid < ddef.extent_count() as u64);
     let one = ImpactedAddr {
-        extent_id: eid as u64,
+        extent_id: eid,
         block: 0,
     };
     let two = ImpactedAddr {
-        extent_id: eid as u64,
+        extent_id: eid,
         block: ddef.extent_size().value - 1,
     };
     ImpactedBlocks::InclusiveRange(one, two)

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -10190,7 +10190,7 @@ fn create_write_eob(
         ds.ds_active.len() as u64,
         dependencies.len() as u64
     ));
-    info!(ds.log, "IO Write {} has deps {:?}", ds_id, dependencies);
+    debug!(ds.log, "IO Write {} has deps {:?}", ds_id, dependencies);
 
     let awrite = if is_write_unwritten {
         IOop::WriteUnwritten {

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -5883,10 +5883,6 @@ impl Upstairs {
          * Create the list of downstairs request numbers (ds_id) we created
          * on behalf of this guest job.
          */
-        info!(
-            downstairs.log,
-            "reserving repair jobs for {impacted_blocks:?}"
-        );
         downstairs.reserve_repair_jobs_for(impacted_blocks);
 
         // After reserving any LiveRepair IDs, go get one for this job.

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -5843,8 +5843,7 @@ impl Upstairs {
          * Create the list of downstairs request numbers (ds_id) we created
          * on behalf of this guest job.
          */
-        let mut dep =
-            downstairs.ds_active.deps_for_write(impacted_blocks, ddef);
+        let mut dep = downstairs.ds_active.deps_for_write(impacted_blocks);
         cdt::gw__write__deps!(|| (
             downstairs.ds_active.len() as u64,
             dep.len() as u64
@@ -6074,7 +6073,7 @@ impl Upstairs {
         let gw_id: u64 = gw.next_gw_id();
         cdt::gw__read__start!(|| (gw_id));
 
-        let mut dep = downstairs.ds_active.deps_for_read(impacted_blocks, ddef);
+        let mut dep = downstairs.ds_active.deps_for_read(impacted_blocks);
 
         let mut future_repair = false;
         let mut deps_to_add: BTreeSet<u32> = BTreeSet::new();
@@ -7185,6 +7184,7 @@ impl Upstairs {
         }
 
         *ddef = RegionDefinitionStatus::Received(client_ddef);
+        ds.ds_active.set_ddef(client_ddef);
         Ok(())
     }
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -3566,7 +3566,6 @@ impl Downstairs {
                                 .map(|(k, _)| *k)
                                 .unwrap_or(first as u64)
                         });
-                    // TODO(matt) is my_limit ever `None` here?
                     assert!(self.repair_min_id.is_some());
                     if io.work.send_io_live_repair(my_limit) {
                         // Leave this IO as New, the downstairs will receive it.

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -4669,7 +4669,7 @@ impl Downstairs {
             }
             // Now that we've collected jobs to retire, remove them from the map
             for &id in &retired {
-                self.ds_active.remove(&id).unwrap();
+                let _ = self.ds_active.remove(&id);
             }
 
             debug!(self.log, "[rc] retire {} clears {:?}", ds_id, retired);
@@ -7184,7 +7184,6 @@ impl Upstairs {
         }
 
         *ddef = RegionDefinitionStatus::Received(client_ddef);
-        ds.ds_active.set_ddef(client_ddef);
         Ok(())
     }
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -3486,7 +3486,7 @@ impl Downstairs {
      * requests for this client.
      */
     fn new_work(&mut self, client_id: u8) -> Vec<u64> {
-        self.ds_new[client_id as usize].drain(..).collect()
+        std::mem::take(&mut self.ds_new[client_id as usize])
     }
 
     /**

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -3563,10 +3563,10 @@ impl Downstairs {
                         self.extent_limit[cid as usize].map(|first| {
                             self.repair_job_ids
                                 .last_key_value()
-                                .map(|(k, _)| *k as u64)
+                                .map(|(k, _)| *k)
                                 .unwrap_or(first as u64)
                         });
-                    // TODO is my_limit ever `None` here?
+                    // TODO(matt) is my_limit ever `None` here?
                     assert!(self.repair_min_id.is_some());
                     if io.work.send_io_live_repair(my_limit) {
                         // Leave this IO as New, the downstairs will receive it.

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -69,7 +69,8 @@ mod live_repair;
 pub use live_repair::{check_for_repair, ExtentInfo, RepairCheck};
 
 mod active_jobs;
-use active_jobs::{ActiveJobs, Dependencies};
+use active_jobs::ActiveJobs;
+pub use active_jobs::Dependencies;
 
 use async_trait::async_trait;
 

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -5936,20 +5936,19 @@ pub mod repair_test {
         let new_deps = ds.remove_dep_if_live_repair(1, current_deps, 1004);
         assert_eq!(new_deps, &[1001, 1002, 1003]);
 
-        // This second write after starting a repair should require jobs 0,1,4
-        // on Active downstairs, and only require the repair on the
-        // LiveRepair downstairs.
+        // This second write after starting a repair should only require the
+        // repair job on all downstairs
         let job = ds.ds_active.get(&1005).unwrap();
         assert_eq!(job.state[&0], IOState::New);
         assert_eq!(job.state[&1], IOState::New);
         assert_eq!(job.state[&2], IOState::New);
 
         let current_deps = job.work.deps().to_vec();
-        assert_eq!(&current_deps, &[1004, 1001, 1000]);
+        assert_eq!(&current_deps, &[1004]);
 
         let new_deps = ds.remove_dep_if_live_repair(1, current_deps, 1005);
         // LiveRepair downstairs won't see past the repair.
-        assert_eq!(new_deps, &[1004, 1001]);
+        assert_eq!(new_deps, &[1004]);
     }
     //       block   block
     // op# | 0 1 2 | 3 4 5 |

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -863,8 +863,7 @@ impl Upstairs {
             let impacted_blocks = extent_to_impacted_blocks(&ddef, eid);
 
             let deps =
-                ds.ds_active
-                    .deps_for_live_repair(impacted_blocks, ds_id, ddef);
+                ds.ds_active.deps_for_live_repair(impacted_blocks, ds_id);
 
             warn!(
                 self.log,
@@ -1079,8 +1078,7 @@ impl Upstairs {
         // that we skipped or finished for that specific downstairs before
         // we send the repair IO over the wire.
         let mut deps =
-            ds.ds_active
-                .deps_for_live_repair(impacted_blocks, close_id, ddef);
+            ds.ds_active.deps_for_live_repair(impacted_blocks, close_id);
 
         info!(
             self.log,
@@ -4064,9 +4062,7 @@ pub mod repair_test {
         // Upstairs "guest" work IDs.
         let gw_close_id: u64 = gw.next_gw_id();
         let close_id = ds.next_id();
-        let deps =
-            ds.ds_active
-                .deps_for_live_repair(impacted_blocks, close_id, ddef);
+        let deps = ds.ds_active.deps_for_live_repair(impacted_blocks, close_id);
 
         // let repair = vec![0, 2];
         let _reopen_brw = create_and_enqueue_close_io(
@@ -4105,9 +4101,9 @@ pub mod repair_test {
         let gw_repair_id: u64 = gw.next_gw_id();
         let extent_repair_ids = ds.get_repair_ids(eid);
         let repair_id = extent_repair_ids.repair_id;
-        let deps =
-            ds.ds_active
-                .deps_for_live_repair(impacted_blocks, repair_id, ddef);
+        let deps = ds
+            .ds_active
+            .deps_for_live_repair(impacted_blocks, repair_id);
 
         let _repair_brw = create_and_enqueue_noop_io(
             &mut ds,
@@ -5879,8 +5875,7 @@ pub mod repair_test {
         let reopen_id = extent_repair_ids.reopen_id;
 
         let mut deps =
-            ds.ds_active
-                .deps_for_live_repair(impacted_blocks, close_id, ddef);
+            ds.ds_active.deps_for_live_repair(impacted_blocks, close_id);
 
         // The initial close IO has the base set of dependencies.
         // Each additional job will depend on the previous.

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -24,7 +24,7 @@ use tokio::sync::mpsc;
 // dependency with all IOs on the same extent.  Any existing IOs on that extent
 // will need to finish, and any new IOs for that extent will depend on all the
 // repair work for that extent before they can proceed.
-// Vec<u64> will treat IOs to different extents as independent of each
+// Dependencies will treat IOs to different extents as independent of each
 // other, and repair on one extent should not effect IOs on other extents.
 // IOs that span an extent under repair are considered as being on that extent
 // and are discussed in detail later.
@@ -55,7 +55,7 @@ use tokio::sync::mpsc;
 // it covers have completed repair.  This may involve allocating and reserving
 // repair job IDs, and making those job IDs dependencies for this spanning IO.
 //
-// * Skipped IOs and Vec<u64> “above” a repair command.
+// * Skipped IOs and Dependencies “above” a repair command.
 // For Repair operations (and operations that follow after them), a downstairs
 // under repair will most likely have a bunch of skipped IOs.  Repair
 // operations will often have dependencies that will need to finish on the

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -2963,10 +2963,11 @@ pub mod repair_test {
         //   1 |       |       | RpRpRp|
         //   2 |       |       | RpRpRp|
         //   3 |       |       | RpRpRp|
-        //   4 | W W W | W W W | W W W | 0,1,2,3
-        //   5 | R R R | R R R | R R R | 0,1,2,3,4
-        //   6 | WuWuWu| WuWuWu| WuWuWu| 0,1,2,3,4,5
+        //   4 | W W W | W W W | W W W | 3
+        //   5 | R R R | R R R | R R R | 3,4
+        //   6 | WuWuWu| WuWuWu| WuWuWu| 3,5
         //
+        // TODO: this has superfluous dependencies
         let up = create_test_upstairs(1).await;
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
 
@@ -3020,7 +3021,7 @@ pub mod repair_test {
 
         assert_eq!(jobs[0].work.deps(), &[1003]);
         assert_eq!(jobs[1].work.deps(), &[1004, 1003]);
-        assert_eq!(jobs[2].work.deps(), &[1005, 1004, 1003]);
+        assert_eq!(jobs[2].work.deps(), &[1005, 1003]);
     }
 
     #[tokio::test]
@@ -3053,7 +3054,7 @@ pub mod repair_test {
         //   1 |       |       | RpRpRp|
         //   2 |       |       | RpRpRp|
         //   3 |       |       | RpRpRp|
-        //   4 | R R R | R R R | R R R | 0,1,2,3
+        //   4 | R R R | R R R | R R R | 3
         //
         let up = create_test_upstairs(1).await;
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
@@ -3119,7 +3120,7 @@ pub mod repair_test {
         //   1 |       |       | RpRpRp|
         //   2 |       |       | RpRpRp|
         //   3 |       |       | RpRpRp|
-        //   4 | W W W | W W W | W W W | 0,1,2,3
+        //   4 | W W W | W W W | W W W | 3
 
         let up = create_test_upstairs(1).await;
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
@@ -3191,7 +3192,7 @@ pub mod repair_test {
         //   5 |       |       | RpRpRp|
         //   6 |       |       | RpRpRp|
         //   7 |       |       | RpRpRp|
-        //   8 | W W W | W W W | W W W | 0,1,2,3,4,5,6,7
+        //   8 | W W W | W W W | W W W | 3,7
         //
         let up = create_test_upstairs(1).await;
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
@@ -4833,7 +4834,7 @@ pub mod repair_test {
         //   5 |       | Rrep  |
         //   6 |       | Rnoop |
         //   7 |       | Ropen |
-        //   5 |     W | W W   | 0,1,2,3
+        //   5 |     W | W W   | 0,1,2,3 XXX This is wrong?
         //
         // We also verify that the job IDs make sense for our repair id
         // reservation that happens when we need to insert a job like this.
@@ -5115,7 +5116,7 @@ pub mod repair_test {
         //   1 |       | RpRpRp|
         //   2 |       | RpRpRp|
         //   3 |       | RpRpRp|
-        //   4 |     W | W W   | 0,1,2
+        //   4 |     W | W W   | 3
 
         let up = create_test_upstairs(1).await;
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
@@ -5169,8 +5170,8 @@ pub mod repair_test {
         //   0 |       | RpRpRp|
         //   1 |       | RpRpRp|
         //   2 |       | RpRpRp|
-        //   2 |       | RpRpRp|
-        //   3 |     R | R R   | 0,1,2
+        //   3 |       | RpRpRp|
+        //   4 |     R | R R   | 3
 
         let up = create_test_upstairs(1).await;
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -2955,8 +2955,6 @@ pub mod repair_test {
         //   4 | W W W | W W W | W W W | 3
         //   5 | R R R | R R R | R R R | 4
         //   6 | WuWuWu| WuWuWu| WuWuWu| 5
-        //
-        // TODO: this has superfluous dependencies
         let up = create_test_upstairs(1).await;
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
 

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -29,26 +29,15 @@ pub(crate) mod up_test {
         (eid, Block::new_512(offset))
     }
 
-    fn generic_read_request() -> (ReadRequest, ImpactedBlocks) {
-        let request = ReadRequest {
+    fn generic_read_request() -> ReadRequest {
+        ReadRequest {
             eid: 0,
             offset: Block::new_512(7),
-        };
-        let iblocks = ImpactedBlocks::new(
-            ImpactedAddr {
-                extent_id: 0,
-                block: 7,
-            },
-            ImpactedAddr {
-                extent_id: 0,
-                block: 7,
-            },
-        );
-        (request, iblocks)
+        }
     }
 
-    fn generic_write_request() -> (crucible_protocol::Write, ImpactedBlocks) {
-        let request = crucible_protocol::Write {
+    fn generic_write_request() -> crucible_protocol::Write {
+        crucible_protocol::Write {
             eid: 0,
             offset: Block::new_512(7),
             data: Bytes::from(vec![1]),
@@ -56,25 +45,12 @@ pub(crate) mod up_test {
                 encryption_context: None,
                 hash: 0,
             },
-        };
-        let iblocks = ImpactedBlocks::new(
-            ImpactedAddr {
-                extent_id: 0,
-                block: 7,
-            },
-            ImpactedAddr {
-                extent_id: 0,
-                block: 7,
-            },
-        );
-        (request, iblocks)
+        }
     }
 
     fn create_generic_read_eob(ds_id: u64) -> (ReadRequest, DownstairsIO) {
-        let (request, iblocks) = generic_read_request();
-
-        let op =
-            create_read_eob(ds_id, vec![], 10, vec![request.clone()], iblocks);
+        let request = generic_read_request();
+        let op = create_read_eob(ds_id, vec![], 10, vec![request.clone()]);
 
         (request, op)
     }
@@ -755,16 +731,7 @@ pub(crate) mod up_test {
 
         let next_id = ds.next_id();
 
-        let op = create_flush(
-            next_id,
-            vec![],
-            10,
-            0,
-            0,
-            None,
-            ImpactedBlocks::Empty,
-            None,
-        );
+        let op = create_flush(next_id, vec![], 10, 0, 0, None, None);
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -825,16 +792,7 @@ pub(crate) mod up_test {
 
         let next_id = ds.next_id();
 
-        let op = create_flush(
-            next_id,
-            vec![],
-            10,
-            0,
-            0,
-            None,
-            ImpactedBlocks::Empty,
-            None,
-        );
+        let op = create_flush(next_id, vec![], 10, 0, 0, None, None);
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -899,16 +857,7 @@ pub(crate) mod up_test {
 
         let next_id = ds.next_id();
 
-        let op = create_flush(
-            next_id,
-            vec![],
-            10,
-            0,
-            0,
-            None,
-            ImpactedBlocks::Empty,
-            None,
-        );
+        let op = create_flush(next_id, vec![], 10, 0, 0, None, None);
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -1234,19 +1183,14 @@ pub(crate) mod up_test {
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         upstairs.set_active().await.unwrap();
 
-        let (request, iblocks) = generic_read_request();
+        let request = generic_read_request();
         let next_id = {
             let mut ds = upstairs.downstairs.lock().await;
 
             let next_id = ds.next_id();
 
-            let op = create_read_eob(
-                next_id,
-                vec![],
-                10,
-                vec![request.clone()],
-                iblocks,
-            );
+            let op =
+                create_read_eob(next_id, vec![], 10, vec![request.clone()]);
 
             ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -1640,14 +1584,13 @@ pub(crate) mod up_test {
 
         // send a write, and clients 0 and 1 will return errors
 
-        let (request, iblocks) = generic_write_request();
+        let request = generic_write_request();
         let op = create_write_eob(
             next_id,
             vec![],
             10,
             vec![request],
             is_write_unwritten,
-            iblocks,
         );
 
         ds.enqueue(op, ds_done_tx.clone()).await;
@@ -1738,14 +1681,13 @@ pub(crate) mod up_test {
 
         // Create a write, enqueue it on both the downstairs
         // and the guest work queues.
-        let (request, iblocks) = generic_write_request();
+        let request = generic_write_request();
         let op = create_write_eob(
             next_id,
             vec![],
             gw_id,
             vec![request],
             is_write_unwritten,
-            iblocks,
         );
 
         let mut sub = HashMap::new();
@@ -1833,14 +1775,13 @@ pub(crate) mod up_test {
 
         // Create a write, enqueue it on both the downstairs
         // and the guest work queues.
-        let (request, iblocks) = generic_write_request();
+        let request = generic_write_request();
         let op = create_write_eob(
             next_id,
             vec![],
             gw_id,
             vec![request],
             is_write_unwritten,
-            iblocks,
         );
 
         let mut sub = HashMap::new();
@@ -1915,14 +1856,13 @@ pub(crate) mod up_test {
 
         // Create a write, enqueue it on both the downstairs
         // and the guest work queues.
-        let (request, iblocks) = generic_write_request();
+        let request = generic_write_request();
         let op = create_write_eob(
             next_id,
             vec![],
             gw_id,
             vec![request],
             is_write_unwritten,
-            iblocks,
         );
 
         let mut sub = HashMap::new();
@@ -2012,7 +1952,6 @@ pub(crate) mod up_test {
             gw_id,
             11, // Gen number
             None,
-            ImpactedBlocks::Empty,
             None,
         );
 
@@ -2097,7 +2036,6 @@ pub(crate) mod up_test {
             gw_id,
             11, // Gen number
             None,
-            ImpactedBlocks::Empty,
             None,
         );
 
@@ -2169,7 +2107,6 @@ pub(crate) mod up_test {
             gw_id,
             11, // Gen number
             None,
-            ImpactedBlocks::Empty,
             None,
         );
 
@@ -2447,16 +2384,7 @@ pub(crate) mod up_test {
         // A flush is required to move work to completed
         // Create the flush then send it to all downstairs.
         let next_id = ds.next_id();
-        let op = create_flush(
-            next_id,
-            vec![],
-            10,
-            0,
-            0,
-            None,
-            ImpactedBlocks::Empty,
-            None,
-        );
+        let op = create_flush(next_id, vec![], 10, 0, 0, None, None);
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -2556,16 +2484,7 @@ pub(crate) mod up_test {
         // A flush is required to move work to completed
         // Create the flush then send it to all downstairs.
         let next_id = ds.next_id();
-        let op = create_flush(
-            next_id,
-            vec![],
-            10,
-            0,
-            0,
-            None,
-            ImpactedBlocks::Empty,
-            None,
-        );
+        let op = create_flush(next_id, vec![], 10, 0, 0, None, None);
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -2623,25 +2542,23 @@ pub(crate) mod up_test {
         let id1 = ds.next_id();
         let id2 = ds.next_id();
 
-        let (request, iblocks) = generic_write_request();
+        let request = generic_write_request();
         let op = create_write_eob(
             id1,
             vec![],
             10,
             vec![request],
             is_write_unwritten,
-            iblocks,
         );
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        let (request, iblocks) = generic_write_request();
+        let request = generic_write_request();
         let op = create_write_eob(
             id2,
             vec![],
             20,
             vec![request],
             is_write_unwritten,
-            iblocks,
         );
         ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -2703,16 +2620,7 @@ pub(crate) mod up_test {
 
         // Create the flush, put on the work queue
         let flush_id = ds.next_id();
-        let op = create_flush(
-            flush_id,
-            vec![],
-            10,
-            0,
-            0,
-            None,
-            ImpactedBlocks::Empty,
-            None,
-        );
+        let op = create_flush(flush_id, vec![], 10, 0, 0, None, None);
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Simulate sending the flush to downstairs 0 and 1
@@ -2825,14 +2733,13 @@ pub(crate) mod up_test {
         // Build our write IO.
         let next_id = ds.next_id();
 
-        let (request, iblocks) = generic_write_request();
+        let request = generic_write_request();
         let op = create_write_eob(
             next_id,
             vec![],
             10,
             vec![request],
             is_write_unwritten,
-            iblocks,
         );
         // Put the write on the queue.
         ds.enqueue(op, ds_done_tx.clone()).await;
@@ -2883,16 +2790,7 @@ pub(crate) mod up_test {
 
         // Create the flush IO
         let next_id = ds.next_id();
-        let op = create_flush(
-            next_id,
-            vec![],
-            10,
-            0,
-            0,
-            None,
-            ImpactedBlocks::Empty,
-            None,
-        );
+        let op = create_flush(next_id, vec![], 10, 0, 0, None, None);
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the flush to all three downstairs.
@@ -2967,26 +2865,19 @@ pub(crate) mod up_test {
         let id1 = ds.next_id();
         let id2 = ds.next_id();
 
-        let (request, iblocks) = generic_write_request();
+        let request = generic_write_request();
         let op = create_write_eob(
             id1,
             vec![],
             10,
             vec![request],
             is_write_unwritten,
-            iblocks,
         );
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        let (request, iblocks) = generic_write_request();
-        let op = create_write_eob(
-            id2,
-            vec![],
-            1,
-            vec![request],
-            is_write_unwritten,
-            iblocks,
-        );
+        let request = generic_write_request();
+        let op =
+            create_write_eob(id2, vec![], 1, vec![request], is_write_unwritten);
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the two writes, to 2/3 of the downstairs.
@@ -3047,16 +2938,7 @@ pub(crate) mod up_test {
 
         // Create and enqueue the flush.
         let flush_id = ds.next_id();
-        let op = create_flush(
-            flush_id,
-            vec![],
-            10,
-            0,
-            0,
-            None,
-            ImpactedBlocks::Empty,
-            None,
-        );
+        let op = create_flush(flush_id, vec![], 10, 0, 0, None, None);
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Send the flush to two downstairs.
@@ -3583,14 +3465,13 @@ pub(crate) mod up_test {
 
         // Create the write and put it on the work queue.
         let id1 = ds.next_id();
-        let (request, iblocks) = generic_write_request();
+        let request = generic_write_request();
         let op = create_write_eob(
             id1,
             vec![],
             10,
             vec![request],
             is_write_unwritten,
-            iblocks,
         );
         ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -3678,14 +3559,13 @@ pub(crate) mod up_test {
 
         // Create the write and put it on the work queue.
         let id1 = ds.next_id();
-        let (request, iblocks) = generic_write_request();
+        let request = generic_write_request();
         let op = create_write_eob(
             id1,
             vec![],
             10,
             vec![request],
             is_write_unwritten,
-            iblocks,
         );
         ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -3878,14 +3758,13 @@ pub(crate) mod up_test {
         // Build a write, put it on the work queue.
         let id1 = ds.next_id();
 
-        let (request, iblocks) = generic_write_request();
+        let request = generic_write_request();
         let op = create_write_eob(
             id1,
             vec![],
             10,
             vec![request],
             is_write_unwritten,
-            iblocks,
         );
         ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -4081,14 +3960,13 @@ pub(crate) mod up_test {
         // Build a write, put it on the work queue.
         let id1 = ds.next_id();
 
-        let (request, iblocks) = generic_write_request();
+        let request = generic_write_request();
         let op = create_write_eob(
             id1,
             vec![],
             10,
             vec![request],
             is_write_unwritten,
-            iblocks,
         );
         ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -5573,15 +5451,9 @@ pub(crate) mod up_test {
 
             let next_id = ds.next_id();
 
-            let (request, iblocks) = generic_write_request();
-            let op = create_write_eob(
-                next_id,
-                vec![],
-                10,
-                vec![request],
-                false,
-                iblocks,
-            );
+            let request = generic_write_request();
+            let op =
+                create_write_eob(next_id, vec![], 10, vec![request], false);
 
             ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -5652,15 +5524,9 @@ pub(crate) mod up_test {
 
             let next_id = ds.next_id();
 
-            let (request, iblocks) = generic_write_request();
-            let op = create_write_eob(
-                next_id,
-                vec![],
-                10,
-                vec![request],
-                false,
-                iblocks,
-            );
+            let request = generic_write_request();
+            let op =
+                create_write_eob(next_id, vec![], 10, vec![request], false);
 
             ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -5703,19 +5569,14 @@ pub(crate) mod up_test {
         up.downstairs.lock().await.ack(next_id);
 
         // Now, do a read.
-        let (request, iblocks) = generic_read_request();
+        let request = generic_read_request();
 
         let next_id = {
             let mut ds = up.downstairs.lock().await;
 
             let next_id = ds.next_id();
-            let op = create_read_eob(
-                next_id,
-                vec![],
-                10,
-                vec![request.clone()],
-                iblocks,
-            );
+            let op =
+                create_read_eob(next_id, vec![], 10, vec![request.clone()]);
 
             ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -5757,16 +5618,7 @@ pub(crate) mod up_test {
             let mut ds = up.downstairs.lock().await;
 
             let next_id = ds.next_id();
-            let op = create_flush(
-                next_id,
-                vec![],
-                10,
-                0,
-                0,
-                None,
-                ImpactedBlocks::Empty,
-                None,
-            );
+            let op = create_flush(next_id, vec![], 10, 0, 0, None, None);
             ds.enqueue(op, ds_done_tx.clone()).await;
 
             // As this DS is failed, it should return none
@@ -5826,15 +5678,9 @@ pub(crate) mod up_test {
 
             let next_id = ds.next_id();
 
-            let (request, iblocks) = generic_write_request();
-            let op = create_write_eob(
-                next_id,
-                vec![],
-                10,
-                vec![request],
-                false,
-                iblocks,
-            );
+            let request = generic_write_request();
+            let op =
+                create_write_eob(next_id, vec![], 10, vec![request], false);
 
             ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -5882,19 +5728,14 @@ pub(crate) mod up_test {
 
         // Now, do a read.
 
-        let (request, iblocks) = generic_read_request();
+        let request = generic_read_request();
         let next_id = {
             let mut ds = up.downstairs.lock().await;
 
             let next_id = ds.next_id();
 
-            let op = create_read_eob(
-                next_id,
-                vec![],
-                10,
-                vec![request.clone()],
-                iblocks,
-            );
+            let op =
+                create_read_eob(next_id, vec![], 10, vec![request.clone()]);
 
             ds.enqueue(op, ds_done_tx.clone()).await;
 
@@ -5933,9 +5774,8 @@ pub(crate) mod up_test {
 
         let id = ds.next_id();
 
-        let (request, iblocks) = generic_write_request();
-        let op =
-            create_write_eob(id, vec![], 10, vec![request], false, iblocks);
+        let request = generic_write_request();
+        let op = create_write_eob(id, vec![], 10, vec![request], false);
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         if make_in_progress {
@@ -5959,16 +5799,7 @@ pub(crate) mod up_test {
 
         let id = ds.next_id();
 
-        let op = create_flush(
-            id,
-            vec![],
-            10,
-            0,
-            0,
-            None,
-            ImpactedBlocks::Empty,
-            None,
-        );
+        let op = create_flush(id, vec![], 10, 0, 0, None, None);
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         if make_in_progress {
@@ -5992,13 +5823,7 @@ pub(crate) mod up_test {
 
         let read_id = ds.next_id();
 
-        let op = create_read_eob(
-            read_id,
-            vec![],
-            10,
-            vec![request],
-            ImpactedBlocks::Empty,
-        );
+        let op = create_read_eob(read_id, vec![], 10, vec![request]);
 
         // Add the reads
         ds.enqueue(op, ds_done_tx.clone()).await;
@@ -6217,16 +6042,7 @@ pub(crate) mod up_test {
             let mut ds = up.downstairs.lock().await;
 
             let next_id = ds.next_id();
-            let op = create_flush(
-                next_id,
-                vec![],
-                10,
-                0,
-                0,
-                None,
-                ImpactedBlocks::Empty,
-                None,
-            );
+            let op = create_flush(next_id, vec![], 10, 0, 0, None, None);
             ds.enqueue(op, ds_done_tx.clone()).await;
 
             assert!(ds.in_progress(next_id, 0).is_some());
@@ -8502,13 +8318,10 @@ pub(crate) mod up_test {
         assert_eq!(jobs.len(), 3);
 
         // confirm which extents are impacted (in case make_upstairs changes)
-        assert_eq!(jobs[0].impacted_blocks.extents().unwrap().count(), 1);
-        assert_eq!(jobs[1].impacted_blocks.extents().unwrap().count(), 2);
-        assert_eq!(jobs[2].impacted_blocks.extents().unwrap().count(), 1);
-        assert_ne!(
-            jobs[0].impacted_blocks.extents(),
-            jobs[2].impacted_blocks.extents()
-        );
+        assert_eq!(ds.get_extents_for(jobs[0]).count(), 1);
+        assert_eq!(ds.get_extents_for(jobs[1]).count(), 2);
+        assert_eq!(ds.get_extents_for(jobs[2]).count(), 1);
+        assert_ne!(ds.get_extents_for(jobs[0]), ds.get_extents_for(jobs[2]));
 
         // confirm deps
         assert!(jobs[0].work.deps().is_empty()); // op 0
@@ -8599,20 +8412,14 @@ pub(crate) mod up_test {
         assert_eq!(jobs.len(), 5);
 
         // confirm which extents are impacted (in case make_upstairs changes)
-        assert_eq!(jobs[0].impacted_blocks.extents().unwrap().count(), 1);
-        assert_eq!(jobs[1].impacted_blocks.extents().unwrap().count(), 2);
-        assert_eq!(jobs[2].impacted_blocks.extents().unwrap().count(), 1);
-        assert_eq!(jobs[3].impacted_blocks.extents().unwrap().count(), 2);
-        assert_eq!(jobs[4].impacted_blocks.extents().unwrap().count(), 1);
+        assert_eq!(ds.get_extents_for(jobs[0]).count(), 1);
+        assert_eq!(ds.get_extents_for(jobs[1]).count(), 2);
+        assert_eq!(ds.get_extents_for(jobs[2]).count(), 1);
+        assert_eq!(ds.get_extents_for(jobs[3]).count(), 2);
+        assert_eq!(ds.get_extents_for(jobs[4]).count(), 1);
 
-        assert_ne!(
-            jobs[0].impacted_blocks.extents(),
-            jobs[2].impacted_blocks.extents()
-        );
-        assert_ne!(
-            jobs[4].impacted_blocks.extents(),
-            jobs[2].impacted_blocks.extents()
-        );
+        assert_ne!(ds.get_extents_for(jobs[0]), ds.get_extents_for(jobs[2]));
+        assert_ne!(ds.get_extents_for(jobs[4]), ds.get_extents_for(jobs[2]));
 
         assert!(jobs[0].work.deps().is_empty()); // op 0
         assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]); // op 1
@@ -8682,14 +8489,11 @@ pub(crate) mod up_test {
         assert_eq!(jobs.len(), 3);
 
         // confirm which extents are impacted (in case make_upstairs changes)
-        assert_eq!(jobs[0].impacted_blocks.extents().unwrap().count(), 1);
-        assert_eq!(jobs[1].impacted_blocks.extents().unwrap().count(), 1);
-        assert_eq!(jobs[2].impacted_blocks.extents().unwrap().count(), 2);
+        assert_eq!(ds.get_extents_for(jobs[0]).count(), 1);
+        assert_eq!(ds.get_extents_for(jobs[1]).count(), 1);
+        assert_eq!(ds.get_extents_for(jobs[2]).count(), 2);
 
-        assert_ne!(
-            jobs[0].impacted_blocks.extents(),
-            jobs[1].impacted_blocks.extents()
-        );
+        assert_ne!(ds.get_extents_for(jobs[0]), ds.get_extents_for(jobs[1]));
 
         assert!(jobs[0].work.deps().is_empty()); // op 0
         assert!(jobs[1].work.deps().is_empty()); // op 1

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -29,15 +29,6 @@ pub(crate) mod up_test {
         (eid, Block::new_512(offset))
     }
 
-    fn extent_repair_ids() -> ExtentRepairIDs {
-        ExtentRepairIDs {
-            close_id: 1,
-            repair_id: 2,
-            noop_id: 3,
-            reopen_id: 4,
-        }
-    }
-
     fn generic_read_request() -> (ReadRequest, ImpactedBlocks) {
         let request = ReadRequest {
             eid: 0,
@@ -6035,8 +6026,7 @@ pub(crate) mod up_test {
             dependencies: Vec::new(),
             requests: vec![request],
         };
-        let mut assigned_job_ids = HashMap::new();
-        assert!(op.send_io_live_repair(Some(2), &assigned_job_ids));
+        assert!(op.send_io_live_repair(Some(2)));
 
         // At limit
         let request = ReadRequest {
@@ -6047,7 +6037,7 @@ pub(crate) mod up_test {
             dependencies: Vec::new(),
             requests: vec![request],
         };
-        assert!(op.send_io_live_repair(Some(2), &assigned_job_ids));
+        assert!(op.send_io_live_repair(Some(2)));
 
         let request = ReadRequest {
             eid: 3,
@@ -6058,12 +6048,10 @@ pub(crate) mod up_test {
             requests: vec![request],
         };
         // We are past the extent limit, so this should return false
-        assert!(!op.send_io_live_repair(Some(2), &assigned_job_ids));
+        assert!(!op.send_io_live_repair(Some(2)));
 
-        // Now, assign a job ID for this live repair, meaning it's in the
-        // dependency tree
-        assigned_job_ids.insert(3, extent_repair_ids());
-        assert!(op.send_io_live_repair(Some(2), &assigned_job_ids));
+        // If we change the extent limit, it should become true
+        assert!(op.send_io_live_repair(Some(2)));
     }
 
     // Construct an IOop::Write or IOop::WriteUnwritten at the given extent
@@ -6096,49 +6084,43 @@ pub(crate) mod up_test {
     #[tokio::test]
     async fn send_io_live_repair_write() {
         // Check the send_io_live_repair for a write below extent limit,
-        // at extent limit, and above extent limit (with and without an assigned
-        // job ID)
-        let mut assigned_job_ids = HashMap::new();
+        // at extent limit, and above extent limit.
 
         // Below limit
         let wr = write_at_extent(0, false);
-        assert!(wr.send_io_live_repair(Some(2), &assigned_job_ids));
+        assert!(wr.send_io_live_repair(Some(2)));
 
         // At the limit
         let wr = write_at_extent(2, false);
-        assert!(wr.send_io_live_repair(Some(2), &assigned_job_ids));
+        assert!(wr.send_io_live_repair(Some(2)));
 
         // Above the limit
         let wr = write_at_extent(3, false);
-        assert!(!wr.send_io_live_repair(Some(2), &assigned_job_ids));
+        assert!(!wr.send_io_live_repair(Some(2)));
 
-        // Above the limit with an assigned job ID
-        assigned_job_ids.insert(3, extent_repair_ids());
-        assert!(wr.send_io_live_repair(Some(3), &assigned_job_ids));
+        // Back to being below the limit
+        assert!(wr.send_io_live_repair(Some(3)));
     }
 
     #[tokio::test]
     async fn send_io_live_repair_unwritten_write() {
         // Check the send_io_live_repair for a write unwritten below extent
-        // at extent limit, and above extent limit (with and without an assigned
-        // job ID)
-        let mut assigned_job_ids = HashMap::new();
+        // at extent limit, and above extent limit.
 
         // Below limit
         let wr = write_at_extent(0, true);
-        assert!(wr.send_io_live_repair(Some(2), &assigned_job_ids));
+        assert!(wr.send_io_live_repair(Some(2)));
 
         // At the limit
         let wr = write_at_extent(2, true);
-        assert!(wr.send_io_live_repair(Some(2), &assigned_job_ids));
+        assert!(wr.send_io_live_repair(Some(2)));
 
         // Above the limit
         let wr = write_at_extent(3, true);
-        assert!(!wr.send_io_live_repair(Some(2), &assigned_job_ids));
+        assert!(!wr.send_io_live_repair(Some(2)));
 
-        // Above the limit with an assigned job ID
-        assigned_job_ids.insert(3, extent_repair_ids());
-        assert!(wr.send_io_live_repair(Some(3), &assigned_job_ids));
+        // Back to being below the limit
+        assert!(wr.send_io_live_repair(Some(3)));
     }
 
     #[tokio::test]

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -5921,7 +5921,7 @@ pub(crate) mod up_test {
             offset: Block::new_512(7),
         };
         let op = IOop::Read {
-            dependencies: Dependencies::empty(),
+            dependencies: vec![],
             requests: vec![request],
         };
         assert!(op.send_io_live_repair(Some(2)));
@@ -5932,7 +5932,7 @@ pub(crate) mod up_test {
             offset: Block::new_512(7),
         };
         let op = IOop::Read {
-            dependencies: Dependencies::empty(),
+            dependencies: vec![],
             requests: vec![request],
         };
         assert!(op.send_io_live_repair(Some(2)));
@@ -5942,7 +5942,7 @@ pub(crate) mod up_test {
             offset: Block::new_512(7),
         };
         let op = IOop::Read {
-            dependencies: Dependencies::empty(),
+            dependencies: vec![],
             requests: vec![request],
         };
         // We are past the extent limit, so this should return false
@@ -5968,12 +5968,12 @@ pub(crate) mod up_test {
 
         if wu {
             IOop::WriteUnwritten {
-                dependencies: Dependencies::empty(),
+                dependencies: vec![],
                 writes,
             }
         } else {
             IOop::Write {
-                dependencies: Dependencies::empty(),
+                dependencies: vec![],
                 writes,
             }
         }

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -7312,7 +7312,7 @@ pub(crate) mod up_test {
         // ----|-------|-----
         //   0 | W     |
         //   1 | W     | 0
-        //   2 | W     | 0,1
+        //   2 | W     | 1
 
         let upstairs = make_upstairs();
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
@@ -7362,10 +7362,7 @@ pub(crate) mod up_test {
 
         assert!(jobs[0].work.deps().is_empty());
         assert_eq!(jobs[1].work.deps(), &[jobs[0].ds_id]);
-        assert_eq!(
-            hashset(jobs[2].work.deps()),
-            hashset(&[jobs[0].ds_id, jobs[1].ds_id]),
-        );
+        assert_eq!(jobs[2].work.deps(), &[jobs[1].ds_id],);
     }
 
     #[tokio::test]
@@ -7563,9 +7560,9 @@ pub(crate) mod up_test {
         //   1 | W     | 0
         //   2 |   W   | 0
         //   3 |     W | 0
-        //   4 | W     | 0,1
-        //   5 |   W   | 0,2
-        //   6 |     W | 0,3
+        //   4 | W     | 1
+        //   5 |   W   | 2
+        //   6 |     W | 3
 
         let upstairs = make_upstairs();
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
@@ -7624,16 +7621,16 @@ pub(crate) mod up_test {
         assert_eq!(jobs[3].work.deps(), &[jobs[0].ds_id]); // write @ 2
 
         assert_eq!(
-            hashset(jobs[4].work.deps()), // second write @ 0
-            hashset(&[jobs[0].ds_id, jobs[1].ds_id]),
+            jobs[4].work.deps(), // second write @ 0
+            &[jobs[1].ds_id],
         );
         assert_eq!(
-            hashset(jobs[5].work.deps()), // second write @ 1
-            hashset(&[jobs[0].ds_id, jobs[2].ds_id]),
+            jobs[5].work.deps(), // second write @ 1
+            &[jobs[2].ds_id],
         );
         assert_eq!(
-            hashset(jobs[6].work.deps()), // second write @ 2
-            hashset(&[jobs[0].ds_id, jobs[3].ds_id]),
+            jobs[6].work.deps(), // second write @ 2
+            &[jobs[3].ds_id],
         );
     }
 
@@ -8548,7 +8545,7 @@ pub(crate) mod up_test {
         //   1 |     W  W  W  W |  W  W  W        | 0
         //   2 |                |     W           | 1
         //   3 |              Wu|  Wu Wu          | 1,2
-        //   4 |              R |                 | 1,3
+        //   4 |              R |                 | 3
 
         let upstairs = make_upstairs();
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
@@ -8642,10 +8639,7 @@ pub(crate) mod up_test {
             hashset(jobs[3].work.deps()),
             hashset(&[jobs[1].ds_id, jobs[2].ds_id])
         ); // op 3
-        assert_eq!(
-            hashset(jobs[4].work.deps()),
-            hashset(&[jobs[1].ds_id, jobs[3].ds_id])
-        ); // op 4
+        assert_eq!(jobs[4].work.deps(), &[jobs[3].ds_id]); // op 4
     }
 
     #[tokio::test]

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -6051,7 +6051,7 @@ pub(crate) mod up_test {
         assert!(!op.send_io_live_repair(Some(2)));
 
         // If we change the extent limit, it should become true
-        assert!(op.send_io_live_repair(Some(2)));
+        assert!(op.send_io_live_repair(Some(3)));
     }
 
     // Construct an IOop::Write or IOop::WriteUnwritten at the given extent


### PR DESCRIPTION
# The problem of dependency tracking
Crucible jobs may be delivered to downstairs instances out of order.  Naively, this is bad news: reads and writes can't be executed in arbitrary order and get consistent results.  To avoid this issue, each job includes a list of dependencies, which are jobs that must be finished before that job is executed.

Dependencies are tracked a per-block basis.  Right now, they are calculated by iterating backwards over every single active job and picking out the ones with overlapping affected blocks; flushes count as affecting every block.

This is not particularly efficient, for two different reasons:
- We have to iterate over a lot of jobs.  Our longest-running tests (e.g. `test_successful_live_repair`) are spending the **vast majority** of their time iterating over jobs repeatedly; this is a classic example of [Accidentally Quadratic](https://accidentallyquadratic.tumblr.com/) behavior.
- We send a bunch of unnecessary dependencies.  Here's an example from one of our repair tests:
```
        //     |       | UNDER |       |
        //     |       | REPAIR|       |
        //     | block | block | block |
        // op# | 0 1 2 | 3 4 5 | 6 7 8 | deps
        // ----|-------|-------|-------|-----
        //   0 |       |       | RpRpRp|
        //   1 |       |       | RpRpRp|
        //   2 |       |       | RpRpRp|
        //   3 |       |       | RpRpRp|
        //   4 | W W W | W W W | W W W | 0,1,2,3
        //   5 | R R R | R R R | R R R | 0,1,2,3,4
        //   6 | WuWuWu| WuWuWu| WuWuWu| 0,1,2,3,4,5
```

Eyeballing this example, we could reduce it to the following without loss of ordering:
```
        //     |       | UNDER |       |
        //     |       | REPAIR|       |
        //     | block | block | block |
        // op# | 0 1 2 | 3 4 5 | 6 7 8 | deps
        // ----|-------|-------|-------|-----
        //   0 |       |       | RpRpRp|
        //   1 |       |       | RpRpRp|
        //   2 |       |       | RpRpRp|
        //   3 |       |       | RpRpRp|
        //   4 | W W W | W W W | W W W | 3
        //   5 | R R R | R R R | R R R | 4
        //   6 | WuWuWu| WuWuWu| WuWuWu| 5
```

# So, how do we fix this?

The answer is a new data structure which maintains a map from `ImpactedBlock` to job dependencies.  You can think of this as tracking a wavefrom of active jobs on a per-block basis; when a new job comes it, we
- Get its dependencies by checking its `ImpactedBlock` range
- Update the map, setting this job as the most recent dependency for its impacted blocks

We wouldn't want to maintain this map on a per-block basis; reads and writes often span many blocks, so iterating over every single block would be inefficient.  Instead the map stores dependencies over **ranges** of blocks (`std::ops::Range<ImpactedAddr>`).  Then, it's a small matter of programming to correctly split / merge / iterate over block ranges when handling dependencies.

This is a tricky data structure, and is tested using `proptest`.

# Reads versus writes
It's slightly more subtle than storing a _single_ active job for each block range, because read jobs don't interfere with each other (and we therefore don't want to impose an ordering on them).  Instead, we store both
- The last blocking job (`Option<u64>`); this is a write / flush / repair / anything but read
- All non-blocking jobs (`Vec<u64>`); these are reads

A new blocking job clears the non-blocking list and replaces the blocking job; a new non-blocking job is appended to the non-blocking list but does not modify the last blocking job.

# Live repair dependencies
Live repairs are a tricky special case: if a write operation spans the live-repair extent, we would reserve new job IDs for the live repair, adding them to `repair_job_ids` but not to `ds_active` (and then jumping through a bunch of hoops to make sure that we respect their dependencies).

Tracking jobs on a per-block basis makes it easier: when we need to reserve live repair job IDs, we get _their_ dependencies with `deps_for_live_repair`, leaving the `ExtentLiveReopen` job ID as the active one for that whole extent.  Then, later jobs (i.e. the read or write) which use that extent will depend on the live repair job _automatically_.
This dramatically simplifies `submit_read/write/flush`.

In general, the new code is more homogeneous between normal operations and reserved live repair jobs.  The pattern is as follows:
- Get the job ID (using `next_id` or similar)
- Compute the job's dependencies and install the job ID into the map, using `deps_for_read/write/flush`
- Enqueue the job once you've got a `DownstairsIO`.  For normal operations, this happens immediately; for reserved repair jobs, it happens when the later extent is reached by live repair.

# Other changes:
- Use `u64` for extent IDs (almost) everywhere, instead of a mix of `u64`, `u32`, and `usize`
- Tons of unit test fixing, because many dependencies changed!
- It's now harder to forge job IDs in unit tests, because we expect any job ID that's enqueued to _previously_ be installed into the dependency tracking map.  Assertions will fire if you forget this, so it's hard to get wrong, but required a bunch of annoying plumbing.