### PR TITLE
Don't pass `MutexGuard` into functions

### DIFF
--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -761,7 +761,7 @@ async fn create_and_enqueue_noop_io(
 // list of downstairs to repair.  If any of those change state from what
 // we expect, we return true here.
 fn repair_ds_state_change(
-    ds: &mut MutexGuard<'_, Downstairs>,
+    ds: &mut Downstairs,
     source: u8,
     repair: &[u8],
 ) -> bool {
@@ -779,7 +779,7 @@ impl Upstairs {
     // IO, then we must indicate that to the ds_done_tx channel.
     async fn abort_repair_ds(
         &self,
-        ds: &mut MutexGuard<'_, Downstairs>,
+        ds: &mut Downstairs,
         up_state: UpState,
         ds_done_tx: &mpsc::Sender<u64>,
     ) {
@@ -818,8 +818,8 @@ impl Upstairs {
     // NoOp jobs for them.
     async fn abort_repair_extent(
         &self,
-        gw: &mut MutexGuard<'_, GuestWork>,
-        ds: &mut MutexGuard<'_, Downstairs>,
+        gw: &mut GuestWork,
+        ds: &mut Downstairs,
         eid: u32,
     ) {
         warn!(self.log, "Extent {} Aborting repair", eid);


### PR DESCRIPTION
Small cleanup: `MutexGuard` implements `deref_mut` into a plain mutable reference, so we can use that instead.

Note that this could _theoretically_ change behavior in `submit_flush_internal`, which took the `MutexGuard` by value (i.e. dropping it at the end of the function).

Now, the `MutexGuard` is now dropped _outside_ of `submit_flush_internal`.  However, the call to `submit_flush_internal` is the last call in all parent function, so there's no actual behavior change.

All other functions changed in this PR were taking a `&mut MutexGuard`, which is harmless to change to a `&mut` reference.