### PR TITLE
Use a strong type for client ID

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -690,8 +690,8 @@ where
                 extent: extent_id,
                 flush_number,
                 gen_number,
-                source_downstairs: ClientId(0), // Unused in the downstairs
-                repair_downstairs: vec![],      // Unused in the downstairs
+                source_downstairs: ClientId::new(0), // Unused in the downstairs
+                repair_downstairs: vec![],           // Unused in the downstairs
             };
 
             let d = ad.lock().await;
@@ -3554,8 +3554,8 @@ mod test {
             extent: 1,
             flush_number: 1,
             gen_number: 2,
-            source_downstairs: ClientId(0),
-            repair_downstairs: vec![ClientId(1)],
+            source_downstairs: ClientId::new(0),
+            repair_downstairs: vec![ClientId::new(1)],
         };
         ds.add_work(upstairs_connection, JobId(1001), rio).await?;
 
@@ -3644,8 +3644,8 @@ mod test {
             extent: 1,
             flush_number: 1,
             gen_number: gen,
-            source_downstairs: ClientId(0),
-            repair_downstairs: vec![ClientId(1)],
+            source_downstairs: ClientId::new(0),
+            repair_downstairs: vec![ClientId::new(1)],
         };
         ds.add_work(upstairs_connection, JobId(1001), rio).await?;
 
@@ -4076,8 +4076,8 @@ mod test {
             extent: eid as usize,
             flush_number: 3,
             gen_number: gen,
-            source_downstairs: ClientId(0),
-            repair_downstairs: vec![ClientId(1)],
+            source_downstairs: ClientId::new(0),
+            repair_downstairs: vec![ClientId::new(1)],
         };
         ds.add_work(upstairs_connection, JobId(1001), rio).await?;
 
@@ -4206,8 +4206,8 @@ mod test {
             extent: eid_one as usize,
             flush_number: 6,
             gen_number: gen,
-            source_downstairs: ClientId(0),
-            repair_downstairs: vec![ClientId(1)],
+            source_downstairs: ClientId::new(0),
+            repair_downstairs: vec![ClientId::new(1)],
         };
         ds.add_work(upstairs_connection, JobId(1002), rio).await?;
 
@@ -4376,8 +4376,8 @@ mod test {
             extent: eid,
             flush_number: 1,
             gen_number: 2,
-            source_downstairs: ClientId(0),
-            repair_downstairs: vec![ClientId(1)],
+            source_downstairs: ClientId::new(0),
+            repair_downstairs: vec![ClientId::new(1)],
         };
         test_misc_work_through_work_queue(JobId(1000), ioop);
     }
@@ -4393,9 +4393,9 @@ mod test {
         let ioop = IOop::ExtentLiveRepair {
             dependencies: vec![],
             extent: eid,
-            source_downstairs: ClientId(0),
+            source_downstairs: ClientId::new(0),
             source_repair_address,
-            repair_downstairs: vec![ClientId(1)],
+            repair_downstairs: vec![ClientId::new(1)],
         };
         test_misc_work_through_work_queue(JobId(1000), ioop);
     }

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -690,8 +690,8 @@ where
                 extent: extent_id,
                 flush_number,
                 gen_number,
-                source_downstairs: 0, // Unused in the downstairs
-                repair_downstairs: vec![], // Unused in the downstairs
+                source_downstairs: ClientId(0), // Unused in the downstairs
+                repair_downstairs: vec![],      // Unused in the downstairs
             };
 
             let d = ad.lock().await;
@@ -3554,8 +3554,8 @@ mod test {
             extent: 1,
             flush_number: 1,
             gen_number: 2,
-            source_downstairs: 0,
-            repair_downstairs: vec![1],
+            source_downstairs: ClientId(0),
+            repair_downstairs: vec![ClientId(1)],
         };
         ds.add_work(upstairs_connection, JobId(1001), rio).await?;
 
@@ -3644,8 +3644,8 @@ mod test {
             extent: 1,
             flush_number: 1,
             gen_number: gen,
-            source_downstairs: 0,
-            repair_downstairs: vec![1],
+            source_downstairs: ClientId(0),
+            repair_downstairs: vec![ClientId(1)],
         };
         ds.add_work(upstairs_connection, JobId(1001), rio).await?;
 
@@ -4076,8 +4076,8 @@ mod test {
             extent: eid as usize,
             flush_number: 3,
             gen_number: gen,
-            source_downstairs: 0,
-            repair_downstairs: vec![1],
+            source_downstairs: ClientId(0),
+            repair_downstairs: vec![ClientId(1)],
         };
         ds.add_work(upstairs_connection, JobId(1001), rio).await?;
 
@@ -4206,8 +4206,8 @@ mod test {
             extent: eid_one as usize,
             flush_number: 6,
             gen_number: gen,
-            source_downstairs: 0,
-            repair_downstairs: vec![1],
+            source_downstairs: ClientId(0),
+            repair_downstairs: vec![ClientId(1)],
         };
         ds.add_work(upstairs_connection, JobId(1002), rio).await?;
 
@@ -4376,8 +4376,8 @@ mod test {
             extent: eid,
             flush_number: 1,
             gen_number: 2,
-            source_downstairs: 0,
-            repair_downstairs: vec![1],
+            source_downstairs: ClientId(0),
+            repair_downstairs: vec![ClientId(1)],
         };
         test_misc_work_through_work_queue(JobId(1000), ioop);
     }
@@ -4393,9 +4393,9 @@ mod test {
         let ioop = IOop::ExtentLiveRepair {
             dependencies: vec![],
             extent: eid,
-            source_downstairs: 0,
+            source_downstairs: ClientId(0),
             source_repair_address,
-            repair_downstairs: vec![1],
+            repair_downstairs: vec![ClientId(1)],
         };
         test_misc_work_through_work_queue(JobId(1000), ioop);
     }

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -43,6 +43,8 @@ impl std::fmt::Display for JobId {
 }
 
 /// Wrapper type for a client ID
+///
+/// This is guaranteed by construction to be in the range `0..3`
 #[derive(
     Copy,
     Clone,
