### PR TITLE
Use a synchronous mutex for `bw/iop_tokens`

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -9019,7 +9019,7 @@ pub struct Guest {
      * pulled off will be limited. No setting means they are sent right
      * away.
      */
-    iop_tokens: Mutex<usize>,
+    iop_tokens: std::sync::Mutex<usize>,
     bytes_per_iop: Option<usize>,
     iop_limit: Option<usize>,
 
@@ -9027,8 +9027,8 @@ pub struct Guest {
      * Setting a bandwidth limit will also limit the rate at which block
      * reqs are pulled off the queue.
      */
-    bw_tokens: Mutex<usize>, // bytes
-    bw_limit: Option<usize>, // bytes per second
+    bw_tokens: std::sync::Mutex<usize>, // bytes
+    bw_limit: Option<usize>,            // bytes per second
 }
 
 /*
@@ -9055,11 +9055,11 @@ impl Guest {
                 completed: AllocRingBuffer::new(2048),
             }),
 
-            iop_tokens: Mutex::new(0),
+            iop_tokens: std::sync::Mutex::new(0),
             bytes_per_iop: None,
             iop_limit: None,
 
-            bw_tokens: Mutex::new(0),
+            bw_tokens: std::sync::Mutex::new(0),
             bw_limit: None,
         }
     }
@@ -9118,8 +9118,8 @@ impl Guest {
      */
     async fn consume_req(&self) -> Option<BlockReq> {
         let mut reqs = self.reqs.lock().await;
-        let mut bw_tokens = self.bw_tokens.lock().await;
-        let mut iop_tokens = self.iop_tokens.lock().await;
+        let mut bw_tokens = self.bw_tokens.lock().unwrap();
+        let mut iop_tokens = self.iop_tokens.lock().unwrap();
 
         self.consume_req_locked(&mut reqs, &mut bw_tokens, &mut iop_tokens)
 
@@ -9208,8 +9208,8 @@ impl Guest {
      * IOPs are IO operations per second, so leak tokens to allow that
      * through.
      */
-    pub async fn leak_iop_tokens(&self, tokens: usize) {
-        let mut iop_tokens = self.iop_tokens.lock().await;
+    pub fn leak_iop_tokens(&self, tokens: usize) {
+        let mut iop_tokens = self.iop_tokens.lock().unwrap();
 
         if tokens > *iop_tokens {
             *iop_tokens = 0;
@@ -9222,8 +9222,8 @@ impl Guest {
     }
 
     // Leak bytes from bandwidth tokens
-    pub async fn leak_bw_tokens(&self, bytes: usize) {
-        let mut bw_tokens = self.bw_tokens.lock().await;
+    pub fn leak_bw_tokens(&self, bytes: usize) {
+        let mut bw_tokens = self.bw_tokens.lock().unwrap();
 
         if bytes > *bw_tokens {
             *bw_tokens = 0;
@@ -10112,12 +10112,12 @@ async fn up_listen(
             _ = sleep_until(leak_deadline) => {
                 if let Some(iop_limit) = up.guest.get_iop_limit() {
                     let tokens = iop_limit / (1000 / LEAK_MS);
-                    up.guest.leak_iop_tokens(tokens).await;
+                    up.guest.leak_iop_tokens(tokens);
                 }
 
                 if let Some(bw_limit) = up.guest.get_bw_limit() {
                     let tokens = bw_limit / (1000 / LEAK_MS);
-                    up.guest.leak_bw_tokens(tokens).await;
+                    up.guest.leak_bw_tokens(tokens);
                 }
 
                 leak_deadline = Instant::now().checked_add(leak_tick).unwrap();


### PR DESCRIPTION
These are POD values that are only locked for a brief time, and the lock is not held across awaits.  The Tokio docs suggest using the standard library mutex in this situation:

> The feature that the async mutex offers over the blocking mutex is the ability to keep it locked across an .await point. This makes the async mutex more expensive than the blocking mutex, so the blocking mutex should be preferred in the cases where it can be used. The primary use case for the async mutex is to provide shared mutable access to IO resources such as a database connection. If the value behind the mutex is just data, it’s usually appropriate to use a blocking mutex such as the one in the standard library or [parking_lot](https://docs.rs/parking_lot).