### PR TITLE
Use `oneshot` channels instead of `mpsc` for notification

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -28,7 +28,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slog::{debug, error, info, o, warn, Logger};
 use tokio::net::{TcpSocket, TcpStream};
-use tokio::sync::{mpsc, watch, Mutex, MutexGuard, Notify, RwLock};
+use tokio::sync::{mpsc, oneshot, watch, Mutex, MutexGuard, Notify, RwLock};
 use tokio::time::{sleep_until, Instant};
 use tokio_util::codec::{FramedRead, FramedWrite};
 use tracing::{instrument, span, Level};
@@ -5033,7 +5033,7 @@ impl UpstairsState {
         self.up_state = UpState::Active;
         let req = self.req.take();
         if let Some(req) = req {
-            req.send_ok().await;
+            req.send_ok();
         }
         Ok(())
     }
@@ -5356,7 +5356,7 @@ impl Upstairs {
         // If something is waiting for activation, they can give up now.
         let req = active.req.take();
         if let Some(req) = req {
-            req.send_err(err).await;
+            req.send_err(err);
         }
         info!(
             self.log,
@@ -5415,12 +5415,12 @@ impl Upstairs {
          */
         if active.up_state == UpState::Initializing {
             if let Some(req) = req {
-                req.send_err(CrucibleError::UpstairsInactive).await;
+                req.send_err(CrucibleError::UpstairsInactive);
             }
             return Err(());
         } else if active.up_state == UpState::Deactivating {
             if let Some(req) = req {
-                req.send_err(CrucibleError::UpstairsDeactivating).await;
+                req.send_err(CrucibleError::UpstairsDeactivating);
             }
             return Err(());
         }
@@ -5454,7 +5454,7 @@ impl Upstairs {
         if ds.ds_active.is_empty() {
             debug!(self.log, "No work, no need to flush, return OK");
             if let Some(req) = req {
-                req.send_ok().await;
+                req.send_ok();
             }
             return Ok(());
         }
@@ -5644,7 +5644,7 @@ impl Upstairs {
                     self.log,
                     "{} active denied while Deactivating", self.uuid
                 );
-                req.send_err(CrucibleError::UpstairsDeactivating).await;
+                req.send_err(CrucibleError::UpstairsDeactivating);
                 crucible_bail!(UpstairsDeactivating);
             }
             UpState::Active => {
@@ -5652,7 +5652,7 @@ impl Upstairs {
                     self.log,
                     "{} Request to activate upstairs already active", self.uuid
                 );
-                req.send_err(CrucibleError::UpstairsAlreadyActive).await;
+                req.send_err(CrucibleError::UpstairsAlreadyActive);
                 crucible_bail!(UpstairsAlreadyActive);
             }
         }
@@ -5835,14 +5835,14 @@ impl Upstairs {
     ) -> Result<(), ()> {
         if !self.guest_io_ready().await {
             if let Some(req) = req {
-                req.send_err(CrucibleError::UpstairsInactive).await;
+                req.send_err(CrucibleError::UpstairsInactive);
             }
             return Err(());
         }
 
         if self.read_only {
             if let Some(req) = req {
-                req.send_err(CrucibleError::ModifyingReadOnlyRegion).await;
+                req.send_err(CrucibleError::ModifyingReadOnlyRegion);
             }
             return Err(());
         }
@@ -5864,7 +5864,7 @@ impl Upstairs {
             Ok(()) => {}
             Err(e) => {
                 if let Some(req) = req {
-                    req.send_err(e).await;
+                    req.send_err(e);
                 }
                 return Err(());
             }
@@ -5979,7 +5979,6 @@ impl Upstairs {
                                 req.send_err(CrucibleError::EncryptionError(
                                     e.to_string(),
                                 ))
-                                .await;
                             }
                             return Err(());
                         }
@@ -6085,7 +6084,7 @@ impl Upstairs {
     ) -> Result<(), ()> {
         if !self.guest_io_ready().await {
             if let Some(req) = req {
-                req.send_err(CrucibleError::UpstairsInactive).await;
+                req.send_err(CrucibleError::UpstairsInactive);
             }
             return Err(());
         }
@@ -6106,7 +6105,7 @@ impl Upstairs {
             Ok(()) => {}
             Err(e) => {
                 if let Some(req) = req {
-                    req.send_err(e).await;
+                    req.send_err(e);
                 }
                 return Err(());
             }
@@ -8814,7 +8813,7 @@ impl GtoS {
          * guest side reasons.
          */
         if let Some(req) = self.req {
-            req.send_result(result).await;
+            req.send_result(result);
         }
     }
 }
@@ -9067,7 +9066,7 @@ impl Guest {
      * This is used to submit a new BlockOp IO request to Crucible.
      */
     async fn send(&self, op: BlockOp) -> BlockReqWaiter {
-        let (send, recv) = mpsc::channel(1);
+        let (send, recv) = oneshot::channel();
 
         self.reqs.lock().await.push_back(BlockReq::new(op, send));
         self.notify.notify_one();
@@ -9712,11 +9711,11 @@ async fn process_new_io(
         }
         BlockOp::QueryGuestIOReady { data } => {
             *data.lock().await = up.guest_io_ready().await;
-            req.send_ok().await;
+            req.send_ok();
         }
         BlockOp::QueryUpstairsUuid { data } => {
             *data.lock().await = up.uuid;
-            req.send_ok().await;
+            req.send_ok();
         }
         /*
          * These options are only functional once the upstairs is
@@ -9780,7 +9779,7 @@ async fn process_new_io(
              * flush command.
              */
             if !up.guest_io_ready().await {
-                req.send_err(CrucibleError::UpstairsInactive).await;
+                req.send_err(CrucibleError::UpstairsInactive);
                 return;
             }
 
@@ -9806,11 +9805,11 @@ async fn process_new_io(
         } => match up.replace_downstairs(id, old, new, &ds_done_tx).await {
             Ok(v) => {
                 *result.lock().await = v;
-                req.send_ok().await;
+                req.send_ok();
             }
 
             Err(e) => {
-                req.send_err(e).await;
+                req.send_err(e);
             }
         },
         // Query ops
@@ -9825,13 +9824,12 @@ async fn process_new_io(
                     );
                     req.send_err(CrucibleError::PropertyNotAvailable(
                         "block size".to_string(),
-                    ))
-                    .await;
+                    ));
                     return;
                 }
             };
             *data.lock().await = size;
-            req.send_ok().await;
+            req.send_ok();
         }
         BlockOp::QueryTotalSize { data } => {
             let size = match up.ddef.lock().await.get_def() {
@@ -9844,13 +9842,12 @@ async fn process_new_io(
                     );
                     req.send_err(CrucibleError::PropertyNotAvailable(
                         "total size".to_string(),
-                    ))
-                    .await;
+                    ));
                     return;
                 }
             };
             *data.lock().await = size;