@@ -60,6 +62,10 @@ impl std::fmt::Display for JobId {
 pub struct ClientId(u8);
 
 impl ClientId {
+    /// Builds a new client ID
+    ///
+    /// # Panics
+    /// If `i >= 3`, the ID is invalid and this constructor will panic
     pub fn new(i: u8) -> Self {
         assert!(i < 3);
         Self(i)

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -59,12 +59,6 @@ impl std::fmt::Display for JobId {
 #[serde(transparent)]
 pub struct ClientId(pub u8);
 
-impl From<ClientId> for usize {
-    fn from(c: ClientId) -> usize {
-        usize::from(c.0)
-    }
-}
-
 impl ClientId {
     pub fn iter() -> impl Iterator<Item = Self> {
         (0..3).map(Self)

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -42,6 +42,45 @@ impl std::fmt::Display for JobId {
     }
 }
 
+/// Wrapper type for a client ID
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Eq,
+    Hash,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+)]
+#[serde(transparent)]
+pub struct ClientId(pub u8);
+
+impl From<ClientId> for usize {
+    fn from(c: ClientId) -> usize {
+        usize::from(c.0)
+    }
+}
+
+impl ClientId {
+    pub fn iter() -> impl Iterator<Item = Self> {
+        (0..3).map(Self)
+    }
+}
+
+impl std::fmt::Display for ClientId {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> Result<(), std::fmt::Error> {
+        // TODO: this could include brackets, e.g. "[0]"
+        self.0.fmt(f)
+    }
+}
+
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Write {
@@ -312,7 +351,7 @@ pub enum Message {
     ExtentFlush {
         repair_id: u64,
         extent_id: usize,
-        client_id: u8,
+        client_id: ClientId,
         flush_number: u64,
         gen_number: u64,
     },
@@ -321,9 +360,9 @@ pub enum Message {
     ExtentRepair {
         repair_id: u64,
         extent_id: usize,
-        source_client_id: u8,
+        source_client_id: ClientId,
         source_repair_address: SocketAddr,
-        dest_clients: Vec<u8>,
+        dest_clients: Vec<ClientId>,
     },
 
     /// The given repair job ID has finished without error
@@ -369,7 +408,7 @@ pub enum Message {
         job_id: JobId,
         dependencies: Vec<JobId>,
         extent_id: usize,
-        source_client_id: u8,
+        source_client_id: ClientId,
         source_repair_address: SocketAddr,
     },
     /// Reopen this extent, for use when upstairs is active.

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -57,11 +57,18 @@ impl std::fmt::Display for JobId {
     schemars::JsonSchema,
 )]
 #[serde(transparent)]
-pub struct ClientId(pub u8);
+pub struct ClientId(u8);
 
 impl ClientId {
+    pub fn new(i: u8) -> Self {
+        assert!(i < 3);
+        Self(i)
+    }
     pub fn iter() -> impl Iterator<Item = Self> {
         (0..3).map(Self)
+    }
+    pub fn get(&self) -> u8 {
+        self.0
     }
 }
 

--- a/upstairs/src/control.rs
+++ b/upstairs/src/control.rs
@@ -233,6 +233,7 @@ async fn fault_downstairs(
             format!("Invalid downstairs client id: {}", cid),
         ));
     }
+    let cid = ClientId(cid);
 
     /*
      * Verify the downstairs is currently in a state where we can
@@ -248,7 +249,7 @@ async fn fault_downstairs(
         ));
     }
     let mut ds = api_context.up.downstairs.lock().await;
-    match ds.ds_state[cid as usize] {
+    match ds.ds_state[usize::from(cid)] {
         DsState::Active
         | DsState::Offline
         | DsState::LiveRepair

--- a/upstairs/src/control.rs
+++ b/upstairs/src/control.rs
@@ -149,6 +149,11 @@ async fn upstairs_fill_info(
     let live_repair_completed = ds.live_repair_completed;
     let live_repair_aborted = ds.live_repair_aborted;
 
+    // Convert from a map of extent limits to a Vec<Option<usize>>
+    let extent_limit = ClientId::iter()
+        .map(|i| extent_limit.get(&i).cloned())
+        .collect();
+
     Ok(HttpResponseOk(UpstairsStats {
         state: act,
         ds_state: ds_state.0.to_vec(),
@@ -158,7 +163,7 @@ async fn upstairs_fill_info(
         repair_needed,
         extents_repaired: extents_repaired.0.to_vec(),
         extents_confirmed: extents_confirmed.0.to_vec(),
-        extent_limit: extent_limit.0.to_vec(),
+        extent_limit,
         live_repair_completed: live_repair_completed.0.to_vec(),
         live_repair_aborted: live_repair_aborted.0.to_vec(),
     }))

--- a/upstairs/src/control.rs
+++ b/upstairs/src/control.rs
@@ -111,16 +111,16 @@ impl UpstairsInfo {
 #[derive(Deserialize, Serialize, JsonSchema)]
 struct UpstairsStats {
     state: UpState,
-    ds_state: Vec<DsState>,
+    ds_state: ClientData<DsState>,
     up_jobs: usize,
     ds_jobs: usize,
     repair_done: usize,
     repair_needed: usize,
-    extents_repaired: Vec<usize>,
-    extents_confirmed: Vec<usize>,
-    extent_limit: Vec<Option<usize>>,
-    live_repair_completed: Vec<usize>,
-    live_repair_aborted: Vec<usize>,
+    extents_repaired: ClientData<usize>,
+    extents_confirmed: ClientData<usize>,
+    extent_limit: ClientData<Option<usize>>,
+    live_repair_completed: ClientData<usize>,
+    live_repair_aborted: ClientData<usize>,
 }
 
 /**
@@ -143,11 +143,11 @@ async fn upstairs_fill_info(
     let ds_jobs = ds.ds_active.len();
     let repair_done = ds.reconcile_repaired;
     let repair_needed = ds.reconcile_repair_needed;
-    let extents_repaired = ds.extents_repaired.clone();
-    let extents_confirmed = ds.extents_confirmed.clone();
-    let extent_limit = ds.extent_limit.clone();
-    let live_repair_completed = ds.live_repair_completed.clone();
-    let live_repair_aborted = ds.live_repair_aborted.clone();
+    let extents_repaired = ds.extents_repaired;
+    let extents_confirmed = ds.extents_confirmed;
+    let extent_limit = ds.extent_limit;
+    let live_repair_completed = ds.live_repair_completed;
+    let live_repair_aborted = ds.live_repair_aborted;
 
     Ok(HttpResponseOk(UpstairsStats {
         state: act,
@@ -249,7 +249,7 @@ async fn fault_downstairs(
         ));
     }
     let mut ds = api_context.up.downstairs.lock().await;
-    match ds.ds_state[usize::from(cid)] {
+    match ds.ds_state[cid] {
         DsState::Active
         | DsState::Offline
         | DsState::LiveRepair

--- a/upstairs/src/control.rs
+++ b/upstairs/src/control.rs
@@ -111,16 +111,16 @@ impl UpstairsInfo {
 #[derive(Deserialize, Serialize, JsonSchema)]
 struct UpstairsStats {
     state: UpState,
-    ds_state: ClientData<DsState>,
+    ds_state: Vec<DsState>,
     up_jobs: usize,
     ds_jobs: usize,
     repair_done: usize,
     repair_needed: usize,
-    extents_repaired: ClientData<usize>,
-    extents_confirmed: ClientData<usize>,
-    extent_limit: ClientData<Option<usize>>,
-    live_repair_completed: ClientData<usize>,
-    live_repair_aborted: ClientData<usize>,
+    extents_repaired: Vec<usize>,
+    extents_confirmed: Vec<usize>,
+    extent_limit: Vec<Option<usize>>,
+    live_repair_completed: Vec<usize>,
+    live_repair_aborted: Vec<usize>,
 }
 
 /**
@@ -151,16 +151,16 @@ async fn upstairs_fill_info(
 
     Ok(HttpResponseOk(UpstairsStats {
         state: act,
-        ds_state,
+        ds_state: ds_state.0.to_vec(),
         up_jobs,
         ds_jobs,
         repair_done,
         repair_needed,
-        extents_repaired,
-        extents_confirmed,
-        extent_limit,
-        live_repair_completed,
-        live_repair_aborted,
+        extents_repaired: extents_repaired.0.to_vec(),
+        extents_confirmed: extents_confirmed.0.to_vec(),
+        extent_limit: extent_limit.0.to_vec(),
+        live_repair_completed: live_repair_completed.0.to_vec(),
+        live_repair_aborted: live_repair_aborted.0.to_vec(),
     }))
 }
 

--- a/upstairs/src/control.rs
+++ b/upstairs/src/control.rs
@@ -233,7 +233,7 @@ async fn fault_downstairs(
             format!("Invalid downstairs client id: {}", cid),
         ));
     }
-    let cid = ClientId(cid);
+    let cid = ClientId::new(cid);
 
     /*
      * Verify the downstairs is currently in a state where we can

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -20,6 +20,7 @@ pub(crate) mod protocol_test {
     use crucible_common::Block;
     use crucible_common::RegionDefinition;
     use crucible_common::RegionOptions;
+    use crucible_protocol::ClientId;
     use crucible_protocol::CrucibleDecoder;
     use crucible_protocol::CrucibleEncoder;
     use crucible_protocol::JobId;
@@ -1508,7 +1509,7 @@ pub(crate) mod protocol_test {
                     source_client_id,
                     ..
                 } => {
-                    bail_assert!(*source_client_id != 0);
+                    bail_assert!(*source_client_id != ClientId(0));
                     bail_assert!(*extent_id == eid);
 
                     ds1.fw
@@ -2303,7 +2304,7 @@ pub(crate) mod protocol_test {
                 source_client_id,
                 ..
             } => {
-                bail_assert!(*source_client_id != 0);
+                bail_assert!(*source_client_id != ClientId(0));
                 bail_assert!(*extent_id == 0);
 
                 // send back error report here!

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -1509,7 +1509,7 @@ pub(crate) mod protocol_test {
                     source_client_id,
                     ..
                 } => {
-                    bail_assert!(*source_client_id != ClientId(0));
+                    bail_assert!(*source_client_id != ClientId::new(0));
                     bail_assert!(*extent_id == eid);
 
                     ds1.fw
@@ -2304,7 +2304,7 @@ pub(crate) mod protocol_test {
                 source_client_id,
                 ..
             } => {
-                bail_assert!(*source_client_id != ClientId(0));
+                bail_assert!(*source_client_id != ClientId::new(0));
                 bail_assert!(*extent_id == 0);
 
                 // send back error report here!

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -401,15 +401,6 @@ impl<T> ClientData<T> {
     }
 }
 
-impl<'a, T> IntoIterator for &'a ClientData<T> {
-    type Item = &'a T;
-    type IntoIter = std::slice::Iter<'a, T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter()
-    }
-}
-
 /// Map of data associated with clients, keyed by `ClientId`
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(transparent)]

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -364,6 +364,7 @@ pub fn deadline_secs(secs: f32) -> Instant {
         .unwrap()
 }
 
+/// Array of data associated with three clients, indexed by `ClientId`
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(transparent)]
 pub struct ClientData<T>([T; 3]);
@@ -409,6 +410,7 @@ impl<'a, T> IntoIterator for &'a ClientData<T> {
     }
 }
 
+/// Map of data associated with clients, keyed by `ClientId`
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(transparent)]
 pub struct ClientMap<T>(ClientData<Option<T>>);

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -8406,7 +8406,6 @@ impl IOStateCount {
 
     pub fn incr(&mut self, state: &IOState, cid: ClientId) {
         let cid = cid.get() as usize;
-        assert!(cid < 3);
         match state {
             IOState::New => {
                 self.new[cid] += 1;
@@ -8428,7 +8427,6 @@ impl IOStateCount {
 
     pub fn decr(&mut self, state: &IOState, cid: ClientId) {
         let cid = cid.get() as usize;
-        assert!(cid < 3);
         match state {
             IOState::New => {
                 self.new[cid] -= 1;

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -5288,17 +5288,17 @@ impl Upstairs {
             let arg = Arg {
                 up_count,
                 ds_count,
-                ds_state: ds_state.0.to_vec(),
+                ds_state: ds_state.0,
                 ds_io_count,
                 ds_reconciled,
                 ds_reconcile_needed,
-                ds_live_repair_completed: ds_live_repair_completed.0.to_vec(),
-                ds_live_repair_aborted: ds_live_repair_aborted.0.to_vec(),
-                ds_connected: ds_connected.0.to_vec(),
-                ds_replaced: ds_replaced.0.to_vec(),
-                ds_flow_control: ds_flow_control.0.to_vec(),
-                ds_extents_repaired: ds_extents_repaired.0.to_vec(),
-                ds_extents_confirmed: ds_extents_confirmed.0.to_vec(),
+                ds_live_repair_completed: ds_live_repair_completed.0,
+                ds_live_repair_aborted: ds_live_repair_aborted.0,
+                ds_connected: ds_connected.0,
+                ds_replaced: ds_replaced.0,
+                ds_flow_control: ds_flow_control.0,
+                ds_extents_repaired: ds_extents_repaired.0,
+                ds_extents_confirmed: ds_extents_confirmed.0,
             };
             (msg, arg)
         });
@@ -9937,17 +9937,17 @@ async fn process_new_io(
 pub struct Arg {
     pub up_count: u32,
     pub ds_count: u32,
-    pub ds_state: Vec<DsState>,
+    pub ds_state: [DsState; 3],
     pub ds_io_count: IOStateCount,
     pub ds_reconciled: usize,
     pub ds_reconcile_needed: usize,
-    pub ds_live_repair_completed: Vec<usize>,
-    pub ds_live_repair_aborted: Vec<usize>,
-    pub ds_connected: Vec<usize>,
-    pub ds_replaced: Vec<usize>,
-    pub ds_flow_control: Vec<usize>,
-    pub ds_extents_repaired: Vec<usize>,
-    pub ds_extents_confirmed: Vec<usize>,
+    pub ds_live_repair_completed: [usize; 3],
+    pub ds_live_repair_aborted: [usize; 3],
+    pub ds_connected: [usize; 3],
+    pub ds_replaced: [usize; 3],
+    pub ds_flow_control: [usize; 3],
+    pub ds_extents_repaired: [usize; 3],
+    pub ds_extents_confirmed: [usize; 3],
 }
 
 /**

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -558,7 +558,7 @@ fn repair_or_noop(
 
     // Now that we have consumed the contents, be sure to clear
     // out anything we did not look at.  There could be something left
-    ds.repair_info = HashMap::new();
+    ds.repair_info = ClientMap::new();
 
     if need_repair.is_empty() {
         info!(ds.log, "No repair needed for extent {}", extent);
@@ -1378,7 +1378,7 @@ pub mod repair_test {
 
     // Test function to create a downstairs.
     fn create_test_downstairs() -> Downstairs {
-        let mut ds = Downstairs::new(csl(), ClientData::new(None));
+        let mut ds = Downstairs::new(csl(), ClientMap::new());
         for cid in ClientId::iter() {
             ds.ds_repair.insert(cid, "127.0.0.1:1234".parse().unwrap());
         }

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -415,15 +415,11 @@ fn create_reopen_io(
         extent: eid,
     };
 
-    let mut state = HashMap::new();
-    for cl in ClientId::iter() {
-        state.insert(cl, IOState::New);
-    }
     DownstairsIO {
         ds_id,
         guest_id: gw_id,
         work: reopen_ioop,
-        state,
+        state: ClientData::new(IOState::New),
         ack_status: AckStatus::NotAcked,
         replay: false,
         data: None,
@@ -453,16 +449,11 @@ fn create_close_io(
         repair_downstairs: repair,
     };
 
-    let mut state = HashMap::new();
-    for cl in ClientId::iter() {
-        state.insert(cl, IOState::New);
-    }
-
     DownstairsIO {
         ds_id,
         guest_id: gw_id,
         work: close_ioop,
-        state,
+        state: ClientData::new(IOState::New),
         ack_status: AckStatus::NotAcked,
         replay: false,
         data: None,
@@ -490,15 +481,11 @@ fn create_repair_io(
         repair_downstairs,
     };
 
-    let mut state = HashMap::new();
-    for cl in ClientId::iter() {
-        state.insert(cl, IOState::New);
-    }
     DownstairsIO {
         ds_id,
         guest_id: gw_id,
         work: repair_ioop,
-        state,
+        state: ClientData::new(IOState::New),
         ack_status: AckStatus::NotAcked,
         replay: false,
         data: None,
@@ -515,15 +502,11 @@ fn create_noop_io(
 ) -> DownstairsIO {
     let noop_ioop = IOop::ExtentLiveNoOp { dependencies };
 
-    let mut state = HashMap::new();
-    for cl in ClientId::iter() {
-        state.insert(cl, IOState::New);
-    }
     DownstairsIO {
         ds_id,
         guest_id: gw_id,
         work: noop_ioop,
-        state,
+        state: ClientData::new(IOState::New),
         ack_status: AckStatus::NotAcked,
         replay: false,
         data: None,
@@ -3869,7 +3852,7 @@ pub mod repair_test {
             }
         }
         for cid in ClientId::iter() {
-            assert_eq!(job.state[&cid], IOState::New);
+            assert_eq!(job.state[cid], IOState::New);
         }
         assert_eq!(job.ack_status, AckStatus::NotAcked);
         assert!(!job.replay);
@@ -3947,7 +3930,7 @@ pub mod repair_test {
             }
         }
         for cid in ClientId::iter() {
-            assert_eq!(job.state[&cid], IOState::New);
+            assert_eq!(job.state[cid], IOState::New);
         }
         assert_eq!(job.ack_status, AckStatus::NotAcked);
         assert!(!job.replay);
@@ -4017,7 +4000,7 @@ pub mod repair_test {
             }
         }
         for cid in ClientId::iter() {
-            assert_eq!(job.state[&cid], IOState::New);
+            assert_eq!(job.state[cid], IOState::New);
         }
         assert_eq!(job.ack_status, AckStatus::NotAcked);
         assert!(!job.replay);
@@ -4109,7 +4092,7 @@ pub mod repair_test {
             }
         }
         for cid in ClientId::iter() {
-            assert_eq!(job.state[&cid], IOState::New);
+            assert_eq!(job.state[cid], IOState::New);
         }
         assert_eq!(job.ack_status, AckStatus::NotAcked);
         assert!(!job.replay);
@@ -5158,9 +5141,9 @@ pub mod repair_test {
         assert!(jobs[1].work.deps().is_empty());
         assert_eq!(jobs[2].work.deps(), &[JobId(1001), JobId(1000)]);
         // Check that the IOs were skipped on downstairs 1.
-        assert_eq!(jobs[0].state[&ClientId(1)], IOState::Skipped);
-        assert_eq!(jobs[1].state[&ClientId(1)], IOState::Skipped);
-        assert_eq!(jobs[2].state[&ClientId(1)], IOState::Skipped);
+        assert_eq!(jobs[0].state[ClientId(1)], IOState::Skipped);
+        assert_eq!(jobs[1].state[ClientId(1)], IOState::Skipped);
+        assert_eq!(jobs[2].state[ClientId(1)], IOState::Skipped);
     }
 
     #[tokio::test]
@@ -5419,9 +5402,9 @@ pub mod repair_test {
         let jobs: Vec<&DownstairsIO> = ds.ds_active.values().collect();
 
         for job in jobs.iter().take(3) {
-            assert_eq!(job.state[&ClientId(0)], IOState::New);
-            assert_eq!(job.state[&ClientId(1)], IOState::Skipped);
-            assert_eq!(job.state[&ClientId(2)], IOState::New);
+            assert_eq!(job.state[ClientId(0)], IOState::New);
+            assert_eq!(job.state[ClientId(1)], IOState::Skipped);
+            assert_eq!(job.state[ClientId(2)], IOState::New);
         }
         assert_eq!(ds.extent_limit[ClientId(1)], None);
     }
@@ -5457,9 +5440,9 @@ pub mod repair_test {
 
         assert_eq!(jobs.len(), 7);
         for job in jobs.iter().take(7) {
-            assert_eq!(job.state[&ClientId(0)], IOState::New);
-            assert_eq!(job.state[&ClientId(1)], IOState::Skipped);
-            assert_eq!(job.state[&ClientId(2)], IOState::New);
+            assert_eq!(job.state[ClientId(0)], IOState::New);
+            assert_eq!(job.state[ClientId(1)], IOState::Skipped);
+            assert_eq!(job.state[ClientId(2)], IOState::New);
         }
 
         // Verify that the four jobs we added match what should have
@@ -5505,9 +5488,9 @@ pub mod repair_test {
         let jobs: Vec<&DownstairsIO> = ds.ds_active.values().collect();
 
         for job in jobs.iter().take(3) {
-            assert_eq!(job.state[&ClientId(0)], IOState::Skipped);
-            assert_eq!(job.state[&ClientId(1)], IOState::Skipped);
-            assert_eq!(job.state[&ClientId(2)], IOState::Skipped);
+            assert_eq!(job.state[ClientId(0)], IOState::Skipped);
+            assert_eq!(job.state[ClientId(1)], IOState::Skipped);
+            assert_eq!(job.state[ClientId(2)], IOState::Skipped);
         }
 
         // No repair jobs should be submitted
@@ -5587,9 +5570,9 @@ pub mod repair_test {
         for job_id in (1003..1006).map(JobId) {
             let job = ds.ds_active.get(&job_id).unwrap();
             // jobs 3,4,5 will be skipped for our LiveRepair downstairs.
-            assert_eq!(job.state[&ClientId(0)], IOState::New);
-            assert_eq!(job.state[&ClientId(1)], IOState::Skipped);
-            assert_eq!(job.state[&ClientId(2)], IOState::New);
+            assert_eq!(job.state[ClientId(0)], IOState::New);
+            assert_eq!(job.state[ClientId(1)], IOState::Skipped);
+            assert_eq!(job.state[ClientId(2)], IOState::New);
         }
 
         // Walk the three new jobs, verify that the dependencies will be
@@ -5692,9 +5675,9 @@ pub mod repair_test {
         // are on an extent we "already repaired".
         for job_id in (1006..1009).map(JobId) {
             let job = ds.ds_active.get(&job_id).unwrap();
-            assert_eq!(job.state[&ClientId(0)], IOState::New);
-            assert_eq!(job.state[&ClientId(1)], IOState::New);
-            assert_eq!(job.state[&ClientId(2)], IOState::New);
+            assert_eq!(job.state[ClientId(0)], IOState::New);
+            assert_eq!(job.state[ClientId(1)], IOState::New);
+            assert_eq!(job.state[ClientId(2)], IOState::New);
         }
 
         // Walk the three final jobs, verify that the dependencies will be
@@ -5871,9 +5854,9 @@ pub mod repair_test {
 
         let mut ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&JobId(1007)).unwrap();
-        assert_eq!(job.state[&ClientId(0)], IOState::New);
-        assert_eq!(job.state[&ClientId(1)], IOState::Skipped);
-        assert_eq!(job.state[&ClientId(2)], IOState::New);
+        assert_eq!(job.state[ClientId(0)], IOState::New);
+        assert_eq!(job.state[ClientId(1)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(2)], IOState::New);
 
         let current_deps = job.work.deps().to_vec();
         assert_eq!(&current_deps, &[JobId(1002), JobId(1001), JobId(1000)]);
@@ -5893,9 +5876,9 @@ pub mod repair_test {
         // on Active downstairs, and only require the repair on the
         // LiveRepair downstairs.
         let job = ds.ds_active.get(&JobId(1008)).unwrap();
-        assert_eq!(job.state[&ClientId(0)], IOState::New);
-        assert_eq!(job.state[&ClientId(1)], IOState::New);
-        assert_eq!(job.state[&ClientId(2)], IOState::New);
+        assert_eq!(job.state[ClientId(0)], IOState::New);
+        assert_eq!(job.state[ClientId(1)], IOState::New);
+        assert_eq!(job.state[ClientId(2)], IOState::New);
 
         let current_deps = job.work.deps().to_vec();
         assert_eq!(&current_deps, &[JobId(1004), JobId(1000)]);
@@ -5911,9 +5894,9 @@ pub mod repair_test {
         // This final job depends on everything on Active downstairs, but
         // a smaller subset for the LiveRepair downstairs
         let job = ds.ds_active.get(&JobId(1013)).unwrap();
-        assert_eq!(job.state[&ClientId(0)], IOState::New);
-        assert_eq!(job.state[&ClientId(1)], IOState::New);
-        assert_eq!(job.state[&ClientId(2)], IOState::New);
+        assert_eq!(job.state[ClientId(0)], IOState::New);
+        assert_eq!(job.state[ClientId(1)], IOState::New);
+        assert_eq!(job.state[ClientId(2)], IOState::New);
 
         // All the current operations, plus four future repair operations
         // that don't exist yet.
@@ -6095,9 +6078,9 @@ pub mod repair_test {
         // on Active downstairs, and only require the repair on the
         // LiveRepair downstairs.
         let job = ds.ds_active.get(&JobId(1005)).unwrap();
-        assert_eq!(job.state[&ClientId(0)], IOState::New);
-        assert_eq!(job.state[&ClientId(1)], IOState::New);
-        assert_eq!(job.state[&ClientId(2)], IOState::New);
+        assert_eq!(job.state[ClientId(0)], IOState::New);
+        assert_eq!(job.state[ClientId(1)], IOState::New);
+        assert_eq!(job.state[ClientId(2)], IOState::New);
 
         let current_deps = job.work.deps().to_vec();
         assert_eq!(&current_deps, &[JobId(1004), JobId(1001), JobId(1000)]);
@@ -6210,15 +6193,15 @@ pub mod repair_test {
         // The first job, should have the dependences for the new repair work
         assert_eq!(jobs[0].ds_id, JobId(1004));
         assert_eq!(jobs[0].work.deps(), &[JobId(1003)]);
-        assert_eq!(jobs[0].state[&ClientId(0)], IOState::New);
-        assert_eq!(jobs[0].state[&ClientId(1)], IOState::New);
-        assert_eq!(jobs[0].state[&ClientId(2)], IOState::New);
+        assert_eq!(jobs[0].state[ClientId(0)], IOState::New);
+        assert_eq!(jobs[0].state[ClientId(1)], IOState::New);
+        assert_eq!(jobs[0].state[ClientId(2)], IOState::New);
 
         // The 2nd job should aldo have the dependences for the new repair work
         assert_eq!(jobs[1].work.deps(), &[JobId(1003)]);
-        assert_eq!(jobs[1].state[&ClientId(0)], IOState::New);
-        assert_eq!(jobs[1].state[&ClientId(1)], IOState::New);
-        assert_eq!(jobs[1].state[&ClientId(2)], IOState::New);
+        assert_eq!(jobs[1].state[ClientId(0)], IOState::New);
+        assert_eq!(jobs[1].state[ClientId(1)], IOState::New);
+        assert_eq!(jobs[1].state[ClientId(2)], IOState::New);
     }
 
     #[tokio::test]
@@ -6317,23 +6300,23 @@ pub mod repair_test {
         // The first job should have no dependencies
         assert_eq!(jobs[0].ds_id, JobId(1000));
         assert!(jobs[0].work.deps().is_empty());
-        assert_eq!(jobs[0].state[&ClientId(0)], IOState::New);
-        assert_eq!(jobs[0].state[&ClientId(1)], IOState::Skipped);
-        assert_eq!(jobs[0].state[&ClientId(2)], IOState::New);
+        assert_eq!(jobs[0].state[ClientId(0)], IOState::New);
+        assert_eq!(jobs[0].state[ClientId(1)], IOState::Skipped);
+        assert_eq!(jobs[0].state[ClientId(2)], IOState::New);
 
         assert_eq!(jobs[1].ds_id, JobId(1005));
         assert_eq!(jobs[1].work.deps(), &[JobId(1000), JobId(1004)]);
-        assert_eq!(jobs[1].state[&ClientId(0)], IOState::New);
-        assert_eq!(jobs[1].state[&ClientId(1)], IOState::New);
-        assert_eq!(jobs[1].state[&ClientId(2)], IOState::New);
+        assert_eq!(jobs[1].state[ClientId(0)], IOState::New);
+        assert_eq!(jobs[1].state[ClientId(1)], IOState::New);
+        assert_eq!(jobs[1].state[ClientId(2)], IOState::New);
 
         assert_eq!(jobs[2].ds_id, JobId(1010));
         assert_eq!(
             jobs[2].work.deps(),
             &[JobId(1000), JobId(1004), JobId(1009)]
         );
-        assert_eq!(jobs[2].state[&ClientId(0)], IOState::New);
-        assert_eq!(jobs[2].state[&ClientId(1)], IOState::New);
-        assert_eq!(jobs[2].state[&ClientId(2)], IOState::New);
+        assert_eq!(jobs[2].state[ClientId(0)], IOState::New);
+        assert_eq!(jobs[2].state[ClientId(1)], IOState::New);
+        assert_eq!(jobs[2].state[ClientId(2)], IOState::New);
     }
 }

--- a/upstairs/src/mend.rs
+++ b/upstairs/src/mend.rs
@@ -250,7 +250,7 @@ fn find_source(
      * index being the client ID.  We use the max_gen vec to see if any
      * of the remaining client IDs have a higher flush number.
      */
-    let rec = vec![c0, c1, c2];
+    let rec = ClientData([c0, c1, c2]);
 
     info!(
         log,
@@ -266,12 +266,12 @@ fn find_source(
     let mut max_flush = Vec::new();
 
     for sc in max_gen.iter() {
-        if rec[usize::from(*sc)].flush_numbers[i] > max {
-            max = rec[usize::from(*sc)].flush_numbers[i];
+        if rec[*sc].flush_numbers[i] > max {
+            max = rec[*sc].flush_numbers[i];
         }
     }
     for sc in max_gen.iter() {
-        if rec[usize::from(*sc)].flush_numbers[i] == max {
+        if rec[*sc].flush_numbers[i] == max {
             max_flush.push(*sc);
         }
     }
@@ -291,7 +291,7 @@ fn find_source(
         "extent:{}  dirty: {} {} {}", i, c0.dirty[i], c1.dirty[i], c2.dirty[i],
     );
     for sc in max_flush.iter() {
-        if rec[usize::from(*sc)].dirty[i] {
+        if rec[*sc].dirty[i] {
             return *sc;
         }
     }
@@ -333,7 +333,7 @@ fn find_dest(
      * Put the three downstairs RegionMetadata structs into an array with the
      * index being the client ID.
      */
-    let rec = vec![c0, c1, c2];
+    let rec = ClientData([c0, c1, c2]);
 
     info!(
         log,
@@ -346,16 +346,13 @@ fn find_dest(
         ClientId(_) => vec![ClientId(0), ClientId(1)],
     };
 
-    let source = usize::from(source);
     for dc in to_check.iter() {
-        if rec[source].generation[i] != rec[usize::from(*dc)].generation[i] {
+        if rec[source].generation[i] != rec[*dc].generation[i] {
             dest.push(*dc);
             info!(log, "source {}, add dest {} gen", source, dc);
             continue;
         }
-        if rec[source].flush_numbers[i]
-            != rec[usize::from(*dc)].flush_numbers[i]
-        {
+        if rec[source].flush_numbers[i] != rec[*dc].flush_numbers[i] {
             dest.push(*dc);
             info!(log, "source {}, add dest {} flush", source, dc);
             continue;
@@ -365,7 +362,7 @@ fn find_dest(
             info!(log, "source {}, add dest {} source flush", source, dc);
             continue;
         }
-        if rec[usize::from(*dc)].dirty[i] {
+        if rec[*dc].dirty[i] {
             dest.push(*dc);
             info!(log, "source {}, add dest {} dc flush", source, dc);
             continue;

--- a/upstairs/src/mend.rs
+++ b/upstairs/src/mend.rs
@@ -327,7 +327,6 @@ fn find_dest(
     c2: &RegionMetadata,
     log: &Logger,
 ) -> Vec<ClientId> {
-    assert!(source.get() < 3);
     let mut dest: Vec<ClientId> = Vec::new();
 
     /*

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -1418,7 +1418,7 @@ pub(crate) mod up_test {
     #[tokio::test]
     async fn work_read_hash_mismatch_third() {
         // Test that a hash mismatch on the third response will trigger a panic.
-        let mut ds = Downstairs::new(csl(), ClientData::new(None));
+        let mut ds = Downstairs::new(csl(), ClientMap::new());
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
 
         let id = ds.next_id();
@@ -1773,7 +1773,7 @@ pub(crate) mod up_test {
 
         assert!(ds.downstairs_errors[ClientId(0)] > 0);
         assert!(ds.downstairs_errors[ClientId(1)] > 0);
-        assert!(ds.downstairs_errors[ClientId(2)] > 0);
+        assert_eq!(ds.downstairs_errors[ClientId(2)], 0);
     }
 
     #[tokio::test]
@@ -2370,9 +2370,9 @@ pub(crate) mod up_test {
             Some(vec![Bytes::from_static(&[3])]),
         );
 
-        assert!(ds.downstairs_errors[ClientId(0)] > 0);
-        assert!(ds.downstairs_errors[ClientId(1)] > 0);
-        assert!(ds.downstairs_errors[ClientId(2)] > 0);
+        assert_eq!(ds.downstairs_errors[ClientId(0)], 0);
+        assert_eq!(ds.downstairs_errors[ClientId(1)], 0);
+        assert_eq!(ds.downstairs_errors[ClientId(2)], 0);
 
         // send another read, and expect all to return something
         // (reads shouldn't cause a Failed transition)
@@ -5181,7 +5181,7 @@ pub(crate) mod up_test {
     #[tokio::test]
     async fn bad_hash_on_encrypted_read_panic() {
         // Verify that a decryption failure on a read will panic.
-        let mut ds = Downstairs::new(csl(), ClientData::new(None));
+        let mut ds = Downstairs::new(csl(), ClientMap::new());
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         let next_id = ds.next_id();
 

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -1771,9 +1771,9 @@ pub(crate) mod up_test {
         // if it's just a write, then it should be false.
         assert_eq!(res, is_write_unwritten);
 
-        assert!(ds.downstairs_errors.get(&ClientId(0)).is_some());
-        assert!(ds.downstairs_errors.get(&ClientId(1)).is_some());
-        assert!(ds.downstairs_errors.get(&ClientId(2)).is_none());
+        assert!(ds.downstairs_errors[ClientId(0)] > 0);
+        assert!(ds.downstairs_errors[ClientId(1)] > 0);
+        assert!(ds.downstairs_errors[ClientId(2)] > 0);
     }
 
     #[tokio::test]
@@ -2370,9 +2370,9 @@ pub(crate) mod up_test {
             Some(vec![Bytes::from_static(&[3])]),
         );
 
-        assert!(ds.downstairs_errors.get(&ClientId(0)).is_none());
-        assert!(ds.downstairs_errors.get(&ClientId(1)).is_none());
-        assert!(ds.downstairs_errors.get(&ClientId(2)).is_none());
+        assert!(ds.downstairs_errors[ClientId(0)] > 0);
+        assert!(ds.downstairs_errors[ClientId(1)] > 0);
+        assert!(ds.downstairs_errors[ClientId(2)] > 0);
 
         // send another read, and expect all to return something
         // (reads shouldn't cause a Failed transition)

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -777,14 +777,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, ClientId(0));
-        ds.in_progress(next_id, ClientId(1));
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -797,7 +797,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -814,7 +814,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(2),
+                ClientId::new(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -847,14 +847,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, ClientId(0));
-        ds.in_progress(next_id, ClientId(1));
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -867,7 +867,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -880,7 +880,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(2),
+                ClientId::new(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -894,9 +894,9 @@ pub(crate) mod up_test {
 
         assert_eq!(ds.completed.len(), 1);
         // No skipped jobs here.
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 0);
     }
 
     #[tokio::test]
@@ -921,14 +921,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, ClientId(0));
-        ds.in_progress(next_id, ClientId(1));
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -941,7 +941,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -954,7 +954,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(2),
+                ClientId::new(2),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -982,9 +982,9 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, ClientId(0));
-        ds.in_progress(next_id, ClientId(1));
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         let response =
             Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
@@ -992,7 +992,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 response,
                 &None,
                 UpState::Active,
@@ -1012,7 +1012,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 response,
                 &None,
                 UpState::Active,
@@ -1028,7 +1028,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(2),
+                ClientId::new(2),
                 response,
                 &None,
                 UpState::Active,
@@ -1053,14 +1053,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, ClientId(0));
-        ds.in_progress(next_id, ClientId(1));
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -1076,7 +1076,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 response,
                 &None,
                 UpState::Active,
@@ -1096,7 +1096,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(2),
+                ClientId::new(2),
                 response,
                 &None,
                 UpState::Active,
@@ -1122,14 +1122,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, ClientId(0));
-        ds.in_progress(next_id, ClientId(1));
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -1142,7 +1142,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -1158,7 +1158,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(2),
+                ClientId::new(2),
                 response,
                 &None,
                 UpState::Active,
@@ -1188,14 +1188,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, ClientId(0));
-        ds.in_progress(next_id, ClientId(1));
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -1208,7 +1208,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -1221,7 +1221,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(2),
+                ClientId::new(2),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -1259,9 +1259,9 @@ pub(crate) mod up_test {
 
             ds.enqueue(op, ds_done_tx.clone()).await;
 
-            ds.in_progress(next_id, ClientId(0));
-            ds.in_progress(next_id, ClientId(1));
-            ds.in_progress(next_id, ClientId(2));
+            ds.in_progress(next_id, ClientId::new(0));
+            ds.in_progress(next_id, ClientId::new(1));
+            ds.in_progress(next_id, ClientId::new(2));
 
             next_id
         };
@@ -1270,12 +1270,17 @@ pub(crate) mod up_test {
             Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
 
         assert!(upstairs
-            .process_ds_operation(next_id, ClientId(2), response.clone(), None)
+            .process_ds_operation(
+                next_id,
+                ClientId::new(2),
+                response.clone(),
+                None
+            )
             .await
             .unwrap());
 
         assert!(!upstairs
-            .process_ds_operation(next_id, ClientId(0), response, None)
+            .process_ds_operation(next_id, ClientId::new(0), response, None)
             .await
             .unwrap());
 
@@ -1293,7 +1298,7 @@ pub(crate) mod up_test {
         assert!(!upstairs
             .process_ds_operation(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 None,
             )
@@ -1322,8 +1327,8 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(id, ClientId(0));
-        ds.in_progress(id, ClientId(1));
+        ds.in_progress(id, ClientId::new(0));
+        ds.in_progress(id, ClientId::new(1));
 
         // Generate the first read response, this will be what we compare
         // future responses with.
@@ -1331,7 +1336,7 @@ pub(crate) mod up_test {
 
         ds.process_ds_completion(
             id,
-            ClientId(0),
+            ClientId::new(0),
             r1,
             &None,
             UpState::Active,
@@ -1351,7 +1356,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     id,
-                    ClientId(1),
+                    ClientId::new(1),
                     r2,
                     &None,
                     UpState::Active,
@@ -1376,8 +1381,8 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(id, ClientId(0));
-        ds.in_progress(id, ClientId(1));
+        ds.in_progress(id, ClientId::new(0));
+        ds.in_progress(id, ClientId::new(1));
 
         // Generate the first read response, this will be what we compare
         // future responses with.
@@ -1385,7 +1390,7 @@ pub(crate) mod up_test {
 
         ds.process_ds_completion(
             id,
-            ClientId(0),
+            ClientId::new(0),
             r1,
             &None,
             UpState::Active,
@@ -1405,7 +1410,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     id,
-                    ClientId(1),
+                    ClientId::new(1),
                     r2,
                     &None,
                     UpState::Active,
@@ -1427,9 +1432,9 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(id, ClientId(0));
-        ds.in_progress(id, ClientId(1));
-        ds.in_progress(id, ClientId(2));
+        ds.in_progress(id, ClientId::new(0));
+        ds.in_progress(id, ClientId::new(1));
+        ds.in_progress(id, ClientId::new(2));
 
         // Generate the first read response, this will be what we compare
         // future responses with.
@@ -1437,7 +1442,7 @@ pub(crate) mod up_test {
 
         ds.process_ds_completion(
             id,
-            ClientId(0),
+            ClientId::new(0),
             r1,
             &None,
             UpState::Active,
@@ -1450,7 +1455,7 @@ pub(crate) mod up_test {
 
         ds.process_ds_completion(
             id,
-            ClientId(1),
+            ClientId::new(1),
             r2,
             &None,
             UpState::Active,
@@ -1464,7 +1469,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     id,
-                    ClientId(2),
+                    ClientId::new(2),
                     r3,
                     &None,
                     UpState::Active,
@@ -1489,9 +1494,9 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(id, ClientId(0));
-        ds.in_progress(id, ClientId(1));
-        ds.in_progress(id, ClientId(2));
+        ds.in_progress(id, ClientId::new(0));
+        ds.in_progress(id, ClientId::new(1));
+        ds.in_progress(id, ClientId::new(2));
 
         // Generate the first read response, this will be what we compare
         // future responses with.
@@ -1499,7 +1504,7 @@ pub(crate) mod up_test {
 
         ds.process_ds_completion(
             id,
-            ClientId(0),
+            ClientId::new(0),
             r1,
             &None,
             UpState::Active,
@@ -1513,7 +1518,7 @@ pub(crate) mod up_test {
         ds.ack(id);
         ds.process_ds_completion(
             id,
-            ClientId(1),
+            ClientId::new(1),
             r2,
             &None,
             UpState::Active,
@@ -1527,7 +1532,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     id,
-                    ClientId(2),
+                    ClientId::new(2),
                     r3,
                     &None,
                     UpState::Active,
@@ -1551,8 +1556,8 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(id, ClientId(0));
-        ds.in_progress(id, ClientId(1));
+        ds.in_progress(id, ClientId::new(0));
+        ds.in_progress(id, ClientId::new(1));
 
         // Generate the first read response, this will be what we compare
         // future responses with.
@@ -1563,7 +1568,7 @@ pub(crate) mod up_test {
 
         ds.process_ds_completion(
             id,
-            ClientId(0),
+            ClientId::new(0),
             r1,
             &None,
             UpState::Active,
@@ -1581,7 +1586,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     id,
-                    ClientId(1),
+                    ClientId::new(1),
                     r2,
                     &None,
                     UpState::Active,
@@ -1606,8 +1611,8 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(id, ClientId(0));
-        ds.in_progress(id, ClientId(1));
+        ds.in_progress(id, ClientId::new(0));
+        ds.in_progress(id, ClientId::new(1));
 
         // Generate the first read response, this will be what we compare
         // future responses with.
@@ -1615,7 +1620,7 @@ pub(crate) mod up_test {
 
         ds.process_ds_completion(
             id,
-            ClientId(0),
+            ClientId::new(0),
             r1,
             &None,
             UpState::Active,
@@ -1630,7 +1635,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     id,
-                    ClientId(1),
+                    ClientId::new(1),
                     r2,
                     &None,
                     UpState::Active,
@@ -1654,8 +1659,8 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(id, ClientId(0));
-        ds.in_progress(id, ClientId(1));
+        ds.in_progress(id, ClientId::new(0));
+        ds.in_progress(id, ClientId::new(1));
 
         // Generate the first read response, this will be what we compare
         // future responses with.
@@ -1663,7 +1668,7 @@ pub(crate) mod up_test {
 
         ds.process_ds_completion(
             id,
-            ClientId(0),
+            ClientId::new(0),
             r1,
             &None,
             UpState::Active,
@@ -1678,7 +1683,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     id,
-                    ClientId(1),
+                    ClientId::new(1),
                     r2,
                     &None,
                     UpState::Active,
@@ -1724,14 +1729,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        assert!(ds.in_progress(next_id, ClientId(0)).is_some());
-        assert!(ds.in_progress(next_id, ClientId(1)).is_some());
-        assert!(ds.in_progress(next_id, ClientId(2)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(0)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(1)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(2)).is_some());
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -1744,7 +1749,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -1759,7 +1764,7 @@ pub(crate) mod up_test {
         let res = ds
             .process_ds_completion(
                 next_id,
-                ClientId(2),
+                ClientId::new(2),
                 response,
                 &None,
                 UpState::Active,
@@ -1771,9 +1776,9 @@ pub(crate) mod up_test {
         // if it's just a write, then it should be false.
         assert_eq!(res, is_write_unwritten);
 
-        assert!(ds.downstairs_errors[ClientId(0)] > 0);
-        assert!(ds.downstairs_errors[ClientId(1)] > 0);
-        assert_eq!(ds.downstairs_errors[ClientId(2)], 0);
+        assert!(ds.downstairs_errors[ClientId::new(0)] > 0);
+        assert!(ds.downstairs_errors[ClientId::new(1)] > 0);
+        assert_eq!(ds.downstairs_errors[ClientId::new(2)], 0);
     }
 
     #[tokio::test]
@@ -1800,7 +1805,7 @@ pub(crate) mod up_test {
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
-        up.ds_transition(ClientId(1), DsState::Faulted).await;
+        up.ds_transition(ClientId::new(1), DsState::Faulted).await;
 
         let mut gw = up.guest.guest_work.lock().await;
         let mut ds = up.downstairs.lock().await;
@@ -1830,13 +1835,13 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        assert!(ds.in_progress(next_id, ClientId(0)).is_some());
-        assert!(ds.in_progress(next_id, ClientId(2)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(0)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(2)).is_some());
 
         let response = Ok(vec![]);
         ds.process_ds_completion(
             next_id,
-            ClientId(0),
+            ClientId::new(0),
             response.clone(),
             &None,
             UpState::Active,
@@ -1846,7 +1851,7 @@ pub(crate) mod up_test {
 
         ds.process_ds_completion(
             next_id,
-            ClientId(2),
+            ClientId::new(2),
             response,
             &None,
             UpState::Active,
@@ -1894,8 +1899,8 @@ pub(crate) mod up_test {
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
-        up.ds_transition(ClientId(1), DsState::Faulted).await;
-        up.ds_transition(ClientId(2), DsState::Faulted).await;
+        up.ds_transition(ClientId::new(1), DsState::Faulted).await;
+        up.ds_transition(ClientId::new(2), DsState::Faulted).await;
 
         let mut gw = up.guest.guest_work.lock().await;
         let mut ds = up.downstairs.lock().await;
@@ -1924,11 +1929,11 @@ pub(crate) mod up_test {
         drop(gw);
 
         ds.enqueue(op, ds_done_tx.clone()).await;
-        assert!(ds.in_progress(next_id, ClientId(0)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(0)).is_some());
 
         ds.process_ds_completion(
             next_id,
-            ClientId(0),
+            ClientId::new(0),
             Ok(vec![]),
             &None,
             UpState::Active,
@@ -1977,7 +1982,7 @@ pub(crate) mod up_test {
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
-        up.ds_transition(ClientId(2), DsState::Faulted).await;
+        up.ds_transition(ClientId::new(2), DsState::Faulted).await;
 
         let mut gw = up.guest.guest_work.lock().await;
         let mut ds = up.downstairs.lock().await;
@@ -2006,13 +2011,13 @@ pub(crate) mod up_test {
         drop(gw);
 
         ds.enqueue(op, ds_done_tx.clone()).await;
-        assert!(ds.in_progress(next_id, ClientId(0)).is_some());
-        assert!(ds.in_progress(next_id, ClientId(1)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(0)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(1)).is_some());
 
         // DS 0, the good IO.
         ds.process_ds_completion(
             next_id,
-            ClientId(0),
+            ClientId::new(0),
             Ok(vec![]),
             &None,
             UpState::Active,
@@ -2026,7 +2031,7 @@ pub(crate) mod up_test {
         let res = ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -2067,7 +2072,7 @@ pub(crate) mod up_test {
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
-        up.ds_transition(ClientId(1), DsState::Faulted).await;
+        up.ds_transition(ClientId::new(1), DsState::Faulted).await;
 
         let mut gw = up.guest.guest_work.lock().await;
         let mut ds = up.downstairs.lock().await;
@@ -2098,13 +2103,13 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        assert!(ds.in_progress(next_id, ClientId(0)).is_some());
-        assert!(ds.in_progress(next_id, ClientId(2)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(0)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(2)).is_some());
 
         let response = Ok(vec![]);
         ds.process_ds_completion(
             next_id,
-            ClientId(0),
+            ClientId::new(0),
             response.clone(),
             &None,
             UpState::Active,
@@ -2114,7 +2119,7 @@ pub(crate) mod up_test {
 
         ds.process_ds_completion(
             next_id,
-            ClientId(2),
+            ClientId::new(2),
             response,
             &None,
             UpState::Active,
@@ -2151,8 +2156,8 @@ pub(crate) mod up_test {
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
-        up.ds_transition(ClientId(1), DsState::Faulted).await;
-        up.ds_transition(ClientId(2), DsState::Faulted).await;
+        up.ds_transition(ClientId::new(1), DsState::Faulted).await;
+        up.ds_transition(ClientId::new(2), DsState::Faulted).await;
 
         let mut gw = up.guest.guest_work.lock().await;
         let mut ds = up.downstairs.lock().await;
@@ -2182,11 +2187,11 @@ pub(crate) mod up_test {
         drop(gw);
 
         ds.enqueue(op, ds_done_tx.clone()).await;
-        assert!(ds.in_progress(next_id, ClientId(0)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(0)).is_some());
 
         ds.process_ds_completion(
             next_id,
-            ClientId(0),
+            ClientId::new(0),
             Ok(vec![]),
             &None,
             UpState::Active,
@@ -2224,7 +2229,7 @@ pub(crate) mod up_test {
             up.ds_transition(cid, DsState::Active).await;
         }
         // Only DS 0 is faulted.
-        up.ds_transition(ClientId(0), DsState::Faulted).await;
+        up.ds_transition(ClientId::new(0), DsState::Faulted).await;
 
         let mut gw = up.guest.guest_work.lock().await;
         let mut ds = up.downstairs.lock().await;
@@ -2254,15 +2259,15 @@ pub(crate) mod up_test {
         drop(gw);
 
         ds.enqueue(op, ds_done_tx.clone()).await;
-        assert!(ds.in_progress(next_id, ClientId(1)).is_some());
-        assert!(ds.in_progress(next_id, ClientId(2)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(1)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(2)).is_some());
 
         // DS 1 has a failure, and this won't return true as we don't
         // have enough success yet to ACK to the guest.
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -2275,7 +2280,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(2),
+                ClientId::new(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2316,14 +2321,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        assert!(ds.in_progress(next_id, ClientId(0)).is_some());
-        assert!(ds.in_progress(next_id, ClientId(1)).is_some());
-        assert!(ds.in_progress(next_id, ClientId(2)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(0)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(1)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(2)).is_some());
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -2336,7 +2341,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -2352,7 +2357,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(2),
+                ClientId::new(2),
                 response,
                 &None,
                 UpState::Active,
@@ -2370,9 +2375,9 @@ pub(crate) mod up_test {
             Some(vec![Bytes::from_static(&[3])]),
         );
 
-        assert_eq!(ds.downstairs_errors[ClientId(0)], 0);
-        assert_eq!(ds.downstairs_errors[ClientId(1)], 0);
-        assert_eq!(ds.downstairs_errors[ClientId(2)], 0);
+        assert_eq!(ds.downstairs_errors[ClientId::new(0)], 0);
+        assert_eq!(ds.downstairs_errors[ClientId::new(1)], 0);
+        assert_eq!(ds.downstairs_errors[ClientId::new(2)], 0);
 
         // send another read, and expect all to return something
         // (reads shouldn't cause a Failed transition)
@@ -2382,14 +2387,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        assert!(ds.in_progress(next_id, ClientId(0)).is_some());
-        assert!(ds.in_progress(next_id, ClientId(1)).is_some());
-        assert!(ds.in_progress(next_id, ClientId(2)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(0)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(1)).is_some());
+        assert!(ds.in_progress(next_id, ClientId::new(2)).is_some());
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -2402,7 +2407,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -2418,7 +2423,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(2),
+                ClientId::new(2),
                 response,
                 &None,
                 UpState::Active,
@@ -2454,9 +2459,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Move the work to submitted like we sent it to each downstairs
-        ds.in_progress(next_id, ClientId(0));
-        ds.in_progress(next_id, ClientId(1));
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         // Downstairs 0 now has completed this work.
         let response =
@@ -2464,7 +2469,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 response,
                 &None,
                 UpState::Active,
@@ -2481,7 +2486,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 response,
                 &None,
                 UpState::Active,
@@ -2494,7 +2499,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(2),
+                ClientId::new(2),
                 response,
                 &None,
                 UpState::Active,
@@ -2532,15 +2537,15 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, ClientId(0));
-        ds.in_progress(next_id, ClientId(1));
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         // Complete the Flush at each downstairs.
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2551,7 +2556,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2561,7 +2566,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(2),
+                ClientId::new(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2599,9 +2604,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Move the work to submitted like we sent it to each downstairs
-        ds.in_progress(next_id, ClientId(0));
-        ds.in_progress(next_id, ClientId(1));
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         // Downstairs 0 now has completed this work.
         let response =
@@ -2609,7 +2614,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 response,
                 &None,
                 UpState::Active,
@@ -2718,16 +2723,16 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Simulate sending both writes to downstairs 0 and 1
-        assert!(ds.in_progress(id1, ClientId(0)).is_some());
-        assert!(ds.in_progress(id1, ClientId(1)).is_some());
-        assert!(ds.in_progress(id2, ClientId(0)).is_some());
-        assert!(ds.in_progress(id2, ClientId(1)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(0)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(1)).is_some());
+        assert!(ds.in_progress(id2, ClientId::new(0)).is_some());
+        assert!(ds.in_progress(id2, ClientId::new(1)).is_some());
 
         // Simulate completing both writes to downstairs 0 and 1
         assert!(!ds
             .process_ds_completion(
                 id1,
-                ClientId(0),
+                ClientId::new(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2737,7 +2742,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 id1,
-                ClientId(1),
+                ClientId::new(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2747,7 +2752,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 id2,
-                ClientId(0),
+                ClientId::new(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2757,7 +2762,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 id2,
-                ClientId(1),
+                ClientId::new(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2788,14 +2793,14 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Simulate sending the flush to downstairs 0 and 1
-        ds.in_progress(flush_id, ClientId(0));
-        ds.in_progress(flush_id, ClientId(1));
+        ds.in_progress(flush_id, ClientId::new(0));
+        ds.in_progress(flush_id, ClientId::new(1));
 
         // Simulate completing the flush to downstairs 0 and 1
         assert!(!ds
             .process_ds_completion(
                 flush_id,
-                ClientId(0),
+                ClientId::new(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2805,7 +2810,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 flush_id,
-                ClientId(1),
+                ClientId::new(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2818,9 +2823,9 @@ pub(crate) mod up_test {
 
         // Make sure downstairs 0 and 1 update their last flush id and
         // that downstairs 2 does not.
-        assert_eq!(ds.ds_last_flush[ClientId(0)], flush_id);
-        assert_eq!(ds.ds_last_flush[ClientId(1)], flush_id);
-        assert_eq!(ds.ds_last_flush[ClientId(2)], JobId(0));
+        assert_eq!(ds.ds_last_flush[ClientId::new(0)], flush_id);
+        assert_eq!(ds.ds_last_flush[ClientId::new(1)], flush_id);
+        assert_eq!(ds.ds_last_flush[ClientId::new(2)], JobId(0));
 
         // Should not retire yet.
         ds.retire_check(flush_id);
@@ -2831,12 +2836,12 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 0);
 
         // Now, finish the writes to downstairs 2
-        assert!(ds.in_progress(id1, ClientId(2)).is_some());
-        assert!(ds.in_progress(id2, ClientId(2)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(2)).is_some());
+        assert!(ds.in_progress(id2, ClientId::new(2)).is_some());
         assert!(!ds
             .process_ds_completion(
                 id1,
-                ClientId(2),
+                ClientId::new(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2846,7 +2851,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 id2,
-                ClientId(2),
+                ClientId::new(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2858,11 +2863,11 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 0);
 
         // Complete the flush on downstairs 2.
-        ds.in_progress(flush_id, ClientId(2));
+        ds.in_progress(flush_id, ClientId::new(2));
         assert!(!ds
             .process_ds_completion(
                 flush_id,
-                ClientId(2),
+                ClientId::new(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2873,7 +2878,7 @@ pub(crate) mod up_test {
         // All three jobs should now move to completed
         assert_eq!(ds.completed.len(), 3);
         // Downstairs 2 should update the last flush it just did.
-        assert_eq!(ds.ds_last_flush[ClientId(2)], flush_id);
+        assert_eq!(ds.ds_last_flush[ClientId::new(2)], flush_id);
     }
 
     #[tokio::test]
@@ -2910,15 +2915,15 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the write to all three downstairs.
-        ds.in_progress(next_id, ClientId(0));
-        ds.in_progress(next_id, ClientId(1));
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         // Complete the write on all three downstairs.
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2928,7 +2933,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2938,7 +2943,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(2),
+                ClientId::new(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2968,15 +2973,15 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the flush to all three downstairs.
-        ds.in_progress(next_id, ClientId(0));
-        ds.in_progress(next_id, ClientId(1));
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         // Complete the flush on all three downstairs.
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2986,7 +2991,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2996,7 +3001,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(2),
+                ClientId::new(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3062,16 +3067,16 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the two writes, to 2/3 of the downstairs.
-        assert!(ds.in_progress(id1, ClientId(0)).is_some());
-        assert!(ds.in_progress(id1, ClientId(1)).is_some());
-        assert!(ds.in_progress(id2, ClientId(1)).is_some());
-        assert!(ds.in_progress(id2, ClientId(2)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(0)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(1)).is_some());
+        assert!(ds.in_progress(id2, ClientId::new(1)).is_some());
+        assert!(ds.in_progress(id2, ClientId::new(2)).is_some());
 
         // Complete the writes that we sent to the 2 downstairs.
         assert!(!ds
             .process_ds_completion(
                 id1,
-                ClientId(0),
+                ClientId::new(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3081,7 +3086,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 id1,
-                ClientId(1),
+                ClientId::new(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3091,7 +3096,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 id2,
-                ClientId(1),
+                ClientId::new(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3101,7 +3106,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 id2,
-                ClientId(2),
+                ClientId::new(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3132,14 +3137,14 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Send the flush to two downstairs.
-        ds.in_progress(flush_id, ClientId(0));
-        ds.in_progress(flush_id, ClientId(2));
+        ds.in_progress(flush_id, ClientId::new(0));
+        ds.in_progress(flush_id, ClientId::new(2));
 
         // Complete the flush on those downstairs.
         assert!(!ds
             .process_ds_completion(
                 flush_id,
-                ClientId(0),
+                ClientId::new(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3149,7 +3154,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 flush_id,
-                ClientId(2),
+                ClientId::new(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3168,17 +3173,17 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 0);
 
         // Verify who has updated their last flush.
-        assert_eq!(ds.ds_last_flush[ClientId(0)], flush_id);
-        assert_eq!(ds.ds_last_flush[ClientId(1)], JobId(0));
-        assert_eq!(ds.ds_last_flush[ClientId(2)], flush_id);
+        assert_eq!(ds.ds_last_flush[ClientId::new(0)], flush_id);
+        assert_eq!(ds.ds_last_flush[ClientId::new(1)], JobId(0));
+        assert_eq!(ds.ds_last_flush[ClientId::new(2)], flush_id);
 
         // Now, finish sending and completing the writes
-        assert!(ds.in_progress(id1, ClientId(2)).is_some());
-        assert!(ds.in_progress(id2, ClientId(0)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(2)).is_some());
+        assert!(ds.in_progress(id2, ClientId::new(0)).is_some());
         assert!(!ds
             .process_ds_completion(
                 id1,
-                ClientId(2),
+                ClientId::new(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3188,7 +3193,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 id2,
-                ClientId(0),
+                ClientId::new(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3200,11 +3205,11 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 0);
 
         // Send and complete the flush
-        ds.in_progress(flush_id, ClientId(1));
+        ds.in_progress(flush_id, ClientId::new(1));
         assert!(!ds
             .process_ds_completion(
                 flush_id,
-                ClientId(1),
+                ClientId::new(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3216,7 +3221,7 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 3);
 
         // downstairs 1 should now have that flush
-        assert_eq!(ds.ds_last_flush[ClientId(1)], flush_id);
+        assert_eq!(ds.ds_last_flush[ClientId::new(1)], flush_id);
     }
 
     #[tokio::test]
@@ -3233,9 +3238,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the read to all three downstairs
-        ds.in_progress(next_id, ClientId(0));
-        ds.in_progress(next_id, ClientId(1));
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         // Complete the read on one downstairs.
         let response =
@@ -3243,7 +3248,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 response,
                 &None,
                 UpState::Active,
@@ -3258,7 +3263,7 @@ pub(crate) mod up_test {
 
         // Be sure the job is not yet in replay
         assert!(!ds.ds_active.get(&next_id).unwrap().replay);
-        ds.re_new(ClientId(0));
+        ds.re_new(ClientId::new(0));
         // Now the IO should be replay
         assert!(ds.ds_active.get(&next_id).unwrap().replay);
 
@@ -3283,9 +3288,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the read to each downstairs.
-        ds.in_progress(next_id, ClientId(0));
-        ds.in_progress(next_id, ClientId(1));
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         // Complete the read on one downstairs, verify it is ack ready.
         let response = Ok(vec![ReadResponse::from_request_with_data(
@@ -3295,7 +3300,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 response,
                 &None,
                 UpState::Active,
@@ -3314,7 +3319,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 response,
                 &None,
                 UpState::Active,
@@ -3323,26 +3328,26 @@ pub(crate) mod up_test {
             .unwrap());
 
         // Now, take the first downstairs offline.
-        ds.re_new(ClientId(0));
+        ds.re_new(ClientId::new(0));
 
         // Should still be ok to ACK this IO
         let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
 
         // Taking the second downstairs offline should revert the ACK.
-        ds.re_new(ClientId(1));
+        ds.re_new(ClientId::new(1));
         let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::NotAcked);
 
         // Redo the read on DS 0, IO should go back to ackable.
-        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId::new(0));
 
         let response =
             Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 response,
                 &None,
                 UpState::Active,
@@ -3369,9 +3374,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the read to each downstairs.
-        ds.in_progress(next_id, ClientId(0));
-        ds.in_progress(next_id, ClientId(1));
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         // Complete the read on one downstairs.
         let response =
@@ -3379,7 +3384,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 response,
                 &None,
                 UpState::Active,
@@ -3404,20 +3409,20 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 0);
 
         // Now, take that downstairs offline
-        ds.re_new(ClientId(0));
+        ds.re_new(ClientId::new(0));
 
         // Acked IO should remain so.
         let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::Acked);
 
         // Redo on DS 0, IO should remain acked.
-        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId::new(0));
         let response =
             Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 response,
                 &None,
                 UpState::Active,
@@ -3463,9 +3468,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the read to each downstairs.
-        ds.in_progress(next_id, ClientId(0));
-        ds.in_progress(next_id, ClientId(1));
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         // Construct our fake response
         let response = Ok(vec![ReadResponse::from_request_with_data(
@@ -3477,7 +3482,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 response,
                 &None,
                 UpState::Active,
@@ -3491,12 +3496,12 @@ pub(crate) mod up_test {
         // Before re re_new, the IO is not replay
         assert!(!ds.ds_active.get(&next_id).unwrap().replay);
         // Now, take that downstairs offline
-        ds.re_new(ClientId(0));
+        ds.re_new(ClientId::new(0));
         // Now the IO should be replay
         assert!(ds.ds_active.get(&next_id).unwrap().replay);
 
         // Move it to in-progress.
-        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId::new(0));
 
         // Now, create a new response that has different data, and will
         // produce a different hash.
@@ -3510,7 +3515,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 response,
                 &None,
                 UpState::Active,
@@ -3556,9 +3561,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the read to each downstairs.
-        ds.in_progress(next_id, ClientId(0));
-        ds.in_progress(next_id, ClientId(1));
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        ds.in_progress(next_id, ClientId::new(1));
+        ds.in_progress(next_id, ClientId::new(2));
 
         // Construct our fake response
         let response = Ok(vec![ReadResponse::from_request_with_data(
@@ -3570,7 +3575,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 response,
                 &None,
                 UpState::Active,
@@ -3588,7 +3593,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 response,
                 &None,
                 UpState::Active,
@@ -3600,12 +3605,12 @@ pub(crate) mod up_test {
         ds.ack(next_id);
 
         // Now, take the second downstairs offline
-        ds.re_new(ClientId(1));
+        ds.re_new(ClientId::new(1));
         // Now the IO should be replay
         assert!(ds.ds_active.get(&next_id).unwrap().replay);
 
         // Move it to in-progress.
-        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId::new(1));
 
         // Now, create a new response that has different data, and will
         // produce a different hash.
@@ -3619,7 +3624,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 response,
                 &None,
                 UpState::Active,
@@ -3667,14 +3672,14 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the read to two downstairs.
-        assert!(ds.in_progress(id1, ClientId(0)).is_some());
-        assert!(ds.in_progress(id1, ClientId(1)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(0)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(1)).is_some());
 
         // Complete the write on two downstairs.
         assert!(!ds
             .process_ds_completion(
                 id1,
-                ClientId(0),
+                ClientId::new(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3684,7 +3689,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 id1,
-                ClientId(1),
+                ClientId::new(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3699,7 +3704,7 @@ pub(crate) mod up_test {
         /* Now, take that downstairs offline */
         // Before re re_new, the IO is not replay
         assert!(!ds.ds_active.get(&id1).unwrap().replay);
-        ds.re_new(ClientId(1));
+        ds.re_new(ClientId::new(1));
         // Now the IO should be replay
         assert!(ds.ds_active.get(&id1).unwrap().replay);
 
@@ -3713,11 +3718,11 @@ pub(crate) mod up_test {
         }
 
         // Re-submit and complete the write
-        assert!(ds.in_progress(id1, ClientId(1)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(1)).is_some());
         assert!(ds
             .process_ds_completion(
                 id1,
-                ClientId(1),
+                ClientId::new(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3762,14 +3767,14 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the write to two downstairs.
-        assert!(ds.in_progress(id1, ClientId(0)).is_some());
-        assert!(ds.in_progress(id1, ClientId(1)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(0)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(1)).is_some());
 
         // Complete the write on two downstairs.
         assert!(!ds
             .process_ds_completion(
                 id1,
-                ClientId(0),
+                ClientId::new(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3779,7 +3784,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 id1,
-                ClientId(1),
+                ClientId::new(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3797,20 +3802,20 @@ pub(crate) mod up_test {
         assert_eq!(ds.ackable_work().len(), 0);
 
         // Now, take that downstairs offline
-        ds.re_new(ClientId(0));
+        ds.re_new(ClientId::new(0));
 
         // State should stay acked
         let state = ds.ds_active.get(&id1).unwrap().ack_status;
         assert_eq!(state, AckStatus::Acked);
 
         // Finish the write all the way out.
-        assert!(ds.in_progress(id1, ClientId(0)).is_some());
-        assert!(ds.in_progress(id1, ClientId(2)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(0)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(2)).is_some());
 
         assert!(!ds
             .process_ds_completion(
                 id1,
-                ClientId(0),
+                ClientId::new(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3820,7 +3825,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 id1,
-                ClientId(2),
+                ClientId::new(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3834,33 +3839,40 @@ pub(crate) mod up_test {
         // Verify the correct downstairs progression
         // New -> WA -> WQ -> Active
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
-        up.ds_transition(ClientId(0), DsState::Active).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::Active).await;
     }
 
     #[tokio::test]
     async fn downstairs_transition_replay() {
         // Verify offline goes to replay
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
         up.set_active().await.unwrap();
-        up.ds_transition(ClientId(0), DsState::Active).await;
-        up.ds_transition(ClientId(0), DsState::Offline).await;
-        up.ds_transition(ClientId(0), DsState::Replay).await;
+        up.ds_transition(ClientId::new(0), DsState::Active).await;
+        up.ds_transition(ClientId::new(0), DsState::Offline).await;
+        up.ds_transition(ClientId::new(0), DsState::Replay).await;
     }
 
     #[tokio::test]
     async fn downstairs_transition_deactivate_new() {
         // Verify deactivate goes to new
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
-        up.ds_transition(ClientId(0), DsState::Active).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::Active).await;
         up.set_active().await.unwrap();
-        up.ds_transition(ClientId(0), DsState::Deactivated).await;
-        up.ds_transition(ClientId(0), DsState::New).await;
+        up.ds_transition(ClientId::new(0), DsState::Deactivated)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::New).await;
     }
 
     #[tokio::test]
@@ -3868,7 +3880,8 @@ pub(crate) mod up_test {
     async fn downstairs_transition_deactivate_not_new() {
         // Verify deactivate goes to new
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::Deactivated).await;
+        up.ds_transition(ClientId::new(0), DsState::Deactivated)
+            .await;
     }
 
     #[tokio::test]
@@ -3876,8 +3889,10 @@ pub(crate) mod up_test {
     async fn downstairs_transition_deactivate_not_wa() {
         // Verify no deactivate from wa
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
-        up.ds_transition(ClientId(0), DsState::Deactivated).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::Deactivated)
+            .await;
     }
 
     #[tokio::test]
@@ -3885,19 +3900,24 @@ pub(crate) mod up_test {
     async fn downstairs_transition_deactivate_not_wq() {
         // Verify no deactivate from wq
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
-        up.ds_transition(ClientId(0), DsState::Deactivated).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::Deactivated)
+            .await;
     }
 
     #[tokio::test]
     async fn downstairs_transition_active_to_faulted() {
         // Verify active upstairs can go to faulted
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
-        up.ds_transition(ClientId(0), DsState::Active).await;
-        up.ds_transition(ClientId(0), DsState::Faulted).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::Active).await;
+        up.ds_transition(ClientId::new(0), DsState::Faulted).await;
     }
 
     #[tokio::test]
@@ -3905,10 +3925,13 @@ pub(crate) mod up_test {
     async fn downstairs_transition_disconnect_no_active() {
         // Verify no activation from disconnected
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
-        up.ds_transition(ClientId(0), DsState::Deactivated).await;
-        up.ds_transition(ClientId(0), DsState::Active).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::Deactivated)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::Active).await;
     }
 
     #[tokio::test]
@@ -3916,11 +3939,13 @@ pub(crate) mod up_test {
     async fn downstairs_transition_offline_no_active() {
         // Verify no activation from offline
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
-        up.ds_transition(ClientId(0), DsState::Active).await;
-        up.ds_transition(ClientId(0), DsState::Offline).await;
-        up.ds_transition(ClientId(0), DsState::Active).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::Active).await;
+        up.ds_transition(ClientId::new(0), DsState::Offline).await;
+        up.ds_transition(ClientId::new(0), DsState::Active).await;
     }
 
     // Deactivate tests
@@ -3943,9 +3968,9 @@ pub(crate) mod up_test {
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
         let mut ds = up.downstairs.lock().await;
-        ds.ds_state[ClientId(0)] = DsState::Active;
-        ds.ds_state[ClientId(1)] = DsState::Active;
-        ds.ds_state[ClientId(2)] = DsState::Active;
+        ds.ds_state[ClientId::new(0)] = DsState::Active;
+        ds.ds_state[ClientId::new(1)] = DsState::Active;
+        ds.ds_state[ClientId::new(2)] = DsState::Active;
 
         // Build a write, put it on the work queue.
         let id1 = ds.next_id();
@@ -3962,9 +3987,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the writes
-        assert!(ds.in_progress(id1, ClientId(0)).is_some());
-        assert!(ds.in_progress(id1, ClientId(1)).is_some());
-        assert!(ds.in_progress(id1, ClientId(2)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(0)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(1)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(2)).is_some());
 
         drop(ds);
 
@@ -3977,7 +4002,7 @@ pub(crate) mod up_test {
         // Complete the writes
         ds.process_ds_completion(
             id1,
-            ClientId(0),
+            ClientId::new(0),
             Ok(vec![]),
             &None,
             UpState::Active,
@@ -3986,7 +4011,7 @@ pub(crate) mod up_test {
         .unwrap();
         ds.process_ds_completion(
             id1,
-            ClientId(1),
+            ClientId::new(1),
             Ok(vec![]),
             &None,
             UpState::Active,
@@ -3995,7 +4020,7 @@ pub(crate) mod up_test {
         .unwrap();
         ds.process_ds_completion(
             id1,
-            ClientId(2),
+            ClientId::new(2),
             Ok(vec![]),
             &None,
             UpState::Active,
@@ -4008,15 +4033,15 @@ pub(crate) mod up_test {
 
         // Send the flush created for us when we set deactivated to
         // the two downstairs.
-        ds.in_progress(flush_id, ClientId(0));
-        ds.in_progress(flush_id, ClientId(2));
+        ds.in_progress(flush_id, ClientId::new(0));
+        ds.in_progress(flush_id, ClientId::new(2));
 
         // Complete the flush on those downstairs.
         // One flush won't result in an ACK
         assert!(!ds
             .process_ds_completion(
                 flush_id,
-                ClientId(0),
+                ClientId::new(0),
                 Ok(vec![]),
                 &None,
                 UpState::Deactivating,
@@ -4028,7 +4053,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 flush_id,
-                ClientId(2),
+                ClientId::new(2),
                 Ok(vec![]),
                 &None,
                 UpState::Deactivating,
@@ -4038,11 +4063,11 @@ pub(crate) mod up_test {
 
         // Verify we can deactivate the completed DS
         drop(ds);
-        assert!(up.ds_deactivate(ClientId(0)).await);
-        assert!(up.ds_deactivate(ClientId(2)).await);
+        assert!(up.ds_deactivate(ClientId::new(0)).await);
+        assert!(up.ds_deactivate(ClientId::new(2)).await);
 
         // Verify the remaining DS can not deactivate
-        assert!(!up.ds_deactivate(ClientId(1)).await);
+        assert!(!up.ds_deactivate(ClientId::new(1)).await);
 
         // Verify the deactivate is not done yet.
         up.deactivate_transition_check().await;
@@ -4050,16 +4075,16 @@ pub(crate) mod up_test {
 
         ds = up.downstairs.lock().await;
         // Make sure the correct DS have changed state.
-        assert_eq!(ds.ds_state[ClientId(0)], DsState::Deactivated);
-        assert_eq!(ds.ds_state[ClientId(2)], DsState::Deactivated);
-        assert_eq!(ds.ds_state[ClientId(1)], DsState::Active);
+        assert_eq!(ds.ds_state[ClientId::new(0)], DsState::Deactivated);
+        assert_eq!(ds.ds_state[ClientId::new(2)], DsState::Deactivated);
+        assert_eq!(ds.ds_state[ClientId::new(1)], DsState::Active);
 
         // Send and complete the flush
-        ds.in_progress(flush_id, ClientId(1));
+        ds.in_progress(flush_id, ClientId::new(1));
         assert!(ds
             .process_ds_completion(
                 flush_id,
-                ClientId(1),
+                ClientId::new(1),
                 Ok(vec![]),
                 &None,
                 UpState::Deactivating,
@@ -4070,12 +4095,12 @@ pub(crate) mod up_test {
         ds.ack(flush_id);
 
         drop(ds);
-        assert!(up.ds_deactivate(ClientId(1)).await);
+        assert!(up.ds_deactivate(ClientId::new(1)).await);
 
         // Report all three DS as missing, which moves them to New
-        up.ds_missing(ClientId(0)).await;
-        up.ds_missing(ClientId(1)).await;
-        up.ds_missing(ClientId(2)).await;
+        up.ds_missing(ClientId::new(0)).await;
+        up.ds_missing(ClientId::new(1)).await;
+        up.ds_missing(ClientId::new(2)).await;
 
         // Verify we have disconnected and can go back to init.
         up.deactivate_transition_check().await;
@@ -4083,9 +4108,9 @@ pub(crate) mod up_test {
 
         // Verify after the ds_missing, all downstairs are New
         let ds = up.downstairs.lock().await;
-        assert_eq!(ds.ds_state[ClientId(0)], DsState::New);
-        assert_eq!(ds.ds_state[ClientId(1)], DsState::New);
-        assert_eq!(ds.ds_state[ClientId(2)], DsState::New);
+        assert_eq!(ds.ds_state[ClientId::new(0)], DsState::New);
+        assert_eq!(ds.ds_state[ClientId::new(1)], DsState::New);
+        assert_eq!(ds.ds_state[ClientId::new(2)], DsState::New);
     }
 
     #[tokio::test]
@@ -4099,29 +4124,29 @@ pub(crate) mod up_test {
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
         let mut ds = up.downstairs.lock().await;
-        ds.ds_state[ClientId(0)] = DsState::Active;
-        ds.ds_state[ClientId(1)] = DsState::Active;
-        ds.ds_state[ClientId(2)] = DsState::Active;
+        ds.ds_state[ClientId::new(0)] = DsState::Active;
+        ds.ds_state[ClientId::new(1)] = DsState::Active;
+        ds.ds_state[ClientId::new(2)] = DsState::Active;
 
         drop(ds);
         up.set_deactivate(None, ds_done_tx.clone()).await.unwrap();
 
         // Verify we can deactivate as there is no work
-        assert!(up.ds_deactivate(ClientId(0)).await);
-        assert!(up.ds_deactivate(ClientId(1)).await);
-        assert!(up.ds_deactivate(ClientId(2)).await);
+        assert!(up.ds_deactivate(ClientId::new(0)).await);
+        assert!(up.ds_deactivate(ClientId::new(1)).await);
+        assert!(up.ds_deactivate(ClientId::new(2)).await);
 
         ds = up.downstairs.lock().await;
         // Make sure the correct DS have changed state.
-        assert_eq!(ds.ds_state[ClientId(0)], DsState::Deactivated);
-        assert_eq!(ds.ds_state[ClientId(1)], DsState::Deactivated);
-        assert_eq!(ds.ds_state[ClientId(2)], DsState::Deactivated);
+        assert_eq!(ds.ds_state[ClientId::new(0)], DsState::Deactivated);
+        assert_eq!(ds.ds_state[ClientId::new(1)], DsState::Deactivated);
+        assert_eq!(ds.ds_state[ClientId::new(2)], DsState::Deactivated);
         drop(ds);
 
         // Mark all three DS as missing, which moves their state to New
-        up.ds_missing(ClientId(0)).await;
-        up.ds_missing(ClientId(1)).await;
-        up.ds_missing(ClientId(2)).await;
+        up.ds_missing(ClientId::new(0)).await;
+        up.ds_missing(ClientId::new(1)).await;
+        up.ds_missing(ClientId::new(2)).await;
 
         // Verify now we can go back to init.
         up.deactivate_transition_check().await;
@@ -4146,9 +4171,9 @@ pub(crate) mod up_test {
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
         let mut ds = up.downstairs.lock().await;
-        ds.ds_state[ClientId(0)] = DsState::Active;
-        ds.ds_state[ClientId(1)] = DsState::Active;
-        ds.ds_state[ClientId(2)] = DsState::Active;
+        ds.ds_state[ClientId::new(0)] = DsState::Active;
+        ds.ds_state[ClientId::new(1)] = DsState::Active;
+        ds.ds_state[ClientId::new(2)] = DsState::Active;
 
         // Build a write, put it on the work queue.
         let id1 = ds.next_id();
@@ -4165,9 +4190,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the writes
-        assert!(ds.in_progress(id1, ClientId(0)).is_some());
-        assert!(ds.in_progress(id1, ClientId(1)).is_some());
-        assert!(ds.in_progress(id1, ClientId(2)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(0)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(1)).is_some());
+        assert!(ds.in_progress(id1, ClientId::new(2)).is_some());
 
         drop(ds);
         up.set_deactivate(None, ds_done_tx.clone()).await.unwrap();
@@ -4176,7 +4201,7 @@ pub(crate) mod up_test {
         // Complete the writes
         ds.process_ds_completion(
             id1,
-            ClientId(0),
+            ClientId::new(0),
             Ok(vec![]),
             &None,
             UpState::Deactivating,
@@ -4185,7 +4210,7 @@ pub(crate) mod up_test {
         .unwrap();
         ds.process_ds_completion(
             id1,
-            ClientId(1),
+            ClientId::new(1),
             Ok(vec![]),
             &None,
             UpState::Deactivating,
@@ -4194,7 +4219,7 @@ pub(crate) mod up_test {
         .unwrap();
         ds.process_ds_completion(
             id1,
-            ClientId(2),
+            ClientId::new(2),
             Ok(vec![]),
             &None,
             UpState::Deactivating,
@@ -4207,9 +4232,9 @@ pub(crate) mod up_test {
 
         // Verify we will not transition to deactivated without a flush.
         drop(ds);
-        assert!(!up.ds_deactivate(ClientId(0)).await);
-        assert!(!up.ds_deactivate(ClientId(1)).await);
-        assert!(!up.ds_deactivate(ClientId(2)).await);
+        assert!(!up.ds_deactivate(ClientId::new(0)).await);
+        assert!(!up.ds_deactivate(ClientId::new(1)).await);
+        assert!(!up.ds_deactivate(ClientId::new(2)).await);
 
         // Verify the deactivate is not done yet.
         up.deactivate_transition_check().await;
@@ -4217,9 +4242,9 @@ pub(crate) mod up_test {
 
         ds = up.downstairs.lock().await;
         // Make sure no DS have changed state.
-        assert_eq!(ds.ds_state[ClientId(0)], DsState::Active);
-        assert_eq!(ds.ds_state[ClientId(2)], DsState::Active);
-        assert_eq!(ds.ds_state[ClientId(1)], DsState::Active);
+        assert_eq!(ds.ds_state[ClientId::new(0)], DsState::Active);
+        assert_eq!(ds.ds_state[ClientId::new(2)], DsState::Active);
+        assert_eq!(ds.ds_state[ClientId::new(1)], DsState::Active);
     }
 
     #[tokio::test]
@@ -4245,22 +4270,22 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         up.set_active().await.unwrap();
         let mut ds = up.downstairs.lock().await;
-        ds.ds_state[ClientId(0)] = DsState::Active;
-        ds.ds_state[ClientId(1)] = DsState::Active;
-        ds.ds_state[ClientId(2)] = DsState::Active;
+        ds.ds_state[ClientId::new(0)] = DsState::Active;
+        ds.ds_state[ClientId::new(1)] = DsState::Active;
+        ds.ds_state[ClientId::new(2)] = DsState::Active;
 
         drop(ds);
 
         // Verify we cannot deactivate even when there is no work
-        assert!(!up.ds_deactivate(ClientId(0)).await);
-        assert!(!up.ds_deactivate(ClientId(1)).await);
-        assert!(!up.ds_deactivate(ClientId(2)).await);
+        assert!(!up.ds_deactivate(ClientId::new(0)).await);
+        assert!(!up.ds_deactivate(ClientId::new(1)).await);
+        assert!(!up.ds_deactivate(ClientId::new(2)).await);
 
         ds = up.downstairs.lock().await;
         // Make sure no DS have changed state.
-        assert_eq!(ds.ds_state[ClientId(0)], DsState::Active);
-        assert_eq!(ds.ds_state[ClientId(1)], DsState::Active);
-        assert_eq!(ds.ds_state[ClientId(2)], DsState::Active);
+        assert_eq!(ds.ds_state[ClientId::new(0)], DsState::Active);
+        assert_eq!(ds.ds_state[ClientId::new(1)], DsState::Active);
+        assert_eq!(ds.ds_state[ClientId::new(2)], DsState::Active);
     }
 
     #[tokio::test]
@@ -4270,15 +4295,15 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
 
         // Verify we cannot deactivate before the upstairs is active
-        assert!(!up.ds_deactivate(ClientId(0)).await);
-        assert!(!up.ds_deactivate(ClientId(1)).await);
-        assert!(!up.ds_deactivate(ClientId(2)).await);
+        assert!(!up.ds_deactivate(ClientId::new(0)).await);
+        assert!(!up.ds_deactivate(ClientId::new(1)).await);
+        assert!(!up.ds_deactivate(ClientId::new(2)).await);
 
         let ds = up.downstairs.lock().await;
         // Make sure no DS have changed state.
-        assert_eq!(ds.ds_state[ClientId(0)], DsState::New);
-        assert_eq!(ds.ds_state[ClientId(1)], DsState::New);
-        assert_eq!(ds.ds_state[ClientId(2)], DsState::New);
+        assert_eq!(ds.ds_state[ClientId::new(0)], DsState::New);
+        assert_eq!(ds.ds_state[ClientId::new(1)], DsState::New);
+        assert_eq!(ds.ds_state[ClientId::new(2)], DsState::New);
     }
 
     #[tokio::test]
@@ -4286,46 +4311,55 @@ pub(crate) mod up_test {
     async fn downstairs_transition_same_wa() {
         // Verify we can't go to the same state we are in
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
     }
 
     #[tokio::test]
     #[should_panic]
     async fn downstairs_transition_same_wq() {
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
     }
 
     #[tokio::test]
     #[should_panic]
     async fn downstairs_transition_same_active() {
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
-        up.ds_transition(ClientId(0), DsState::Active).await;
-        up.ds_transition(ClientId(0), DsState::Active).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::Active).await;
+        up.ds_transition(ClientId::new(0), DsState::Active).await;
     }
 
     #[tokio::test]
     #[should_panic]
     async fn downstairs_transition_no_new_to_offline() {
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::Offline).await;
-        up.ds_transition(ClientId(0), DsState::Offline).await;
+        up.ds_transition(ClientId::new(0), DsState::Offline).await;
+        up.ds_transition(ClientId::new(0), DsState::Offline).await;
     }
 
     #[tokio::test]
     #[should_panic]
     async fn downstairs_transition_same_offline() {
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
-        up.ds_transition(ClientId(0), DsState::Active).await;
-        up.ds_transition(ClientId(0), DsState::Offline).await;
-        up.ds_transition(ClientId(0), DsState::Offline).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::Active).await;
+        up.ds_transition(ClientId::new(0), DsState::Offline).await;
+        up.ds_transition(ClientId::new(0), DsState::Offline).await;
     }
 
     #[tokio::test]
@@ -4334,9 +4368,12 @@ pub(crate) mod up_test {
         // Verify state can't go backwards
         // New -> WA -> WQ -> WA
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
     }
 
     #[tokio::test]
@@ -4344,7 +4381,8 @@ pub(crate) mod up_test {
     async fn downstairs_bad_transition_wq() {
         // Verify error when going straight to WQ
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
     }
 
     #[tokio::test]
@@ -4352,7 +4390,7 @@ pub(crate) mod up_test {
     async fn downstairs_transition_bad_replay() {
         // Verify new goes to replay will fail
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::Replay).await;
+        up.ds_transition(ClientId::new(0), DsState::Replay).await;
     }
 
     #[tokio::test]
@@ -4360,11 +4398,14 @@ pub(crate) mod up_test {
     async fn downstairs_transition_bad_offline() {
         // Verify offline cannot go to WQ
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
-        up.ds_transition(ClientId(0), DsState::Active).await;
-        up.ds_transition(ClientId(0), DsState::Offline).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::Active).await;
+        up.ds_transition(ClientId::new(0), DsState::Offline).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
     }
 
     #[tokio::test]
@@ -4372,31 +4413,40 @@ pub(crate) mod up_test {
     async fn downstairs_transition_bad_active() {
         // Verify active can't go back to WQ
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
-        up.ds_transition(ClientId(0), DsState::Active).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::Active).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
     }
 
     #[tokio::test]
     async fn downstairs_transition_active_faulted() {
         // Verify
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
-        up.ds_transition(ClientId(0), DsState::Active).await;
-        up.ds_transition(ClientId(0), DsState::Faulted).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::Active).await;
+        up.ds_transition(ClientId::new(0), DsState::Faulted).await;
     }
 
     #[tokio::test]
     async fn reconcile_not_ready() {
         // Verify reconcile returns false when a downstairs is not ready
         let up = Upstairs::test_default(None);
-        up.ds_transition(ClientId(0), DsState::WaitActive).await;
-        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId::new(0), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(0), DsState::WaitQuorum)
+            .await;
 
-        up.ds_transition(ClientId(1), DsState::WaitActive).await;
-        up.ds_transition(ClientId(1), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId::new(1), DsState::WaitActive)
+            .await;
+        up.ds_transition(ClientId::new(1), DsState::WaitQuorum)
+            .await;
 
         let (ds_work_tx, _) = mpsc::channel(500);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
@@ -4427,10 +4477,10 @@ pub(crate) mod up_test {
         // No repairs on the queue, should return None
         let up = Upstairs::test_default(None);
         let mut ds = up.downstairs.lock().await;
-        ds.ds_state[ClientId(0)] = DsState::Repair;
-        ds.ds_state[ClientId(1)] = DsState::Repair;
-        ds.ds_state[ClientId(2)] = DsState::Repair;
-        let w = ds.rep_in_progress(ClientId(0));
+        ds.ds_state[ClientId::new(0)] = DsState::Repair;
+        ds.ds_state[ClientId::new(1)] = DsState::Repair;
+        ds.ds_state[ClientId::new(2)] = DsState::Repair;
+        let w = ds.rep_in_progress(ClientId::new(0));
         assert_eq!(w, None);
     }
 
@@ -4452,23 +4502,23 @@ pub(crate) mod up_test {
                 },
             ));
             // A downstairs is not in Repair state
-            ds.ds_state[ClientId(0)] = DsState::Repair;
-            ds.ds_state[ClientId(1)] = DsState::WaitQuorum;
-            ds.ds_state[ClientId(2)] = DsState::Repair;
+            ds.ds_state[ClientId::new(0)] = DsState::Repair;
+            ds.ds_state[ClientId::new(1)] = DsState::WaitQuorum;
+            ds.ds_state[ClientId::new(2)] = DsState::Repair;
         }
         // Move that job to next to do.
         let nw = up.new_rec_work().await;
         assert!(nw.is_err());
         let mut ds = up.downstairs.lock().await;
-        assert_eq!(ds.ds_state[ClientId(0)], DsState::FailedRepair);
-        assert_eq!(ds.ds_state[ClientId(1)], DsState::WaitQuorum);
-        assert_eq!(ds.ds_state[ClientId(2)], DsState::FailedRepair);
+        assert_eq!(ds.ds_state[ClientId::new(0)], DsState::FailedRepair);
+        assert_eq!(ds.ds_state[ClientId::new(1)], DsState::WaitQuorum);
+        assert_eq!(ds.ds_state[ClientId::new(2)], DsState::FailedRepair);
 
         // Verify rep_in_progress now returns none for all DS
         assert!(ds.reconcile_task_list.is_empty());
-        assert!(ds.rep_in_progress(ClientId(0)).is_none());
-        assert!(ds.rep_in_progress(ClientId(1)).is_none());
-        assert!(ds.rep_in_progress(ClientId(2)).is_none());
+        assert!(ds.rep_in_progress(ClientId::new(0)).is_none());
+        assert!(ds.rep_in_progress(ClientId::new(1)).is_none());
+        assert!(ds.rep_in_progress(ClientId::new(2)).is_none());
     }
 
     #[tokio::test]
@@ -4480,9 +4530,9 @@ pub(crate) mod up_test {
         let rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[ClientId(0)] = DsState::Repair;
-            ds.ds_state[ClientId(1)] = DsState::Repair;
-            ds.ds_state[ClientId(2)] = DsState::Repair;
+            ds.ds_state[ClientId::new(0)] = DsState::Repair;
+            ds.ds_state[ClientId::new(1)] = DsState::Repair;
+            ds.ds_state[ClientId::new(2)] = DsState::Repair;
             // Put two jobs on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -4497,16 +4547,16 @@ pub(crate) mod up_test {
         assert!(nw.unwrap());
         let mut ds = up.downstairs.lock().await;
         // Mark all three as in progress
-        assert!(ds.rep_in_progress(ClientId(0)).is_some());
-        assert!(ds.rep_in_progress(ClientId(1)).is_some());
-        assert!(ds.rep_in_progress(ClientId(2)).is_some());
+        assert!(ds.rep_in_progress(ClientId::new(0)).is_some());
+        assert!(ds.rep_in_progress(ClientId::new(1)).is_some());
+        assert!(ds.rep_in_progress(ClientId::new(2)).is_some());
 
         // Now verify we can be done even if a DS is gone
-        ds.ds_state[ClientId(1)] = DsState::New;
+        ds.ds_state[ClientId::new(1)] = DsState::New;
         // Now, make sure we consider this done only after all three are done
-        assert!(!ds.rep_done(ClientId(0), rep_id));
-        assert!(!ds.rep_done(ClientId(1), rep_id));
-        assert!(ds.rep_done(ClientId(2), rep_id));
+        assert!(!ds.rep_done(ClientId::new(0), rep_id));
+        assert!(!ds.rep_done(ClientId::new(1), rep_id));
+        assert!(ds.rep_done(ClientId::new(2), rep_id));
 
         // Getting the next work to do should verify the previous is done,
         // and handle a state change for a downstairs.
@@ -4514,15 +4564,15 @@ pub(crate) mod up_test {
         let nw = up.new_rec_work().await;
         assert!(nw.is_err());
         let mut ds = up.downstairs.lock().await;
-        assert_eq!(ds.ds_state[ClientId(0)], DsState::FailedRepair);
-        assert_eq!(ds.ds_state[ClientId(1)], DsState::New);
-        assert_eq!(ds.ds_state[ClientId(2)], DsState::FailedRepair);
+        assert_eq!(ds.ds_state[ClientId::new(0)], DsState::FailedRepair);
+        assert_eq!(ds.ds_state[ClientId::new(1)], DsState::New);
+        assert_eq!(ds.ds_state[ClientId::new(2)], DsState::FailedRepair);
 
         // Verify rep_in_progress now returns none for all DS
         assert!(ds.reconcile_task_list.is_empty());
-        assert!(ds.rep_in_progress(ClientId(0)).is_none());
-        assert!(ds.rep_in_progress(ClientId(1)).is_none());
-        assert!(ds.rep_in_progress(ClientId(2)).is_none());
+        assert!(ds.rep_in_progress(ClientId::new(0)).is_none());
+        assert!(ds.rep_in_progress(ClientId::new(1)).is_none());
+        assert!(ds.rep_in_progress(ClientId::new(2)).is_none());
     }
 
     #[tokio::test]
@@ -4533,9 +4583,9 @@ pub(crate) mod up_test {
         let rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[ClientId(0)] = DsState::Repair;
-            ds.ds_state[ClientId(1)] = DsState::Repair;
-            ds.ds_state[ClientId(2)] = DsState::Repair;
+            ds.ds_state[ClientId::new(0)] = DsState::Repair;
+            ds.ds_state[ClientId::new(1)] = DsState::Repair;
+            ds.ds_state[ClientId::new(2)] = DsState::Repair;
             // Put a job on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -4550,15 +4600,15 @@ pub(crate) mod up_test {
         assert!(nw.unwrap());
         let mut ds = up.downstairs.lock().await;
         // Mark all three as in progress
-        assert!(ds.rep_in_progress(ClientId(0)).is_some());
-        assert!(ds.rep_in_progress(ClientId(1)).is_some());
-        ds.ds_state[ClientId(2)] = DsState::New;
-        assert!(ds.rep_in_progress(ClientId(2)).is_none());
+        assert!(ds.rep_in_progress(ClientId::new(0)).is_some());
+        assert!(ds.rep_in_progress(ClientId::new(1)).is_some());
+        ds.ds_state[ClientId::new(2)] = DsState::New;
+        assert!(ds.rep_in_progress(ClientId::new(2)).is_none());
 
         // Okay, now the DS is back and ready for repair, verify it will
         // start taking work.
-        ds.ds_state[ClientId(2)] = DsState::Repair;
-        assert!(ds.rep_in_progress(ClientId(2)).is_some());
+        ds.ds_state[ClientId::new(2)] = DsState::Repair;
+        assert!(ds.rep_in_progress(ClientId::new(2)).is_some());
     }
 
     #[tokio::test]
@@ -4569,9 +4619,9 @@ pub(crate) mod up_test {
         let rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[ClientId(0)] = DsState::Repair;
-            ds.ds_state[ClientId(1)] = DsState::Repair;
-            ds.ds_state[ClientId(2)] = DsState::Repair;
+            ds.ds_state[ClientId::new(0)] = DsState::Repair;
+            ds.ds_state[ClientId::new(1)] = DsState::Repair;
+            ds.ds_state[ClientId::new(2)] = DsState::Repair;
             // Put a job on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -4584,8 +4634,8 @@ pub(crate) mod up_test {
         // Move that job to next to do.
         let _ = up.new_rec_work().await;
         let mut ds = up.downstairs.lock().await;
-        assert!(ds.rep_in_progress(ClientId(0)).is_some());
-        assert!(ds.rep_in_progress(ClientId(0)).is_some());
+        assert!(ds.rep_in_progress(ClientId::new(0)).is_some());
+        assert!(ds.rep_in_progress(ClientId::new(0)).is_some());
     }
 
     #[tokio::test]
@@ -4596,9 +4646,9 @@ pub(crate) mod up_test {
         let rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[ClientId(0)] = DsState::Repair;
-            ds.ds_state[ClientId(1)] = DsState::Repair;
-            ds.ds_state[ClientId(2)] = DsState::Repair;
+            ds.ds_state[ClientId::new(0)] = DsState::Repair;
+            ds.ds_state[ClientId::new(1)] = DsState::Repair;
+            ds.ds_state[ClientId::new(2)] = DsState::Repair;
             // Put a job on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -4611,7 +4661,7 @@ pub(crate) mod up_test {
         // Move that job to next to do.
         let _ = up.new_rec_work().await;
         let mut ds = up.downstairs.lock().await;
-        ds.rep_done(ClientId(0), rep_id);
+        ds.rep_done(ClientId::new(0), rep_id);
     }
 
     #[tokio::test]
@@ -4620,9 +4670,9 @@ pub(crate) mod up_test {
         let mut rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[ClientId(0)] = DsState::Repair;
-            ds.ds_state[ClientId(1)] = DsState::Repair;
-            ds.ds_state[ClientId(2)] = DsState::Repair;
+            ds.ds_state[ClientId::new(0)] = DsState::Repair;
+            ds.ds_state[ClientId::new(1)] = DsState::Repair;
+            ds.ds_state[ClientId::new(2)] = DsState::Repair;
             // Put two jobs on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -4644,14 +4694,14 @@ pub(crate) mod up_test {
         assert!(nw.unwrap());
         let mut ds = up.downstairs.lock().await;
         // Mark all three as in progress
-        assert!(ds.rep_in_progress(ClientId(0)).is_some());
-        assert!(ds.rep_in_progress(ClientId(1)).is_some());
-        assert!(ds.rep_in_progress(ClientId(2)).is_some());
+        assert!(ds.rep_in_progress(ClientId::new(0)).is_some());
+        assert!(ds.rep_in_progress(ClientId::new(1)).is_some());
+        assert!(ds.rep_in_progress(ClientId::new(2)).is_some());
 
         // Now, make sure we consider this done only after all three are done
-        assert!(!ds.rep_done(ClientId(0), rep_id));
-        assert!(!ds.rep_done(ClientId(1), rep_id));
-        assert!(ds.rep_done(ClientId(2), rep_id));
+        assert!(!ds.rep_done(ClientId::new(0), rep_id));
+        assert!(!ds.rep_done(ClientId::new(1), rep_id));
+        assert!(ds.rep_done(ClientId::new(2), rep_id));
 
         // Getting the next work to do should verify the previous is done
         drop(ds);
@@ -4659,15 +4709,15 @@ pub(crate) mod up_test {
         assert!(nw.unwrap());
         let mut ds = up.downstairs.lock().await;
         // Mark all three as in progress
-        assert!(ds.rep_in_progress(ClientId(0)).is_some());
-        assert!(ds.rep_in_progress(ClientId(1)).is_some());
-        assert!(ds.rep_in_progress(ClientId(2)).is_some());
+        assert!(ds.rep_in_progress(ClientId::new(0)).is_some());
+        assert!(ds.rep_in_progress(ClientId::new(1)).is_some());
+        assert!(ds.rep_in_progress(ClientId::new(2)).is_some());
 
         // Now, make sure we consider this done only after all three are done
         rep_id += 1;
-        assert!(!ds.rep_done(ClientId(0), rep_id));
-        assert!(!ds.rep_done(ClientId(1), rep_id));
-        assert!(ds.rep_done(ClientId(2), rep_id));
+        assert!(!ds.rep_done(ClientId::new(0), rep_id));
+        assert!(!ds.rep_done(ClientId::new(1), rep_id));
+        assert!(ds.rep_done(ClientId::new(2), rep_id));
 
         drop(ds);
         // Now, we should be empty, so nw is false
@@ -4682,9 +4732,9 @@ pub(crate) mod up_test {
         let rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[ClientId(0)] = DsState::Repair;
-            ds.ds_state[ClientId(1)] = DsState::Repair;
-            ds.ds_state[ClientId(2)] = DsState::Repair;
+            ds.ds_state[ClientId::new(0)] = DsState::Repair;
+            ds.ds_state[ClientId::new(1)] = DsState::Repair;
+            ds.ds_state[ClientId::new(2)] = DsState::Repair;
             // Put two jobs on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -4706,13 +4756,13 @@ pub(crate) mod up_test {
         assert!(nw.unwrap());
         let mut ds = up.downstairs.lock().await;
         // Mark all three as in progress
-        assert!(ds.rep_in_progress(ClientId(0)).is_some());
-        assert!(ds.rep_in_progress(ClientId(1)).is_some());
-        assert!(ds.rep_in_progress(ClientId(2)).is_some());
+        assert!(ds.rep_in_progress(ClientId::new(0)).is_some());
+        assert!(ds.rep_in_progress(ClientId::new(1)).is_some());
+        assert!(ds.rep_in_progress(ClientId::new(2)).is_some());
 
         // Now, make sure we consider this done only after all three are done
-        assert!(!ds.rep_done(ClientId(0), rep_id));
-        assert!(!ds.rep_done(ClientId(1), rep_id));
+        assert!(!ds.rep_done(ClientId::new(0), rep_id));
+        assert!(!ds.rep_done(ClientId::new(1), rep_id));
         // don't finish
 
         // Getting the next work to do should verify the previous is done
@@ -4728,9 +4778,9 @@ pub(crate) mod up_test {
         let rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[ClientId(0)] = DsState::Repair;
-            ds.ds_state[ClientId(1)] = DsState::Repair;
-            ds.ds_state[ClientId(2)] = DsState::Repair;
+            ds.ds_state[ClientId::new(0)] = DsState::Repair;
+            ds.ds_state[ClientId::new(1)] = DsState::Repair;
+            ds.ds_state[ClientId::new(2)] = DsState::Repair;
             // Put a job on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -4745,20 +4795,20 @@ pub(crate) mod up_test {
         assert!(nw.unwrap());
         let mut ds = up.downstairs.lock().await;
         // Mark all three as in progress
-        assert!(ds.rep_in_progress(ClientId(0)).is_some());
+        assert!(ds.rep_in_progress(ClientId::new(0)).is_some());
         if let Some(job) = &mut ds.reconcile_current_work {
-            let oldstate = job.state.insert(ClientId(1), IOState::Skipped);
+            let oldstate = job.state.insert(ClientId::new(1), IOState::Skipped);
             assert_eq!(oldstate, IOState::New);
         } else {
             panic!("Failed to find next task");
         }
 
-        assert!(ds.rep_in_progress(ClientId(2)).is_some());
+        assert!(ds.rep_in_progress(ClientId::new(2)).is_some());
 
         // Now, make sure we consider this done only after all three are done
-        assert!(!ds.rep_done(ClientId(0), rep_id));
+        assert!(!ds.rep_done(ClientId::new(0), rep_id));
         // This should panic: assert!(!ds.rep_done(1, rep_id));
-        assert!(ds.rep_done(ClientId(2), rep_id));
+        assert!(ds.rep_done(ClientId::new(2), rep_id));
     }
 
     #[tokio::test]
@@ -4769,9 +4819,9 @@ pub(crate) mod up_test {
         let rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[ClientId(0)] = DsState::Repair;
-            ds.ds_state[ClientId(1)] = DsState::Repair;
-            ds.ds_state[ClientId(2)] = DsState::Repair;
+            ds.ds_state[ClientId::new(0)] = DsState::Repair;
+            ds.ds_state[ClientId::new(1)] = DsState::Repair;
+            ds.ds_state[ClientId::new(2)] = DsState::Repair;
             // Put a job on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -4787,14 +4837,14 @@ pub(crate) mod up_test {
         let mut ds = up.downstairs.lock().await;
         // Mark one as skipped
         if let Some(job) = &mut ds.reconcile_current_work {
-            let oldstate = job.state.insert(ClientId(1), IOState::Skipped);
+            let oldstate = job.state.insert(ClientId::new(1), IOState::Skipped);
             assert_eq!(oldstate, IOState::New);
         } else {
             panic!("Failed to find next task");
         }
 
         // Can't mark done a skipped job
-        ds.rep_done(ClientId(1), rep_id);
+        ds.rep_done(ClientId::new(1), rep_id);
     }
 
     #[tokio::test]
@@ -4805,9 +4855,9 @@ pub(crate) mod up_test {
         let rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[ClientId(0)] = DsState::Repair;
-            ds.ds_state[ClientId(1)] = DsState::Repair;
-            ds.ds_state[ClientId(2)] = DsState::Repair;
+            ds.ds_state[ClientId::new(0)] = DsState::Repair;
+            ds.ds_state[ClientId::new(1)] = DsState::Repair;
+            ds.ds_state[ClientId::new(2)] = DsState::Repair;
             // Put a job on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -4823,7 +4873,7 @@ pub(crate) mod up_test {
         let mut ds = up.downstairs.lock().await;
         // Jump straight to done.
         // Now, make sure we consider this done only after all three are done
-        ds.rep_done(ClientId(0), rep_id);
+        ds.rep_done(ClientId::new(0), rep_id);
     }
 
     #[tokio::test]
@@ -4836,15 +4886,15 @@ pub(crate) mod up_test {
         let r0 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 801);
         let r1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 802);
         let r2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 803);
-        ds.ds_repair.insert(ClientId(0), r0);
-        ds.ds_repair.insert(ClientId(1), r1);
-        ds.ds_repair.insert(ClientId(2), r2);
+        ds.ds_repair.insert(ClientId::new(0), r0);
+        ds.ds_repair.insert(ClientId::new(1), r1);
+        ds.ds_repair.insert(ClientId::new(2), r2);
 
         let repair_extent = 9;
         let mut rec_list = HashMap::new();
         let ef = ExtentFix {
-            source: ClientId(0),
-            dest: vec![ClientId(1), ClientId(2)],
+            source: ClientId::new(0),
+            dest: vec![ClientId::new(1), ClientId::new(2)],
         };
         rec_list.insert(repair_extent, ef);
         let max_flush = 22;
@@ -4867,7 +4917,7 @@ pub(crate) mod up_test {
             } => {
                 assert_eq!(repair_id, 0);
                 assert_eq!(extent_id, repair_extent);
-                assert_eq!(client_id, ClientId(0));
+                assert_eq!(client_id, ClientId::new(0));
                 assert_eq!(flush_number, max_flush);
                 assert_eq!(gen_number, max_gen);
             }
@@ -4875,9 +4925,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentFlush()", m);
             }
         }
-        assert_eq!(IOState::New, rio.state[ClientId(0)]);
-        assert_eq!(IOState::New, rio.state[ClientId(1)]);
-        assert_eq!(IOState::New, rio.state[ClientId(2)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(0)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(1)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(2)]);
 
         // Second task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -4894,9 +4944,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentClose()", m);
             }
         }
-        assert_eq!(IOState::New, rio.state[ClientId(0)]);
-        assert_eq!(IOState::New, rio.state[ClientId(1)]);
-        assert_eq!(IOState::New, rio.state[ClientId(2)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(0)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(1)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(2)]);
 
         // Third task, repair extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -4911,17 +4961,20 @@ pub(crate) mod up_test {
             } => {
                 assert_eq!(repair_id, rio.id);
                 assert_eq!(extent_id, repair_extent);
-                assert_eq!(source_client_id, ClientId(0));
+                assert_eq!(source_client_id, ClientId::new(0));
                 assert_eq!(source_repair_address, r0);
-                assert_eq!(dest_clients, vec![ClientId(1), ClientId(2)]);
+                assert_eq!(
+                    dest_clients,
+                    vec![ClientId::new(1), ClientId::new(2)]
+                );
             }
             m => {
                 panic!("{:?} not ExtentRepair", m);
             }
         }
-        assert_eq!(IOState::New, rio.state[ClientId(0)]);
-        assert_eq!(IOState::New, rio.state[ClientId(1)]);
-        assert_eq!(IOState::New, rio.state[ClientId(2)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(0)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(1)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(2)]);
 
         // Third task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -4938,9 +4991,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentClose()", m);
             }
         }
-        assert_eq!(IOState::New, rio.state[ClientId(0)]);
-        assert_eq!(IOState::New, rio.state[ClientId(1)]);
-        assert_eq!(IOState::New, rio.state[ClientId(2)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(0)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(1)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(2)]);
     }
 
     #[tokio::test]
@@ -4953,15 +5006,15 @@ pub(crate) mod up_test {
         let r0 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 801);
         let r1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 802);
         let r2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 803);
-        ds.ds_repair.insert(ClientId(0), r0);
-        ds.ds_repair.insert(ClientId(1), r1);
-        ds.ds_repair.insert(ClientId(2), r2);
+        ds.ds_repair.insert(ClientId::new(0), r0);
+        ds.ds_repair.insert(ClientId::new(1), r1);
+        ds.ds_repair.insert(ClientId::new(2), r2);
 
         let repair_extent = 5;
         let mut rec_list = HashMap::new();
         let ef = ExtentFix {
-            source: ClientId(2),
-            dest: vec![ClientId(0), ClientId(1)],
+            source: ClientId::new(2),
+            dest: vec![ClientId::new(0), ClientId::new(1)],
         };
         rec_list.insert(repair_extent, ef);
         let max_flush = 66;
@@ -4984,7 +5037,7 @@ pub(crate) mod up_test {
             } => {
                 assert_eq!(repair_id, 0);
                 assert_eq!(extent_id, repair_extent);
-                assert_eq!(client_id, ClientId(2));
+                assert_eq!(client_id, ClientId::new(2));
                 assert_eq!(flush_number, max_flush);
                 assert_eq!(gen_number, max_gen);
             }
@@ -4992,9 +5045,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentFlush()", m);
             }
         }
-        assert_eq!(IOState::New, rio.state[ClientId(0)]);
-        assert_eq!(IOState::New, rio.state[ClientId(1)]);
-        assert_eq!(IOState::New, rio.state[ClientId(2)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(0)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(1)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(2)]);
 
         // Second task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -5011,9 +5064,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentClose()", m);
             }
         }
-        assert_eq!(IOState::New, rio.state[ClientId(0)]);
-        assert_eq!(IOState::New, rio.state[ClientId(1)]);
-        assert_eq!(IOState::New, rio.state[ClientId(2)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(0)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(1)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(2)]);
 
         // Third task, repair extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -5028,17 +5081,20 @@ pub(crate) mod up_test {
             } => {
                 assert_eq!(repair_id, rio.id);
                 assert_eq!(extent_id, repair_extent);
-                assert_eq!(source_client_id, ClientId(2));
+                assert_eq!(source_client_id, ClientId::new(2));
                 assert_eq!(source_repair_address, r2);
-                assert_eq!(dest_clients, vec![ClientId(0), ClientId(1)]);
+                assert_eq!(
+                    dest_clients,
+                    vec![ClientId::new(0), ClientId::new(1)]
+                );
             }
             m => {
                 panic!("{:?} not ExtentRepair", m);
             }
         }
-        assert_eq!(IOState::New, rio.state[ClientId(0)]);
-        assert_eq!(IOState::New, rio.state[ClientId(1)]);
-        assert_eq!(IOState::New, rio.state[ClientId(2)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(0)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(1)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(2)]);
 
         // Third task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -5055,9 +5111,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentClose()", m);
             }
         }
-        assert_eq!(IOState::New, rio.state[ClientId(0)]);
-        assert_eq!(IOState::New, rio.state[ClientId(1)]);
-        assert_eq!(IOState::New, rio.state[ClientId(2)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(0)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(1)]);
+        assert_eq!(IOState::New, rio.state[ClientId::new(2)]);
     }
 
     #[tokio::test]
@@ -5084,7 +5140,7 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId::new(0));
 
         // fake read response from downstairs that will fail decryption
 
@@ -5123,7 +5179,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     next_id,
-                    ClientId(0),
+                    ClientId::new(0),
                     response,
                     &Some(context),
                     UpState::Active,
@@ -5146,7 +5202,7 @@ pub(crate) mod up_test {
         let (request, op) = create_generic_read_eob(next_id);
 
         ds.enqueue(op, ds_done_tx.clone()).await;
-        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId::new(0));
 
         // fake read response from downstairs that will fail integrity hash
         // check
@@ -5168,7 +5224,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     next_id,
-                    ClientId(0),
+                    ClientId::new(0),
                     response,
                     &None,
                     UpState::Active,
@@ -5198,7 +5254,7 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId::new(0));
 
         // fake read response from downstairs that will fail integrity hash
         // check
@@ -5226,7 +5282,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     next_id,
-                    ClientId(0),
+                    ClientId::new(0),
                     response,
                     &Some(context),
                     UpState::Active,
@@ -5657,9 +5713,9 @@ pub(crate) mod up_test {
 
             ds.enqueue(op, ds_done_tx.clone()).await;
 
-            assert!(ds.in_progress(next_id, ClientId(0)).is_some());
-            assert!(ds.in_progress(next_id, ClientId(1)).is_some());
-            assert!(ds.in_progress(next_id, ClientId(2)).is_some());
+            assert!(ds.in_progress(next_id, ClientId::new(0)).is_some());
+            assert!(ds.in_progress(next_id, ClientId::new(1)).is_some());
+            assert!(ds.in_progress(next_id, ClientId::new(2)).is_some());
 
             next_id
         };
@@ -5669,33 +5725,43 @@ pub(crate) mod up_test {
 
         // Process the operation for client 0
         assert!(!up
-            .process_ds_operation(next_id, ClientId(0), response.clone(), None)
+            .process_ds_operation(
+                next_id,
+                ClientId::new(0),
+                response.clone(),
+                None
+            )
             .await
             .unwrap(),);
         // client 0 is failed, the others should be okay still
-        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Faulted);
-        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Active);
-        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(0)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(1)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(2)).await, DsState::Active);
 
         // Process the operation for client 1
         assert!(!up
-            .process_ds_operation(next_id, ClientId(1), response.clone(), None)
+            .process_ds_operation(
+                next_id,
+                ClientId::new(1),
+                response.clone(),
+                None
+            )
             .await
             .unwrap(),);
-        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Faulted);
-        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Faulted);
-        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(0)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(1)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(2)).await, DsState::Active);
 
         // Three failures, But since this is a write we already have marked
         // the ACK as ready.
         // Process the operation for client 2
         assert!(!up
-            .process_ds_operation(next_id, ClientId(2), response, None)
+            .process_ds_operation(next_id, ClientId::new(2), response, None)
             .await
             .unwrap());
-        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Faulted);
-        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Faulted);
-        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(0)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(1)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(2)).await, DsState::Faulted);
 
         // Verify we can still ack this (failed) work
         let mut ds = up.downstairs.lock().await;
@@ -5736,9 +5802,9 @@ pub(crate) mod up_test {
 
             ds.enqueue(op, ds_done_tx.clone()).await;
 
-            ds.in_progress(next_id, ClientId(0));
-            ds.in_progress(next_id, ClientId(1));
-            ds.in_progress(next_id, ClientId(2));
+            ds.in_progress(next_id, ClientId::new(0));
+            ds.in_progress(next_id, ClientId::new(1));
+            ds.in_progress(next_id, ClientId::new(2));
 
             next_id
         };
@@ -5748,18 +5814,18 @@ pub(crate) mod up_test {
 
         // Process the error operation for client 0
         assert!(!up
-            .process_ds_operation(next_id, ClientId(0), err_response, None)
+            .process_ds_operation(next_id, ClientId::new(0), err_response, None)
             .await
             .unwrap());
         // client 0 should be marked failed.
-        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(0)).await, DsState::Faulted);
 
         let ok_response = Ok(vec![]);
         // Process the good operation for client 1
         assert!(!up
             .process_ds_operation(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 ok_response.clone(),
                 None
             )
@@ -5768,12 +5834,12 @@ pub(crate) mod up_test {
 
         // process_ds_operation should return true after we process this.
         assert!(up
-            .process_ds_operation(next_id, ClientId(2), ok_response, None)
+            .process_ds_operation(next_id, ClientId::new(2), ok_response, None)
             .await
             .unwrap());
-        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Faulted);
-        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Active);
-        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(0)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(1)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(2)).await, DsState::Active);
 
         // Verify we can ack this work, then ack it.
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 1);
@@ -5797,15 +5863,15 @@ pub(crate) mod up_test {
             ds.enqueue(op, ds_done_tx.clone()).await;
 
             // As this DS is failed, it should return none
-            assert_eq!(ds.in_progress(next_id, ClientId(0)), None);
+            assert_eq!(ds.in_progress(next_id, ClientId::new(0)), None);
 
-            assert!(ds.in_progress(next_id, ClientId(1)).is_some());
-            assert!(ds.in_progress(next_id, ClientId(2)).is_some());
+            assert!(ds.in_progress(next_id, ClientId::new(1)).is_some());
+            assert!(ds.in_progress(next_id, ClientId::new(2)).is_some());
 
             // We should have one job on the skipped job list for failed DS
-            assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
-            assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
-            assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
+            assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 1);
+            assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 0);
+            assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 0);
 
             next_id
         };
@@ -5815,13 +5881,18 @@ pub(crate) mod up_test {
 
         // Process the operation for client 1 this should return true
         assert!(up
-            .process_ds_operation(next_id, ClientId(1), response.clone(), None)
+            .process_ds_operation(
+                next_id,
+                ClientId::new(1),
+                response.clone(),
+                None
+            )
             .await
             .unwrap(),);
 
         // Process the operation for client 2 this should return false
         assert!(!up
-            .process_ds_operation(next_id, ClientId(2), response, None)
+            .process_ds_operation(next_id, ClientId::new(2), response, None)
             .await
             .unwrap());
 
@@ -5847,9 +5918,9 @@ pub(crate) mod up_test {
             ds.enqueue(op, ds_done_tx.clone()).await;
 
             // As this DS is failed, it should return none
-            assert_eq!(ds.in_progress(next_id, ClientId(0)), None);
-            assert!(ds.in_progress(next_id, ClientId(1)).is_some());
-            assert!(ds.in_progress(next_id, ClientId(2)).is_some());
+            assert_eq!(ds.in_progress(next_id, ClientId::new(0)), None);
+            assert!(ds.in_progress(next_id, ClientId::new(1)).is_some());
+            assert!(ds.in_progress(next_id, ClientId::new(2)).is_some());
 
             next_id
         };
@@ -5859,7 +5930,7 @@ pub(crate) mod up_test {
         assert!(!up
             .process_ds_operation(
                 next_id,
-                ClientId(1),
+                ClientId::new(1),
                 ok_response.clone(),
                 None
             )
@@ -5868,7 +5939,7 @@ pub(crate) mod up_test {
 
         // process_ds_operation should return true after we process this.
         assert!(up
-            .process_ds_operation(next_id, ClientId(2), ok_response, None)
+            .process_ds_operation(next_id, ClientId::new(2), ok_response, None)
             .await
             .unwrap());
 
@@ -5884,10 +5955,10 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 3);
 
         // The last skipped flush should still be on the skipped list
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
-        assert!(ds.ds_skipped_jobs[ClientId(0)].contains(&JobId(1002)));
-        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 1);
+        assert!(ds.ds_skipped_jobs[ClientId::new(0)].contains(&JobId(1002)));
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 0);
     }
 
     #[tokio::test]
@@ -5920,9 +5991,9 @@ pub(crate) mod up_test {
 
             ds.enqueue(op, ds_done_tx.clone()).await;
 
-            ds.in_progress(next_id, ClientId(0));
-            ds.in_progress(next_id, ClientId(1));
-            ds.in_progress(next_id, ClientId(2));
+            ds.in_progress(next_id, ClientId::new(0));
+            ds.in_progress(next_id, ClientId::new(1));
+            ds.in_progress(next_id, ClientId::new(2));
 
             next_id
         };
@@ -5934,35 +6005,35 @@ pub(crate) mod up_test {
         assert!(!up
             .process_ds_operation(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 err_response.clone(),
                 None
             )
             .await
             .unwrap());
         // client 0 is failed, the others should be okay still
-        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Faulted);
-        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Active);
-        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(0)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(1)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(2)).await, DsState::Active);
 
         // Process the operation for client 1
         assert!(!up
-            .process_ds_operation(next_id, ClientId(1), err_response, None)
+            .process_ds_operation(next_id, ClientId::new(1), err_response, None)
             .await
             .unwrap());
