### PR TITLE
Add a "dynamometer" option to crucible-downstairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,7 @@ dependencies = [
  "slog-async",
  "slog-dtrace",
  "slog-term",
+ "statistical",
  "tempfile",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ opentelemetry = "0.20.0"
 opentelemetry-jaeger = { version = "0.17.0" }
 percent-encoding = "2.3"
 proptest = "1.2.0"
-rand = { version = "0.8.5", features = ["min_const_gen"] }
+rand = { version = "0.8.5", features = ["min_const_gen", "small_rng"] }
 rand_chacha = "0.3.1"
 reedline = "0.23.0"
 reqwest = { version = "0.11", features = ["default", "blocking", "json", "stream"] }

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -43,6 +43,7 @@ slog-async.workspace = true
 slog-dtrace.workspace = true
 slog-term.workspace = true
 slog.workspace = true
+statistical.workspace = true
 tokio-rustls.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true

--- a/downstairs/src/dynamometer.rs
+++ b/downstairs/src/dynamometer.rs
@@ -5,6 +5,7 @@ pub enum DynoFlushConfig {
     FlushPerIops(usize),
     FlushPerBlocks(usize),
     FlushPerMs(Duration),
+    None,
 }
 
 pub async fn dynamometer(

--- a/downstairs/src/dynamometer.rs
+++ b/downstairs/src/dynamometer.rs
@@ -4,7 +4,7 @@ use super::*;
 pub enum DynoFlushConfig {
     FlushPerIops(usize),
     FlushPerBlocks(usize),
-    FlushPerMs(usize),
+    FlushPerMs(Duration),
 }
 
 pub async fn dynamometer(
@@ -122,8 +122,7 @@ pub async fn dynamometer(
                     }
 
                     DynoFlushConfig::FlushPerMs(value)
-                        if flush_time.elapsed()
-                            > Duration::from_millis(value as u64) =>
+                        if flush_time.elapsed() > value =>
                     {
                         flush_time = Instant::now();
                         true

--- a/downstairs/src/dynamometer.rs
+++ b/downstairs/src/dynamometer.rs
@@ -1,0 +1,105 @@
+// Copyright 2023 Oxide Computer Company
+use super::*;
+
+pub async fn dynamometer(mut region: Region) -> Result<()> {
+    // TODO: pull into another crate? this is copied from measure-iops tool
+    let mut io_operations_sent = 0;
+    let mut bw_consumed = 0;
+    let mut measurement_time = Instant::now();
+    let mut total_io_time = Duration::ZERO;
+    let mut iops: Vec<f32> = vec![];
+    let mut bws: Vec<f32> = vec![];
+
+    let ddef = region.def();
+
+    // Fill test: write bytes in whole region
+    let block = vec![0x1; ddef.block_size() as usize];
+    let nonce =
+        vec![0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb];
+    let tag = vec![
+        0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd,
+        0xe, 0xf,
+    ];
+    let hash = integrity_hash(&[&nonce, &tag, &block]);
+
+    for eid in 0..ddef.extent_count() {
+        for block_offset in 0..ddef.extent_size().value {
+            let block = block.clone();
+            let nonce = nonce.clone();
+            let tag = tag.clone();
+
+            let io_operation_time = Instant::now();
+            region
+                .region_write(
+                    &[crucible_protocol::Write {
+                        eid: eid as u64,
+                        offset: Block::new_with_ddef(block_offset, &ddef),
+                        data: bytes::Bytes::from(block),
+                        block_context: BlockContext {
+                            hash,
+                            encryption_context: Some(
+                                crucible_protocol::EncryptionContext {
+                                    nonce,
+                                    tag,
+                                },
+                            ),
+                        },
+                    }],
+                    JobId(1000),
+                    false,
+                )
+                .await?;
+
+            total_io_time += io_operation_time.elapsed();
+            io_operations_sent += 1;
+            bw_consumed += ddef.block_size();
+
+            if measurement_time.elapsed() > Duration::from_secs(1) {
+                let fractional_seconds: f32 = total_io_time.as_secs() as f32
+                    + (total_io_time.subsec_nanos() as f32 / 1e9);
+
+                iops.push(io_operations_sent as f32 / fractional_seconds);
+                bws.push(bw_consumed as f32 / fractional_seconds);
+
+                io_operations_sent = 0;
+                bw_consumed = 0;
+                measurement_time = Instant::now();
+                total_io_time = Duration::ZERO;
+            }
+        }
+    }
+
+    println!("IOPS: {:?}", iops);
+    println!(
+        "IOPS mean {} stddev {}",
+        statistical::mean(&iops),
+        statistical::standard_deviation(&iops, None),
+    );
+
+    iops.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    println!(
+        "IOPS min {} max {}",
+        iops.first().unwrap(),
+        iops.last().unwrap(),
+    );
+
+    println!("BW: {:?}", bws);
+    println!(
+        "BW mean {} stddev {}",
+        statistical::mean(&bws),
+        statistical::standard_deviation(&bws, None),
+    );
+
+    bws.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    println!(
+        "BW min {} max {}",
+        bws.first().unwrap(),
+        bws.last().unwrap(),
+    );
+
+    // Random write test
+
+    Ok(())
+}

--- a/downstairs/src/dynamometer.rs
+++ b/downstairs/src/dynamometer.rs
@@ -182,7 +182,5 @@ pub async fn dynamometer(
         bws.last().unwrap(),
     );
 
-    // Random write test
-
     Ok(())
 }

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -31,6 +31,7 @@ use uuid::Uuid;
 
 pub mod admin;
 mod dump;
+mod dynamometer;
 pub mod region;
 pub mod repair;
 mod stats;
@@ -39,6 +40,7 @@ use region::Region;
 
 pub use admin::run_dropshot;
 pub use dump::dump_region;
+pub use dynamometer::*;
 pub use stats::*;
 
 fn deadline_secs(secs: u64) -> Instant {

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -182,6 +182,25 @@ enum Args {
         bind_addr: SocketAddr,
     },
     Version,
+    /*
+    Measure an isolated downstairs
+    */
+    Dynamometer {
+        #[clap(long, default_value = "512", action)]
+        block_size: u64,
+
+        #[clap(short, long, name = "DIRECTORY", action)]
+        data: PathBuf,
+
+        #[clap(long, default_value = "100", action)]
+        extent_size: u64,
+
+        #[clap(long, default_value = "15", action)]
+        extent_count: u64,
+
+        #[clap(long, action)]
+        encrypted: bool,
+    },
 }
 
 #[tokio::main]
@@ -384,6 +403,29 @@ async fn main() -> Result<()> {
                 "Upstairs <-> Downstairs Message Version: {}",
                 CRUCIBLE_MESSAGE_VERSION
             );
+            Ok(())
+        }
+        Args::Dynamometer {
+            block_size,
+            data,
+            extent_size,
+            extent_count,
+            encrypted,
+        } => {
+            let uuid = Uuid::new_v4();
+
+            let region = create_region(
+                block_size,
+                data,
+                extent_size,
+                extent_count,
+                uuid,
+                encrypted,
+                log.clone(),
+            )
+            .await?;
+
+            dynamometer(region).await?;
             Ok(())
         }
     }

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -187,27 +187,27 @@ enum Args {
     Measure an isolated downstairs
     */
     Dynamometer {
-        #[clap(long, default_value = "512", action)]
+        #[clap(long, default_value_t = 512, action)]
         block_size: u64,
 
         #[clap(short, long, name = "DIRECTORY", action)]
         data: PathBuf,
 
-        #[clap(long, default_value = "100", action)]
+        #[clap(long, default_value_t = 100, action)]
         extent_size: u64,
 
-        #[clap(long, default_value = "15", action)]
+        #[clap(long, default_value_t = 15, action)]
         extent_count: u64,
 
         #[clap(long, action)]
         encrypted: bool,
 
         // Number of writes to submit at one time to region_write
-        #[clap(short, long, action, default_value = "1")]
+        #[clap(short, long, action, default_value_t = 1)]
         num_writes: usize,
 
         // Number of samples to exit for
-        #[clap(short, long, action, default_value = "10")]
+        #[clap(short, long, action, default_value_t = 10)]
         samples: usize,
 
         // Flush per iops

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -200,6 +200,14 @@ enum Args {
 
         #[clap(long, action)]
         encrypted: bool,
+
+        // Number of writes to submit at one time to region_write
+        #[clap(short, long, action, default_value = "1")]
+        num_writes: usize,
+
+        // Number of samples to exit for
+        #[clap(short, long, action, default_value = "10")]
+        samples: usize,
     },
 }
 
@@ -411,6 +419,8 @@ async fn main() -> Result<()> {
             extent_size,
             extent_count,
             encrypted,
+            num_writes,
+            samples,
         } => {
             let uuid = Uuid::new_v4();
 
@@ -425,7 +435,8 @@ async fn main() -> Result<()> {
             )
             .await?;
 
-            dynamometer(region).await?;
+            dynamometer(region, num_writes, samples).await?;
+
             Ok(())
         }
     }

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -185,27 +185,27 @@ enum Args {
     Version,
     /// Measure an isolated downstairs
     Dynamometer {
-        #[clap(long, default_value_t = 512, action)]
+        #[clap(long, default_value_t = 512)]
         block_size: u64,
 
-        #[clap(short, long, name = "DIRECTORY", action)]
+        #[clap(short, long, name = "DIRECTORY")]
         data: PathBuf,
 
-        #[clap(long, default_value_t = 100, action)]
+        #[clap(long, default_value_t = 100)]
         extent_size: u64,
 
-        #[clap(long, default_value_t = 15, action)]
+        #[clap(long, default_value_t = 15)]
         extent_count: u64,
 
-        #[clap(long, action)]
+        #[clap(long)]
         encrypted: bool,
 
         /// Number of writes to submit at one time to region_write
-        #[clap(short, long, action, default_value_t = 1)]
+        #[clap(short, long, default_value_t = 1)]
         num_writes: usize,
 
         /// Number of samples to exit for
-        #[clap(short, long, action, default_value_t = 10)]
+        #[clap(short, long, default_value_t = 10)]
         samples: usize,
 
         /// Flush per iops

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -4,6 +4,7 @@
 
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::{bail, Result};
 use clap::Parser;
@@ -210,17 +211,22 @@ enum Args {
         samples: usize,
 
         // Flush per iops
-        #[clap(long, action, default_value = None)]
+        #[clap(long)]
         flush_per_iops: Option<usize>,
 
         // Flush per blocks written
-        #[clap(long, action, default_value = None)]
+        #[clap(long)]
         flush_per_blocks: Option<usize>,
 
         // Flush per ms
-        #[clap(long, action, default_value = None)]
-        flush_per_ms: Option<usize>,
+        #[clap(long, value_parser = parse_duration)]
+        flush_per_ms: Option<Duration>,
     },
+}
+
+fn parse_duration(arg: &str) -> Result<Duration, std::num::ParseIntError> {
+    let ms = arg.parse()?;
+    Ok(Duration::from_millis(ms))
 }
 
 #[tokio::main]

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -183,9 +183,7 @@ enum Args {
         bind_addr: SocketAddr,
     },
     Version,
-    /*
-    Measure an isolated downstairs
-    */
+    /// Measure an isolated downstairs
     Dynamometer {
         #[clap(long, default_value_t = 512, action)]
         block_size: u64,
@@ -202,23 +200,23 @@ enum Args {
         #[clap(long, action)]
         encrypted: bool,
 
-        // Number of writes to submit at one time to region_write
+        /// Number of writes to submit at one time to region_write
         #[clap(short, long, action, default_value_t = 1)]
         num_writes: usize,
 
-        // Number of samples to exit for
+        /// Number of samples to exit for
         #[clap(short, long, action, default_value_t = 10)]
         samples: usize,
 
-        // Flush per iops
+        /// Flush per iops
         #[clap(long, conflicts_with_all = ["flush_per_blocks", "flush_per_ms"])]
         flush_per_iops: Option<usize>,
 
-        // Flush per blocks written
+        /// Flush per blocks written
         #[clap(long, conflicts_with_all = ["flush_per_iops", "flush_per_ms"])]
         flush_per_blocks: Option<usize>,
 
-        // Flush per ms
+        /// Flush per ms
         #[clap(long, value_parser = parse_duration, conflicts_with_all = ["flush_per_iops", "flush_per_blocks"])]
         flush_per_ms: Option<Duration>,
     },


### PR DESCRIPTION
Before measuring the performance impact of a new on-disk format, add a dynamometer option: measure the performance of sending writes to a Region in isolation from the rest of Crucible.