-            req.send_ok().await;
+            req.send_ok();
         }
         // Testing options
         BlockOp::QueryExtentSize { data } => {
@@ -9865,13 +9862,12 @@ async fn process_new_io(
                     );
                     req.send_err(CrucibleError::PropertyNotAvailable(
                         "extent size".to_string(),
-                    ))
-                    .await;
+                    ));
                     return;
                 }
             };
             *data.lock().await = size;
-            req.send_ok().await;
+            req.send_ok();
         }
         BlockOp::QueryWorkQueue { data } => {
             // TODO should this first check if the Upstairs is active?
@@ -9887,16 +9883,16 @@ async fn process_new_io(
                 ds_count: up.downstairs.lock().await.ds_active.len(),
                 active_count,
             };
-            req.send_ok().await;
+            req.send_ok();
         }
         BlockOp::ShowWork { data } => {
             // TODO should this first check if the Upstairs is active?
             *data.lock().await = show_all_work(up).await;
-            req.send_ok().await;
+            req.send_ok();
         }
         BlockOp::Commit => {
             if !up.guest_io_ready().await {
-                req.send_err(CrucibleError::UpstairsInactive).await;
+                req.send_err(CrucibleError::UpstairsInactive);
                 return;
             }
             send_work(dst, *lastcast, &up.log).await;

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 Oxide Computer Company
 
 use super::*;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 // Live Repair
 // This handles the situation where one (or two) downstairs are no longer
@@ -344,7 +344,7 @@ async fn live_repair_main(
     // Send a final flush, wait for it to finish so we know the downstairs
     // has cleared all the repair jobs and our "last flush" is set.
 
-    let (send, recv) = mpsc::channel(1);
+    let (send, recv) = oneshot::channel();
     let op = BlockOp::Flush {
         snapshot_details: None,
     };
@@ -611,7 +611,7 @@ async fn create_and_enqueue_reopen_io(
     sub.insert(reopen_id, 0);
 
     cdt::gw__reopen__start!(|| (gw_reopen_id, eid));
-    let (send, recv) = mpsc::channel(1);
+    let (send, recv) = oneshot::channel();
     let op = BlockOp::RepairOp;
     let reopen_br = BlockReq::new(op, send);
     let reopen_brw = BlockReqWaiter::new(recv);
@@ -655,7 +655,7 @@ async fn create_and_enqueue_close_io(
     sub.insert(close_id, 0);
 
     cdt::gw__close__start!(|| (gw_close_id, eid));
-    let (send, recv) = mpsc::channel(1);
+    let (send, recv) = oneshot::channel();
     let op = BlockOp::RepairOp;
     let close_br = BlockReq::new(op, send);
     let close_brw = BlockReqWaiter::new(recv);
@@ -695,7 +695,7 @@ async fn create_and_enqueue_repair_io(
     sub.insert(repair_id, 0);
 
     cdt::gw__repair__start!(|| (gw_repair_id, eid));
-    let (send, recv) = mpsc::channel(1);
+    let (send, recv) = oneshot::channel();
     let op = BlockOp::RepairOp;
     let repair_br = BlockReq::new(op, send);
     let repair_brw = BlockReqWaiter::new(recv);
@@ -722,7 +722,7 @@ async fn create_and_enqueue_noop_io(
     sub.insert(noop_id, 0);
 
     cdt::gw__noop__start!(|| (gw_noop_id));
-    let (send, recv) = mpsc::channel(1);
+    let (send, recv) = oneshot::channel();
     let op = BlockOp::RepairOp;
     let noop_br = BlockReq::new(op, send);
     let noop_brw = BlockReqWaiter::new(recv);
@@ -3250,7 +3250,7 @@ pub mod repair_test {
         let mut sub = HashMap::new();
         sub.insert(close_id, 0);
 
-        let (send, recv) = mpsc::channel(1);
+        let (send, recv) = oneshot::channel();
         let op = BlockOp::RepairOp;
         let close_br = BlockReq::new(op, send);
         let _close_brw = BlockReqWaiter::new(recv);


### PR DESCRIPTION
Notifications from a `BlockReq` to a `BlockReqWaiter` are a single `Result<(), CrucibleError` message.  Right now, we're using `tokio::sync::mpsc::channel(1)`.  This  adds a sync point during `send` (because from the APIs perspective, the channel may be full, so `send` must be async).

Because we're only ever sending a single value through this channel, we can instead use a `tokio::sync::oneshot` channel, which is designed for this use case.

This is a small but statistically significant improvement on read IOPS (> 2 stdev change when running `crutest` 10x), and a small but statistically insignificant improvement for write speed (which has much higher variance).

## Reads
### `main`
```
    TEST SECONDS COUNT DPTH    IOPS    MEAN     P95     P99      MAX    ES    EC
  rreads    6.55 30000    1 4583.10 0.00022 0.00025 0.00029  0.01471 16384   640
  rreads    6.46 30000    1 4646.06 0.00022 0.00025 0.00028  0.01525 16384   640
  rreads    6.51 30000    1 4608.56 0.00022 0.00025 0.00028  0.01525 16384   640
  rreads    6.52 30000    1 4603.10 0.00022 0.00025 0.00029  0.01525 16384   640
  rreads    6.51 30000    1 4607.41 0.00022 0.00025 0.00028  0.01562 16384   640
  rreads    6.49 30000    1 4620.88 0.00022 0.00025 0.00028  0.01562 16384   640
  rreads    6.51 30000    1 4607.92 0.00022 0.00025 0.00028  0.01562 16384   640
  rreads    6.49 30000    1 4621.01 0.00022 0.00025 0.00028  0.01562 16384   640
  rreads    6.48 30000    1 4632.23 0.00022 0.00025 0.00028  0.01562 16384   640
  rreads    6.51 30000    1 4610.36 0.00022 0.00025 0.00028  0.01562 16384   640
  IOPS: 4614 ± 16.3
  rreads    6.64 30000    1 4514.81 0.00022 0.00026 0.00030  0.01471 16384  1280
  rreads    6.52 30000    1 4599.36 0.00022 0.00025 0.00029  0.01471 16384  1280
  rreads    6.52 30000    1 4600.90 0.00022 0.00025 0.00029  0.01471 16384  1280
  rreads    6.52 30000    1 4597.74 0.00022 0.00025 0.00029  0.01471 16384  1280
  rreads    6.54 30000    1 4586.79 0.00022 0.00025 0.00029  0.01516 16384  1280
  rreads    6.53 30000    1 4593.17 0.00022 0.00025 0.00028  0.01534 16384  1280
  rreads    6.58 30000    1 4560.66 0.00022 0.00025 0.00028  0.01534 16384  1280
  rreads    6.55 30000    1 4581.24 0.00022 0.00025 0.00028  0.01563 16384  1280
  rreads    6.57 30000    1 4565.13 0.00022 0.00025 0.00028  0.01563 16384  1280
  rreads    6.52 30000    1 4601.92 0.00022 0.00025 0.00028  0.01563 16384  1280
  IOPS: 4580 ± 25.8
```
### `use-oneshot-channels`
```
    TEST SECONDS COUNT DPTH    IOPS    MEAN     P95     P99      MAX    ES    EC
  rreads    6.50 30000    1 4617.65 0.00022 0.00025 0.00029  0.01503 16384   640
  rreads    6.43 30000    1 4669.15 0.00022 0.00025 0.00029  0.01563 16384   640
  rreads    6.45 30000    1 4652.06 0.00022 0.00025 0.00028  0.01563 16384   640
  rreads    6.44 30000    1 4658.43 0.00021 0.00025 0.00028  0.01563 16384   640
  rreads    6.44 30000    1 4660.41 0.00021 0.00025 0.00028  0.01563 16384   640
  rreads    6.43 30000    1 4662.25 0.00021 0.00025 0.00028  0.01563 16384   640
  rreads    6.43 30000    1 4668.85 0.00021 0.00025 0.00028  0.01563 16384   640
  rreads    6.43 30000    1 4668.34 0.00021 0.00025 0.00028  0.01563 16384   640
  rreads    6.43 30000    1 4665.86 0.00021 0.00025 0.00028  0.01563 16384   640
  rreads    6.44 30000    1 4658.88 0.00021 0.00025 0.00028  0.01563 16384   640
  IOPS: 4658 ± 14.5
  rreads    6.55 30000    1 4582.55 0.00022 0.00025 0.00029  0.01474 16384  1280
  rreads    6.42 30000    1 4670.73 0.00022 0.00025 0.00029  0.01474 16384  1280
  rreads    6.45 30000    1 4649.84 0.00022 0.00025 0.00028  0.01474 16384  1280
  rreads    6.50 30000    1 4614.15 0.00022 0.00025 0.00028  0.01474 16384  1280
  rreads    6.47 30000    1 4634.51 0.00022 0.00025 0.00028  0.01518 16384  1280
  rreads    6.48 30000    1 4632.67 0.00022 0.00025 0.00028  0.01518 16384  1280
  rreads    6.45 30000    1 4654.31 0.00022 0.00025 0.00028  0.01518 16384  1280
  rreads    6.46 30000    1 4641.43 0.00022 0.00025 0.00028  0.01518 16384  1280
  rreads    6.45 30000    1 4652.11 0.00022 0.00025 0.00028  0.01529 16384  1280
  rreads    6.47 30000    1 4636.72 0.00022 0.00025 0.00028  0.01559 16384  1280
  IOPS: 4636 ± 23.2
```

## Writes
### `main`
```
    TEST SECONDS COUNT DPTH    IOPS    MEAN     P95     P99      MAX    ES    EC
 rwrites    7.10 30000    1 4227.72 0.00024 0.00032 0.00067  0.01331 16384   640
 rwrites    6.89 30000    1 4355.05 0.00023 0.00031 0.00066  0.01631 16384   640
 rwrites    6.85 30000    1 4377.51 0.00023 0.00030 0.00056  0.01824 16384   640
 rwrites    6.92 30000    1 4332.38 0.00023 0.00031 0.00060  0.01436 16384   640
 rwrites    6.87 30000    1 4366.58 0.00023 0.00031 0.00069  0.01503 16384   640
 rwrites    6.97 30000    1 4303.62 0.00023 0.00031 0.00069  0.01445 16384   640
 rwrites    7.09 30000    1 4231.12 0.00024 0.00032 0.00068  0.01692 16384   640
 rwrites    7.05 30000    1 4253.96 0.00023 0.00031 0.00068  0.01424 16384   640
 rwrites    7.06 30000    1 4250.98 0.00024 0.00032 0.00067  0.01822 16384   640
 rwrites    7.14 30000    1 4198.80 0.00024 0.00032 0.00061  0.01515 16384   640
 IOPS: 4289 ± 61.8
 rwrites    7.56 30000    1 3967.94 0.00025 0.00035 0.00080  0.01308 16384  1280
 rwrites    7.47 30000    1 4014.44 0.00025 0.00035 0.00090  0.01793 16384  1280
 rwrites    7.41 30000    1 4048.19 0.00025 0.00033 0.00078  0.01511 16384  1280
 rwrites    7.56 30000    1 3967.28 0.00025 0.00035 0.00086  0.01492 16384  1280
 rwrites    7.65 30000    1 3923.07 0.00025 0.00035 0.00084  0.01692 16384  1280
 rwrites    7.59 30000    1 3953.03 0.00025 0.00036 0.00087  0.01494 16384  1280
 rwrites    7.65 30000    1 3923.95 0.00025 0.00036 0.00084  0.02104 16384  1280
 rwrites    7.62 30000    1 3939.42 0.00025 0.00034 0.00079  0.01837 16384  1280
 rwrites    7.58 30000    1 3955.26 0.00025 0.00035 0.00083  0.02386 16384  1280
 rwrites    7.79 30000    1 3850.71 0.00026 0.00037 0.00091  0.01399 16384  1280
 IOPS: 3954 ± 50.6
 ```
 
### `use-oneshot-channels`
```
    TEST SECONDS COUNT DPTH    IOPS    MEAN     P95     P99      MAX    ES    EC
 rwrites    6.84 30000    1 4387.68 0.00023 0.00031 0.00060  0.01490 16384   640
 rwrites    6.76 30000    1 4439.42 0.00023 0.00031 0.00064  0.02136 16384   640
 rwrites    6.71 30000    1 4470.80 0.00022 0.00030 0.00063  0.01495 16384   640
 rwrites    6.87 30000    1 4365.02 0.00023 0.00031 0.00063  0.01553 16384   640
 rwrites    6.98 30000    1 4298.77 0.00023 0.00032 0.00071  0.01379 16384   640
 rwrites    6.91 30000    1 4338.87 0.00023 0.00031 0.00065  0.01949 16384   640
 rwrites    6.94 30000    1 4321.55 0.00023 0.00032 0.00066  0.01771 16384   640
 rwrites    6.96 30000    1 4310.83 0.00023 0.00032 0.00062  0.01384 16384   640
 rwrites    6.95 30000    1 4316.72 0.00023 0.00032 0.00059  0.01501 16384   640
 rwrites    7.17 30000    1 4182.85 0.00024 0.00032 0.00056  0.02147 16384   640
 IOPS: 4343 ± 76.1
 rwrites    7.44 30000    1 4030.18 0.00025 0.00035 0.00080  0.01301 16384  1280
 rwrites    7.37 30000    1 4069.49 0.00025 0.00033 0.00079  0.01766 16384  1280
 rwrites    7.50 30000    1 4000.72 0.00025 0.00034 0.00083  0.01800 16384  1280
 rwrites    7.50 30000    1 3999.46 0.00025 0.00033 0.00078  0.01748 16384  1280
 rwrites    7.49 30000    1 4006.84 0.00025 0.00035 0.00085  0.02014 16384  1280
 rwrites    7.52 30000    1 3986.80 0.00025 0.00035 0.00087  0.01885 16384  1280
 rwrites    7.53 30000    1 3986.03 0.00025 0.00035 0.00085  0.01559 16384  1280
 rwrites    7.56 30000    1 3968.88 0.00025 0.00035 0.00088  0.01416 16384  1280
 rwrites    7.64 30000    1 3926.24 0.00025 0.00036 0.00088  0.01641 16384  1280
 rwrites    7.63 30000    1 3932.45 0.00025 0.00034 0.00089  0.02201 16384  1280
 IOPS: 3990 ± 40.3
```