-        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Faulted);
-        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Faulted);
-        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(0)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(1)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(2)).await, DsState::Active);
 
         let ok_response = Ok(vec![]);
         // Because we ACK writes, this op will always return false
         assert!(!up
-            .process_ds_operation(next_id, ClientId(2), ok_response, None)
+            .process_ds_operation(next_id, ClientId::new(2), ok_response, None)
             .await
             .unwrap());
-        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Faulted);
-        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Faulted);
-        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(0)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(1)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(2)).await, DsState::Active);
 
         // Verify we can ack this work
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 1);
@@ -5986,14 +6057,14 @@ pub(crate) mod up_test {
             ds.enqueue(op, ds_done_tx.clone()).await;
 
             // As this DS is failed, it should return none
-            assert_eq!(ds.in_progress(next_id, ClientId(0)), None);
-            assert_eq!(ds.in_progress(next_id, ClientId(1)), None);
-            assert!(ds.in_progress(next_id, ClientId(2)).is_some());
+            assert_eq!(ds.in_progress(next_id, ClientId::new(0)), None);
+            assert_eq!(ds.in_progress(next_id, ClientId::new(1)), None);
+            assert!(ds.in_progress(next_id, ClientId::new(2)).is_some());
 
             // Two downstairs should have a skipped job on their lists.
-            assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
-            assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
-            assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
+            assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 1);
+            assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 1);
+            assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 0);
 
             next_id
         };
