### PR TITLE
A few Crucible Agent fixes

### DIFF
--- a/agent/src/smf_interface.rs
+++ b/agent/src/smf_interface.rs
@@ -518,9 +518,12 @@ impl SmfInstance for MockSmfInstance {
         (Option<crucible_smf::State>, Option<crucible_smf::State>),
         crucible_smf::ScfError,
     > {
-        // TODO is this necessary for testing? it's only used for debug print
-        // right now
-        Ok((None, None))
+        let inner = self.inner.lock().unwrap();
+        if inner.enabled {
+            Ok((Some(crucible_smf::State::Online), None))
+        } else {
+            Ok((Some(crucible_smf::State::Disabled), None))
+        }
     }
 
     fn disable(&self, temporary: bool) -> Result<(), crucible_smf::ScfError> {


### PR DESCRIPTION
All these issues were found running the snapshot antagonist as part of testing for oxidecomputer/omicron#3866.

It is possible to call `delete_running_snapshot_request` for a snapshot that was in any state, and that function would Tombstone the running snapshot, even if it was already Destroyed! This would result in a cycle of Tombstoned -> Destroyed -> Tombstoned -> Destroyed ...  for as long as delete requests were being made. This commit changes that function to do the right thing: only Tombstone running snapshots that are in Requested or Created. Unit tests were added to validate some transitions.

The Crucible agent is very noisy: choose to use `debug` for messages that repeat a lot, and hide some messages behind conditionals.

Add more information to some log messages, and correctly identify region and running snapshot IDs.