### PR TITLE
Do less in control

### DIFF
--- a/openapi/crucible-control.json
+++ b/openapi/crucible-control.json
@@ -5,34 +5,6 @@
     "version": "0.0.0"
   },
   "paths": {
-    "/downstairs/fault/{cid}": {
-      "post": {
-        "operationId": "fault_downstairs",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "cid",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "resource updated"
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
     "/info": {
       "get": {
         "summary": "Fetch the current value for all the stats in the UpstairsStats struct",
@@ -44,39 +16,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/UpstairsStats"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/snapshot": {
-      "post": {
-        "operationId": "take_snapshot",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TakeSnapshotParams"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "successful creation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TakeSnapshotResponse"
                 }
               }
             }
@@ -201,29 +140,6 @@
         "required": [
           "message",
           "request_id"
-        ]
-      },
-      "TakeSnapshotParams": {
-        "description": "Signal to the Upstairs to take a snapshot",
-        "type": "object",
-        "properties": {
-          "snapshot_name": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "snapshot_name"
-        ]
-      },
-      "TakeSnapshotResponse": {
-        "type": "object",
-        "properties": {
-          "snapshot_name": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "snapshot_name"
         ]
       },
       "UpState": {

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -10284,9 +10284,8 @@ pub async fn up_main(
     // If requested, start the control http server on the given address:port
     if let Some(control) = opt.control {
         let upi = Arc::clone(&up);
-        let ds_done_tx_c = ds_done_tx.clone();
         tokio::spawn(async move {
-            let r = control::start(&upi, control, ds_done_tx_c).await;
+            let r = control::start(&upi, control).await;
             info!(upi.log, "Control HTTP task finished with {:?}", r);
         });
     }


### PR DESCRIPTION
Remove the unused snapshot ability from the control interface.
Remove the unused downstairs fault ability from the control interface.

Neither of these are used any longer, and leaving them around can serve no purpose.