@@ -6003,7 +6074,7 @@ pub(crate) mod up_test {
 
         // Process the operation for client 1 this should return true
         assert!(up
-            .process_ds_operation(next_id, ClientId(2), response, None)
+            .process_ds_operation(next_id, ClientId::new(2), response, None)
             .await
             .unwrap());
     }
@@ -6026,9 +6097,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         if make_in_progress {
-            ds.in_progress(id, ClientId(0));
-            ds.in_progress(id, ClientId(1));
-            ds.in_progress(id, ClientId(2));
+            ds.in_progress(id, ClientId::new(0));
+            ds.in_progress(id, ClientId::new(1));
+            ds.in_progress(id, ClientId::new(2));
         }
 
         id
@@ -6059,9 +6130,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         if make_in_progress {
-            ds.in_progress(id, ClientId(0));
-            ds.in_progress(id, ClientId(1));
-            ds.in_progress(id, ClientId(2));
+            ds.in_progress(id, ClientId::new(0));
+            ds.in_progress(id, ClientId::new(1));
+            ds.in_progress(id, ClientId::new(2));
         }
 
         id
@@ -6091,9 +6162,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         if make_in_progress {
-            ds.in_progress(read_id, ClientId(0));
-            ds.in_progress(read_id, ClientId(1));
-            ds.in_progress(read_id, ClientId(2));
+            ds.in_progress(read_id, ClientId::new(0));
+            ds.in_progress(read_id, ClientId::new(1));
+            ds.in_progress(read_id, ClientId::new(2));
         }
 
         read_id
@@ -6244,7 +6315,7 @@ pub(crate) mod up_test {
         assert!(!up
             .process_ds_operation(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 ok_response.clone(),
                 None
             )
@@ -6253,7 +6324,7 @@ pub(crate) mod up_test {
 
         // Process the error for client 1
         assert!(!up
-            .process_ds_operation(next_id, ClientId(1), err_response, None)
+            .process_ds_operation(next_id, ClientId::new(1), err_response, None)
             .await
             .unwrap());
 
@@ -6261,7 +6332,7 @@ pub(crate) mod up_test {
         assert!(up
             .process_ds_operation(
                 next_id,
-                ClientId(2),
+                ClientId::new(2),
                 ok_response.clone(),
                 None
             )
@@ -6269,15 +6340,15 @@ pub(crate) mod up_test {
             .unwrap(),);
 
         // Verify client states
-        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Active);
-        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Faulted);
-        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(0)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(1)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(2)).await, DsState::Active);
 
         // A faulted write won't change skipped job count.
         let ds = up.downstairs.lock().await;
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 0);
         drop(ds);
 
         // Verify we can ack this work
@@ -6287,9 +6358,9 @@ pub(crate) mod up_test {
         // Now, do another write.
         let next_id = enqueue_write(&up, false, ds_done_tx.clone()).await;
         let mut ds = up.downstairs.lock().await;
-        ds.in_progress(next_id, ClientId(0));
-        assert_eq!(ds.in_progress(next_id, ClientId(1)), None);
-        ds.in_progress(next_id, ClientId(2));
+        ds.in_progress(next_id, ClientId::new(0));
+        assert_eq!(ds.in_progress(next_id, ClientId::new(1)), None);
+        ds.in_progress(next_id, ClientId::new(2));
         drop(ds);
 
         // Process the operation for client 0, re-use ok_response from above.
@@ -6297,7 +6368,7 @@ pub(crate) mod up_test {
         assert!(!up
             .process_ds_operation(
                 next_id,
-                ClientId(0),
+                ClientId::new(0),
                 ok_response.clone(),
                 None
             )
@@ -6308,7 +6379,7 @@ pub(crate) mod up_test {
 
         // process_ds_operation should return true after we process this.
         assert!(up
-            .process_ds_operation(next_id, ClientId(2), ok_response, None)
+            .process_ds_operation(next_id, ClientId::new(2), ok_response, None)
             .await
             .unwrap());
 
@@ -6317,10 +6388,10 @@ pub(crate) mod up_test {
 
         // One downstairs should have a skipped job on its list.
         let ds = up.downstairs.lock().await;
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
-        assert!(ds.ds_skipped_jobs[ClientId(1)].contains(&JobId(1001)));
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 1);
+        assert!(ds.ds_skipped_jobs[ClientId::new(1)].contains(&JobId(1001)));
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 0);
         drop(ds);
 
         // Enqueue the flush.
@@ -6340,10 +6411,10 @@ pub(crate) mod up_test {
             );
             ds.enqueue(op, ds_done_tx.clone()).await;
 
-            assert!(ds.in_progress(next_id, ClientId(0)).is_some());
+            assert!(ds.in_progress(next_id, ClientId::new(0)).is_some());
             // As this DS is failed, it should return none
-            assert_eq!(ds.in_progress(next_id, ClientId(1)), None);
-            assert!(ds.in_progress(next_id, ClientId(2)).is_some());
+            assert_eq!(ds.in_progress(next_id, ClientId::new(1)), None);
+            assert!(ds.in_progress(next_id, ClientId::new(2)).is_some());
 
             next_id
         };
@@ -6353,7 +6424,7 @@ pub(crate) mod up_test {
         assert!(!up
             .process_ds_operation(
                 flush_id,
-                ClientId(0),
+                ClientId::new(0),
                 ok_response.clone(),
                 None
             )
@@ -6362,7 +6433,7 @@ pub(crate) mod up_test {
 
         // process_ds_operation should return true after we process client 2.
         assert!(up
-            .process_ds_operation(flush_id, ClientId(2), ok_response, None)
+            .process_ds_operation(flush_id, ClientId::new(2), ok_response, None)
             .await
             .unwrap());
 
@@ -6380,10 +6451,10 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 3);
 
         // Only the skipped flush should remain.
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
-        assert!(ds.ds_skipped_jobs[ClientId(1)].contains(&JobId(1002)));
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 1);
+        assert!(ds.ds_skipped_jobs[ClientId::new(1)].contains(&JobId(1002)));
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 0);
     }
 
     #[tokio::test]
@@ -6417,9 +6488,9 @@ pub(crate) mod up_test {
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&read_id).unwrap();
 
-        assert_eq!(job.state[ClientId(0)], IOState::New);
-        assert_eq!(job.state[ClientId(1)], IOState::New);
-        assert_eq!(job.state[ClientId(2)], IOState::New);
+        assert_eq!(job.state[ClientId::new(0)], IOState::New);
+        assert_eq!(job.state[ClientId::new(1)], IOState::New);
+        assert_eq!(job.state[ClientId::new(2)], IOState::New);
 
         drop(ds);
 
@@ -6428,26 +6499,31 @@ pub(crate) mod up_test {
 
         // Process the operation for client 0
         assert!(!up
-            .process_ds_operation(write_id, ClientId(0), Ok(vec![]), None)
+            .process_ds_operation(write_id, ClientId::new(0), Ok(vec![]), None)
             .await
             .unwrap());
 
         // Process the error for client 1
         assert!(!up
-            .process_ds_operation(write_id, ClientId(1), err_response, None)
+            .process_ds_operation(
+                write_id,
+                ClientId::new(1),
+                err_response,
+                None
+            )
             .await
             .unwrap());
 
         // process_ds_operation should return true after we process this.
         assert!(up
-            .process_ds_operation(write_id, ClientId(2), Ok(vec![]), None)
+            .process_ds_operation(write_id, ClientId::new(2), Ok(vec![]), None)
             .await
             .unwrap(),);
 
         // Verify client states
-        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Active);
-        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Faulted);
-        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(0)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(1)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(2)).await, DsState::Active);
 
         // Verify we can ack this work
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 1);
@@ -6456,13 +6532,13 @@ pub(crate) mod up_test {
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&read_id).unwrap();
 
-        assert_eq!(job.state[ClientId(0)], IOState::New);
-        assert_eq!(job.state[ClientId(1)], IOState::Skipped);
-        assert_eq!(job.state[ClientId(2)], IOState::New);
+        assert_eq!(job.state[ClientId::new(0)], IOState::New);
+        assert_eq!(job.state[ClientId::new(1)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(2)], IOState::New);
 
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 0);
 
         drop(ds);
     }
@@ -6497,25 +6573,30 @@ pub(crate) mod up_test {
         let ok_res = Ok(vec![]);
 
         // Process the operation for client 0
-        up.process_ds_operation(write_id, ClientId(0), ok_res.clone(), None)
-            .await
-            .unwrap();
+        up.process_ds_operation(
+            write_id,
+            ClientId::new(0),
+            ok_res.clone(),
+            None,
+        )
+        .await
+        .unwrap();
 
         // Process the error for client 1
-        up.process_ds_operation(write_id, ClientId(1), err_response, None)
+        up.process_ds_operation(write_id, ClientId::new(1), err_response, None)
             .await
             .unwrap();
 
         // process_ds_operation should return true after we process this.
         assert!(up
-            .process_ds_operation(write_id, ClientId(2), ok_res, None)
+            .process_ds_operation(write_id, ClientId::new(2), ok_res, None)
             .await
             .unwrap());
 
         // Verify client states
-        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Active);
-        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Faulted);
-        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(0)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(1)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(2)).await, DsState::Active);
 
         // Verify we can ack this work
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 1);
@@ -6524,13 +6605,13 @@ pub(crate) mod up_test {
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&read_id).unwrap();
 
-        assert_eq!(job.state[ClientId(0)], IOState::InProgress);
-        assert_eq!(job.state[ClientId(1)], IOState::Skipped);
-        assert_eq!(job.state[ClientId(2)], IOState::InProgress);
+        assert_eq!(job.state[ClientId::new(0)], IOState::InProgress);
+        assert_eq!(job.state[ClientId::new(1)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(2)], IOState::InProgress);
 
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 0);
         drop(ds);
     }
 
@@ -6581,9 +6662,9 @@ pub(crate) mod up_test {
             let job = ds.ds_active.get(&write_one).unwrap();
             assert_eq!(job.state[cid], IOState::Done);
         }
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 0);
         drop(ds);
 
         // New write, this one will have a failure
@@ -6593,20 +6674,25 @@ pub(crate) mod up_test {
         let err_response = Err(CrucibleError::GenericError("bad".to_string()));
 
         // Process the operation for client 0, 1
-        up.process_ds_operation(write_fail, ClientId(0), Ok(vec![]), None)
+        up.process_ds_operation(write_fail, ClientId::new(0), Ok(vec![]), None)
             .await
             .unwrap();
-        up.process_ds_operation(write_fail, ClientId(1), Ok(vec![]), None)
+        up.process_ds_operation(write_fail, ClientId::new(1), Ok(vec![]), None)
             .await
             .unwrap();
-        up.process_ds_operation(write_fail, ClientId(2), err_response, None)
-            .await
-            .unwrap();
+        up.process_ds_operation(
+            write_fail,
+            ClientId::new(2),
+            err_response,
+            None,
+        )
+        .await
+        .unwrap();
 
         // Verify client states
-        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Active);
-        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Active);
-        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(0)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(1)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(2)).await, DsState::Faulted);
 
         // Verify we can ack this work plus the previous two
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 3);
@@ -6620,17 +6706,17 @@ pub(crate) mod up_test {
             assert_eq!(job.state[cid], IOState::Done);
         }
         let job = ds.ds_active.get(&write_fail).unwrap();
-        assert_eq!(job.state[ClientId(0)], IOState::Done);
-        assert_eq!(job.state[ClientId(1)], IOState::Done);
+        assert_eq!(job.state[ClientId::new(0)], IOState::Done);
+        assert_eq!(job.state[ClientId::new(1)], IOState::Done);
         assert_eq!(
-            job.state[ClientId(2)],
+            job.state[ClientId::new(2)],
             IOState::Error(CrucibleError::GenericError("bad".to_string()))
         );
 
         // A failed job does not change the skipped count.
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 0);
         drop(ds);
     }
 
@@ -6696,21 +6782,26 @@ pub(crate) mod up_test {
             enqueue_read(&up, request.clone(), true, ds_done_tx.clone()).await;
 
         // Process the write operation for downstairs 0, 1
-        up.process_ds_operation(write_fail, ClientId(0), Ok(vec![]), None)
+        up.process_ds_operation(write_fail, ClientId::new(0), Ok(vec![]), None)
             .await
             .unwrap();
-        up.process_ds_operation(write_fail, ClientId(1), Ok(vec![]), None)
+        up.process_ds_operation(write_fail, ClientId::new(1), Ok(vec![]), None)
             .await
             .unwrap();
         // Have downstairs 2 return error.
-        up.process_ds_operation(write_fail, ClientId(2), err_response, None)
-            .await
-            .unwrap();
+        up.process_ds_operation(
+            write_fail,
+            ClientId::new(2),
+            err_response,
+            None,
+        )
+        .await
+        .unwrap();
 
         // Verify client states
-        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Active);
-        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Active);
-        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId::new(0)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(1)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId::new(2)).await, DsState::Faulted);
 
         // Verify we can ack this work plus the previous two
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 3);
@@ -6727,23 +6818,23 @@ pub(crate) mod up_test {
         }
         // The failing write, done on 0,1
         let job = ds.ds_active.get(&write_fail).unwrap();
-        assert_eq!(job.state[ClientId(0)], IOState::Done);
-        assert_eq!(job.state[ClientId(1)], IOState::Done);
+        assert_eq!(job.state[ClientId::new(0)], IOState::Done);
+        assert_eq!(job.state[ClientId::new(1)], IOState::Done);
         // The failing write, error on 2
         assert_eq!(
-            job.state[ClientId(2)],
+            job.state[ClientId::new(2)],
             IOState::Error(CrucibleError::GenericError("bad".to_string()))
         );
 
         // The reads that were in progress
         let job = ds.ds_active.get(&read_two).unwrap();
-        assert_eq!(job.state[ClientId(0)], IOState::InProgress);
-        assert_eq!(job.state[ClientId(1)], IOState::InProgress);
-        assert_eq!(job.state[ClientId(2)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(0)], IOState::InProgress);
+        assert_eq!(job.state[ClientId::new(1)], IOState::InProgress);
+        assert_eq!(job.state[ClientId::new(2)], IOState::Skipped);
 
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 1);
         drop(ds);
     }
 
@@ -6759,7 +6850,7 @@ pub(crate) mod up_test {
             up.ds_transition(cid, DsState::Active).await;
         }
         up.set_active().await.unwrap();
-        up.ds_transition(ClientId(0), DsState::Faulted).await;
+        up.ds_transition(ClientId::new(0), DsState::Faulted).await;
 
         // Create a write
         let write_one = enqueue_write(&up, false, ds_done_tx.clone()).await;
@@ -6777,24 +6868,24 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
-        assert_eq!(job.state[ClientId(1)], IOState::New);
-        assert_eq!(job.state[ClientId(2)], IOState::New);
+        assert_eq!(job.state[ClientId::new(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(1)], IOState::New);
+        assert_eq!(job.state[ClientId::new(2)], IOState::New);
 
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
-        assert_eq!(job.state[ClientId(1)], IOState::New);
-        assert_eq!(job.state[ClientId(2)], IOState::New);
+        assert_eq!(job.state[ClientId::new(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(1)], IOState::New);
+        assert_eq!(job.state[ClientId::new(2)], IOState::New);
 
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
-        assert_eq!(job.state[ClientId(1)], IOState::New);
-        assert_eq!(job.state[ClientId(2)], IOState::New);
+        assert_eq!(job.state[ClientId::new(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(1)], IOState::New);
+        assert_eq!(job.state[ClientId::new(2)], IOState::New);
 
         // Three skipped jobs for downstairs zero
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 3);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 3);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 0);
         drop(ds);
     }
 
@@ -6810,7 +6901,7 @@ pub(crate) mod up_test {
             up.ds_transition(cid, DsState::Active).await;
         }
         up.set_active().await.unwrap();
-        up.ds_transition(ClientId(0), DsState::Faulted).await;
+        up.ds_transition(ClientId::new(0), DsState::Faulted).await;
 
         // Create a write
         let write_one = enqueue_write(&up, true, ds_done_tx.clone()).await;
@@ -6829,49 +6920,49 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
-        assert_eq!(job.state[ClientId(1)], IOState::InProgress);
-        assert_eq!(job.state[ClientId(2)], IOState::InProgress);
+        assert_eq!(job.state[ClientId::new(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(1)], IOState::InProgress);
+        assert_eq!(job.state[ClientId::new(2)], IOState::InProgress);
 
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
-        assert_eq!(job.state[ClientId(1)], IOState::InProgress);
-        assert_eq!(job.state[ClientId(2)], IOState::InProgress);
+        assert_eq!(job.state[ClientId::new(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(1)], IOState::InProgress);
+        assert_eq!(job.state[ClientId::new(2)], IOState::InProgress);
 
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
-        assert_eq!(job.state[ClientId(1)], IOState::InProgress);
-        assert_eq!(job.state[ClientId(2)], IOState::InProgress);
+        assert_eq!(job.state[ClientId::new(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(1)], IOState::InProgress);
+        assert_eq!(job.state[ClientId::new(2)], IOState::InProgress);
 
         // Three skipped jobs on downstairs client 0
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 3);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 3);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 0);
         drop(ds);
 
         // Do the write
