### PR TITLE
Fast return for zero length IOs

### DIFF
--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -1164,8 +1164,11 @@ fn fill_vec(
     wl: &WriteLog,
     bs: u64,
 ) -> Vec<u8> {
-    assert_ne!(blocks, 0);
+    if blocks == 0 {
+        println!("Warning: fill requested of zero length buffer");
+    }
     assert_ne!(bs, 0);
+
     /*
      * Each block we are filling the buffer for can have a different
      * seed value.  For multiple block sized writes, we need to create
@@ -1229,7 +1232,9 @@ fn validate_vec(
 ) -> ValidateStatus {
     let bs = bs as usize;
     assert_eq!(data.len() % bs, 0);
-    assert_ne!(data.len(), 0);
+    if data.is_empty() {
+        println!("Warning: Validation of zero length buffer");
+    }
 
     let blocks = data.len() / bs;
     let mut data_offset: usize = 0;

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -352,6 +352,48 @@ mod test {
     }
 
     #[tokio::test]
+    async fn volume_zero_length_io() -> Result<()> {
+        const BLOCK_SIZE: usize = 512;
+
+        let tds = TestDownstairsSet::small(false).await?;
+        let opts = tds.opts();
+
+        let vcr: VolumeConstructionRequest =
+            VolumeConstructionRequest::Volume {
+                id: Uuid::new_v4(),
+                block_size: BLOCK_SIZE as u64,
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds.blocks_per_extent(),
+                    extent_count: tds.extent_count(),
+                    opts,
+                    gen: 1,
+                }],
+                read_only_parent: None,
+            };
+
+        let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
+
+        volume.activate().await?;
+
+        // A read of zero length does not error.
+        let buffer = Buffer::new(0);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+            .await?;
+
+        // A write of zero length does not return error.
+        volume
+            .write(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![0x55; 0]),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn integration_test_two_layers() -> Result<()> {
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();
@@ -2715,6 +2757,40 @@ mod test {
             .await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec().await);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn integration_test_guest_zero_length_io() -> Result<()> {
+        // Test the guest layer with a write and read of zero length
+        const BLOCK_SIZE: usize = 512;
+
+        // Spin off three downstairs, build our Crucible struct.
+        let tds = TestDownstairsSet::small(false).await?;
+        let opts = tds.opts();
+
+        let guest = Arc::new(Guest::new());
+        let gc = guest.clone();
+
+        let _join_handle = up_main(opts, 1, None, gc, None, None).await?;
+
+        guest.activate().await?;
+        guest.query_work_queue().await?;
+
+        // Verify contents are zero on init
+        let buffer = Buffer::new(0);
+        guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+            .await?;
+
+        // Write zero data in
+        guest
+            .write(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(Vec::new()),
+            )
+            .await?;
 
         Ok(())
     }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -2778,13 +2778,13 @@ mod test {
         guest.activate().await?;
         guest.query_work_queue().await?;
 
-        // Verify contents are zero on init
+        // Read of length 0
         let buffer = Buffer::new(0);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
 
-        // Write zero data in
+        // Write of length 0
         guest
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -9293,6 +9293,9 @@ impl BlockIO for Guest {
             crucible_bail!(BlockSizeMismatch);
         }
 
+        if data.is_empty() {
+            return Ok(());
+        }
         let rio = BlockOp::Read { offset, data };
         Ok(self.send(rio).await.wait().await?)
     }
@@ -9312,6 +9315,9 @@ impl BlockIO for Guest {
             crucible_bail!(BlockSizeMismatch);
         }
 
+        if data.is_empty() {
+            return Ok(());
+        }
         let wio = BlockOp::Write { offset, data };
         Ok(self.send(wio).await.wait().await?)
     }
@@ -9331,6 +9337,9 @@ impl BlockIO for Guest {
             crucible_bail!(BlockSizeMismatch);
         }
 
+        if data.is_empty() {
+            return Ok(());
+        }
         let wio = BlockOp::WriteUnwritten { offset, data };
         Ok(self.send(wio).await.wait().await?)
     }


### PR DESCRIPTION
If a read or write with length zero is submitted to either the Volume layer or via a Guest, we just return success without having to involve any of the layers below us.

Updated crutest to allow a zero length IO.
Added tests to verify a zero length IO via Volume or Guest does not return error or panic.