### PR TITLE
dsc and clippy cleanup.

### DIFF
--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -152,7 +152,7 @@ enum Action {
         block_size: u32,
 
         /// Delete all existing test and region directories
-        #[clap(long, action)]
+        #[clap(long, action, requires = "create")]
         cleanup: bool,
 
         /// The IP/Port where the control server will listen

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -10406,7 +10406,7 @@ async fn show_all_work(up: &Arc<Upstairs>) -> WQCounts {
     let gior = up.guest_io_ready().await;
     let up_count = up.guest.guest_work.lock().await.active.len();
 
-    let mut ds = up.downstairs.lock().await;
+    let ds = up.downstairs.lock().await;
     let ds_count = ds.ds_active.len();
 
     println!(


### PR DESCRIPTION
`dsc` now requires `--create` with `--cleanup` for the `start` subcommand. 
[fixes 933](https://github.com/oxidecomputer/crucible/issues/933)

Remove a mut that was no longer needed due to recent changes.