-        up.process_ds_operation(write_one, ClientId(1), Ok(vec![]), None)
+        up.process_ds_operation(write_one, ClientId::new(1), Ok(vec![]), None)
             .await
             .unwrap();
-        up.process_ds_operation(write_one, ClientId(2), Ok(vec![]), None)
+        up.process_ds_operation(write_one, ClientId::new(2), Ok(vec![]), None)
             .await
             .unwrap();
 
         // Make the read ok response, do the read
         let rr = Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
 
-        up.process_ds_operation(read_one, ClientId(1), rr.clone(), None)
+        up.process_ds_operation(read_one, ClientId::new(1), rr.clone(), None)
             .await
             .unwrap();
-        up.process_ds_operation(read_one, ClientId(2), rr.clone(), None)
+        up.process_ds_operation(read_one, ClientId::new(2), rr.clone(), None)
             .await
             .unwrap();
 
         // Do the flush
-        up.process_ds_operation(flush_one, ClientId(1), Ok(vec![]), None)
+        up.process_ds_operation(flush_one, ClientId::new(1), Ok(vec![]), None)
             .await
             .unwrap();
-        up.process_ds_operation(flush_one, ClientId(2), Ok(vec![]), None)
+        up.process_ds_operation(flush_one, ClientId::new(2), Ok(vec![]), None)
             .await
             .unwrap();
 
@@ -6882,14 +6973,14 @@ pub(crate) mod up_test {
         let mut ds = up.downstairs.lock().await;
 
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state[ClientId(1)], IOState::Done);
-        assert_eq!(job.state[ClientId(2)], IOState::Done);
+        assert_eq!(job.state[ClientId::new(1)], IOState::Done);
+        assert_eq!(job.state[ClientId::new(2)], IOState::Done);
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state[ClientId(1)], IOState::Done);
-        assert_eq!(job.state[ClientId(2)], IOState::Done);
+        assert_eq!(job.state[ClientId::new(1)], IOState::Done);
+        assert_eq!(job.state[ClientId::new(2)], IOState::Done);
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state[ClientId(1)], IOState::Done);
-        assert_eq!(job.state[ClientId(2)], IOState::Done);
+        assert_eq!(job.state[ClientId::new(1)], IOState::Done);
+        assert_eq!(job.state[ClientId::new(2)], IOState::Done);
 
         ds.ack(read_one);
         ds.ack(write_one);
@@ -6897,8 +6988,8 @@ pub(crate) mod up_test {
         ds.retire_check(flush_one);
 
         // Skipped jobs just has the flush
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
-        assert!(ds.ds_skipped_jobs[ClientId(0)].contains(&JobId(1002)));
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 1);
+        assert!(ds.ds_skipped_jobs[ClientId::new(0)].contains(&JobId(1002)));
         assert_eq!(ds.ackable_work().len(), 0);
 
         // The writes, the read, and the flush should be completed.
@@ -6922,8 +7013,8 @@ pub(crate) mod up_test {
             up.ds_transition(cid, DsState::Active).await;
         }
         up.set_active().await.unwrap();
-        up.ds_transition(ClientId(0), DsState::Faulted).await;
-        up.ds_transition(ClientId(2), DsState::Faulted).await;
+        up.ds_transition(ClientId::new(0), DsState::Faulted).await;
+        up.ds_transition(ClientId::new(2), DsState::Faulted).await;
 
         // Create a write
         let write_one = enqueue_write(&up, true, ds_done_tx.clone()).await;
@@ -6942,40 +7033,40 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
-        assert_eq!(job.state[ClientId(1)], IOState::InProgress);
-        assert_eq!(job.state[ClientId(2)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(1)], IOState::InProgress);
+        assert_eq!(job.state[ClientId::new(2)], IOState::Skipped);
 
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
-        assert_eq!(job.state[ClientId(1)], IOState::InProgress);
-        assert_eq!(job.state[ClientId(2)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(1)], IOState::InProgress);
+        assert_eq!(job.state[ClientId::new(2)], IOState::Skipped);
 
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
-        assert_eq!(job.state[ClientId(1)], IOState::InProgress);
-        assert_eq!(job.state[ClientId(2)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(1)], IOState::InProgress);
+        assert_eq!(job.state[ClientId::new(2)], IOState::Skipped);
 
         // Skipped jobs added on downstairs client 0
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 3);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 3);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 3);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 3);
         drop(ds);
 
         // Do the write
-        up.process_ds_operation(write_one, ClientId(1), Ok(vec![]), None)
+        up.process_ds_operation(write_one, ClientId::new(1), Ok(vec![]), None)
             .await
             .unwrap();
 
         // Make the read ok response, do the read
         let rr = Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
 
-        up.process_ds_operation(read_one, ClientId(1), rr.clone(), None)
+        up.process_ds_operation(read_one, ClientId::new(1), rr.clone(), None)
             .await
             .unwrap();
 
         // Do the flush
-        up.process_ds_operation(flush_one, ClientId(1), Ok(vec![]), None)
+        up.process_ds_operation(flush_one, ClientId::new(1), Ok(vec![]), None)
             .await
             .unwrap();
 
@@ -6986,11 +7077,11 @@ pub(crate) mod up_test {
         let mut ds = up.downstairs.lock().await;
 
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state[ClientId(1)], IOState::Done);
+        assert_eq!(job.state[ClientId::new(1)], IOState::Done);
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state[ClientId(1)], IOState::Done);
+        assert_eq!(job.state[ClientId::new(1)], IOState::Done);
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state[ClientId(1)], IOState::Done);
+        assert_eq!(job.state[ClientId::new(1)], IOState::Done);
 
         ds.ack(read_one);
         ds.ack(write_one);
@@ -6998,10 +7089,10 @@ pub(crate) mod up_test {
         ds.retire_check(flush_one);
 
         // Skipped jobs now just have the flush.
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
-        assert!(ds.ds_skipped_jobs[ClientId(0)].contains(&JobId(1002)));
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 1);
-        assert!(ds.ds_skipped_jobs[ClientId(2)].contains(&JobId(1002)));
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 1);
+        assert!(ds.ds_skipped_jobs[ClientId::new(0)].contains(&JobId(1002)));
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 1);
+        assert!(ds.ds_skipped_jobs[ClientId::new(2)].contains(&JobId(1002)));
         assert_eq!(ds.ackable_work().len(), 0);
 
         // The writes, the read, and the flush should be completed.
@@ -7040,13 +7131,13 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
-        assert_eq!(job.state[ClientId(1)], IOState::Skipped);
-        assert_eq!(job.state[ClientId(2)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(1)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(2)], IOState::Skipped);
 
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 1);
         drop(ds);
 
         // Verify jobs can be acked.
@@ -7061,9 +7152,9 @@ pub(crate) mod up_test {
         ds.retire_check(read_one);
 
         // Our skipped jobs have not yet been cleared.
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 1);
         assert_eq!(ds.ackable_work().len(), 0);
     }
 
@@ -7089,13 +7180,13 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
-        assert_eq!(job.state[ClientId(1)], IOState::Skipped);
-        assert_eq!(job.state[ClientId(2)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(1)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(2)], IOState::Skipped);
 
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 1);
         drop(ds);
 
         // Verify jobs can be acked.
@@ -7109,9 +7200,9 @@ pub(crate) mod up_test {
 
         ds.retire_check(write_one);
         // No flush, no change in skipped jobs.
-        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(0)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(1)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId::new(2)].len(), 1);
 
         assert_eq!(ds.ackable_work().len(), 0);
     }
@@ -7138,9 +7229,9 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
-        assert_eq!(job.state[ClientId(1)], IOState::Skipped);
-        assert_eq!(job.state[ClientId(2)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(1)], IOState::Skipped);
+        assert_eq!(job.state[ClientId::new(2)], IOState::Skipped);
         for cid in ClientId::iter() {
             assert_eq!(ds.ds_skipped_jobs[cid].len(), 1);
             assert!(ds.ds_skipped_jobs[cid].contains(&JobId(1000)));

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -894,9 +894,9 @@ pub(crate) mod up_test {
 
         assert_eq!(ds.completed.len(), 1);
         // No skipped jobs here.
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[1].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
     }
 
     #[tokio::test]
@@ -1418,7 +1418,7 @@ pub(crate) mod up_test {
     #[tokio::test]
     async fn work_read_hash_mismatch_third() {
         // Test that a hash mismatch on the third response will trigger a panic.
-        let mut ds = Downstairs::new(csl(), Vec::new());
+        let mut ds = Downstairs::new(csl(), ClientData::new(None));
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
 
         let id = ds.next_id();
@@ -1795,7 +1795,7 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -1889,7 +1889,7 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -1972,7 +1972,7 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -2062,7 +2062,7 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -2146,7 +2146,7 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -2218,7 +2218,7 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -2642,7 +2642,7 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Send and complete the Flush at each downstairs.
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             ds.in_progress(next_id, cid);
             ds.process_ds_completion(
                 next_id,
@@ -2818,9 +2818,9 @@ pub(crate) mod up_test {
 
         // Make sure downstairs 0 and 1 update their last flush id and
         // that downstairs 2 does not.
-        assert_eq!(ds.ds_last_flush[0], flush_id);
-        assert_eq!(ds.ds_last_flush[1], flush_id);
-        assert_eq!(ds.ds_last_flush[2], JobId(0));
+        assert_eq!(ds.ds_last_flush[ClientId(0)], flush_id);
+        assert_eq!(ds.ds_last_flush[ClientId(1)], flush_id);
+        assert_eq!(ds.ds_last_flush[ClientId(2)], JobId(0));
 
         // Should not retire yet.
         ds.retire_check(flush_id);
@@ -2873,7 +2873,7 @@ pub(crate) mod up_test {
         // All three jobs should now move to completed
         assert_eq!(ds.completed.len(), 3);
         // Downstairs 2 should update the last flush it just did.
-        assert_eq!(ds.ds_last_flush[2], flush_id);
+        assert_eq!(ds.ds_last_flush[ClientId(2)], flush_id);
     }
 
     #[tokio::test]
@@ -3168,9 +3168,9 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 0);
 
         // Verify who has updated their last flush.
-        assert_eq!(ds.ds_last_flush[0], flush_id);
-        assert_eq!(ds.ds_last_flush[1], JobId(0));
-        assert_eq!(ds.ds_last_flush[2], flush_id);
+        assert_eq!(ds.ds_last_flush[ClientId(0)], flush_id);
+        assert_eq!(ds.ds_last_flush[ClientId(1)], JobId(0));
+        assert_eq!(ds.ds_last_flush[ClientId(2)], flush_id);
 
         // Now, finish sending and completing the writes
         assert!(ds.in_progress(id1, ClientId(2)).is_some());
@@ -3216,7 +3216,7 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 3);
 
         // downstairs 1 should now have that flush
-        assert_eq!(ds.ds_last_flush[1], flush_id);
+        assert_eq!(ds.ds_last_flush[ClientId(1)], flush_id);
     }
 
     #[tokio::test]
@@ -3943,9 +3943,9 @@ pub(crate) mod up_test {
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
         let mut ds = up.downstairs.lock().await;
-        ds.ds_state[0] = DsState::Active;
-        ds.ds_state[1] = DsState::Active;
-        ds.ds_state[2] = DsState::Active;
+        ds.ds_state[ClientId(0)] = DsState::Active;
+        ds.ds_state[ClientId(1)] = DsState::Active;
+        ds.ds_state[ClientId(2)] = DsState::Active;
 
         // Build a write, put it on the work queue.
         let id1 = ds.next_id();
@@ -4050,9 +4050,9 @@ pub(crate) mod up_test {
 
         ds = up.downstairs.lock().await;
         // Make sure the correct DS have changed state.
-        assert_eq!(ds.ds_state[0], DsState::Deactivated);
-        assert_eq!(ds.ds_state[2], DsState::Deactivated);
-        assert_eq!(ds.ds_state[1], DsState::Active);
+        assert_eq!(ds.ds_state[ClientId(0)], DsState::Deactivated);
+        assert_eq!(ds.ds_state[ClientId(2)], DsState::Deactivated);
+        assert_eq!(ds.ds_state[ClientId(1)], DsState::Active);
 
         // Send and complete the flush
         ds.in_progress(flush_id, ClientId(1));
@@ -4083,9 +4083,9 @@ pub(crate) mod up_test {
 
         // Verify after the ds_missing, all downstairs are New
         let ds = up.downstairs.lock().await;
-        assert_eq!(ds.ds_state[0], DsState::New);
-        assert_eq!(ds.ds_state[1], DsState::New);
-        assert_eq!(ds.ds_state[2], DsState::New);
+        assert_eq!(ds.ds_state[ClientId(0)], DsState::New);
+        assert_eq!(ds.ds_state[ClientId(1)], DsState::New);
+        assert_eq!(ds.ds_state[ClientId(2)], DsState::New);
     }
 
     #[tokio::test]
@@ -4099,9 +4099,9 @@ pub(crate) mod up_test {
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
         let mut ds = up.downstairs.lock().await;
-        ds.ds_state[0] = DsState::Active;
-        ds.ds_state[1] = DsState::Active;
-        ds.ds_state[2] = DsState::Active;
+        ds.ds_state[ClientId(0)] = DsState::Active;
+        ds.ds_state[ClientId(1)] = DsState::Active;
+        ds.ds_state[ClientId(2)] = DsState::Active;
 
         drop(ds);
         up.set_deactivate(None, ds_done_tx.clone()).await.unwrap();
@@ -4113,9 +4113,9 @@ pub(crate) mod up_test {
 
         ds = up.downstairs.lock().await;
         // Make sure the correct DS have changed state.
-        assert_eq!(ds.ds_state[0], DsState::Deactivated);
-        assert_eq!(ds.ds_state[1], DsState::Deactivated);
-        assert_eq!(ds.ds_state[2], DsState::Deactivated);
+        assert_eq!(ds.ds_state[ClientId(0)], DsState::Deactivated);
+        assert_eq!(ds.ds_state[ClientId(1)], DsState::Deactivated);
+        assert_eq!(ds.ds_state[ClientId(2)], DsState::Deactivated);
         drop(ds);
 
         // Mark all three DS as missing, which moves their state to New
@@ -4146,9 +4146,9 @@ pub(crate) mod up_test {
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
         let mut ds = up.downstairs.lock().await;
-        ds.ds_state[0] = DsState::Active;
-        ds.ds_state[1] = DsState::Active;
-        ds.ds_state[2] = DsState::Active;
+        ds.ds_state[ClientId(0)] = DsState::Active;
+        ds.ds_state[ClientId(1)] = DsState::Active;
+        ds.ds_state[ClientId(2)] = DsState::Active;
 
         // Build a write, put it on the work queue.
         let id1 = ds.next_id();
@@ -4217,9 +4217,9 @@ pub(crate) mod up_test {
 
         ds = up.downstairs.lock().await;
         // Make sure no DS have changed state.
-        assert_eq!(ds.ds_state[0], DsState::Active);
-        assert_eq!(ds.ds_state[2], DsState::Active);
-        assert_eq!(ds.ds_state[1], DsState::Active);
+        assert_eq!(ds.ds_state[ClientId(0)], DsState::Active);
+        assert_eq!(ds.ds_state[ClientId(2)], DsState::Active);
+        assert_eq!(ds.ds_state[ClientId(1)], DsState::Active);
     }
 
     #[tokio::test]
@@ -4245,9 +4245,9 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         up.set_active().await.unwrap();
         let mut ds = up.downstairs.lock().await;
-        ds.ds_state[0] = DsState::Active;
-        ds.ds_state[1] = DsState::Active;
-        ds.ds_state[2] = DsState::Active;
+        ds.ds_state[ClientId(0)] = DsState::Active;
+        ds.ds_state[ClientId(1)] = DsState::Active;
+        ds.ds_state[ClientId(2)] = DsState::Active;
 
         drop(ds);
 
@@ -4258,9 +4258,9 @@ pub(crate) mod up_test {
 
         ds = up.downstairs.lock().await;
         // Make sure no DS have changed state.
-        assert_eq!(ds.ds_state[0], DsState::Active);
-        assert_eq!(ds.ds_state[1], DsState::Active);
-        assert_eq!(ds.ds_state[2], DsState::Active);
+        assert_eq!(ds.ds_state[ClientId(0)], DsState::Active);
+        assert_eq!(ds.ds_state[ClientId(1)], DsState::Active);
+        assert_eq!(ds.ds_state[ClientId(2)], DsState::Active);
     }
 
     #[tokio::test]
@@ -4276,9 +4276,9 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         // Make sure no DS have changed state.
-        assert_eq!(ds.ds_state[0], DsState::New);
-        assert_eq!(ds.ds_state[1], DsState::New);
-        assert_eq!(ds.ds_state[2], DsState::New);
+        assert_eq!(ds.ds_state[ClientId(0)], DsState::New);
+        assert_eq!(ds.ds_state[ClientId(1)], DsState::New);
+        assert_eq!(ds.ds_state[ClientId(2)], DsState::New);
     }
 
     #[tokio::test]
@@ -4427,9 +4427,9 @@ pub(crate) mod up_test {
         // No repairs on the queue, should return None
         let up = Upstairs::test_default(None);
         let mut ds = up.downstairs.lock().await;
-        ds.ds_state[0] = DsState::Repair;
-        ds.ds_state[1] = DsState::Repair;
-        ds.ds_state[2] = DsState::Repair;
+        ds.ds_state[ClientId(0)] = DsState::Repair;
+        ds.ds_state[ClientId(1)] = DsState::Repair;
+        ds.ds_state[ClientId(2)] = DsState::Repair;
         let w = ds.rep_in_progress(ClientId(0));
         assert_eq!(w, None);
     }
@@ -4452,17 +4452,17 @@ pub(crate) mod up_test {
                 },
             ));
             // A downstairs is not in Repair state
-            ds.ds_state[0] = DsState::Repair;
-            ds.ds_state[1] = DsState::WaitQuorum;
-            ds.ds_state[2] = DsState::Repair;
+            ds.ds_state[ClientId(0)] = DsState::Repair;
+            ds.ds_state[ClientId(1)] = DsState::WaitQuorum;
+            ds.ds_state[ClientId(2)] = DsState::Repair;
         }
         // Move that job to next to do.
         let nw = up.new_rec_work().await;
         assert!(nw.is_err());
         let mut ds = up.downstairs.lock().await;
-        assert_eq!(ds.ds_state[0], DsState::FailedRepair);
-        assert_eq!(ds.ds_state[1], DsState::WaitQuorum);
-        assert_eq!(ds.ds_state[2], DsState::FailedRepair);
+        assert_eq!(ds.ds_state[ClientId(0)], DsState::FailedRepair);
+        assert_eq!(ds.ds_state[ClientId(1)], DsState::WaitQuorum);
+        assert_eq!(ds.ds_state[ClientId(2)], DsState::FailedRepair);
 
         // Verify rep_in_progress now returns none for all DS
         assert!(ds.reconcile_task_list.is_empty());
@@ -4480,9 +4480,9 @@ pub(crate) mod up_test {
         let rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[0] = DsState::Repair;
-            ds.ds_state[1] = DsState::Repair;
-            ds.ds_state[2] = DsState::Repair;
+            ds.ds_state[ClientId(0)] = DsState::Repair;
+            ds.ds_state[ClientId(1)] = DsState::Repair;
+            ds.ds_state[ClientId(2)] = DsState::Repair;
             // Put two jobs on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -4502,7 +4502,7 @@ pub(crate) mod up_test {
         assert!(ds.rep_in_progress(ClientId(2)).is_some());
 
         // Now verify we can be done even if a DS is gone
-        ds.ds_state[1] = DsState::New;
+        ds.ds_state[ClientId(1)] = DsState::New;
         // Now, make sure we consider this done only after all three are done
         assert!(!ds.rep_done(ClientId(0), rep_id));
         assert!(!ds.rep_done(ClientId(1), rep_id));
@@ -4514,9 +4514,9 @@ pub(crate) mod up_test {
         let nw = up.new_rec_work().await;
         assert!(nw.is_err());
         let mut ds = up.downstairs.lock().await;
-        assert_eq!(ds.ds_state[0], DsState::FailedRepair);
-        assert_eq!(ds.ds_state[1], DsState::New);
-        assert_eq!(ds.ds_state[2], DsState::FailedRepair);
+        assert_eq!(ds.ds_state[ClientId(0)], DsState::FailedRepair);
+        assert_eq!(ds.ds_state[ClientId(1)], DsState::New);
+        assert_eq!(ds.ds_state[ClientId(2)], DsState::FailedRepair);
 
         // Verify rep_in_progress now returns none for all DS
         assert!(ds.reconcile_task_list.is_empty());
@@ -4533,9 +4533,9 @@ pub(crate) mod up_test {
         let rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[0] = DsState::Repair;
-            ds.ds_state[1] = DsState::Repair;
-            ds.ds_state[2] = DsState::Repair;
+            ds.ds_state[ClientId(0)] = DsState::Repair;
+            ds.ds_state[ClientId(1)] = DsState::Repair;
+            ds.ds_state[ClientId(2)] = DsState::Repair;
             // Put a job on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -4552,12 +4552,12 @@ pub(crate) mod up_test {
         // Mark all three as in progress
         assert!(ds.rep_in_progress(ClientId(0)).is_some());
         assert!(ds.rep_in_progress(ClientId(1)).is_some());
-        ds.ds_state[2] = DsState::New;
+        ds.ds_state[ClientId(2)] = DsState::New;
         assert!(ds.rep_in_progress(ClientId(2)).is_none());
 
         // Okay, now the DS is back and ready for repair, verify it will
         // start taking work.
-        ds.ds_state[2] = DsState::Repair;
+        ds.ds_state[ClientId(2)] = DsState::Repair;
         assert!(ds.rep_in_progress(ClientId(2)).is_some());
     }
 
@@ -4569,9 +4569,9 @@ pub(crate) mod up_test {
         let rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[0] = DsState::Repair;
-            ds.ds_state[1] = DsState::Repair;
-            ds.ds_state[2] = DsState::Repair;
+            ds.ds_state[ClientId(0)] = DsState::Repair;
+            ds.ds_state[ClientId(1)] = DsState::Repair;
+            ds.ds_state[ClientId(2)] = DsState::Repair;
             // Put a job on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -4596,9 +4596,9 @@ pub(crate) mod up_test {
         let rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[0] = DsState::Repair;
-            ds.ds_state[1] = DsState::Repair;
-            ds.ds_state[2] = DsState::Repair;
+            ds.ds_state[ClientId(0)] = DsState::Repair;
+            ds.ds_state[ClientId(1)] = DsState::Repair;
+            ds.ds_state[ClientId(2)] = DsState::Repair;
             // Put a job on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -4620,9 +4620,9 @@ pub(crate) mod up_test {
         let mut rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[0] = DsState::Repair;
-            ds.ds_state[1] = DsState::Repair;
-            ds.ds_state[2] = DsState::Repair;
+            ds.ds_state[ClientId(0)] = DsState::Repair;
+            ds.ds_state[ClientId(1)] = DsState::Repair;
+            ds.ds_state[ClientId(2)] = DsState::Repair;
             // Put two jobs on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -4682,9 +4682,9 @@ pub(crate) mod up_test {
         let rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[0] = DsState::Repair;
-            ds.ds_state[1] = DsState::Repair;
-            ds.ds_state[2] = DsState::Repair;
+            ds.ds_state[ClientId(0)] = DsState::Repair;
+            ds.ds_state[ClientId(1)] = DsState::Repair;
+            ds.ds_state[ClientId(2)] = DsState::Repair;
             // Put two jobs on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -4728,9 +4728,9 @@ pub(crate) mod up_test {
         let rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[0] = DsState::Repair;
-            ds.ds_state[1] = DsState::Repair;
-            ds.ds_state[2] = DsState::Repair;
+            ds.ds_state[ClientId(0)] = DsState::Repair;
+            ds.ds_state[ClientId(1)] = DsState::Repair;
+            ds.ds_state[ClientId(2)] = DsState::Repair;
             // Put a job on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -4769,9 +4769,9 @@ pub(crate) mod up_test {
         let rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[0] = DsState::Repair;
-            ds.ds_state[1] = DsState::Repair;
-            ds.ds_state[2] = DsState::Repair;
+            ds.ds_state[ClientId(0)] = DsState::Repair;
+            ds.ds_state[ClientId(1)] = DsState::Repair;
+            ds.ds_state[ClientId(2)] = DsState::Repair;
             // Put a job on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -4805,9 +4805,9 @@ pub(crate) mod up_test {
         let rep_id = 0;
         {
             let mut ds = up.downstairs.lock().await;
-            ds.ds_state[0] = DsState::Repair;
-            ds.ds_state[1] = DsState::Repair;
-            ds.ds_state[2] = DsState::Repair;
+            ds.ds_state[ClientId(0)] = DsState::Repair;
+            ds.ds_state[ClientId(1)] = DsState::Repair;
+            ds.ds_state[ClientId(2)] = DsState::Repair;
             // Put a job on the todo list
             ds.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -5181,7 +5181,7 @@ pub(crate) mod up_test {
     #[tokio::test]
     async fn bad_hash_on_encrypted_read_panic() {
         // Verify that a decryption failure on a read will panic.
-        let mut ds = Downstairs::new(csl(), Vec::new());
+        let mut ds = Downstairs::new(csl(), ClientData::new(None));
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         let next_id = ds.next_id();
 
@@ -5633,7 +5633,7 @@ pub(crate) mod up_test {
         // process_ds_operation.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -5711,7 +5711,7 @@ pub(crate) mod up_test {
         // clear the jobs (some now failed/skipped) from the work queue.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -5803,9 +5803,9 @@ pub(crate) mod up_test {
             assert!(ds.in_progress(next_id, ClientId(2)).is_some());
 
             // We should have one job on the skipped job list for failed DS
-            assert_eq!(ds.ds_skipped_jobs[0].len(), 1);
-            assert_eq!(ds.ds_skipped_jobs[1].len(), 0);
-            assert_eq!(ds.ds_skipped_jobs[2].len(), 0);
+            assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
+            assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
+            assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
 
             next_id
         };
@@ -5884,10 +5884,10 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 3);
 
         // The last skipped flush should still be on the skipped list
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 1);
-        assert!(ds.ds_skipped_jobs[0].contains(&JobId(1002)));
-        assert_eq!(ds.ds_skipped_jobs[1].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
+        assert!(ds.ds_skipped_jobs[ClientId(0)].contains(&JobId(1002)));
+        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
     }
 
     #[tokio::test]
@@ -5895,7 +5895,7 @@ pub(crate) mod up_test {
         // Verify that if two writes fail, a read can still be acked.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -5991,9 +5991,9 @@ pub(crate) mod up_test {
             assert!(ds.in_progress(next_id, ClientId(2)).is_some());
 
             // Two downstairs should have a skipped job on their lists.
-            assert_eq!(ds.ds_skipped_jobs[0].len(), 1);
-            assert_eq!(ds.ds_skipped_jobs[1].len(), 1);
-            assert_eq!(ds.ds_skipped_jobs[2].len(), 0);
+            assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
+            assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
+            assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
 
             next_id
         };
@@ -6226,7 +6226,7 @@ pub(crate) mod up_test {
         // Then, send a flush and verify the work queue is cleared.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -6275,9 +6275,9 @@ pub(crate) mod up_test {
 
         // A faulted write won't change skipped job count.
         let ds = up.downstairs.lock().await;
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[1].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
         drop(ds);
 
         // Verify we can ack this work
@@ -6317,10 +6317,10 @@ pub(crate) mod up_test {
 
         // One downstairs should have a skipped job on its list.
         let ds = up.downstairs.lock().await;
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[1].len(), 1);
-        assert!(ds.ds_skipped_jobs[1].contains(&JobId(1001)));
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
+        assert!(ds.ds_skipped_jobs[ClientId(1)].contains(&JobId(1001)));
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
         drop(ds);
 
         // Enqueue the flush.
@@ -6380,10 +6380,10 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 3);
 
         // Only the skipped flush should remain.
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[1].len(), 1);
-        assert!(ds.ds_skipped_jobs[1].contains(&JobId(1002)));
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
+        assert!(ds.ds_skipped_jobs[ClientId(1)].contains(&JobId(1002)));
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
     }
 
     #[tokio::test]
@@ -6395,7 +6395,7 @@ pub(crate) mod up_test {
         // to it.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -6460,9 +6460,9 @@ pub(crate) mod up_test {
         assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::New);
 
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[1].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
 
         drop(ds);
     }
@@ -6474,7 +6474,7 @@ pub(crate) mod up_test {
         // to IOState::Skipped.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -6528,9 +6528,9 @@ pub(crate) mod up_test {
         assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::InProgress);
 
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[1].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
         drop(ds);
     }
 
@@ -6541,7 +6541,7 @@ pub(crate) mod up_test {
         // skipped.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -6561,7 +6561,7 @@ pub(crate) mod up_test {
         // Make the read ok response
         let rr = Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
 
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.process_ds_operation(write_one, cid, Ok(vec![]), None)
                 .await
                 .unwrap();
@@ -6575,15 +6575,15 @@ pub(crate) mod up_test {
 
         // Verify all IOs are done
         let ds = up.downstairs.lock().await;
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             let job = ds.ds_active.get(&read_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
             let job = ds.ds_active.get(&write_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
         }
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[1].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
         drop(ds);
 
         // New write, this one will have a failure
@@ -6613,7 +6613,7 @@ pub(crate) mod up_test {
 
         // Verify all IOs are done
         let ds = up.downstairs.lock().await;
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             let job = ds.ds_active.get(&read_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
             let job = ds.ds_active.get(&write_one).unwrap();
@@ -6628,9 +6628,9 @@ pub(crate) mod up_test {
         );
 
         // A failed job does not change the skipped count.
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[1].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
         drop(ds);
     }
 
@@ -6642,7 +6642,7 @@ pub(crate) mod up_test {
         // transitioned to skipped.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -6664,7 +6664,7 @@ pub(crate) mod up_test {
         // Make the read ok response
         let rr = Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
 
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.process_ds_operation(write_one, cid, Ok(vec![]), None)
                 .await
                 .unwrap();
@@ -6678,7 +6678,7 @@ pub(crate) mod up_test {
 
         // Verify all IOs are done
         let ds = up.downstairs.lock().await;
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             let job = ds.ds_active.get(&read_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
             let job = ds.ds_active.get(&write_one).unwrap();
@@ -6717,7 +6717,7 @@ pub(crate) mod up_test {
 
         // Verify all IOs are done
         let ds = up.downstairs.lock().await;
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             // First read, still Done
             let job = ds.ds_active.get(&read_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
@@ -6741,9 +6741,9 @@ pub(crate) mod up_test {
         assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::InProgress);
         assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
 
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[1].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 1);
         drop(ds);
     }
 
@@ -6753,7 +6753,7 @@ pub(crate) mod up_test {
         // automatically moved to skipped.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -6792,9 +6792,9 @@ pub(crate) mod up_test {
         assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::New);
 
         // Three skipped jobs for downstairs zero
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 3);
-        assert_eq!(ds.ds_skipped_jobs[1].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 3);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
         drop(ds);
     }
 
@@ -6804,7 +6804,7 @@ pub(crate) mod up_test {
         // downstairs has failed. One write, one read, and one flush.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -6844,9 +6844,9 @@ pub(crate) mod up_test {
         assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::InProgress);
 
         // Three skipped jobs on downstairs client 0
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 3);
-        assert_eq!(ds.ds_skipped_jobs[1].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 3);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 0);
         drop(ds);
 
         // Do the write
@@ -6897,8 +6897,8 @@ pub(crate) mod up_test {
         ds.retire_check(flush_one);
 
         // Skipped jobs just has the flush
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 1);
-        assert!(ds.ds_skipped_jobs[0].contains(&JobId(1002)));
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
+        assert!(ds.ds_skipped_jobs[ClientId(0)].contains(&JobId(1002)));
         assert_eq!(ds.ackable_work().len(), 0);
 
         // The writes, the read, and the flush should be completed.
@@ -6916,7 +6916,7 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
 
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -6957,9 +6957,9 @@ pub(crate) mod up_test {
         assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
 
         // Skipped jobs added on downstairs client 0
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 3);
-        assert_eq!(ds.ds_skipped_jobs[1].len(), 0);
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 3);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 3);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 3);
         drop(ds);
 
         // Do the write
@@ -6998,10 +6998,10 @@ pub(crate) mod up_test {
         ds.retire_check(flush_one);
 
         // Skipped jobs now just have the flush.
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 1);
-        assert!(ds.ds_skipped_jobs[0].contains(&JobId(1002)));
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 1);
-        assert!(ds.ds_skipped_jobs[2].contains(&JobId(1002)));
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
+        assert!(ds.ds_skipped_jobs[ClientId(0)].contains(&JobId(1002)));
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 1);
+        assert!(ds.ds_skipped_jobs[ClientId(2)].contains(&JobId(1002)));
         assert_eq!(ds.ackable_work().len(), 0);
 
         // The writes, the read, and the flush should be completed.
@@ -7019,13 +7019,13 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
 
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
         up.set_active().await.unwrap();
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::Faulted).await;
         }
 
@@ -7044,9 +7044,9 @@ pub(crate) mod up_test {
         assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
 
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[1].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 1);
         drop(ds);
 
         // Verify jobs can be acked.
@@ -7061,9 +7061,9 @@ pub(crate) mod up_test {
         ds.retire_check(read_one);
 
         // Our skipped jobs have not yet been cleared.
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[1].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 1);
         assert_eq!(ds.ackable_work().len(), 0);
     }
 
@@ -7074,13 +7074,13 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
 
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
         up.set_active().await.unwrap();
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::Faulted).await;
         }
 
@@ -7093,9 +7093,9 @@ pub(crate) mod up_test {
         assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
 
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[1].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 1);
         drop(ds);
 
         // Verify jobs can be acked.
@@ -7109,9 +7109,9 @@ pub(crate) mod up_test {
 
         ds.retire_check(write_one);
         // No flush, no change in skipped jobs.
-        assert_eq!(ds.ds_skipped_jobs[0].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[1].len(), 1);
-        assert_eq!(ds.ds_skipped_jobs[2].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
+        assert_eq!(ds.ds_skipped_jobs[ClientId(2)].len(), 1);
 
         assert_eq!(ds.ackable_work().len(), 0);
     }
@@ -7123,13 +7123,13 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
 
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
         up.set_active().await.unwrap();
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::Faulted).await;
         }
 
@@ -7141,7 +7141,7 @@ pub(crate) mod up_test {
         assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Skipped);
         assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
