### PR TITLE
Wait for a snapshot to finish on all downstairs

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -10414,7 +10414,7 @@ async fn show_all_work(up: &Arc<Upstairs>) -> WQCounts {
     let gior = up.guest_io_ready().await;
     let up_count = up.guest.guest_work.lock().await.active.len();
 
-    let mut ds = up.downstairs.lock().await;
+    let ds = up.downstairs.lock().await;
     let ds_count = ds.ds_active.len();
 
     println!(

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -4479,20 +4479,27 @@ impl Downstairs {
                     dependencies: _dependencies,
                     flush_number: _flush_number,
                     gen_number: _gen_number,
-                    snapshot_details: _,
+                    snapshot_details,
                     extent_limit: _,
                 } => {
                     assert!(read_data.is_empty());
                     assert!(extent_info.is_none());
                     /*
-                     * If we are deactivating, then we want an ACK from
-                     * all three downstairs, not the usual two.
+                     * If we are deactivating or have requested a
+                     * snapshot, then we want an ACK from all three
+                     * downstairs, not the usual two.
+                     *
                      * TODO here for handling the case where one (or two,
                      * or three! gasp!) downstairs are Offline.
                      */
-                    if (deactivate && jobs_completed_ok == 3)
-                        || (!deactivate && jobs_completed_ok == 2)
-                    {
+                    let ack_at_num_jobs =
+                        if deactivate || snapshot_details.is_some() {
+                            3
+                        } else {
+                            2
+                        };
+
+                    if jobs_completed_ok == ack_at_num_jobs {
                         notify_guest = true;
                         job.ack_status = AckStatus::AckReady;
                         cdt::up__to__ds__flush__done!(|| job.guest_id);

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -816,6 +816,85 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 1);
     }
 
+    // Ensure that a snapshot requires all three downstairs to return Ok
+    #[tokio::test]
+    async fn work_flush_snapshot_needs_three() {
+        let upstairs = Upstairs::test_default(None);
+        let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
+        upstairs.set_active().await.unwrap();
+        let mut ds = upstairs.downstairs.lock().await;
+
+        let next_id = ds.next_id();
+
+        let op = create_flush(
+            next_id,
+            vec![],
+            10,
+            0,
+            0,
+            Some(SnapshotDetails {
+                snapshot_name: String::from("snap"),
+            }),
+            ImpactedBlocks::Empty,
+            None,
+        );
+
+        ds.enqueue(op, ds_done_tx.clone()).await;
+
+        ds.in_progress(next_id, 0);
+        ds.in_progress(next_id, 1);
+        ds.in_progress(next_id, 2);
+
+        assert!(!ds
+            .process_ds_completion(
+                next_id,
+                0,
+                Ok(vec![]),
+                &None,
+                UpState::Active,
+                None,
+            )
+            .unwrap());
+
+        assert_eq!(ds.ackable_work().len(), 0);
+        assert_eq!(ds.completed.len(), 0);
+
+        assert!(!ds
+            .process_ds_completion(
+                next_id,
+                1,
+                Ok(vec![]),
+                &None,
+                UpState::Active,
+                None,
+            )
+            .unwrap());
+
+        assert_eq!(ds.ackable_work().len(), 0);
+        assert_eq!(ds.completed.len(), 0);
+
+        assert!(ds
+            .process_ds_completion(
+                next_id,
+                2,
+                Ok(vec![]),
+                &None,
+                UpState::Active,
+                None,
+            )
+            .unwrap());
+
+        assert_eq!(ds.ackable_work().len(), 1);
+
+        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        assert_eq!(state, AckStatus::AckReady);
+        ds.ack(next_id);
+
+        ds.retire_check(next_id);
+
+        assert_eq!(ds.completed.len(), 1);
+    }
+
     #[tokio::test]
     async fn work_flush_one_error_then_ok() {
         let upstairs = Upstairs::test_default(None);

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -850,14 +850,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId::new(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -871,7 +871,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId::new(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -885,7 +885,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                2,
+                ClientId::new(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -895,7 +895,7 @@ pub(crate) mod up_test {
 
         assert_eq!(ds.ackable_work().len(), 1);
 
-        let state = ds.ds_active.get_mut(&next_id).unwrap().ack_status;
+        let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
         ds.ack(next_id);
 


### PR DESCRIPTION
Nexus, when running a snapshot-create saga, will attempt to start read-only downstairs corresponding to a snapshot after it has returned from taking that snapshot (either through the instance's propolis or via the pantry), but the upstairs acks all non-deactivate flushes after only two jobs have been seen. This can lead to a 404 trying to start a read-only downstairs (as the snapshot may not exist yet). See #431.

Wait for all downstairs to return Ok for flush + snapshot jobs before acking to the Guest.