### PR TITLE
Use a strong type for repair ID

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -811,9 +811,7 @@ where
                         extent_id,
                         gen_number,
                         flush_number,
-                        // TODO(matt) this is a repair ID, not a job ID, but is
-                        // only used for logging, so ¯\_(ツ)_/¯
-                        JobId(repair_id.0),
+                        repair_id,
                     )
                     .await
                 {

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -813,7 +813,7 @@ where
                         flush_number,
                         // TODO(matt) this is a repair ID, not a job ID, but is
                         // only used for logging, so ¯\_(ツ)_/¯
-                        JobId(repair_id),
+                        JobId(repair_id.0),
                     )
                     .await
                 {

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -42,7 +42,7 @@ impl std::fmt::Display for JobId {
     }
 }
 
-/// Wrapper type for a repair ID, used during initial volume repair
+/// Wrapper type for a reconciliation ID, used during initial startup
 #[derive(
     Copy,
     Clone,
@@ -57,9 +57,9 @@ impl std::fmt::Display for JobId {
     schemars::JsonSchema,
 )]
 #[serde(transparent)]
-pub struct RepairId(pub u64);
+pub struct ReconciliationId(pub u64);
 
-impl std::fmt::Display for RepairId {
+impl std::fmt::Display for ReconciliationId {
     fn fmt(
         &self,
         f: &mut std::fmt::Formatter<'_>,
@@ -370,19 +370,19 @@ pub enum Message {
      */
     /// Send a close the given extent ID on the downstairs.
     ExtentClose {
-        repair_id: RepairId,
+        repair_id: ReconciliationId,
         extent_id: usize,
     },
 
     /// Send a request to reopen the given extent.
     ExtentReopen {
-        repair_id: RepairId,
+        repair_id: ReconciliationId,
         extent_id: usize,
     },
 
     /// Flush just this extent on just this downstairs client.
     ExtentFlush {
-        repair_id: RepairId,
+        repair_id: ReconciliationId,
         extent_id: usize,
         client_id: ClientId,
         flush_number: u64,
@@ -391,7 +391,7 @@ pub enum Message {
 
     /// Replace an extent with data from the given downstairs.
     ExtentRepair {
-        repair_id: RepairId,
+        repair_id: ReconciliationId,
         extent_id: usize,
         source_client_id: ClientId,
         source_repair_address: SocketAddr,
@@ -400,12 +400,12 @@ pub enum Message {
 
     /// The given repair job ID has finished without error
     RepairAckId {
-        repair_id: RepairId,
+        repair_id: ReconciliationId,
     },
 
     /// A problem with the given extent
     ExtentError {
-        repair_id: RepairId,
+        repair_id: ReconciliationId,
         extent_id: usize,
         error: CrucibleError,
     },

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -42,6 +42,32 @@ impl std::fmt::Display for JobId {
     }
 }
 
+/// Wrapper type for a repair ID, used during initial volume repair
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Eq,
+    Hash,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+)]
+#[serde(transparent)]
+pub struct RepairId(pub u64);
+
+impl std::fmt::Display for RepairId {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> Result<(), std::fmt::Error> {
+        self.0.fmt(f)
+    }
+}
+
 /// Wrapper type for a client ID
 ///
 /// This is guaranteed by construction to be in the range `0..3`
@@ -344,19 +370,19 @@ pub enum Message {
      */
     /// Send a close the given extent ID on the downstairs.
     ExtentClose {
-        repair_id: u64,
+        repair_id: RepairId,
         extent_id: usize,
     },
 
     /// Send a request to reopen the given extent.
     ExtentReopen {
-        repair_id: u64,
+        repair_id: RepairId,
         extent_id: usize,
     },
 
     /// Flush just this extent on just this downstairs client.
     ExtentFlush {
-        repair_id: u64,
+        repair_id: RepairId,
         extent_id: usize,
         client_id: ClientId,
         flush_number: u64,
@@ -365,7 +391,7 @@ pub enum Message {
 
     /// Replace an extent with data from the given downstairs.
     ExtentRepair {
-        repair_id: u64,
+        repair_id: RepairId,
         extent_id: usize,
         source_client_id: ClientId,
         source_repair_address: SocketAddr,
@@ -374,12 +400,12 @@ pub enum Message {
 
     /// The given repair job ID has finished without error
     RepairAckId {
-        repair_id: u64,
+        repair_id: RepairId,
     },
 
     /// A problem with the given extent
     ExtentError {
-        repair_id: u64,
+        repair_id: RepairId,
         extent_id: usize,
         error: CrucibleError,
     },

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -3258,19 +3258,14 @@ impl Downstairs {
      * Mark a reconcile work request as done for this client and return
      * true if all work requests are done
      */
-    fn rep_done(&mut self, client_id: ClientId, rep_id: u64) -> bool {
+    fn rep_done(&mut self, client_id: ClientId, rep_id: RepairId) -> bool {
         if let Some(job) = &mut self.reconcile_current_work {
             let old_state = job.state.insert(client_id, IOState::Done);
             assert_eq!(old_state, IOState::InProgress);
             assert_eq!(job.id, rep_id);
-            let mut done = 0;
-
-            for s in job.state.iter() {
-                if s == &IOState::Done || s == &IOState::Skipped {
-                    done += 1;
-                }
-            }
-            done == 3
+            job.state
+                .iter()
+                .all(|s| matches!(s, IOState::Done | IOState::Skipped))
         } else {
             panic!(
                 "[{}] Attempted to complete job {} that does not exist",
@@ -3300,7 +3295,7 @@ impl Downstairs {
         max_flush: u64,
         max_gen: u64,
     ) {
-        let mut rep_id = 0;
+        let mut rep_id = RepairId(0);
         info!(self.log, "Full repair list: {:?}", rec_list);
         for (ext, ef) in rec_list.drain() {
             /*
@@ -3321,7 +3316,7 @@ impl Downstairs {
                     gen_number: max_gen,
                 },
             ));
-            rep_id += 1;
+            rep_id.0 += 1;
 
             self.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -3330,7 +3325,7 @@ impl Downstairs {
                     extent_id: ext,
                 },
             ));
-            rep_id += 1;
+            rep_id.0 += 1;
 
             let repair = self.repair_addr(ef.source);
             self.reconcile_task_list.push_back(ReconcileIO::new(
@@ -3343,7 +3338,7 @@ impl Downstairs {
                     dest_clients: ef.dest,
                 },
             ));
-            rep_id += 1;
+            rep_id.0 += 1;
 
             self.reconcile_task_list.push_back(ReconcileIO::new(
                 rep_id,
@@ -3352,7 +3347,7 @@ impl Downstairs {
                     extent_id: ext,
                 },
             ));
-            rep_id += 1;
+            rep_id.0 += 1;
         }
 
         info!(self.log, "Task list: {:?}", self.reconcile_task_list);
@@ -6536,7 +6531,7 @@ impl Upstairs {
     async fn ds_repair_done_notify(
         &self,
         client_id: ClientId,
-        rep_id: u64,
+        rep_id: RepairId,
         ds_reconcile_done_tx: &mpsc::Sender<Repair>,
     ) -> Result<()> {
         debug!(
@@ -7982,13 +7977,13 @@ struct WorkSummary {
 
 #[derive(Debug)]
 struct ReconcileIO {
-    id: u64,
+    id: RepairId,
     op: Message,
     state: ClientData<IOState>,
 }
 
 impl ReconcileIO {
-    fn new(id: u64, op: Message) -> ReconcileIO {
+    fn new(id: RepairId, op: Message) -> ReconcileIO {
         ReconcileIO {
             id,
             op,
@@ -9464,7 +9459,7 @@ impl Default for Guest {
 struct Repair {
     repair: bool,
     client_id: ClientId,
-    rep_id: u64,
+    rep_id: RepairId,
 }
 
 /**

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -3258,7 +3258,11 @@ impl Downstairs {
      * Mark a reconcile work request as done for this client and return
      * true if all work requests are done
      */
-    fn rep_done(&mut self, client_id: ClientId, rep_id: RepairId) -> bool {
+    fn rep_done(
+        &mut self,
+        client_id: ClientId,
+        rep_id: ReconciliationId,
+    ) -> bool {
         if let Some(job) = &mut self.reconcile_current_work {
             let old_state = job.state.insert(client_id, IOState::Done);
             assert_eq!(old_state, IOState::InProgress);
@@ -3295,7 +3299,7 @@ impl Downstairs {
         max_flush: u64,
         max_gen: u64,
     ) {
-        let mut rep_id = RepairId(0);
+        let mut rep_id = ReconciliationId(0);
         info!(self.log, "Full repair list: {:?}", rec_list);
         for (ext, ef) in rec_list.drain() {
             /*
@@ -6531,7 +6535,7 @@ impl Upstairs {
     async fn ds_repair_done_notify(
         &self,
         client_id: ClientId,
-        rep_id: RepairId,
+        rep_id: ReconciliationId,
         ds_reconcile_done_tx: &mpsc::Sender<Repair>,
     ) -> Result<()> {
         debug!(
@@ -7977,13 +7981,13 @@ struct WorkSummary {
 
 #[derive(Debug)]
 struct ReconcileIO {
-    id: RepairId,
+    id: ReconciliationId,
     op: Message,
     state: ClientData<IOState>,
 }
 
 impl ReconcileIO {
-    fn new(id: RepairId, op: Message) -> ReconcileIO {
+    fn new(id: ReconciliationId, op: Message) -> ReconcileIO {
         ReconcileIO {
             id,
             op,
@@ -9459,7 +9463,7 @@ impl Default for Guest {
 struct Repair {
     repair: bool,
     client_id: ClientId,
-    rep_id: RepairId,
+    rep_id: ReconciliationId,
 }
 
 /**

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -4490,7 +4490,7 @@ pub(crate) mod up_test {
         // downstairs is not in the correct state, and that it will
         // clear the work queue and mark other downstairs as failed.
         let up = Upstairs::test_default(None);
-        let rep_id = RepairId(0);
+        let rep_id = ReconciliationId(0);
         {
             let mut ds = up.downstairs.lock().await;
             // Put a jobs on the todo list
@@ -4527,7 +4527,7 @@ pub(crate) mod up_test {
         // in the FailedRepair state. Verify that attempts to get new work
         // after a failed repair now return none.
         let up = Upstairs::test_default(None);
-        let rep_id = RepairId(0);
+        let rep_id = ReconciliationId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4580,7 +4580,7 @@ pub(crate) mod up_test {
         // Verify that a downstairs not in repair mode will ignore new
         // work requests until it transitions to repair.
         let up = Upstairs::test_default(None);
-        let rep_id = RepairId(0);
+        let rep_id = ReconciliationId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4616,7 +4616,7 @@ pub(crate) mod up_test {
     async fn reconcile_rep_in_progress_bad1() {
         // Verify the same downstairs can't mark a job in progress twice
         let up = Upstairs::test_default(None);
-        let rep_id = RepairId(0);
+        let rep_id = ReconciliationId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4643,7 +4643,7 @@ pub(crate) mod up_test {
     async fn reconcile_rep_done_too_soon() {
         // Verify a job can't go new -> done
         let up = Upstairs::test_default(None);
-        let rep_id = RepairId(0);
+        let rep_id = ReconciliationId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4667,7 +4667,7 @@ pub(crate) mod up_test {
     #[tokio::test]
     async fn reconcile_repair_workflow_1() {
         let up = Upstairs::test_default(None);
-        let mut rep_id = RepairId(0);
+        let mut rep_id = ReconciliationId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4682,7 +4682,7 @@ pub(crate) mod up_test {
                 },
             ));
             ds.reconcile_task_list.push_back(ReconcileIO::new(
-                RepairId(rep_id.0 + 1),
+                ReconciliationId(rep_id.0 + 1),
                 Message::ExtentClose {
                     repair_id: rep_id,
                     extent_id: 1,
@@ -4729,7 +4729,7 @@ pub(crate) mod up_test {
     async fn reconcile_leave_no_job_behind() {
         // Verify we can't start a new job before the old is finished.
         let up = Upstairs::test_default(None);
-        let rep_id = RepairId(0);
+        let rep_id = ReconciliationId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4744,7 +4744,7 @@ pub(crate) mod up_test {
                 },
             ));
             ds.reconcile_task_list.push_back(ReconcileIO::new(
-                RepairId(rep_id.0 + 1),
+                ReconciliationId(rep_id.0 + 1),
                 Message::ExtentClose {
                     repair_id: rep_id,
                     extent_id: 1,
@@ -4775,7 +4775,7 @@ pub(crate) mod up_test {
     async fn reconcile_repair_workflow_2() {
         // Verify Done or Skipped works for rep_done
         let up = Upstairs::test_default(None);
-        let rep_id = RepairId(0);
+        let rep_id = ReconciliationId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4816,7 +4816,7 @@ pub(crate) mod up_test {
     async fn reconcile_repair_inprogress_not_done() {
         // Verify Done or Skipped works for rep_done
         let up = Upstairs::test_default(None);
-        let rep_id = RepairId(0);
+        let rep_id = ReconciliationId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4852,7 +4852,7 @@ pub(crate) mod up_test {
     async fn reconcile_repair_workflow_too_soon() {
         // Verify that jobs must be in progress before done.
         let up = Upstairs::test_default(None);
-        let rep_id = RepairId(0);
+        let rep_id = ReconciliationId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4906,7 +4906,7 @@ pub(crate) mod up_test {
 
         // First task, flush
         let rio = ds.reconcile_task_list.pop_front().unwrap();
-        assert_eq!(rio.id, RepairId(0));
+        assert_eq!(rio.id, ReconciliationId(0));
         match rio.op {
             Message::ExtentFlush {
                 repair_id,
@@ -4915,7 +4915,7 @@ pub(crate) mod up_test {
                 flush_number,
                 gen_number,
             } => {
-                assert_eq!(repair_id, RepairId(0));
+                assert_eq!(repair_id, ReconciliationId(0));
                 assert_eq!(extent_id, repair_extent);
                 assert_eq!(client_id, ClientId::new(0));
                 assert_eq!(flush_number, max_flush);
@@ -4931,13 +4931,13 @@ pub(crate) mod up_test {
 
         // Second task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
-        assert_eq!(rio.id, RepairId(1));
+        assert_eq!(rio.id, ReconciliationId(1));
         match rio.op {
             Message::ExtentClose {
                 repair_id,
                 extent_id,
             } => {
-                assert_eq!(repair_id, RepairId(1));
+                assert_eq!(repair_id, ReconciliationId(1));
                 assert_eq!(extent_id, repair_extent);
             }
             m => {
@@ -4950,7 +4950,7 @@ pub(crate) mod up_test {
 
         // Third task, repair extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
-        assert_eq!(rio.id, RepairId(2));
+        assert_eq!(rio.id, ReconciliationId(2));
         match rio.op {
             Message::ExtentRepair {
                 repair_id,
@@ -4978,13 +4978,13 @@ pub(crate) mod up_test {
 
         // Third task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
-        assert_eq!(rio.id, RepairId(3));
+        assert_eq!(rio.id, ReconciliationId(3));
         match rio.op {
             Message::ExtentReopen {
                 repair_id,
                 extent_id,
             } => {
-                assert_eq!(repair_id, RepairId(3));
+                assert_eq!(repair_id, ReconciliationId(3));
                 assert_eq!(extent_id, repair_extent);
             }
             m => {
@@ -5026,7 +5026,7 @@ pub(crate) mod up_test {
 
         // First task, flush
         let rio = ds.reconcile_task_list.pop_front().unwrap();
-        assert_eq!(rio.id, RepairId(0));
+        assert_eq!(rio.id, ReconciliationId(0));
         match rio.op {
             Message::ExtentFlush {
                 repair_id,
@@ -5035,7 +5035,7 @@ pub(crate) mod up_test {
                 flush_number,
                 gen_number,
             } => {
-                assert_eq!(repair_id, RepairId(0));
+                assert_eq!(repair_id, ReconciliationId(0));
                 assert_eq!(extent_id, repair_extent);
                 assert_eq!(client_id, ClientId::new(2));
                 assert_eq!(flush_number, max_flush);
@@ -5051,13 +5051,13 @@ pub(crate) mod up_test {
 
         // Second task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
-        assert_eq!(rio.id, RepairId(1));
+        assert_eq!(rio.id, ReconciliationId(1));
         match rio.op {
             Message::ExtentClose {
                 repair_id,
                 extent_id,
             } => {
-                assert_eq!(repair_id, RepairId(1));
+                assert_eq!(repair_id, ReconciliationId(1));
                 assert_eq!(extent_id, repair_extent);
             }
             m => {
@@ -5070,7 +5070,7 @@ pub(crate) mod up_test {
 
         // Third task, repair extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
-        assert_eq!(rio.id, RepairId(2));
+        assert_eq!(rio.id, ReconciliationId(2));
         match rio.op {
             Message::ExtentRepair {
                 repair_id,
@@ -5098,13 +5098,13 @@ pub(crate) mod up_test {
 
         // Third task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
-        assert_eq!(rio.id, RepairId(3));
+        assert_eq!(rio.id, ReconciliationId(3));
         match rio.op {
             Message::ExtentReopen {
                 repair_id,
                 extent_id,
             } => {
-                assert_eq!(repair_id, RepairId(3));
+                assert_eq!(repair_id, ReconciliationId(3));
                 assert_eq!(extent_id, repair_extent);
             }
             m => {

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -4490,7 +4490,7 @@ pub(crate) mod up_test {
         // downstairs is not in the correct state, and that it will
         // clear the work queue and mark other downstairs as failed.
         let up = Upstairs::test_default(None);
-        let rep_id = 0;
+        let rep_id = RepairId(0);
         {
             let mut ds = up.downstairs.lock().await;
             // Put a jobs on the todo list
@@ -4527,7 +4527,7 @@ pub(crate) mod up_test {
         // in the FailedRepair state. Verify that attempts to get new work
         // after a failed repair now return none.
         let up = Upstairs::test_default(None);
-        let rep_id = 0;
+        let rep_id = RepairId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4580,7 +4580,7 @@ pub(crate) mod up_test {
         // Verify that a downstairs not in repair mode will ignore new
         // work requests until it transitions to repair.
         let up = Upstairs::test_default(None);
-        let rep_id = 0;
+        let rep_id = RepairId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4616,7 +4616,7 @@ pub(crate) mod up_test {
     async fn reconcile_rep_in_progress_bad1() {
         // Verify the same downstairs can't mark a job in progress twice
         let up = Upstairs::test_default(None);
-        let rep_id = 0;
+        let rep_id = RepairId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4643,7 +4643,7 @@ pub(crate) mod up_test {
     async fn reconcile_rep_done_too_soon() {
         // Verify a job can't go new -> done
         let up = Upstairs::test_default(None);
-        let rep_id = 0;
+        let rep_id = RepairId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4667,7 +4667,7 @@ pub(crate) mod up_test {
     #[tokio::test]
     async fn reconcile_repair_workflow_1() {
         let up = Upstairs::test_default(None);
-        let mut rep_id = 0;
+        let mut rep_id = RepairId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4682,7 +4682,7 @@ pub(crate) mod up_test {
                 },
             ));
             ds.reconcile_task_list.push_back(ReconcileIO::new(
-                rep_id + 1,
+                RepairId(rep_id.0 + 1),
                 Message::ExtentClose {
                     repair_id: rep_id,
                     extent_id: 1,
@@ -4714,7 +4714,7 @@ pub(crate) mod up_test {
         assert!(ds.rep_in_progress(ClientId::new(2)).is_some());
 
         // Now, make sure we consider this done only after all three are done
-        rep_id += 1;
+        rep_id.0 += 1;
         assert!(!ds.rep_done(ClientId::new(0), rep_id));
         assert!(!ds.rep_done(ClientId::new(1), rep_id));
         assert!(ds.rep_done(ClientId::new(2), rep_id));
@@ -4729,7 +4729,7 @@ pub(crate) mod up_test {
     async fn reconcile_leave_no_job_behind() {
         // Verify we can't start a new job before the old is finished.
         let up = Upstairs::test_default(None);
-        let rep_id = 0;
+        let rep_id = RepairId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4744,7 +4744,7 @@ pub(crate) mod up_test {
                 },
             ));
             ds.reconcile_task_list.push_back(ReconcileIO::new(
-                rep_id + 1,
+                RepairId(rep_id.0 + 1),
                 Message::ExtentClose {
                     repair_id: rep_id,
                     extent_id: 1,
@@ -4775,7 +4775,7 @@ pub(crate) mod up_test {
     async fn reconcile_repair_workflow_2() {
         // Verify Done or Skipped works for rep_done
         let up = Upstairs::test_default(None);
-        let rep_id = 0;
+        let rep_id = RepairId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4816,7 +4816,7 @@ pub(crate) mod up_test {
     async fn reconcile_repair_inprogress_not_done() {
         // Verify Done or Skipped works for rep_done
         let up = Upstairs::test_default(None);
-        let rep_id = 0;
+        let rep_id = RepairId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4852,7 +4852,7 @@ pub(crate) mod up_test {
     async fn reconcile_repair_workflow_too_soon() {
         // Verify that jobs must be in progress before done.
         let up = Upstairs::test_default(None);
-        let rep_id = 0;
+        let rep_id = RepairId(0);
         {
             let mut ds = up.downstairs.lock().await;
             ds.ds_state[ClientId::new(0)] = DsState::Repair;
@@ -4906,7 +4906,7 @@ pub(crate) mod up_test {
 
         // First task, flush
         let rio = ds.reconcile_task_list.pop_front().unwrap();
-        assert_eq!(rio.id, 0);
+        assert_eq!(rio.id, RepairId(0));
         match rio.op {
             Message::ExtentFlush {
                 repair_id,
@@ -4915,7 +4915,7 @@ pub(crate) mod up_test {
                 flush_number,
                 gen_number,
             } => {
-                assert_eq!(repair_id, 0);
+                assert_eq!(repair_id, RepairId(0));
                 assert_eq!(extent_id, repair_extent);
                 assert_eq!(client_id, ClientId::new(0));
                 assert_eq!(flush_number, max_flush);
@@ -4931,13 +4931,13 @@ pub(crate) mod up_test {
 
         // Second task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
-        assert_eq!(rio.id, 1);
+        assert_eq!(rio.id, RepairId(1));
         match rio.op {
             Message::ExtentClose {
                 repair_id,
                 extent_id,
             } => {
-                assert_eq!(repair_id, 1);
+                assert_eq!(repair_id, RepairId(1));
                 assert_eq!(extent_id, repair_extent);
             }
             m => {
@@ -4950,7 +4950,7 @@ pub(crate) mod up_test {
 
         // Third task, repair extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
-        assert_eq!(rio.id, 2);
+        assert_eq!(rio.id, RepairId(2));
         match rio.op {
             Message::ExtentRepair {
                 repair_id,
@@ -4978,13 +4978,13 @@ pub(crate) mod up_test {
 
         // Third task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
-        assert_eq!(rio.id, 3);
+        assert_eq!(rio.id, RepairId(3));
         match rio.op {
             Message::ExtentReopen {
                 repair_id,
                 extent_id,
             } => {
-                assert_eq!(repair_id, 3);
+                assert_eq!(repair_id, RepairId(3));
                 assert_eq!(extent_id, repair_extent);
             }
             m => {
@@ -5026,7 +5026,7 @@ pub(crate) mod up_test {
 
         // First task, flush
         let rio = ds.reconcile_task_list.pop_front().unwrap();
-        assert_eq!(rio.id, 0);
+        assert_eq!(rio.id, RepairId(0));
         match rio.op {
             Message::ExtentFlush {
                 repair_id,
@@ -5035,7 +5035,7 @@ pub(crate) mod up_test {
                 flush_number,
                 gen_number,
             } => {
-                assert_eq!(repair_id, 0);
+                assert_eq!(repair_id, RepairId(0));
                 assert_eq!(extent_id, repair_extent);
                 assert_eq!(client_id, ClientId::new(2));
                 assert_eq!(flush_number, max_flush);
@@ -5051,13 +5051,13 @@ pub(crate) mod up_test {
 
         // Second task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
-        assert_eq!(rio.id, 1);
+        assert_eq!(rio.id, RepairId(1));
         match rio.op {
             Message::ExtentClose {
                 repair_id,
                 extent_id,
             } => {
-                assert_eq!(repair_id, 1);
+                assert_eq!(repair_id, RepairId(1));
                 assert_eq!(extent_id, repair_extent);
             }
             m => {
@@ -5070,7 +5070,7 @@ pub(crate) mod up_test {
 
         // Third task, repair extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
-        assert_eq!(rio.id, 2);
+        assert_eq!(rio.id, RepairId(2));
         match rio.op {
             Message::ExtentRepair {
                 repair_id,
@@ -5098,13 +5098,13 @@ pub(crate) mod up_test {
 
         // Third task, close extent
         let rio = ds.reconcile_task_list.pop_front().unwrap();
-        assert_eq!(rio.id, 3);
+        assert_eq!(rio.id, RepairId(3));
         match rio.op {
             Message::ExtentReopen {
                 repair_id,
                 extent_id,
             } => {
-                assert_eq!(repair_id, 3);
+                assert_eq!(repair_id, RepairId(3));
                 assert_eq!(extent_id, repair_extent);
             }
             m => {


### PR DESCRIPTION
In the same vein as #925 and #919, this switches from a `u64` to a strong type for repair IDs.  Luckily, there's less to change here!

I'm ambivalent about the `RepairId` name, and wonder if we should use `ReconciliationId` instead (to more strongly distinguish from live repair, which also has the word "repair").  Opinions are welcome!