-        for cid in 0..3 {
+        for cid in ClientId::iter() {
             assert_eq!(ds.ds_skipped_jobs[cid].len(), 1);
             assert!(ds.ds_skipped_jobs[cid].contains(&JobId(1000)));
         }
@@ -7165,7 +7165,7 @@ pub(crate) mod up_test {
         assert_eq!(ds.ds_active.len(), 0);
 
         // Skipped jobs still has the flush.
-        for cid in 0..3 {
+        for cid in ClientId::iter() {
             assert_eq!(ds.ds_skipped_jobs[cid].len(), 1);
             assert!(ds.ds_skipped_jobs[cid].contains(&JobId(1000)));
         }
@@ -7180,13 +7180,13 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
 
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
         up.set_active().await.unwrap();
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::Faulted).await;
         }
 
@@ -7208,7 +7208,7 @@ pub(crate) mod up_test {
         assert_eq!(ds.ackable_work().len(), 3);
 
         // Skipped jobs are not yet cleared.
-        for cid in 0..3 {
+        for cid in ClientId::iter() {
             assert!(ds.ds_skipped_jobs[cid].contains(&JobId(1000)));
             assert!(ds.ds_skipped_jobs[cid].contains(&JobId(1001)));
             assert!(ds.ds_skipped_jobs[cid].contains(&JobId(1002)));
@@ -7235,7 +7235,7 @@ pub(crate) mod up_test {
         assert_eq!(ds.ds_active.len(), 0);
 
         // Skipped jobs now just has the flush
-        for cid in 0..3 {
+        for cid in ClientId::iter() {
             assert!(ds.ds_skipped_jobs[cid].contains(&JobId(1002)));
             assert_eq!(ds.ds_skipped_jobs[cid].len(), 1);
         }
@@ -7251,13 +7251,13 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
 
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
         up.set_active().await.unwrap();
-        for cid in (0..3).map(ClientId) {
+        for cid in ClientId::iter() {
             up.ds_transition(cid, DsState::Faulted).await;
         }
 
@@ -7286,7 +7286,7 @@ pub(crate) mod up_test {
         let mut ds = up.downstairs.lock().await;
 
         // Six jobs have been skipped.
-        for cid in 0..3 {
+        for cid in ClientId::iter() {
             assert!(ds.ds_skipped_jobs[cid].contains(&JobId(1000)));
             assert!(ds.ds_skipped_jobs[cid].contains(&JobId(1001)));
             assert!(ds.ds_skipped_jobs[cid].contains(&JobId(1002)));
@@ -7307,7 +7307,7 @@ pub(crate) mod up_test {
 
         // The first two skipped jobs are now cleared and the non-acked
         // jobs remain on the list, as well as the last flush.
-        for cid in 0..3 {
+        for cid in ClientId::iter() {
             assert!(ds.ds_skipped_jobs[cid].contains(&JobId(1002)));
             assert!(ds.ds_skipped_jobs[cid].contains(&JobId(1003)));
             assert!(ds.ds_skipped_jobs[cid].contains(&JobId(1004)));
@@ -8867,7 +8867,7 @@ pub(crate) mod up_test {
 
             let ds_id = jobs[0].ds_id;
 
-            for client_id in (0..3).map(ClientId) {
+            for client_id in ClientId::iter() {
                 ds.in_progress(ds_id, client_id);
                 ds.process_ds_completion(
                     ds_id,

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -777,14 +777,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId(2));
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -797,7 +797,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -814,7 +814,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                2,
+                ClientId(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -847,14 +847,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId(2));
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -867,7 +867,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -880,7 +880,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                2,
+                ClientId(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -921,14 +921,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId(2));
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -941,7 +941,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -954,7 +954,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                2,
+                ClientId(2),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -982,9 +982,9 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId(2));
 
         let response =
             Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
@@ -992,7 +992,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 response,
                 &None,
                 UpState::Active,
@@ -1012,7 +1012,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 response,
                 &None,
                 UpState::Active,
@@ -1028,7 +1028,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                2,
+                ClientId(2),
                 response,
                 &None,
                 UpState::Active,
@@ -1053,14 +1053,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId(2));
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -1076,7 +1076,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 response,
                 &None,
                 UpState::Active,
@@ -1096,7 +1096,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                2,
+                ClientId(2),
                 response,
                 &None,
                 UpState::Active,
@@ -1122,14 +1122,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId(2));
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -1142,7 +1142,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -1158,7 +1158,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                2,
+                ClientId(2),
                 response,
                 &None,
                 UpState::Active,
@@ -1188,14 +1188,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId(2));
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -1208,7 +1208,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -1221,7 +1221,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                2,
+                ClientId(2),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -1259,9 +1259,9 @@ pub(crate) mod up_test {
 
             ds.enqueue(op, ds_done_tx.clone()).await;
 
-            ds.in_progress(next_id, 0);
-            ds.in_progress(next_id, 1);
-            ds.in_progress(next_id, 2);
+            ds.in_progress(next_id, ClientId(0));
+            ds.in_progress(next_id, ClientId(1));
+            ds.in_progress(next_id, ClientId(2));
 
             next_id
         };
@@ -1270,12 +1270,12 @@ pub(crate) mod up_test {
             Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
 
         assert!(upstairs
-            .process_ds_operation(next_id, 2, response.clone(), None)
+            .process_ds_operation(next_id, ClientId(2), response.clone(), None)
             .await
             .unwrap());
 
         assert!(!upstairs
-            .process_ds_operation(next_id, 0, response, None)
+            .process_ds_operation(next_id, ClientId(0), response, None)
             .await
             .unwrap());
 
@@ -1293,7 +1293,7 @@ pub(crate) mod up_test {
         assert!(!upstairs
             .process_ds_operation(
                 next_id,
-                1,
+                ClientId(1),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 None,
             )
@@ -1322,15 +1322,22 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(id, 0);
-        ds.in_progress(id, 1);
+        ds.in_progress(id, ClientId(0));
+        ds.in_progress(id, ClientId(1));
 
         // Generate the first read response, this will be what we compare
         // future responses with.
         let r1 = Ok(vec![ReadResponse::from_request_with_data(&request, &[9])]);
 
-        ds.process_ds_completion(id, 0, r1, &None, UpState::Active, None)
-            .unwrap();
+        ds.process_ds_completion(
+            id,
+            ClientId(0),
+            r1,
+            &None,
+            UpState::Active,
+            None,
+        )
+        .unwrap();
 
         // We must move the completed job along the process, this enables
         // process_ds_completion to know to compare future jobs to this
@@ -1344,7 +1351,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     id,
-                    1,
+                    ClientId(1),
                     r2,
                     &None,
                     UpState::Active,
@@ -1369,15 +1376,22 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(id, 0);
-        ds.in_progress(id, 1);
+        ds.in_progress(id, ClientId(0));
+        ds.in_progress(id, ClientId(1));
 
         // Generate the first read response, this will be what we compare
         // future responses with.
         let r1 = Ok(vec![ReadResponse::from_request_with_data(&request, &[0])]);
 
-        ds.process_ds_completion(id, 0, r1, &None, UpState::Active, None)
-            .unwrap();
+        ds.process_ds_completion(
+            id,
+            ClientId(0),
+            r1,
+            &None,
+            UpState::Active,
+            None,
+        )
+        .unwrap();
 
         // We must move the completed job along the process, this enables
         // process_ds_completion to know to compare future jobs to this
@@ -1391,7 +1405,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     id,
-                    1,
+                    ClientId(1),
                     r2,
                     &None,
                     UpState::Active,
@@ -1413,22 +1427,36 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(id, 0);
-        ds.in_progress(id, 1);
-        ds.in_progress(id, 2);
+        ds.in_progress(id, ClientId(0));
+        ds.in_progress(id, ClientId(1));
+        ds.in_progress(id, ClientId(2));
 
         // Generate the first read response, this will be what we compare
         // future responses with.
         let r1 = Ok(vec![ReadResponse::from_request_with_data(&request, &[1])]);
 
-        ds.process_ds_completion(id, 0, r1, &None, UpState::Active, None)
-            .unwrap();
+        ds.process_ds_completion(
+            id,
+            ClientId(0),
+            r1,
+            &None,
+            UpState::Active,
+            None,
+        )
+        .unwrap();
 
         // Second read response, it matches the first.
         let r2 = Ok(vec![ReadResponse::from_request_with_data(&request, &[1])]);
 
-        ds.process_ds_completion(id, 1, r2, &None, UpState::Active, None)
-            .unwrap();
+        ds.process_ds_completion(
+            id,
+            ClientId(1),
+            r2,
+            &None,
+            UpState::Active,
+            None,
+        )
+        .unwrap();
 
         let r3 = Ok(vec![ReadResponse::from_request_with_data(&request, &[2])]);
 
@@ -1436,7 +1464,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     id,
-                    2,
+                    ClientId(2),
                     r3,
                     &None,
                     UpState::Active,
@@ -1461,23 +1489,37 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(id, 0);
-        ds.in_progress(id, 1);
-        ds.in_progress(id, 2);
+        ds.in_progress(id, ClientId(0));
+        ds.in_progress(id, ClientId(1));
+        ds.in_progress(id, ClientId(2));
 
         // Generate the first read response, this will be what we compare
         // future responses with.
         let r1 = Ok(vec![ReadResponse::from_request_with_data(&request, &[1])]);
 
-        ds.process_ds_completion(id, 0, r1, &None, UpState::Active, None)
-            .unwrap();
+        ds.process_ds_completion(
+            id,
+            ClientId(0),
+            r1,
+            &None,
+            UpState::Active,
+            None,
+        )
+        .unwrap();
 
         // Second read response, it matches the first.
         let r2 = Ok(vec![ReadResponse::from_request_with_data(&request, &[1])]);
 
         ds.ack(id);
-        ds.process_ds_completion(id, 1, r2, &None, UpState::Active, None)
-            .unwrap();
+        ds.process_ds_completion(
+            id,
+            ClientId(1),
+            r2,
+            &None,
+            UpState::Active,
+            None,
+        )
+        .unwrap();
 
         let r3 = Ok(vec![ReadResponse::from_request_with_data(&request, &[2])]);
 
@@ -1485,7 +1527,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     id,
-                    2,
+                    ClientId(2),
                     r3,
                     &None,
                     UpState::Active,
@@ -1509,8 +1551,8 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(id, 0);
-        ds.in_progress(id, 1);
+        ds.in_progress(id, ClientId(0));
+        ds.in_progress(id, ClientId(1));
 
         // Generate the first read response, this will be what we compare
         // future responses with.
@@ -1519,8 +1561,15 @@ pub(crate) mod up_test {
             &[1, 2, 3, 4],
         )]);
 
-        ds.process_ds_completion(id, 0, r1, &None, UpState::Active, None)
-            .unwrap();
+        ds.process_ds_completion(
+            id,
+            ClientId(0),
+            r1,
+            &None,
+            UpState::Active,
+            None,
+        )
+        .unwrap();
 
         // Second read response, hash vec has different length/
         let r2 = Ok(vec![ReadResponse::from_request_with_data(
@@ -1532,7 +1581,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     id,
-                    1,
+                    ClientId(1),
                     r2,
                     &None,
                     UpState::Active,
@@ -1557,15 +1606,22 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(id, 0);
-        ds.in_progress(id, 1);
+        ds.in_progress(id, ClientId(0));
+        ds.in_progress(id, ClientId(1));
 
         // Generate the first read response, this will be what we compare
         // future responses with.
         let r1 = Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
 
-        ds.process_ds_completion(id, 0, r1, &None, UpState::Active, None)
-            .unwrap();
+        ds.process_ds_completion(
+            id,
+            ClientId(0),
+            r1,
+            &None,
+            UpState::Active,
+            None,
+        )
+        .unwrap();
 
         // Second read response, hash vec has different length/
         let r2 = Ok(vec![ReadResponse::from_request_with_data(&request, &[1])]);
@@ -1574,7 +1630,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     id,
-                    1,
+                    ClientId(1),
                     r2,
                     &None,
                     UpState::Active,
@@ -1598,15 +1654,22 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(id, 0);
-        ds.in_progress(id, 1);
+        ds.in_progress(id, ClientId(0));
+        ds.in_progress(id, ClientId(1));
 
         // Generate the first read response, this will be what we compare
         // future responses with.
         let r1 = Ok(vec![ReadResponse::from_request_with_data(&request, &[1])]);
 
-        ds.process_ds_completion(id, 0, r1, &None, UpState::Active, None)
-            .unwrap();
+        ds.process_ds_completion(
+            id,
+            ClientId(0),
+            r1,
+            &None,
+            UpState::Active,
+            None,
+        )
+        .unwrap();
 
         // Second read response, hash vec has different length/
         let r2 = Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
@@ -1615,7 +1678,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     id,
-                    1,
+                    ClientId(1),
                     r2,
                     &None,
                     UpState::Active,
@@ -1661,14 +1724,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        assert!(ds.in_progress(next_id, 0).is_some());
-        assert!(ds.in_progress(next_id, 1).is_some());
-        assert!(ds.in_progress(next_id, 2).is_some());
+        assert!(ds.in_progress(next_id, ClientId(0)).is_some());
+        assert!(ds.in_progress(next_id, ClientId(1)).is_some());
+        assert!(ds.in_progress(next_id, ClientId(2)).is_some());
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -1681,7 +1744,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -1696,7 +1759,7 @@ pub(crate) mod up_test {
         let res = ds
             .process_ds_completion(
                 next_id,
-                2,
+                ClientId(2),
                 response,
                 &None,
                 UpState::Active,
@@ -1708,9 +1771,9 @@ pub(crate) mod up_test {
         // if it's just a write, then it should be false.
         assert_eq!(res, is_write_unwritten);
 
-        assert!(ds.downstairs_errors.get(&0).is_some());
-        assert!(ds.downstairs_errors.get(&1).is_some());
-        assert!(ds.downstairs_errors.get(&2).is_none());
+        assert!(ds.downstairs_errors.get(&ClientId(0)).is_some());
+        assert!(ds.downstairs_errors.get(&ClientId(1)).is_some());
+        assert!(ds.downstairs_errors.get(&ClientId(2)).is_none());
     }
 
     #[tokio::test]
@@ -1732,12 +1795,12 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
-        up.ds_transition(1, DsState::Faulted).await;
+        up.ds_transition(ClientId(1), DsState::Faulted).await;
 
         let mut gw = up.guest.guest_work.lock().await;
         let mut ds = up.downstairs.lock().await;
@@ -1767,13 +1830,13 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        assert!(ds.in_progress(next_id, 0).is_some());
-        assert!(ds.in_progress(next_id, 2).is_some());
+        assert!(ds.in_progress(next_id, ClientId(0)).is_some());
+        assert!(ds.in_progress(next_id, ClientId(2)).is_some());
 
         let response = Ok(vec![]);
         ds.process_ds_completion(
             next_id,
-            0,
+            ClientId(0),
             response.clone(),
             &None,
             UpState::Active,
@@ -1783,7 +1846,7 @@ pub(crate) mod up_test {
 
         ds.process_ds_completion(
             next_id,
-            2,
+            ClientId(2),
             response,
             &None,
             UpState::Active,
@@ -1826,13 +1889,13 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
-        up.ds_transition(1, DsState::Faulted).await;
-        up.ds_transition(2, DsState::Faulted).await;
+        up.ds_transition(ClientId(1), DsState::Faulted).await;
+        up.ds_transition(ClientId(2), DsState::Faulted).await;
 
         let mut gw = up.guest.guest_work.lock().await;
         let mut ds = up.downstairs.lock().await;
@@ -1861,11 +1924,11 @@ pub(crate) mod up_test {
         drop(gw);
 
         ds.enqueue(op, ds_done_tx.clone()).await;
-        assert!(ds.in_progress(next_id, 0).is_some());
+        assert!(ds.in_progress(next_id, ClientId(0)).is_some());
 
         ds.process_ds_completion(
             next_id,
-            0,
+            ClientId(0),
             Ok(vec![]),
             &None,
             UpState::Active,
@@ -1909,12 +1972,12 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
-        up.ds_transition(2, DsState::Faulted).await;
+        up.ds_transition(ClientId(2), DsState::Faulted).await;
 
         let mut gw = up.guest.guest_work.lock().await;
         let mut ds = up.downstairs.lock().await;
@@ -1943,13 +2006,13 @@ pub(crate) mod up_test {
         drop(gw);
 
         ds.enqueue(op, ds_done_tx.clone()).await;
-        assert!(ds.in_progress(next_id, 0).is_some());
-        assert!(ds.in_progress(next_id, 1).is_some());
+        assert!(ds.in_progress(next_id, ClientId(0)).is_some());
+        assert!(ds.in_progress(next_id, ClientId(1)).is_some());
 
         // DS 0, the good IO.
         ds.process_ds_completion(
             next_id,
-            0,
+            ClientId(0),
             Ok(vec![]),
             &None,
             UpState::Active,
@@ -1963,7 +2026,7 @@ pub(crate) mod up_test {
         let res = ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -1999,12 +2062,12 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
-        up.ds_transition(1, DsState::Faulted).await;
+        up.ds_transition(ClientId(1), DsState::Faulted).await;
 
         let mut gw = up.guest.guest_work.lock().await;
         let mut ds = up.downstairs.lock().await;
@@ -2035,13 +2098,13 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        assert!(ds.in_progress(next_id, 0).is_some());
-        assert!(ds.in_progress(next_id, 2).is_some());
+        assert!(ds.in_progress(next_id, ClientId(0)).is_some());
+        assert!(ds.in_progress(next_id, ClientId(2)).is_some());
 
         let response = Ok(vec![]);
         ds.process_ds_completion(
             next_id,
-            0,
+            ClientId(0),
             response.clone(),
             &None,
             UpState::Active,
@@ -2051,7 +2114,7 @@ pub(crate) mod up_test {
 
         ds.process_ds_completion(
             next_id,
-            2,
+            ClientId(2),
             response,
             &None,
             UpState::Active,
@@ -2083,13 +2146,13 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
-        up.ds_transition(1, DsState::Faulted).await;
-        up.ds_transition(2, DsState::Faulted).await;
+        up.ds_transition(ClientId(1), DsState::Faulted).await;
+        up.ds_transition(ClientId(2), DsState::Faulted).await;
 
         let mut gw = up.guest.guest_work.lock().await;
         let mut ds = up.downstairs.lock().await;
@@ -2119,11 +2182,11 @@ pub(crate) mod up_test {
         drop(gw);
 
         ds.enqueue(op, ds_done_tx.clone()).await;
-        assert!(ds.in_progress(next_id, 0).is_some());
+        assert!(ds.in_progress(next_id, ClientId(0)).is_some());
 
         ds.process_ds_completion(
             next_id,
-            0,
+            ClientId(0),
             Ok(vec![]),
             &None,
             UpState::Active,
@@ -2155,13 +2218,13 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
         up.set_active().await.unwrap();
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
         // Only DS 0 is faulted.
-        up.ds_transition(0, DsState::Faulted).await;
+        up.ds_transition(ClientId(0), DsState::Faulted).await;
 
         let mut gw = up.guest.guest_work.lock().await;
         let mut ds = up.downstairs.lock().await;
@@ -2191,15 +2254,15 @@ pub(crate) mod up_test {
         drop(gw);
 
         ds.enqueue(op, ds_done_tx.clone()).await;
-        assert!(ds.in_progress(next_id, 1).is_some());
-        assert!(ds.in_progress(next_id, 2).is_some());
+        assert!(ds.in_progress(next_id, ClientId(1)).is_some());
+        assert!(ds.in_progress(next_id, ClientId(2)).is_some());
 
         // DS 1 has a failure, and this won't return true as we don't
         // have enough success yet to ACK to the guest.
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -2212,7 +2275,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                2,
+                ClientId(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2253,14 +2316,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        assert!(ds.in_progress(next_id, 0).is_some());
-        assert!(ds.in_progress(next_id, 1).is_some());
-        assert!(ds.in_progress(next_id, 2).is_some());
+        assert!(ds.in_progress(next_id, ClientId(0)).is_some());
+        assert!(ds.in_progress(next_id, ClientId(1)).is_some());
+        assert!(ds.in_progress(next_id, ClientId(2)).is_some());
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -2273,7 +2336,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -2289,7 +2352,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                2,
+                ClientId(2),
                 response,
                 &None,
                 UpState::Active,
@@ -2307,9 +2370,9 @@ pub(crate) mod up_test {
             Some(vec![Bytes::from_static(&[3])]),
         );
 
-        assert!(ds.downstairs_errors.get(&0).is_none());
-        assert!(ds.downstairs_errors.get(&1).is_none());
-        assert!(ds.downstairs_errors.get(&2).is_none());
+        assert!(ds.downstairs_errors.get(&ClientId(0)).is_none());
+        assert!(ds.downstairs_errors.get(&ClientId(1)).is_none());
+        assert!(ds.downstairs_errors.get(&ClientId(2)).is_none());
 
         // send another read, and expect all to return something
         // (reads shouldn't cause a Failed transition)
@@ -2319,14 +2382,14 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        assert!(ds.in_progress(next_id, 0).is_some());
-        assert!(ds.in_progress(next_id, 1).is_some());
-        assert!(ds.in_progress(next_id, 2).is_some());
+        assert!(ds.in_progress(next_id, ClientId(0)).is_some());
+        assert!(ds.in_progress(next_id, ClientId(1)).is_some());
+        assert!(ds.in_progress(next_id, ClientId(2)).is_some());
 
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -2339,7 +2402,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 Err(CrucibleError::GenericError("bad".to_string())),
                 &None,
                 UpState::Active,
@@ -2355,7 +2418,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                2,
+                ClientId(2),
                 response,
                 &None,
                 UpState::Active,
@@ -2391,9 +2454,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Move the work to submitted like we sent it to each downstairs
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId(2));
 
         // Downstairs 0 now has completed this work.
         let response =
@@ -2401,7 +2464,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 response,
                 &None,
                 UpState::Active,
@@ -2418,7 +2481,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 response,
                 &None,
                 UpState::Active,
@@ -2431,7 +2494,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                2,
+                ClientId(2),
                 response,
                 &None,
                 UpState::Active,
@@ -2469,15 +2532,15 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId(2));
 
         // Complete the Flush at each downstairs.
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2488,7 +2551,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2498,7 +2561,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                2,
+                ClientId(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2536,9 +2599,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Move the work to submitted like we sent it to each downstairs
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId(2));
 
         // Downstairs 0 now has completed this work.
         let response =
@@ -2546,7 +2609,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 response,
                 &None,
                 UpState::Active,
@@ -2579,7 +2642,7 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Send and complete the Flush at each downstairs.
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             ds.in_progress(next_id, cid);
             ds.process_ds_completion(
                 next_id,
@@ -2655,16 +2718,16 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Simulate sending both writes to downstairs 0 and 1
-        assert!(ds.in_progress(id1, 0).is_some());
-        assert!(ds.in_progress(id1, 1).is_some());
-        assert!(ds.in_progress(id2, 0).is_some());
-        assert!(ds.in_progress(id2, 1).is_some());
+        assert!(ds.in_progress(id1, ClientId(0)).is_some());
+        assert!(ds.in_progress(id1, ClientId(1)).is_some());
+        assert!(ds.in_progress(id2, ClientId(0)).is_some());
+        assert!(ds.in_progress(id2, ClientId(1)).is_some());
 
         // Simulate completing both writes to downstairs 0 and 1
         assert!(!ds
             .process_ds_completion(
                 id1,
-                0,
+                ClientId(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2674,7 +2737,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 id1,
-                1,
+                ClientId(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2684,7 +2747,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 id2,
-                0,
+                ClientId(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2694,7 +2757,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 id2,
-                1,
+                ClientId(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2725,14 +2788,14 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Simulate sending the flush to downstairs 0 and 1
-        ds.in_progress(flush_id, 0);
-        ds.in_progress(flush_id, 1);
+        ds.in_progress(flush_id, ClientId(0));
+        ds.in_progress(flush_id, ClientId(1));
 
         // Simulate completing the flush to downstairs 0 and 1
         assert!(!ds
             .process_ds_completion(
                 flush_id,
-                0,
+                ClientId(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2742,7 +2805,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 flush_id,
-                1,
+                ClientId(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2768,12 +2831,12 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 0);
 
         // Now, finish the writes to downstairs 2
-        assert!(ds.in_progress(id1, 2).is_some());
-        assert!(ds.in_progress(id2, 2).is_some());
+        assert!(ds.in_progress(id1, ClientId(2)).is_some());
+        assert!(ds.in_progress(id2, ClientId(2)).is_some());
         assert!(!ds
             .process_ds_completion(
                 id1,
-                2,
+                ClientId(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2783,7 +2846,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 id2,
-                2,
+                ClientId(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2795,11 +2858,11 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 0);
 
         // Complete the flush on downstairs 2.
-        ds.in_progress(flush_id, 2);
+        ds.in_progress(flush_id, ClientId(2));
         assert!(!ds
             .process_ds_completion(
                 flush_id,
-                2,
+                ClientId(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2847,15 +2910,15 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the write to all three downstairs.
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId(2));
 
         // Complete the write on all three downstairs.
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2865,7 +2928,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2875,7 +2938,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                2,
+                ClientId(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2905,15 +2968,15 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the flush to all three downstairs.
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId(2));
 
         // Complete the flush on all three downstairs.
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2923,7 +2986,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2933,7 +2996,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                2,
+                ClientId(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -2999,16 +3062,16 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the two writes, to 2/3 of the downstairs.
-        assert!(ds.in_progress(id1, 0).is_some());
-        assert!(ds.in_progress(id1, 1).is_some());
-        assert!(ds.in_progress(id2, 1).is_some());
-        assert!(ds.in_progress(id2, 2).is_some());
+        assert!(ds.in_progress(id1, ClientId(0)).is_some());
+        assert!(ds.in_progress(id1, ClientId(1)).is_some());
+        assert!(ds.in_progress(id2, ClientId(1)).is_some());
+        assert!(ds.in_progress(id2, ClientId(2)).is_some());
 
         // Complete the writes that we sent to the 2 downstairs.
         assert!(!ds
             .process_ds_completion(
                 id1,
-                0,
+                ClientId(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3018,7 +3081,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 id1,
-                1,
+                ClientId(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3028,7 +3091,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 id2,
-                1,
+                ClientId(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3038,7 +3101,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 id2,
-                2,
+                ClientId(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3069,14 +3132,14 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Send the flush to two downstairs.
-        ds.in_progress(flush_id, 0);
-        ds.in_progress(flush_id, 2);
+        ds.in_progress(flush_id, ClientId(0));
+        ds.in_progress(flush_id, ClientId(2));
 
         // Complete the flush on those downstairs.
         assert!(!ds
             .process_ds_completion(
                 flush_id,
-                0,
+                ClientId(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3086,7 +3149,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 flush_id,
-                2,
+                ClientId(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3110,12 +3173,12 @@ pub(crate) mod up_test {
         assert_eq!(ds.ds_last_flush[2], flush_id);
 
         // Now, finish sending and completing the writes
-        assert!(ds.in_progress(id1, 2).is_some());
-        assert!(ds.in_progress(id2, 0).is_some());
+        assert!(ds.in_progress(id1, ClientId(2)).is_some());
+        assert!(ds.in_progress(id2, ClientId(0)).is_some());
         assert!(!ds
             .process_ds_completion(
                 id1,
-                2,
+                ClientId(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3125,7 +3188,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 id2,
-                0,
+                ClientId(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3137,11 +3200,11 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 0);
 
         // Send and complete the flush
-        ds.in_progress(flush_id, 1);
+        ds.in_progress(flush_id, ClientId(1));
         assert!(!ds
             .process_ds_completion(
                 flush_id,
-                1,
+                ClientId(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3170,9 +3233,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the read to all three downstairs
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId(2));
 
         // Complete the read on one downstairs.
         let response =
@@ -3180,7 +3243,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 response,
                 &None,
                 UpState::Active,
@@ -3195,7 +3258,7 @@ pub(crate) mod up_test {
 
         // Be sure the job is not yet in replay
         assert!(!ds.ds_active.get(&next_id).unwrap().replay);
-        ds.re_new(0);
+        ds.re_new(ClientId(0));
         // Now the IO should be replay
         assert!(ds.ds_active.get(&next_id).unwrap().replay);
 
@@ -3220,9 +3283,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the read to each downstairs.
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId(2));
 
         // Complete the read on one downstairs, verify it is ack ready.
         let response = Ok(vec![ReadResponse::from_request_with_data(
@@ -3232,7 +3295,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 response,
                 &None,
                 UpState::Active,
@@ -3251,7 +3314,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 response,
                 &None,
                 UpState::Active,
@@ -3260,26 +3323,26 @@ pub(crate) mod up_test {
             .unwrap());
 
         // Now, take the first downstairs offline.
-        ds.re_new(0);
+        ds.re_new(ClientId(0));
 
         // Should still be ok to ACK this IO
         let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::AckReady);
 
         // Taking the second downstairs offline should revert the ACK.
-        ds.re_new(1);
+        ds.re_new(ClientId(1));
         let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::NotAcked);
 
         // Redo the read on DS 0, IO should go back to ackable.
-        ds.in_progress(next_id, 0);
+        ds.in_progress(next_id, ClientId(0));
 
         let response =
             Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
         assert!(ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 response,
                 &None,
                 UpState::Active,
@@ -3306,9 +3369,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the read to each downstairs.
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId(2));
 
         // Complete the read on one downstairs.
         let response =
@@ -3316,7 +3379,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 response,
                 &None,
                 UpState::Active,
@@ -3341,20 +3404,20 @@ pub(crate) mod up_test {
         assert_eq!(ds.completed.len(), 0);
 
         // Now, take that downstairs offline
-        ds.re_new(0);
+        ds.re_new(ClientId(0));
 
         // Acked IO should remain so.
         let state = ds.ds_active.get(&next_id).unwrap().ack_status;
         assert_eq!(state, AckStatus::Acked);
 
         // Redo on DS 0, IO should remain acked.
-        ds.in_progress(next_id, 0);
+        ds.in_progress(next_id, ClientId(0));
         let response =
             Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 response,
                 &None,
                 UpState::Active,
@@ -3400,9 +3463,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the read to each downstairs.
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId(2));
 
         // Construct our fake response
         let response = Ok(vec![ReadResponse::from_request_with_data(
@@ -3414,7 +3477,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 response,
                 &None,
                 UpState::Active,
@@ -3428,12 +3491,12 @@ pub(crate) mod up_test {
         // Before re re_new, the IO is not replay
         assert!(!ds.ds_active.get(&next_id).unwrap().replay);
         // Now, take that downstairs offline
-        ds.re_new(0);
+        ds.re_new(ClientId(0));
         // Now the IO should be replay
         assert!(ds.ds_active.get(&next_id).unwrap().replay);
 
         // Move it to in-progress.
-        ds.in_progress(next_id, 0);
+        ds.in_progress(next_id, ClientId(0));
 
         // Now, create a new response that has different data, and will
         // produce a different hash.
@@ -3447,7 +3510,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 response,
                 &None,
                 UpState::Active,
@@ -3493,9 +3556,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the read to each downstairs.
-        ds.in_progress(next_id, 0);
-        ds.in_progress(next_id, 1);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        ds.in_progress(next_id, ClientId(1));
+        ds.in_progress(next_id, ClientId(2));
 
         // Construct our fake response
         let response = Ok(vec![ReadResponse::from_request_with_data(
@@ -3507,7 +3570,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 next_id,
-                0,
+                ClientId(0),
                 response,
                 &None,
                 UpState::Active,
@@ -3525,7 +3588,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 response,
                 &None,
                 UpState::Active,
@@ -3537,12 +3600,12 @@ pub(crate) mod up_test {
         ds.ack(next_id);
 
         // Now, take the second downstairs offline
-        ds.re_new(1);
+        ds.re_new(ClientId(1));
         // Now the IO should be replay
         assert!(ds.ds_active.get(&next_id).unwrap().replay);
 
         // Move it to in-progress.
-        ds.in_progress(next_id, 1);
+        ds.in_progress(next_id, ClientId(1));
 
         // Now, create a new response that has different data, and will
         // produce a different hash.
@@ -3556,7 +3619,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 next_id,
-                1,
+                ClientId(1),
                 response,
                 &None,
                 UpState::Active,
@@ -3604,14 +3667,14 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the read to two downstairs.
-        assert!(ds.in_progress(id1, 0).is_some());
-        assert!(ds.in_progress(id1, 1).is_some());
+        assert!(ds.in_progress(id1, ClientId(0)).is_some());
+        assert!(ds.in_progress(id1, ClientId(1)).is_some());
 
         // Complete the write on two downstairs.
         assert!(!ds
             .process_ds_completion(
                 id1,
-                0,
+                ClientId(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3621,7 +3684,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 id1,
-                1,
+                ClientId(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3636,7 +3699,7 @@ pub(crate) mod up_test {
         /* Now, take that downstairs offline */
         // Before re re_new, the IO is not replay
         assert!(!ds.ds_active.get(&id1).unwrap().replay);
-        ds.re_new(1);
+        ds.re_new(ClientId(1));
         // Now the IO should be replay
         assert!(ds.ds_active.get(&id1).unwrap().replay);
 
@@ -3650,11 +3713,11 @@ pub(crate) mod up_test {
         }
 
         // Re-submit and complete the write
-        assert!(ds.in_progress(id1, 1).is_some());
+        assert!(ds.in_progress(id1, ClientId(1)).is_some());
         assert!(ds
             .process_ds_completion(
                 id1,
-                1,
+                ClientId(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3699,14 +3762,14 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the write to two downstairs.
-        assert!(ds.in_progress(id1, 0).is_some());
-        assert!(ds.in_progress(id1, 1).is_some());
+        assert!(ds.in_progress(id1, ClientId(0)).is_some());
+        assert!(ds.in_progress(id1, ClientId(1)).is_some());
 
         // Complete the write on two downstairs.
         assert!(!ds
             .process_ds_completion(
                 id1,
-                0,
+                ClientId(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3716,7 +3779,7 @@ pub(crate) mod up_test {
         assert!(ds
             .process_ds_completion(
                 id1,
-                1,
+                ClientId(1),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3734,20 +3797,20 @@ pub(crate) mod up_test {
         assert_eq!(ds.ackable_work().len(), 0);
 
         // Now, take that downstairs offline
-        ds.re_new(0);
+        ds.re_new(ClientId(0));
 
         // State should stay acked
         let state = ds.ds_active.get(&id1).unwrap().ack_status;
         assert_eq!(state, AckStatus::Acked);
 
         // Finish the write all the way out.
-        assert!(ds.in_progress(id1, 0).is_some());
-        assert!(ds.in_progress(id1, 2).is_some());
+        assert!(ds.in_progress(id1, ClientId(0)).is_some());
+        assert!(ds.in_progress(id1, ClientId(2)).is_some());
 
         assert!(!ds
             .process_ds_completion(
                 id1,
-                0,
+                ClientId(0),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3757,7 +3820,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 id1,
-                2,
+                ClientId(2),
                 Ok(vec![]),
                 &None,
                 UpState::Active,
@@ -3771,33 +3834,33 @@ pub(crate) mod up_test {
         // Verify the correct downstairs progression
         // New -> WA -> WQ -> Active
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitActive).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
-        up.ds_transition(0, DsState::Active).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::Active).await;
     }
 
     #[tokio::test]
     async fn downstairs_transition_replay() {
         // Verify offline goes to replay
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitActive).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
         up.set_active().await.unwrap();
-        up.ds_transition(0, DsState::Active).await;
-        up.ds_transition(0, DsState::Offline).await;
-        up.ds_transition(0, DsState::Replay).await;
+        up.ds_transition(ClientId(0), DsState::Active).await;
+        up.ds_transition(ClientId(0), DsState::Offline).await;
+        up.ds_transition(ClientId(0), DsState::Replay).await;
     }
 
     #[tokio::test]
     async fn downstairs_transition_deactivate_new() {
         // Verify deactivate goes to new
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitActive).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
-        up.ds_transition(0, DsState::Active).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::Active).await;
         up.set_active().await.unwrap();
-        up.ds_transition(0, DsState::Deactivated).await;
-        up.ds_transition(0, DsState::New).await;
+        up.ds_transition(ClientId(0), DsState::Deactivated).await;
+        up.ds_transition(ClientId(0), DsState::New).await;
     }
 
     #[tokio::test]
@@ -3805,7 +3868,7 @@ pub(crate) mod up_test {
     async fn downstairs_transition_deactivate_not_new() {
         // Verify deactivate goes to new
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::Deactivated).await;
+        up.ds_transition(ClientId(0), DsState::Deactivated).await;
     }
 
     #[tokio::test]
@@ -3813,8 +3876,8 @@ pub(crate) mod up_test {
     async fn downstairs_transition_deactivate_not_wa() {
         // Verify no deactivate from wa
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitActive).await;
-        up.ds_transition(0, DsState::Deactivated).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::Deactivated).await;
     }
 
     #[tokio::test]
@@ -3822,19 +3885,19 @@ pub(crate) mod up_test {
     async fn downstairs_transition_deactivate_not_wq() {
         // Verify no deactivate from wq
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitActive).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
-        up.ds_transition(0, DsState::Deactivated).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::Deactivated).await;
     }
 
     #[tokio::test]
     async fn downstairs_transition_active_to_faulted() {
         // Verify active upstairs can go to faulted
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitActive).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
-        up.ds_transition(0, DsState::Active).await;
-        up.ds_transition(0, DsState::Faulted).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::Active).await;
+        up.ds_transition(ClientId(0), DsState::Faulted).await;
     }
 
     #[tokio::test]
@@ -3842,10 +3905,10 @@ pub(crate) mod up_test {
     async fn downstairs_transition_disconnect_no_active() {
         // Verify no activation from disconnected
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitActive).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
-        up.ds_transition(0, DsState::Deactivated).await;
-        up.ds_transition(0, DsState::Active).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::Deactivated).await;
+        up.ds_transition(ClientId(0), DsState::Active).await;
     }
 
     #[tokio::test]
@@ -3853,11 +3916,11 @@ pub(crate) mod up_test {
     async fn downstairs_transition_offline_no_active() {
         // Verify no activation from offline
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitActive).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
-        up.ds_transition(0, DsState::Active).await;
-        up.ds_transition(0, DsState::Offline).await;
-        up.ds_transition(0, DsState::Active).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::Active).await;
+        up.ds_transition(ClientId(0), DsState::Offline).await;
+        up.ds_transition(ClientId(0), DsState::Active).await;
     }
 
     // Deactivate tests
@@ -3899,9 +3962,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the writes
-        assert!(ds.in_progress(id1, 0).is_some());
-        assert!(ds.in_progress(id1, 1).is_some());
-        assert!(ds.in_progress(id1, 2).is_some());
+        assert!(ds.in_progress(id1, ClientId(0)).is_some());
+        assert!(ds.in_progress(id1, ClientId(1)).is_some());
+        assert!(ds.in_progress(id1, ClientId(2)).is_some());
 
         drop(ds);
 
@@ -3914,7 +3977,7 @@ pub(crate) mod up_test {
         // Complete the writes
         ds.process_ds_completion(
             id1,
-            0,
+            ClientId(0),
             Ok(vec![]),
             &None,
             UpState::Active,
@@ -3923,7 +3986,7 @@ pub(crate) mod up_test {
         .unwrap();
         ds.process_ds_completion(
             id1,
-            1,
+            ClientId(1),
             Ok(vec![]),
             &None,
             UpState::Active,
@@ -3932,7 +3995,7 @@ pub(crate) mod up_test {
         .unwrap();
         ds.process_ds_completion(
             id1,
-            2,
+            ClientId(2),
             Ok(vec![]),
             &None,
             UpState::Active,
@@ -3945,15 +4008,15 @@ pub(crate) mod up_test {
 
         // Send the flush created for us when we set deactivated to
         // the two downstairs.
-        ds.in_progress(flush_id, 0);
-        ds.in_progress(flush_id, 2);
+        ds.in_progress(flush_id, ClientId(0));
+        ds.in_progress(flush_id, ClientId(2));
 
         // Complete the flush on those downstairs.
         // One flush won't result in an ACK
         assert!(!ds
             .process_ds_completion(
                 flush_id,
-                0,
+                ClientId(0),
                 Ok(vec![]),
                 &None,
                 UpState::Deactivating,
@@ -3965,7 +4028,7 @@ pub(crate) mod up_test {
         assert!(!ds
             .process_ds_completion(
                 flush_id,
-                2,
+                ClientId(2),
                 Ok(vec![]),
                 &None,
                 UpState::Deactivating,
@@ -3975,11 +4038,11 @@ pub(crate) mod up_test {
 
         // Verify we can deactivate the completed DS
         drop(ds);
-        assert!(up.ds_deactivate(0).await);
-        assert!(up.ds_deactivate(2).await);
+        assert!(up.ds_deactivate(ClientId(0)).await);
+        assert!(up.ds_deactivate(ClientId(2)).await);
 
         // Verify the remaining DS can not deactivate
-        assert!(!up.ds_deactivate(1).await);
+        assert!(!up.ds_deactivate(ClientId(1)).await);
 
         // Verify the deactivate is not done yet.
         up.deactivate_transition_check().await;
@@ -3992,11 +4055,11 @@ pub(crate) mod up_test {
         assert_eq!(ds.ds_state[1], DsState::Active);
 
         // Send and complete the flush
-        ds.in_progress(flush_id, 1);
+        ds.in_progress(flush_id, ClientId(1));
         assert!(ds
             .process_ds_completion(
                 flush_id,
-                1,
+                ClientId(1),
                 Ok(vec![]),
                 &None,
                 UpState::Deactivating,
@@ -4007,12 +4070,12 @@ pub(crate) mod up_test {
         ds.ack(flush_id);
 
         drop(ds);
-        assert!(up.ds_deactivate(1).await);
+        assert!(up.ds_deactivate(ClientId(1)).await);
 
         // Report all three DS as missing, which moves them to New
-        up.ds_missing(0).await;
-        up.ds_missing(1).await;
-        up.ds_missing(2).await;
+        up.ds_missing(ClientId(0)).await;
+        up.ds_missing(ClientId(1)).await;
+        up.ds_missing(ClientId(2)).await;
 
         // Verify we have disconnected and can go back to init.
         up.deactivate_transition_check().await;
@@ -4044,9 +4107,9 @@ pub(crate) mod up_test {
         up.set_deactivate(None, ds_done_tx.clone()).await.unwrap();
 
         // Verify we can deactivate as there is no work
-        assert!(up.ds_deactivate(0).await);
-        assert!(up.ds_deactivate(1).await);
-        assert!(up.ds_deactivate(2).await);
+        assert!(up.ds_deactivate(ClientId(0)).await);
+        assert!(up.ds_deactivate(ClientId(1)).await);
+        assert!(up.ds_deactivate(ClientId(2)).await);
 
         ds = up.downstairs.lock().await;
         // Make sure the correct DS have changed state.
@@ -4056,9 +4119,9 @@ pub(crate) mod up_test {
         drop(ds);
 
         // Mark all three DS as missing, which moves their state to New
-        up.ds_missing(0).await;
-        up.ds_missing(1).await;
-        up.ds_missing(2).await;
+        up.ds_missing(ClientId(0)).await;
+        up.ds_missing(ClientId(1)).await;
+        up.ds_missing(ClientId(2)).await;
 
         // Verify now we can go back to init.
         up.deactivate_transition_check().await;
@@ -4102,9 +4165,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         // Submit the writes
-        assert!(ds.in_progress(id1, 0).is_some());
-        assert!(ds.in_progress(id1, 1).is_some());
-        assert!(ds.in_progress(id1, 2).is_some());
+        assert!(ds.in_progress(id1, ClientId(0)).is_some());
+        assert!(ds.in_progress(id1, ClientId(1)).is_some());
+        assert!(ds.in_progress(id1, ClientId(2)).is_some());
 
         drop(ds);
         up.set_deactivate(None, ds_done_tx.clone()).await.unwrap();
@@ -4113,7 +4176,7 @@ pub(crate) mod up_test {
         // Complete the writes
         ds.process_ds_completion(
             id1,
-            0,
+            ClientId(0),
             Ok(vec![]),
             &None,
             UpState::Deactivating,
@@ -4122,7 +4185,7 @@ pub(crate) mod up_test {
         .unwrap();
         ds.process_ds_completion(
             id1,
-            1,
+            ClientId(1),
             Ok(vec![]),
             &None,
             UpState::Deactivating,
@@ -4131,7 +4194,7 @@ pub(crate) mod up_test {
         .unwrap();
         ds.process_ds_completion(
             id1,
-            2,
+            ClientId(2),
             Ok(vec![]),
             &None,
             UpState::Deactivating,
@@ -4144,9 +4207,9 @@ pub(crate) mod up_test {
 
         // Verify we will not transition to deactivated without a flush.
         drop(ds);
-        assert!(!up.ds_deactivate(0).await);
-        assert!(!up.ds_deactivate(1).await);
-        assert!(!up.ds_deactivate(2).await);
+        assert!(!up.ds_deactivate(ClientId(0)).await);
+        assert!(!up.ds_deactivate(ClientId(1)).await);
+        assert!(!up.ds_deactivate(ClientId(2)).await);
 
         // Verify the deactivate is not done yet.
         up.deactivate_transition_check().await;
@@ -4189,9 +4252,9 @@ pub(crate) mod up_test {
         drop(ds);
 
         // Verify we cannot deactivate even when there is no work
-        assert!(!up.ds_deactivate(0).await);
-        assert!(!up.ds_deactivate(1).await);
-        assert!(!up.ds_deactivate(2).await);
+        assert!(!up.ds_deactivate(ClientId(0)).await);
+        assert!(!up.ds_deactivate(ClientId(1)).await);
+        assert!(!up.ds_deactivate(ClientId(2)).await);
 
         ds = up.downstairs.lock().await;
         // Make sure no DS have changed state.
@@ -4207,9 +4270,9 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
 
         // Verify we cannot deactivate before the upstairs is active
-        assert!(!up.ds_deactivate(0).await);
-        assert!(!up.ds_deactivate(1).await);
-        assert!(!up.ds_deactivate(2).await);
+        assert!(!up.ds_deactivate(ClientId(0)).await);
+        assert!(!up.ds_deactivate(ClientId(1)).await);
+        assert!(!up.ds_deactivate(ClientId(2)).await);
 
         let ds = up.downstairs.lock().await;
         // Make sure no DS have changed state.
@@ -4223,46 +4286,46 @@ pub(crate) mod up_test {
     async fn downstairs_transition_same_wa() {
         // Verify we can't go to the same state we are in
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitActive).await;
-        up.ds_transition(0, DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
     }
 
     #[tokio::test]
     #[should_panic]
     async fn downstairs_transition_same_wq() {
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitActive).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
     }
 
     #[tokio::test]
     #[should_panic]
     async fn downstairs_transition_same_active() {
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitActive).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
-        up.ds_transition(0, DsState::Active).await;
-        up.ds_transition(0, DsState::Active).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::Active).await;
+        up.ds_transition(ClientId(0), DsState::Active).await;
     }
 
     #[tokio::test]
     #[should_panic]
     async fn downstairs_transition_no_new_to_offline() {
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::Offline).await;
-        up.ds_transition(0, DsState::Offline).await;
+        up.ds_transition(ClientId(0), DsState::Offline).await;
+        up.ds_transition(ClientId(0), DsState::Offline).await;
     }
 
     #[tokio::test]
     #[should_panic]
     async fn downstairs_transition_same_offline() {
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitActive).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
-        up.ds_transition(0, DsState::Active).await;
-        up.ds_transition(0, DsState::Offline).await;
-        up.ds_transition(0, DsState::Offline).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::Active).await;
+        up.ds_transition(ClientId(0), DsState::Offline).await;
+        up.ds_transition(ClientId(0), DsState::Offline).await;
     }
 
     #[tokio::test]
@@ -4271,9 +4334,9 @@ pub(crate) mod up_test {
         // Verify state can't go backwards
         // New -> WA -> WQ -> WA
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitActive).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
-        up.ds_transition(0, DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
     }
 
     #[tokio::test]
@@ -4281,7 +4344,7 @@ pub(crate) mod up_test {
     async fn downstairs_bad_transition_wq() {
         // Verify error when going straight to WQ
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
     }
 
     #[tokio::test]
@@ -4289,7 +4352,7 @@ pub(crate) mod up_test {
     async fn downstairs_transition_bad_replay() {
         // Verify new goes to replay will fail
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::Replay).await;
+        up.ds_transition(ClientId(0), DsState::Replay).await;
     }
 
     #[tokio::test]
@@ -4297,11 +4360,11 @@ pub(crate) mod up_test {
     async fn downstairs_transition_bad_offline() {
         // Verify offline cannot go to WQ
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitActive).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
-        up.ds_transition(0, DsState::Active).await;
-        up.ds_transition(0, DsState::Offline).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::Active).await;
+        up.ds_transition(ClientId(0), DsState::Offline).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
     }
 
     #[tokio::test]
@@ -4309,31 +4372,31 @@ pub(crate) mod up_test {
     async fn downstairs_transition_bad_active() {
         // Verify active can't go back to WQ
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitActive).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
-        up.ds_transition(0, DsState::Active).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::Active).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
     }
 
     #[tokio::test]
     async fn downstairs_transition_active_faulted() {
         // Verify
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitActive).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
-        up.ds_transition(0, DsState::Active).await;
-        up.ds_transition(0, DsState::Faulted).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::Active).await;
+        up.ds_transition(ClientId(0), DsState::Faulted).await;
     }
 
     #[tokio::test]
     async fn reconcile_not_ready() {
         // Verify reconcile returns false when a downstairs is not ready
         let up = Upstairs::test_default(None);
-        up.ds_transition(0, DsState::WaitActive).await;
-        up.ds_transition(0, DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(0), DsState::WaitActive).await;
+        up.ds_transition(ClientId(0), DsState::WaitQuorum).await;
 
-        up.ds_transition(1, DsState::WaitActive).await;
-        up.ds_transition(1, DsState::WaitQuorum).await;
+        up.ds_transition(ClientId(1), DsState::WaitActive).await;
+        up.ds_transition(ClientId(1), DsState::WaitQuorum).await;
 
         let (ds_work_tx, _) = mpsc::channel(500);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
@@ -4367,7 +4430,7 @@ pub(crate) mod up_test {
         ds.ds_state[0] = DsState::Repair;
         ds.ds_state[1] = DsState::Repair;
         ds.ds_state[2] = DsState::Repair;
-        let w = ds.rep_in_progress(0);
+        let w = ds.rep_in_progress(ClientId(0));
         assert_eq!(w, None);
     }
 
@@ -4403,9 +4466,9 @@ pub(crate) mod up_test {
 
         // Verify rep_in_progress now returns none for all DS
         assert!(ds.reconcile_task_list.is_empty());
-        assert!(ds.rep_in_progress(0).is_none());
-        assert!(ds.rep_in_progress(1).is_none());
-        assert!(ds.rep_in_progress(2).is_none());
+        assert!(ds.rep_in_progress(ClientId(0)).is_none());
+        assert!(ds.rep_in_progress(ClientId(1)).is_none());
+        assert!(ds.rep_in_progress(ClientId(2)).is_none());
     }
 
     #[tokio::test]
@@ -4434,16 +4497,16 @@ pub(crate) mod up_test {
         assert!(nw.unwrap());
         let mut ds = up.downstairs.lock().await;
         // Mark all three as in progress
-        assert!(ds.rep_in_progress(0).is_some());
-        assert!(ds.rep_in_progress(1).is_some());
-        assert!(ds.rep_in_progress(2).is_some());
+        assert!(ds.rep_in_progress(ClientId(0)).is_some());
+        assert!(ds.rep_in_progress(ClientId(1)).is_some());
+        assert!(ds.rep_in_progress(ClientId(2)).is_some());
 
         // Now verify we can be done even if a DS is gone
         ds.ds_state[1] = DsState::New;
         // Now, make sure we consider this done only after all three are done
-        assert!(!ds.rep_done(0, rep_id));
-        assert!(!ds.rep_done(1, rep_id));
-        assert!(ds.rep_done(2, rep_id));
+        assert!(!ds.rep_done(ClientId(0), rep_id));
+        assert!(!ds.rep_done(ClientId(1), rep_id));
+        assert!(ds.rep_done(ClientId(2), rep_id));
 
         // Getting the next work to do should verify the previous is done,
         // and handle a state change for a downstairs.
@@ -4457,9 +4520,9 @@ pub(crate) mod up_test {
 
         // Verify rep_in_progress now returns none for all DS
         assert!(ds.reconcile_task_list.is_empty());
-        assert!(ds.rep_in_progress(0).is_none());
-        assert!(ds.rep_in_progress(1).is_none());
-        assert!(ds.rep_in_progress(2).is_none());
+        assert!(ds.rep_in_progress(ClientId(0)).is_none());
+        assert!(ds.rep_in_progress(ClientId(1)).is_none());
+        assert!(ds.rep_in_progress(ClientId(2)).is_none());
     }
 
     #[tokio::test]
@@ -4487,15 +4550,15 @@ pub(crate) mod up_test {
         assert!(nw.unwrap());
         let mut ds = up.downstairs.lock().await;
         // Mark all three as in progress
-        assert!(ds.rep_in_progress(0).is_some());
-        assert!(ds.rep_in_progress(1).is_some());
+        assert!(ds.rep_in_progress(ClientId(0)).is_some());
+        assert!(ds.rep_in_progress(ClientId(1)).is_some());
         ds.ds_state[2] = DsState::New;
-        assert!(ds.rep_in_progress(2).is_none());
+        assert!(ds.rep_in_progress(ClientId(2)).is_none());
 
         // Okay, now the DS is back and ready for repair, verify it will
         // start taking work.
         ds.ds_state[2] = DsState::Repair;
-        assert!(ds.rep_in_progress(2).is_some());
+        assert!(ds.rep_in_progress(ClientId(2)).is_some());
     }
 
     #[tokio::test]
@@ -4521,8 +4584,8 @@ pub(crate) mod up_test {
         // Move that job to next to do.
         let _ = up.new_rec_work().await;
         let mut ds = up.downstairs.lock().await;
-        assert!(ds.rep_in_progress(0).is_some());
-        assert!(ds.rep_in_progress(0).is_some());
+        assert!(ds.rep_in_progress(ClientId(0)).is_some());
+        assert!(ds.rep_in_progress(ClientId(0)).is_some());
     }
 
     #[tokio::test]
@@ -4548,7 +4611,7 @@ pub(crate) mod up_test {
         // Move that job to next to do.
         let _ = up.new_rec_work().await;
         let mut ds = up.downstairs.lock().await;
-        ds.rep_done(0, rep_id);
+        ds.rep_done(ClientId(0), rep_id);
     }
 
     #[tokio::test]
@@ -4581,14 +4644,14 @@ pub(crate) mod up_test {
         assert!(nw.unwrap());
         let mut ds = up.downstairs.lock().await;
         // Mark all three as in progress
-        assert!(ds.rep_in_progress(0).is_some());
-        assert!(ds.rep_in_progress(1).is_some());
-        assert!(ds.rep_in_progress(2).is_some());
+        assert!(ds.rep_in_progress(ClientId(0)).is_some());
+        assert!(ds.rep_in_progress(ClientId(1)).is_some());
+        assert!(ds.rep_in_progress(ClientId(2)).is_some());
 
         // Now, make sure we consider this done only after all three are done
-        assert!(!ds.rep_done(0, rep_id));
-        assert!(!ds.rep_done(1, rep_id));
-        assert!(ds.rep_done(2, rep_id));
+        assert!(!ds.rep_done(ClientId(0), rep_id));
+        assert!(!ds.rep_done(ClientId(1), rep_id));
+        assert!(ds.rep_done(ClientId(2), rep_id));
 
         // Getting the next work to do should verify the previous is done
         drop(ds);
@@ -4596,15 +4659,15 @@ pub(crate) mod up_test {
         assert!(nw.unwrap());
         let mut ds = up.downstairs.lock().await;
         // Mark all three as in progress
-        assert!(ds.rep_in_progress(0).is_some());
-        assert!(ds.rep_in_progress(1).is_some());
-        assert!(ds.rep_in_progress(2).is_some());
+        assert!(ds.rep_in_progress(ClientId(0)).is_some());
+        assert!(ds.rep_in_progress(ClientId(1)).is_some());
+        assert!(ds.rep_in_progress(ClientId(2)).is_some());
 
         // Now, make sure we consider this done only after all three are done
         rep_id += 1;
-        assert!(!ds.rep_done(0, rep_id));
-        assert!(!ds.rep_done(1, rep_id));
-        assert!(ds.rep_done(2, rep_id));
+        assert!(!ds.rep_done(ClientId(0), rep_id));
+        assert!(!ds.rep_done(ClientId(1), rep_id));
+        assert!(ds.rep_done(ClientId(2), rep_id));
 
         drop(ds);
         // Now, we should be empty, so nw is false
@@ -4643,13 +4706,13 @@ pub(crate) mod up_test {
         assert!(nw.unwrap());
         let mut ds = up.downstairs.lock().await;
         // Mark all three as in progress
-        assert!(ds.rep_in_progress(0).is_some());
-        assert!(ds.rep_in_progress(1).is_some());
-        assert!(ds.rep_in_progress(2).is_some());
+        assert!(ds.rep_in_progress(ClientId(0)).is_some());
+        assert!(ds.rep_in_progress(ClientId(1)).is_some());
+        assert!(ds.rep_in_progress(ClientId(2)).is_some());
 
         // Now, make sure we consider this done only after all three are done
-        assert!(!ds.rep_done(0, rep_id));
-        assert!(!ds.rep_done(1, rep_id));
+        assert!(!ds.rep_done(ClientId(0), rep_id));
+        assert!(!ds.rep_done(ClientId(1), rep_id));
         // don't finish
 
         // Getting the next work to do should verify the previous is done
@@ -4682,20 +4745,20 @@ pub(crate) mod up_test {
         assert!(nw.unwrap());
         let mut ds = up.downstairs.lock().await;
         // Mark all three as in progress
-        assert!(ds.rep_in_progress(0).is_some());
+        assert!(ds.rep_in_progress(ClientId(0)).is_some());
         if let Some(job) = &mut ds.reconcile_current_work {
-            let oldstate = job.state.insert(1, IOState::Skipped);
+            let oldstate = job.state.insert(ClientId(1), IOState::Skipped);
             assert_eq!(oldstate, Some(IOState::New));
         } else {
             panic!("Failed to find next task");
         }
 
-        assert!(ds.rep_in_progress(2).is_some());
+        assert!(ds.rep_in_progress(ClientId(2)).is_some());
 
         // Now, make sure we consider this done only after all three are done
-        assert!(!ds.rep_done(0, rep_id));
+        assert!(!ds.rep_done(ClientId(0), rep_id));
         // This should panic: assert!(!ds.rep_done(1, rep_id));
-        assert!(ds.rep_done(2, rep_id));
+        assert!(ds.rep_done(ClientId(2), rep_id));
     }
 
     #[tokio::test]
@@ -4724,14 +4787,14 @@ pub(crate) mod up_test {
         let mut ds = up.downstairs.lock().await;
         // Mark one as skipped
         if let Some(job) = &mut ds.reconcile_current_work {
-            let oldstate = job.state.insert(1, IOState::Skipped);
+            let oldstate = job.state.insert(ClientId(1), IOState::Skipped);
             assert_eq!(oldstate, Some(IOState::New));
         } else {
             panic!("Failed to find next task");
         }
 
         // Can't mark done a skipped job
-        ds.rep_done(1, rep_id);
+        ds.rep_done(ClientId(1), rep_id);
     }
 
     #[tokio::test]
@@ -4760,7 +4823,7 @@ pub(crate) mod up_test {
         let mut ds = up.downstairs.lock().await;
         // Jump straight to done.
         // Now, make sure we consider this done only after all three are done
-        ds.rep_done(0, rep_id);
+        ds.rep_done(ClientId(0), rep_id);
     }
 
     #[tokio::test]
@@ -4773,15 +4836,15 @@ pub(crate) mod up_test {
         let r0 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 801);
         let r1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 802);
         let r2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 803);
-        ds.ds_repair.insert(0, r0);
-        ds.ds_repair.insert(1, r1);
-        ds.ds_repair.insert(2, r2);
+        ds.ds_repair.insert(ClientId(0), r0);
+        ds.ds_repair.insert(ClientId(1), r1);
+        ds.ds_repair.insert(ClientId(2), r2);
 
         let repair_extent = 9;
         let mut rec_list = HashMap::new();
         let ef = ExtentFix {
-            source: 0,
-            dest: vec![1, 2],
+            source: ClientId(0),
+            dest: vec![ClientId(1), ClientId(2)],
         };
         rec_list.insert(repair_extent, ef);
         let max_flush = 22;
@@ -4804,7 +4867,7 @@ pub(crate) mod up_test {
             } => {
                 assert_eq!(repair_id, 0);
                 assert_eq!(extent_id, repair_extent);
-                assert_eq!(client_id, 0);
+                assert_eq!(client_id, ClientId(0));
                 assert_eq!(flush_number, max_flush);
                 assert_eq!(gen_number, max_gen);
             }
@@ -4812,9 +4875,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentFlush()", m);
             }
         }
-        assert_eq!(Some(&IOState::New), rio.state.get(&0));
-        assert_eq!(Some(&IOState::New), rio.state.get(&1));
-        assert_eq!(Some(&IOState::New), rio.state.get(&2));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(0)));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(1)));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(2)));
 
         // Second task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -4831,9 +4894,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentClose()", m);
             }
         }
-        assert_eq!(Some(&IOState::New), rio.state.get(&0));
-        assert_eq!(Some(&IOState::New), rio.state.get(&1));
-        assert_eq!(Some(&IOState::New), rio.state.get(&2));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(0)));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(1)));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(2)));
 
         // Third task, repair extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -4848,17 +4911,17 @@ pub(crate) mod up_test {
             } => {
                 assert_eq!(repair_id, rio.id);
                 assert_eq!(extent_id, repair_extent);
-                assert_eq!(source_client_id, 0);
+                assert_eq!(source_client_id, ClientId(0));
                 assert_eq!(source_repair_address, r0);
-                assert_eq!(dest_clients, vec![1, 2]);
+                assert_eq!(dest_clients, vec![ClientId(1), ClientId(2)]);
             }
             m => {
                 panic!("{:?} not ExtentRepair", m);
             }
         }
-        assert_eq!(Some(&IOState::New), rio.state.get(&0));
-        assert_eq!(Some(&IOState::New), rio.state.get(&1));
-        assert_eq!(Some(&IOState::New), rio.state.get(&2));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(0)));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(1)));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(2)));
 
         // Third task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -4875,9 +4938,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentClose()", m);
             }
         }
-        assert_eq!(Some(&IOState::New), rio.state.get(&0));
-        assert_eq!(Some(&IOState::New), rio.state.get(&1));
-        assert_eq!(Some(&IOState::New), rio.state.get(&2));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(0)));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(1)));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(2)));
     }
 
     #[tokio::test]
@@ -4890,15 +4953,15 @@ pub(crate) mod up_test {
         let r0 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 801);
         let r1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 802);
         let r2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 803);
-        ds.ds_repair.insert(0, r0);
-        ds.ds_repair.insert(1, r1);
-        ds.ds_repair.insert(2, r2);
+        ds.ds_repair.insert(ClientId(0), r0);
+        ds.ds_repair.insert(ClientId(1), r1);
+        ds.ds_repair.insert(ClientId(2), r2);
 
         let repair_extent = 5;
         let mut rec_list = HashMap::new();
         let ef = ExtentFix {
-            source: 2,
-            dest: vec![0, 1],
+            source: ClientId(2),
+            dest: vec![ClientId(0), ClientId(1)],
         };
         rec_list.insert(repair_extent, ef);
         let max_flush = 66;
@@ -4921,7 +4984,7 @@ pub(crate) mod up_test {
             } => {
                 assert_eq!(repair_id, 0);
                 assert_eq!(extent_id, repair_extent);
-                assert_eq!(client_id, 2);
+                assert_eq!(client_id, ClientId(2));
                 assert_eq!(flush_number, max_flush);
                 assert_eq!(gen_number, max_gen);
             }
@@ -4929,9 +4992,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentFlush()", m);
             }
         }
-        assert_eq!(Some(&IOState::New), rio.state.get(&0));
-        assert_eq!(Some(&IOState::New), rio.state.get(&1));
-        assert_eq!(Some(&IOState::New), rio.state.get(&2));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(0)));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(1)));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(2)));
 
         // Second task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -4948,9 +5011,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentClose()", m);
             }
         }
-        assert_eq!(Some(&IOState::New), rio.state.get(&0));
-        assert_eq!(Some(&IOState::New), rio.state.get(&1));
-        assert_eq!(Some(&IOState::New), rio.state.get(&2));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(0)));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(1)));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(2)));
 
         // Third task, repair extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -4965,17 +5028,17 @@ pub(crate) mod up_test {
             } => {
                 assert_eq!(repair_id, rio.id);
                 assert_eq!(extent_id, repair_extent);
-                assert_eq!(source_client_id, 2);
+                assert_eq!(source_client_id, ClientId(2));
                 assert_eq!(source_repair_address, r2);
-                assert_eq!(dest_clients, vec![0, 1]);
+                assert_eq!(dest_clients, vec![ClientId(0), ClientId(1)]);
             }
             m => {
                 panic!("{:?} not ExtentRepair", m);
             }
         }
-        assert_eq!(Some(&IOState::New), rio.state.get(&0));
-        assert_eq!(Some(&IOState::New), rio.state.get(&1));
-        assert_eq!(Some(&IOState::New), rio.state.get(&2));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(0)));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(1)));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(2)));
 
         // Third task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -4992,9 +5055,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentClose()", m);
             }
         }
-        assert_eq!(Some(&IOState::New), rio.state.get(&0));
-        assert_eq!(Some(&IOState::New), rio.state.get(&1));
-        assert_eq!(Some(&IOState::New), rio.state.get(&2));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(0)));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(1)));
+        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(2)));
     }
 
     #[tokio::test]
@@ -5021,7 +5084,7 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, 0);
+        ds.in_progress(next_id, ClientId(0));
 
         // fake read response from downstairs that will fail decryption
 
@@ -5060,7 +5123,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     next_id,
-                    0,
+                    ClientId(0),
                     response,
                     &Some(context),
                     UpState::Active,
@@ -5083,7 +5146,7 @@ pub(crate) mod up_test {
         let (request, op) = create_generic_read_eob(next_id);
 
         ds.enqueue(op, ds_done_tx.clone()).await;
-        ds.in_progress(next_id, 0);
+        ds.in_progress(next_id, ClientId(0));
 
         // fake read response from downstairs that will fail integrity hash
         // check
@@ -5105,7 +5168,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     next_id,
-                    0,
+                    ClientId(0),
                     response,
                     &None,
                     UpState::Active,
@@ -5135,7 +5198,7 @@ pub(crate) mod up_test {
 
         ds.enqueue(op, ds_done_tx.clone()).await;
 
-        ds.in_progress(next_id, 0);
+        ds.in_progress(next_id, ClientId(0));
 
         // fake read response from downstairs that will fail integrity hash
         // check
@@ -5163,7 +5226,7 @@ pub(crate) mod up_test {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 ds.process_ds_completion(
                     next_id,
-                    0,
+                    ClientId(0),
                     response,
                     &Some(context),
                     UpState::Active,
@@ -5570,7 +5633,7 @@ pub(crate) mod up_test {
         // process_ds_operation.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -5594,9 +5657,9 @@ pub(crate) mod up_test {
 
             ds.enqueue(op, ds_done_tx.clone()).await;
 
-            assert!(ds.in_progress(next_id, 0).is_some());
-            assert!(ds.in_progress(next_id, 1).is_some());
-            assert!(ds.in_progress(next_id, 2).is_some());
+            assert!(ds.in_progress(next_id, ClientId(0)).is_some());
+            assert!(ds.in_progress(next_id, ClientId(1)).is_some());
+            assert!(ds.in_progress(next_id, ClientId(2)).is_some());
 
             next_id
         };
@@ -5606,33 +5669,33 @@ pub(crate) mod up_test {
 
         // Process the operation for client 0
         assert!(!up
-            .process_ds_operation(next_id, 0, response.clone(), None)
+            .process_ds_operation(next_id, ClientId(0), response.clone(), None)
             .await
             .unwrap(),);
         // client 0 is failed, the others should be okay still
-        assert_eq!(up.ds_state(0).await, DsState::Faulted);
-        assert_eq!(up.ds_state(1).await, DsState::Active);
-        assert_eq!(up.ds_state(2).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
 
         // Process the operation for client 1
         assert!(!up
-            .process_ds_operation(next_id, 1, response.clone(), None)
+            .process_ds_operation(next_id, ClientId(1), response.clone(), None)
             .await
             .unwrap(),);
-        assert_eq!(up.ds_state(0).await, DsState::Faulted);
-        assert_eq!(up.ds_state(1).await, DsState::Faulted);
-        assert_eq!(up.ds_state(2).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
 
         // Three failures, But since this is a write we already have marked
         // the ACK as ready.
         // Process the operation for client 2
         assert!(!up
-            .process_ds_operation(next_id, 2, response, None)
+            .process_ds_operation(next_id, ClientId(2), response, None)
             .await
             .unwrap());
-        assert_eq!(up.ds_state(0).await, DsState::Faulted);
-        assert_eq!(up.ds_state(1).await, DsState::Faulted);
-        assert_eq!(up.ds_state(2).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Faulted);
 
         // Verify we can still ack this (failed) work
         let mut ds = up.downstairs.lock().await;
@@ -5648,7 +5711,7 @@ pub(crate) mod up_test {
         // clear the jobs (some now failed/skipped) from the work queue.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -5673,9 +5736,9 @@ pub(crate) mod up_test {
 
             ds.enqueue(op, ds_done_tx.clone()).await;
 
-            ds.in_progress(next_id, 0);
-            ds.in_progress(next_id, 1);
-            ds.in_progress(next_id, 2);
+            ds.in_progress(next_id, ClientId(0));
+            ds.in_progress(next_id, ClientId(1));
+            ds.in_progress(next_id, ClientId(2));
 
             next_id
         };
@@ -5685,27 +5748,32 @@ pub(crate) mod up_test {
 
         // Process the error operation for client 0
         assert!(!up
-            .process_ds_operation(next_id, 0, err_response, None)
+            .process_ds_operation(next_id, ClientId(0), err_response, None)
             .await
             .unwrap());
         // client 0 should be marked failed.
-        assert_eq!(up.ds_state(0).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Faulted);
 
         let ok_response = Ok(vec![]);
         // Process the good operation for client 1
         assert!(!up
-            .process_ds_operation(next_id, 1, ok_response.clone(), None)
+            .process_ds_operation(
+                next_id,
+                ClientId(1),
+                ok_response.clone(),
+                None
+            )
             .await
             .unwrap());
 
         // process_ds_operation should return true after we process this.
         assert!(up
-            .process_ds_operation(next_id, 2, ok_response, None)
+            .process_ds_operation(next_id, ClientId(2), ok_response, None)
             .await
             .unwrap());
-        assert_eq!(up.ds_state(0).await, DsState::Faulted);
-        assert_eq!(up.ds_state(1).await, DsState::Active);
-        assert_eq!(up.ds_state(2).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
 
         // Verify we can ack this work, then ack it.
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 1);
@@ -5729,10 +5797,10 @@ pub(crate) mod up_test {
             ds.enqueue(op, ds_done_tx.clone()).await;
 
             // As this DS is failed, it should return none
-            assert_eq!(ds.in_progress(next_id, 0), None);
+            assert_eq!(ds.in_progress(next_id, ClientId(0)), None);
 
-            assert!(ds.in_progress(next_id, 1).is_some());
-            assert!(ds.in_progress(next_id, 2).is_some());
+            assert!(ds.in_progress(next_id, ClientId(1)).is_some());
+            assert!(ds.in_progress(next_id, ClientId(2)).is_some());
 
             // We should have one job on the skipped job list for failed DS
             assert_eq!(ds.ds_skipped_jobs[0].len(), 1);
@@ -5747,13 +5815,13 @@ pub(crate) mod up_test {
 
         // Process the operation for client 1 this should return true
         assert!(up
-            .process_ds_operation(next_id, 1, response.clone(), None)
+            .process_ds_operation(next_id, ClientId(1), response.clone(), None)
             .await
             .unwrap(),);
 
         // Process the operation for client 2 this should return false
         assert!(!up
-            .process_ds_operation(next_id, 2, response, None)
+            .process_ds_operation(next_id, ClientId(2), response, None)
             .await
             .unwrap());
 
@@ -5779,9 +5847,9 @@ pub(crate) mod up_test {
             ds.enqueue(op, ds_done_tx.clone()).await;
 
             // As this DS is failed, it should return none
-            assert_eq!(ds.in_progress(next_id, 0), None);
-            assert!(ds.in_progress(next_id, 1).is_some());
-            assert!(ds.in_progress(next_id, 2).is_some());
+            assert_eq!(ds.in_progress(next_id, ClientId(0)), None);
+            assert!(ds.in_progress(next_id, ClientId(1)).is_some());
+            assert!(ds.in_progress(next_id, ClientId(2)).is_some());
 
             next_id
         };
@@ -5789,13 +5857,18 @@ pub(crate) mod up_test {
         let ok_response = Ok(vec![]);
         // Process the operation for client 1
         assert!(!up
-            .process_ds_operation(next_id, 1, ok_response.clone(), None)
+            .process_ds_operation(
+                next_id,
+                ClientId(1),
+                ok_response.clone(),
+                None
+            )
             .await
             .unwrap(),);
 
         // process_ds_operation should return true after we process this.
         assert!(up
-            .process_ds_operation(next_id, 2, ok_response, None)
+            .process_ds_operation(next_id, ClientId(2), ok_response, None)
             .await
             .unwrap());
 
@@ -5822,7 +5895,7 @@ pub(crate) mod up_test {
         // Verify that if two writes fail, a read can still be acked.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -5847,9 +5920,9 @@ pub(crate) mod up_test {
 
             ds.enqueue(op, ds_done_tx.clone()).await;
 
-            ds.in_progress(next_id, 0);
-            ds.in_progress(next_id, 1);
-            ds.in_progress(next_id, 2);
+            ds.in_progress(next_id, ClientId(0));
+            ds.in_progress(next_id, ClientId(1));
+            ds.in_progress(next_id, ClientId(2));
 
             next_id
         };
@@ -5859,32 +5932,37 @@ pub(crate) mod up_test {
 
         // Process the operation for client 0
         assert!(!up
-            .process_ds_operation(next_id, 0, err_response.clone(), None)
+            .process_ds_operation(
+                next_id,
+                ClientId(0),
+                err_response.clone(),
+                None
+            )
             .await
             .unwrap());
         // client 0 is failed, the others should be okay still
-        assert_eq!(up.ds_state(0).await, DsState::Faulted);
-        assert_eq!(up.ds_state(1).await, DsState::Active);
-        assert_eq!(up.ds_state(2).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
 
         // Process the operation for client 1
         assert!(!up
-            .process_ds_operation(next_id, 1, err_response, None)
+            .process_ds_operation(next_id, ClientId(1), err_response, None)
             .await
             .unwrap());
-        assert_eq!(up.ds_state(0).await, DsState::Faulted);
-        assert_eq!(up.ds_state(1).await, DsState::Faulted);
-        assert_eq!(up.ds_state(2).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
 
         let ok_response = Ok(vec![]);
         // Because we ACK writes, this op will always return false
         assert!(!up
-            .process_ds_operation(next_id, 2, ok_response, None)
+            .process_ds_operation(next_id, ClientId(2), ok_response, None)
             .await
             .unwrap());
-        assert_eq!(up.ds_state(0).await, DsState::Faulted);
-        assert_eq!(up.ds_state(1).await, DsState::Faulted);
-        assert_eq!(up.ds_state(2).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
 
         // Verify we can ack this work
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 1);
@@ -5908,9 +5986,9 @@ pub(crate) mod up_test {
             ds.enqueue(op, ds_done_tx.clone()).await;
 
             // As this DS is failed, it should return none
-            assert_eq!(ds.in_progress(next_id, 0), None);
-            assert_eq!(ds.in_progress(next_id, 1), None);
-            assert!(ds.in_progress(next_id, 2).is_some());
+            assert_eq!(ds.in_progress(next_id, ClientId(0)), None);
+            assert_eq!(ds.in_progress(next_id, ClientId(1)), None);
+            assert!(ds.in_progress(next_id, ClientId(2)).is_some());
 
             // Two downstairs should have a skipped job on their lists.
             assert_eq!(ds.ds_skipped_jobs[0].len(), 1);
@@ -5925,7 +6003,7 @@ pub(crate) mod up_test {
 
         // Process the operation for client 1 this should return true
         assert!(up
-            .process_ds_operation(next_id, 2, response, None)
+            .process_ds_operation(next_id, ClientId(2), response, None)
             .await
             .unwrap());
     }
@@ -5948,9 +6026,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         if make_in_progress {
-            ds.in_progress(id, 0);
-            ds.in_progress(id, 1);
-            ds.in_progress(id, 2);
+            ds.in_progress(id, ClientId(0));
+            ds.in_progress(id, ClientId(1));
+            ds.in_progress(id, ClientId(2));
         }
 
         id
@@ -5981,9 +6059,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         if make_in_progress {
-            ds.in_progress(id, 0);
-            ds.in_progress(id, 1);
-            ds.in_progress(id, 2);
+            ds.in_progress(id, ClientId(0));
+            ds.in_progress(id, ClientId(1));
+            ds.in_progress(id, ClientId(2));
         }
 
         id
@@ -6013,9 +6091,9 @@ pub(crate) mod up_test {
         ds.enqueue(op, ds_done_tx.clone()).await;
 
         if make_in_progress {
-            ds.in_progress(read_id, 0);
-            ds.in_progress(read_id, 1);
-            ds.in_progress(read_id, 2);
+            ds.in_progress(read_id, ClientId(0));
+            ds.in_progress(read_id, ClientId(1));
+            ds.in_progress(read_id, ClientId(2));
         }
 
         read_id
@@ -6148,7 +6226,7 @@ pub(crate) mod up_test {
         // Then, send a flush and verify the work queue is cleared.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -6164,26 +6242,36 @@ pub(crate) mod up_test {
 
         // Process the operation for client 0
         assert!(!up
-            .process_ds_operation(next_id, 0, ok_response.clone(), None)
+            .process_ds_operation(
+                next_id,
+                ClientId(0),
+                ok_response.clone(),
+                None
+            )
             .await
             .unwrap(),);
 
         // Process the error for client 1
         assert!(!up
-            .process_ds_operation(next_id, 1, err_response, None)
+            .process_ds_operation(next_id, ClientId(1), err_response, None)
             .await
             .unwrap());
 
         // process_ds_operation should return true after we process this.
         assert!(up
-            .process_ds_operation(next_id, 2, ok_response.clone(), None)
+            .process_ds_operation(
+                next_id,
+                ClientId(2),
+                ok_response.clone(),
+                None
+            )
             .await
             .unwrap(),);
 
         // Verify client states
-        assert_eq!(up.ds_state(0).await, DsState::Active);
-        assert_eq!(up.ds_state(1).await, DsState::Faulted);
-        assert_eq!(up.ds_state(2).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
 
         // A faulted write won't change skipped job count.
         let ds = up.downstairs.lock().await;
@@ -6199,15 +6287,20 @@ pub(crate) mod up_test {
         // Now, do another write.
         let next_id = enqueue_write(&up, false, ds_done_tx.clone()).await;
         let mut ds = up.downstairs.lock().await;
-        ds.in_progress(next_id, 0);
-        assert_eq!(ds.in_progress(next_id, 1), None);
-        ds.in_progress(next_id, 2);
+        ds.in_progress(next_id, ClientId(0));
+        assert_eq!(ds.in_progress(next_id, ClientId(1)), None);
+        ds.in_progress(next_id, ClientId(2));
         drop(ds);
 
         // Process the operation for client 0, re-use ok_response from above.
         // This will return false as we don't have enough work done yet.
         assert!(!up
-            .process_ds_operation(next_id, 0, ok_response.clone(), None)
+            .process_ds_operation(
+                next_id,
+                ClientId(0),
+                ok_response.clone(),
+                None
+            )
             .await
             .unwrap());
 
@@ -6215,7 +6308,7 @@ pub(crate) mod up_test {
 
         // process_ds_operation should return true after we process this.
         assert!(up
-            .process_ds_operation(next_id, 2, ok_response, None)
+            .process_ds_operation(next_id, ClientId(2), ok_response, None)
             .await
             .unwrap());
 
@@ -6247,10 +6340,10 @@ pub(crate) mod up_test {
             );
             ds.enqueue(op, ds_done_tx.clone()).await;
 
-            assert!(ds.in_progress(next_id, 0).is_some());
+            assert!(ds.in_progress(next_id, ClientId(0)).is_some());
             // As this DS is failed, it should return none
-            assert_eq!(ds.in_progress(next_id, 1), None);
-            assert!(ds.in_progress(next_id, 2).is_some());
+            assert_eq!(ds.in_progress(next_id, ClientId(1)), None);
+            assert!(ds.in_progress(next_id, ClientId(2)).is_some());
 
             next_id
         };
@@ -6258,13 +6351,18 @@ pub(crate) mod up_test {
         let ok_response = Ok(vec![]);
         // Process the operation for client 0
         assert!(!up
-            .process_ds_operation(flush_id, 0, ok_response.clone(), None)
+            .process_ds_operation(
+                flush_id,
+                ClientId(0),
+                ok_response.clone(),
+                None
+            )
             .await
             .unwrap());
 
         // process_ds_operation should return true after we process client 2.
         assert!(up
-            .process_ds_operation(flush_id, 2, ok_response, None)
+            .process_ds_operation(flush_id, ClientId(2), ok_response, None)
             .await
             .unwrap());
 
@@ -6297,7 +6395,7 @@ pub(crate) mod up_test {
         // to it.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -6319,9 +6417,9 @@ pub(crate) mod up_test {
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&read_id).unwrap();
 
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::New);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::New);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::New);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::New);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::New);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::New);
 
         drop(ds);
 
@@ -6330,26 +6428,26 @@ pub(crate) mod up_test {
 
         // Process the operation for client 0
         assert!(!up
-            .process_ds_operation(write_id, 0, Ok(vec![]), None)
+            .process_ds_operation(write_id, ClientId(0), Ok(vec![]), None)
             .await
             .unwrap());
 
         // Process the error for client 1
         assert!(!up
-            .process_ds_operation(write_id, 1, err_response, None)
+            .process_ds_operation(write_id, ClientId(1), err_response, None)
             .await
             .unwrap());
 
         // process_ds_operation should return true after we process this.
         assert!(up
-            .process_ds_operation(write_id, 2, Ok(vec![]), None)
+            .process_ds_operation(write_id, ClientId(2), Ok(vec![]), None)
             .await
             .unwrap(),);
 
         // Verify client states
-        assert_eq!(up.ds_state(0).await, DsState::Active);
-        assert_eq!(up.ds_state(1).await, DsState::Faulted);
-        assert_eq!(up.ds_state(2).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
 
         // Verify we can ack this work
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 1);
@@ -6358,9 +6456,9 @@ pub(crate) mod up_test {
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&read_id).unwrap();
 
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::New);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::New);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::New);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::New);
 
         assert_eq!(ds.ds_skipped_jobs[0].len(), 0);
         assert_eq!(ds.ds_skipped_jobs[1].len(), 1);
@@ -6376,7 +6474,7 @@ pub(crate) mod up_test {
         // to IOState::Skipped.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -6399,25 +6497,25 @@ pub(crate) mod up_test {
         let ok_res = Ok(vec![]);
 
         // Process the operation for client 0
-        up.process_ds_operation(write_id, 0, ok_res.clone(), None)
+        up.process_ds_operation(write_id, ClientId(0), ok_res.clone(), None)
             .await
             .unwrap();
 
         // Process the error for client 1
-        up.process_ds_operation(write_id, 1, err_response, None)
+        up.process_ds_operation(write_id, ClientId(1), err_response, None)
             .await
             .unwrap();
 
         // process_ds_operation should return true after we process this.
         assert!(up
-            .process_ds_operation(write_id, 2, ok_res, None)
+            .process_ds_operation(write_id, ClientId(2), ok_res, None)
             .await
             .unwrap());
 
         // Verify client states
-        assert_eq!(up.ds_state(0).await, DsState::Active);
-        assert_eq!(up.ds_state(1).await, DsState::Faulted);
-        assert_eq!(up.ds_state(2).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Active);
 
         // Verify we can ack this work
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 1);
@@ -6426,9 +6524,9 @@ pub(crate) mod up_test {
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&read_id).unwrap();
 
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::InProgress);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::InProgress);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::InProgress);
 
         assert_eq!(ds.ds_skipped_jobs[0].len(), 0);
         assert_eq!(ds.ds_skipped_jobs[1].len(), 1);
@@ -6443,7 +6541,7 @@ pub(crate) mod up_test {
         // skipped.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -6463,7 +6561,7 @@ pub(crate) mod up_test {
         // Make the read ok response
         let rr = Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
 
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.process_ds_operation(write_one, cid, Ok(vec![]), None)
                 .await
                 .unwrap();
@@ -6477,7 +6575,7 @@ pub(crate) mod up_test {
 
         // Verify all IOs are done
         let ds = up.downstairs.lock().await;
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             let job = ds.ds_active.get(&read_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
             let job = ds.ds_active.get(&write_one).unwrap();
@@ -6495,37 +6593,37 @@ pub(crate) mod up_test {
         let err_response = Err(CrucibleError::GenericError("bad".to_string()));
 
         // Process the operation for client 0, 1
-        up.process_ds_operation(write_fail, 0, Ok(vec![]), None)
+        up.process_ds_operation(write_fail, ClientId(0), Ok(vec![]), None)
             .await
             .unwrap();
-        up.process_ds_operation(write_fail, 1, Ok(vec![]), None)
+        up.process_ds_operation(write_fail, ClientId(1), Ok(vec![]), None)
             .await
             .unwrap();
-        up.process_ds_operation(write_fail, 2, err_response, None)
+        up.process_ds_operation(write_fail, ClientId(2), err_response, None)
             .await
             .unwrap();
 
         // Verify client states
-        assert_eq!(up.ds_state(0).await, DsState::Active);
-        assert_eq!(up.ds_state(1).await, DsState::Active);
-        assert_eq!(up.ds_state(2).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Faulted);
 
         // Verify we can ack this work plus the previous two
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 3);
 
         // Verify all IOs are done
         let ds = up.downstairs.lock().await;
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             let job = ds.ds_active.get(&read_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
             let job = ds.ds_active.get(&write_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
         }
         let job = ds.ds_active.get(&write_fail).unwrap();
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::Done);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::Done);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Done);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Done);
         assert_eq!(
-            job.state.get(&2).unwrap(),
+            job.state.get(&ClientId(2)).unwrap(),
             &IOState::Error(CrucibleError::GenericError("bad".to_string()))
         );
 
@@ -6544,7 +6642,7 @@ pub(crate) mod up_test {
         // transitioned to skipped.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
@@ -6566,7 +6664,7 @@ pub(crate) mod up_test {
         // Make the read ok response
         let rr = Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
 
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.process_ds_operation(write_one, cid, Ok(vec![]), None)
                 .await
                 .unwrap();
@@ -6580,7 +6678,7 @@ pub(crate) mod up_test {
 
         // Verify all IOs are done
         let ds = up.downstairs.lock().await;
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             let job = ds.ds_active.get(&read_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
             let job = ds.ds_active.get(&write_one).unwrap();
@@ -6598,28 +6696,28 @@ pub(crate) mod up_test {
             enqueue_read(&up, request.clone(), true, ds_done_tx.clone()).await;
 
         // Process the write operation for downstairs 0, 1
-        up.process_ds_operation(write_fail, 0, Ok(vec![]), None)
+        up.process_ds_operation(write_fail, ClientId(0), Ok(vec![]), None)
             .await
             .unwrap();
-        up.process_ds_operation(write_fail, 1, Ok(vec![]), None)
+        up.process_ds_operation(write_fail, ClientId(1), Ok(vec![]), None)
             .await
             .unwrap();
         // Have downstairs 2 return error.
-        up.process_ds_operation(write_fail, 2, err_response, None)
+        up.process_ds_operation(write_fail, ClientId(2), err_response, None)
             .await
             .unwrap();
 
         // Verify client states
-        assert_eq!(up.ds_state(0).await, DsState::Active);
-        assert_eq!(up.ds_state(1).await, DsState::Active);
-        assert_eq!(up.ds_state(2).await, DsState::Faulted);
+        assert_eq!(up.ds_state(ClientId(0)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(1)).await, DsState::Active);
+        assert_eq!(up.ds_state(ClientId(2)).await, DsState::Faulted);
 
         // Verify we can ack this work plus the previous two
         assert_eq!(up.downstairs.lock().await.ackable_work().len(), 3);
 
         // Verify all IOs are done
         let ds = up.downstairs.lock().await;
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             // First read, still Done
             let job = ds.ds_active.get(&read_one).unwrap();
             assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
@@ -6629,19 +6727,19 @@ pub(crate) mod up_test {
         }
         // The failing write, done on 0,1
         let job = ds.ds_active.get(&write_fail).unwrap();
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::Done);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::Done);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Done);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Done);
         // The failing write, error on 2
         assert_eq!(
-            job.state.get(&2).unwrap(),
+            job.state.get(&ClientId(2)).unwrap(),
             &IOState::Error(CrucibleError::GenericError("bad".to_string()))
         );
 
         // The reads that were in progress
         let job = ds.ds_active.get(&read_two).unwrap();
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::InProgress);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::InProgress);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
 
         assert_eq!(ds.ds_skipped_jobs[0].len(), 0);
         assert_eq!(ds.ds_skipped_jobs[1].len(), 0);
@@ -6655,13 +6753,13 @@ pub(crate) mod up_test {
         // automatically moved to skipped.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
         up.set_active().await.unwrap();
-        up.ds_transition(0, DsState::Faulted).await;
+        up.ds_transition(ClientId(0), DsState::Faulted).await;
 
         // Create a write
         let write_one = enqueue_write(&up, false, ds_done_tx.clone()).await;
@@ -6679,19 +6777,19 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::New);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::New);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::New);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::New);
 
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::New);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::New);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::New);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::New);
 
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::New);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::New);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::New);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::New);
 
         // Three skipped jobs for downstairs zero
         assert_eq!(ds.ds_skipped_jobs[0].len(), 3);
@@ -6706,13 +6804,13 @@ pub(crate) mod up_test {
         // downstairs has failed. One write, one read, and one flush.
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
         up.set_active().await.unwrap();
-        up.ds_transition(0, DsState::Faulted).await;
+        up.ds_transition(ClientId(0), DsState::Faulted).await;
 
         // Create a write
         let write_one = enqueue_write(&up, true, ds_done_tx.clone()).await;
@@ -6731,19 +6829,19 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::InProgress);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::InProgress);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::InProgress);
 
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::InProgress);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::InProgress);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::InProgress);
 
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::InProgress);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::InProgress);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::InProgress);
 
         // Three skipped jobs on downstairs client 0
         assert_eq!(ds.ds_skipped_jobs[0].len(), 3);
@@ -6752,28 +6850,28 @@ pub(crate) mod up_test {
         drop(ds);
 
         // Do the write
-        up.process_ds_operation(write_one, 1, Ok(vec![]), None)
+        up.process_ds_operation(write_one, ClientId(1), Ok(vec![]), None)
             .await
             .unwrap();
-        up.process_ds_operation(write_one, 2, Ok(vec![]), None)
+        up.process_ds_operation(write_one, ClientId(2), Ok(vec![]), None)
             .await
             .unwrap();
 
         // Make the read ok response, do the read
         let rr = Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
 
-        up.process_ds_operation(read_one, 1, rr.clone(), None)
+        up.process_ds_operation(read_one, ClientId(1), rr.clone(), None)
             .await
             .unwrap();
-        up.process_ds_operation(read_one, 2, rr.clone(), None)
+        up.process_ds_operation(read_one, ClientId(2), rr.clone(), None)
             .await
             .unwrap();
 
         // Do the flush
-        up.process_ds_operation(flush_one, 1, Ok(vec![]), None)
+        up.process_ds_operation(flush_one, ClientId(1), Ok(vec![]), None)
             .await
             .unwrap();
-        up.process_ds_operation(flush_one, 2, Ok(vec![]), None)
+        up.process_ds_operation(flush_one, ClientId(2), Ok(vec![]), None)
             .await
             .unwrap();
 
@@ -6784,14 +6882,14 @@ pub(crate) mod up_test {
         let mut ds = up.downstairs.lock().await;
 
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::Done);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::Done);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Done);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Done);
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::Done);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::Done);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Done);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Done);
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::Done);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::Done);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Done);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Done);
 
         ds.ack(read_one);
         ds.ack(write_one);
@@ -6818,14 +6916,14 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
 
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
         up.set_active().await.unwrap();
-        up.ds_transition(0, DsState::Faulted).await;
-        up.ds_transition(2, DsState::Faulted).await;
+        up.ds_transition(ClientId(0), DsState::Faulted).await;
+        up.ds_transition(ClientId(2), DsState::Faulted).await;
 
         // Create a write
         let write_one = enqueue_write(&up, true, ds_done_tx.clone()).await;
@@ -6844,19 +6942,19 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::InProgress);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
 
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::InProgress);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
 
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::InProgress);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
 
         // Skipped jobs added on downstairs client 0
         assert_eq!(ds.ds_skipped_jobs[0].len(), 3);
@@ -6865,19 +6963,19 @@ pub(crate) mod up_test {
         drop(ds);
 
         // Do the write
-        up.process_ds_operation(write_one, 1, Ok(vec![]), None)
+        up.process_ds_operation(write_one, ClientId(1), Ok(vec![]), None)
             .await
             .unwrap();
 
         // Make the read ok response, do the read
         let rr = Ok(vec![ReadResponse::from_request_with_data(&request, &[])]);
 
-        up.process_ds_operation(read_one, 1, rr.clone(), None)
+        up.process_ds_operation(read_one, ClientId(1), rr.clone(), None)
             .await
             .unwrap();
 
         // Do the flush
-        up.process_ds_operation(flush_one, 1, Ok(vec![]), None)
+        up.process_ds_operation(flush_one, ClientId(1), Ok(vec![]), None)
             .await
             .unwrap();
 
@@ -6888,11 +6986,11 @@ pub(crate) mod up_test {
         let mut ds = up.downstairs.lock().await;
 
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::Done);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Done);
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::Done);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Done);
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::Done);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Done);
 
         ds.ack(read_one);
         ds.ack(write_one);
@@ -6921,13 +7019,13 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
 
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
         up.set_active().await.unwrap();
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::Faulted).await;
         }
 
@@ -6942,9 +7040,9 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
 
         assert_eq!(ds.ds_skipped_jobs[0].len(), 1);
         assert_eq!(ds.ds_skipped_jobs[1].len(), 1);
@@ -6976,13 +7074,13 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
 
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
         up.set_active().await.unwrap();
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::Faulted).await;
         }
 
@@ -6991,9 +7089,9 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
 
         assert_eq!(ds.ds_skipped_jobs[0].len(), 1);
         assert_eq!(ds.ds_skipped_jobs[1].len(), 1);
@@ -7025,13 +7123,13 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
 
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
         up.set_active().await.unwrap();
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::Faulted).await;
         }
 
@@ -7040,9 +7138,9 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state.get(&0).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&1).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&2).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
         for cid in 0..3 {
             assert_eq!(ds.ds_skipped_jobs[cid].len(), 1);
             assert!(ds.ds_skipped_jobs[cid].contains(&JobId(1000)));
@@ -7082,13 +7180,13 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
 
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
         up.set_active().await.unwrap();
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::Faulted).await;
         }
 
@@ -7153,13 +7251,13 @@ pub(crate) mod up_test {
         let up = Upstairs::test_default(None);
         let (ds_done_tx, _ds_done_rx) = mpsc::channel(500);
 
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::WaitActive).await;
             up.ds_transition(cid, DsState::WaitQuorum).await;
             up.ds_transition(cid, DsState::Active).await;
         }
         up.set_active().await.unwrap();
-        for cid in 0..3 {
+        for cid in (0..3).map(ClientId) {
             up.ds_transition(cid, DsState::Faulted).await;
         }
 
@@ -8769,7 +8867,7 @@ pub(crate) mod up_test {
 
             let ds_id = jobs[0].ds_id;
 
-            for client_id in 0..3 {
+            for client_id in (0..3).map(ClientId) {
                 ds.in_progress(ds_id, client_id);
                 ds.process_ds_completion(
                     ds_id,

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -4748,7 +4748,7 @@ pub(crate) mod up_test {
         assert!(ds.rep_in_progress(ClientId(0)).is_some());
         if let Some(job) = &mut ds.reconcile_current_work {
             let oldstate = job.state.insert(ClientId(1), IOState::Skipped);
-            assert_eq!(oldstate, Some(IOState::New));
+            assert_eq!(oldstate, IOState::New);
         } else {
             panic!("Failed to find next task");
         }
@@ -4788,7 +4788,7 @@ pub(crate) mod up_test {
         // Mark one as skipped
         if let Some(job) = &mut ds.reconcile_current_work {
             let oldstate = job.state.insert(ClientId(1), IOState::Skipped);
-            assert_eq!(oldstate, Some(IOState::New));
+            assert_eq!(oldstate, IOState::New);
         } else {
             panic!("Failed to find next task");
         }
@@ -4875,9 +4875,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentFlush()", m);
             }
         }
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(0)));
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(1)));
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(2)));
+        assert_eq!(IOState::New, rio.state[ClientId(0)]);
+        assert_eq!(IOState::New, rio.state[ClientId(1)]);
+        assert_eq!(IOState::New, rio.state[ClientId(2)]);
 
         // Second task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -4894,9 +4894,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentClose()", m);
             }
         }
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(0)));
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(1)));
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(2)));
+        assert_eq!(IOState::New, rio.state[ClientId(0)]);
+        assert_eq!(IOState::New, rio.state[ClientId(1)]);
+        assert_eq!(IOState::New, rio.state[ClientId(2)]);
 
         // Third task, repair extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -4919,9 +4919,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentRepair", m);
             }
         }
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(0)));
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(1)));
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(2)));
+        assert_eq!(IOState::New, rio.state[ClientId(0)]);
+        assert_eq!(IOState::New, rio.state[ClientId(1)]);
+        assert_eq!(IOState::New, rio.state[ClientId(2)]);
 
         // Third task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -4938,9 +4938,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentClose()", m);
             }
         }
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(0)));
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(1)));
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(2)));
+        assert_eq!(IOState::New, rio.state[ClientId(0)]);
+        assert_eq!(IOState::New, rio.state[ClientId(1)]);
+        assert_eq!(IOState::New, rio.state[ClientId(2)]);
     }
 
     #[tokio::test]
@@ -4992,9 +4992,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentFlush()", m);
             }
         }
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(0)));
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(1)));
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(2)));
+        assert_eq!(IOState::New, rio.state[ClientId(0)]);
+        assert_eq!(IOState::New, rio.state[ClientId(1)]);
+        assert_eq!(IOState::New, rio.state[ClientId(2)]);
 
         // Second task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -5011,9 +5011,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentClose()", m);
             }
         }
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(0)));
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(1)));
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(2)));
+        assert_eq!(IOState::New, rio.state[ClientId(0)]);
+        assert_eq!(IOState::New, rio.state[ClientId(1)]);
+        assert_eq!(IOState::New, rio.state[ClientId(2)]);
 
         // Third task, repair extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -5036,9 +5036,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentRepair", m);
             }
         }
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(0)));
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(1)));
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(2)));
+        assert_eq!(IOState::New, rio.state[ClientId(0)]);
+        assert_eq!(IOState::New, rio.state[ClientId(1)]);
+        assert_eq!(IOState::New, rio.state[ClientId(2)]);
 
         // Third task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
@@ -5055,9 +5055,9 @@ pub(crate) mod up_test {
                 panic!("{:?} not ExtentClose()", m);
             }
         }
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(0)));
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(1)));
-        assert_eq!(Some(&IOState::New), rio.state.get(&ClientId(2)));
+        assert_eq!(IOState::New, rio.state[ClientId(0)]);
+        assert_eq!(IOState::New, rio.state[ClientId(1)]);
+        assert_eq!(IOState::New, rio.state[ClientId(2)]);
     }
 
     #[tokio::test]
@@ -6417,9 +6417,9 @@ pub(crate) mod up_test {
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&read_id).unwrap();
 
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::New);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::New);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::New);
+        assert_eq!(job.state[ClientId(0)], IOState::New);
+        assert_eq!(job.state[ClientId(1)], IOState::New);
+        assert_eq!(job.state[ClientId(2)], IOState::New);
 
         drop(ds);
 
@@ -6456,9 +6456,9 @@ pub(crate) mod up_test {
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&read_id).unwrap();
 
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::New);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::New);
+        assert_eq!(job.state[ClientId(0)], IOState::New);
+        assert_eq!(job.state[ClientId(1)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(2)], IOState::New);
 
         assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
         assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
@@ -6524,9 +6524,9 @@ pub(crate) mod up_test {
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&read_id).unwrap();
 
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::InProgress);
+        assert_eq!(job.state[ClientId(0)], IOState::InProgress);
+        assert_eq!(job.state[ClientId(1)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(2)], IOState::InProgress);
 
         assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
         assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
@@ -6577,9 +6577,9 @@ pub(crate) mod up_test {
         let ds = up.downstairs.lock().await;
         for cid in ClientId::iter() {
             let job = ds.ds_active.get(&read_one).unwrap();
-            assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
+            assert_eq!(job.state[cid], IOState::Done);
             let job = ds.ds_active.get(&write_one).unwrap();
-            assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
+            assert_eq!(job.state[cid], IOState::Done);
         }
         assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
         assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
@@ -6615,16 +6615,16 @@ pub(crate) mod up_test {
         let ds = up.downstairs.lock().await;
         for cid in ClientId::iter() {
             let job = ds.ds_active.get(&read_one).unwrap();
-            assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
+            assert_eq!(job.state[cid], IOState::Done);
             let job = ds.ds_active.get(&write_one).unwrap();
-            assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
+            assert_eq!(job.state[cid], IOState::Done);
         }
         let job = ds.ds_active.get(&write_fail).unwrap();
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Done);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Done);
+        assert_eq!(job.state[ClientId(0)], IOState::Done);
+        assert_eq!(job.state[ClientId(1)], IOState::Done);
         assert_eq!(
-            job.state.get(&ClientId(2)).unwrap(),
-            &IOState::Error(CrucibleError::GenericError("bad".to_string()))
+            job.state[ClientId(2)],
+            IOState::Error(CrucibleError::GenericError("bad".to_string()))
         );
 
         // A failed job does not change the skipped count.
@@ -6680,9 +6680,9 @@ pub(crate) mod up_test {
         let ds = up.downstairs.lock().await;
         for cid in ClientId::iter() {
             let job = ds.ds_active.get(&read_one).unwrap();
-            assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
+            assert_eq!(job.state[cid], IOState::Done);
             let job = ds.ds_active.get(&write_one).unwrap();
-            assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
+            assert_eq!(job.state[cid], IOState::Done);
         }
         drop(ds);
 
@@ -6720,26 +6720,26 @@ pub(crate) mod up_test {
         for cid in ClientId::iter() {
             // First read, still Done
             let job = ds.ds_active.get(&read_one).unwrap();
-            assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
+            assert_eq!(job.state[cid], IOState::Done);
             // First write, still Done
             let job = ds.ds_active.get(&write_one).unwrap();
-            assert_eq!(job.state.get(&cid).unwrap(), &IOState::Done);
+            assert_eq!(job.state[cid], IOState::Done);
         }
         // The failing write, done on 0,1
         let job = ds.ds_active.get(&write_fail).unwrap();
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Done);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Done);
+        assert_eq!(job.state[ClientId(0)], IOState::Done);
+        assert_eq!(job.state[ClientId(1)], IOState::Done);
         // The failing write, error on 2
         assert_eq!(
-            job.state.get(&ClientId(2)).unwrap(),
-            &IOState::Error(CrucibleError::GenericError("bad".to_string()))
+            job.state[ClientId(2)],
+            IOState::Error(CrucibleError::GenericError("bad".to_string()))
         );
 
         // The reads that were in progress
         let job = ds.ds_active.get(&read_two).unwrap();
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state[ClientId(0)], IOState::InProgress);
+        assert_eq!(job.state[ClientId(1)], IOState::InProgress);
+        assert_eq!(job.state[ClientId(2)], IOState::Skipped);
 
         assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 0);
         assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 0);
@@ -6777,19 +6777,19 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::New);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::New);
+        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(1)], IOState::New);
+        assert_eq!(job.state[ClientId(2)], IOState::New);
 
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::New);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::New);
+        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(1)], IOState::New);
+        assert_eq!(job.state[ClientId(2)], IOState::New);
 
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::New);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::New);
+        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(1)], IOState::New);
+        assert_eq!(job.state[ClientId(2)], IOState::New);
 
         // Three skipped jobs for downstairs zero
         assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 3);
@@ -6829,19 +6829,19 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::InProgress);
+        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(1)], IOState::InProgress);
+        assert_eq!(job.state[ClientId(2)], IOState::InProgress);
 
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::InProgress);
+        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(1)], IOState::InProgress);
+        assert_eq!(job.state[ClientId(2)], IOState::InProgress);
 
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::InProgress);
+        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(1)], IOState::InProgress);
+        assert_eq!(job.state[ClientId(2)], IOState::InProgress);
 
         // Three skipped jobs on downstairs client 0
         assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 3);
@@ -6882,14 +6882,14 @@ pub(crate) mod up_test {
         let mut ds = up.downstairs.lock().await;
 
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Done);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Done);
+        assert_eq!(job.state[ClientId(1)], IOState::Done);
+        assert_eq!(job.state[ClientId(2)], IOState::Done);
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Done);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Done);
+        assert_eq!(job.state[ClientId(1)], IOState::Done);
+        assert_eq!(job.state[ClientId(2)], IOState::Done);
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Done);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Done);
+        assert_eq!(job.state[ClientId(1)], IOState::Done);
+        assert_eq!(job.state[ClientId(2)], IOState::Done);
 
         ds.ack(read_one);
         ds.ack(write_one);
@@ -6942,19 +6942,19 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(1)], IOState::InProgress);
+        assert_eq!(job.state[ClientId(2)], IOState::Skipped);
 
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(1)], IOState::InProgress);
+        assert_eq!(job.state[ClientId(2)], IOState::Skipped);
 
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::InProgress);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(1)], IOState::InProgress);
+        assert_eq!(job.state[ClientId(2)], IOState::Skipped);
 
         // Skipped jobs added on downstairs client 0
         assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 3);
@@ -6986,11 +6986,11 @@ pub(crate) mod up_test {
         let mut ds = up.downstairs.lock().await;
 
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Done);
+        assert_eq!(job.state[ClientId(1)], IOState::Done);
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Done);
+        assert_eq!(job.state[ClientId(1)], IOState::Done);
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Done);
+        assert_eq!(job.state[ClientId(1)], IOState::Done);
 
         ds.ack(read_one);
         ds.ack(write_one);
@@ -7040,9 +7040,9 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&read_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(1)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(2)], IOState::Skipped);
 
         assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
         assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
@@ -7089,9 +7089,9 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&write_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(1)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(2)], IOState::Skipped);
 
         assert_eq!(ds.ds_skipped_jobs[ClientId(0)].len(), 1);
         assert_eq!(ds.ds_skipped_jobs[ClientId(1)].len(), 1);
@@ -7138,9 +7138,9 @@ pub(crate) mod up_test {
 
         let ds = up.downstairs.lock().await;
         let job = ds.ds_active.get(&flush_one).unwrap();
-        assert_eq!(job.state.get(&ClientId(0)).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&ClientId(1)).unwrap(), &IOState::Skipped);
-        assert_eq!(job.state.get(&ClientId(2)).unwrap(), &IOState::Skipped);
+        assert_eq!(job.state[ClientId(0)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(1)], IOState::Skipped);
+        assert_eq!(job.state[ClientId(2)], IOState::Skipped);
         for cid in ClientId::iter() {
             assert_eq!(ds.ds_skipped_jobs[cid].len(), 1);
             assert!(ds.ds_skipped_jobs[cid].contains(&JobId(1000)));


### PR DESCRIPTION
Crucible always runs with three clients, and we need a "client ID" data type.

Previously, client ID was (usually) a `u8`, and "data `T` for every client" was variously

- `Vec<T>` (with 3 elements, guaranteed)
- `Vec<T>` (_usually_ with 3 elements, but with 0 elements during some tests)
- `[T; 3]` (the only type which _actually_ guarantees 3 elements)
- `HashMap<u8, T>` (with 3 elements, guaranteed)
- `HashMap<u8, T>` (with 0-3 elements)

This PR has two goals:
- Replace the `u8` with a `ClientId(u8)` (guaranteed at construction to be `0..3`), and fix everything that broke when I did that.  This is similar to #919, which did the same thing for job ID.
- Replace the eclectic set of data structures above with only two things:
    - `ClientData<T>`, which represents "3 values, must be present"
    - `ClientMap<T>`, which is equivalent to a `HashMap<ClientId, T>` but is specialized to only contain 3 values max.  (Under the hood, this is implemented as `ClientData<Option<T>>`)

Both of these new data structures can be indexed with a `ClientId` directly, so this removes a vast number of `client_id as usize` casts.  The new data structures are free of allocation, require zero hashing, and can be copied instead of cloned (if `T` is `Copy`).

`ClientId` is annotated with `#[serde(transparent)]`, so it looks the same on the wire and should work fine with mixed upstairs / downstairs versions.