### PR TITLE
Make stats mutex synchronous

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -3824,7 +3824,7 @@ impl Downstairs {
      * This function does a match on IOop type and updates the oximeter
      * stat and dtrace probe for that operation.
      */
-    async fn cdt_gw_work_done(
+    fn cdt_gw_work_done(
         &self,
         ds_id: JobId,
         gw_id: u64,
@@ -3843,14 +3843,14 @@ impl Downstairs {
                 requests: _,
             } => {
                 cdt::gw__read__done!(|| (gw_id));
-                stats.add_read(io_size as i64).await;
+                stats.add_read(io_size as i64);
             }
             IOop::Write {
                 dependencies: _,
                 writes: _,
             } => {
                 cdt::gw__write__done!(|| (gw_id));
-                stats.add_write(io_size as i64).await;
+                stats.add_write(io_size as i64);
             }
             IOop::WriteUnwritten {
                 dependencies: _,
@@ -3868,7 +3868,7 @@ impl Downstairs {
                 extent_limit: _,
             } => {
                 cdt::gw__flush__done!(|| (gw_id));
-                stats.add_flush().await;
+                stats.add_flush();
             }
             IOop::ExtentClose {
                 dependencies: _,
@@ -3893,7 +3893,7 @@ impl Downstairs {
                 repair_downstairs: _,
             } => {
                 cdt::gw__close__done!(|| (gw_id, extent));
-                stats.add_flush_close().await;
+                stats.add_flush_close();
             }
             IOop::ExtentLiveRepair {
                 dependencies: _,
@@ -3903,18 +3903,18 @@ impl Downstairs {
                 repair_downstairs: _,
             } => {
                 cdt::gw__repair__done!(|| (gw_id, extent));
-                stats.add_extent_repair().await;
+                stats.add_extent_repair();
             }
             IOop::ExtentLiveNoOp { dependencies: _ } => {
                 cdt::gw__noop__done!(|| (gw_id));
-                stats.add_extent_noop().await;
+                stats.add_extent_noop();
             }
             IOop::ExtentLiveReopen {
                 dependencies: _,
                 extent,
             } => {
                 cdt::gw__reopen__done!(|| (gw_id, extent));
-                stats.add_extent_reopen().await;
+                stats.add_extent_reopen();
             }
         }
     }
@@ -5260,7 +5260,9 @@ impl Upstairs {
         let uuid = opt.id;
         info!(log, "Crucible stats registered with UUID: {}", uuid);
         let stats = UpStatOuter {
-            up_stat_wrap: Arc::new(Mutex::new(UpCountStat::new(uuid))),
+            up_stat_wrap: Arc::new(std::sync::Mutex::new(UpCountStat::new(
+                uuid,
+            ))),
         };
 
         let rd_status = match expected_region_def {
@@ -5358,7 +5360,7 @@ impl Upstairs {
     #[cfg(test)]
     async fn set_active(&self) -> Result<(), CrucibleError> {
         let mut active = self.active.lock().await;
-        self.stats.add_activation().await;
+        self.stats.add_activation();
         active.set_active()?;
         info!(
             self.log,
@@ -7055,7 +7057,7 @@ impl Upstairs {
                         self.uuid,
                         self.session_id
                     );
-                    self.stats.add_activation().await;
+                    self.stats.add_activation();
                 }
             }
             Ok(false) => {
@@ -7091,7 +7093,7 @@ impl Upstairs {
                         self.uuid,
                         self.session_id
                     );
-                    self.stats.add_activation().await;
+                    self.stats.add_activation();
                     info!(self.log, "{} Set Active after no repair", self.uuid);
                 }
             }
@@ -9620,7 +9622,7 @@ async fn up_ds_listen(up: &Arc<Upstairs>, mut ds_done_rx: mpsc::Receiver<()>) {
             gw.gw_ds_complete(gw_id, ds_id, data, ds.result(ds_id), &up.log)
                 .await;
 
-            ds.cdt_gw_work_done(ds_id, gw_id, io_size, &up.stats).await;
+            ds.cdt_gw_work_done(ds_id, gw_id, io_size, &up.stats);
 
             ds.retire_check(ds_id);
         }

--- a/upstairs/src/stats.rs
+++ b/upstairs/src/stats.rs
@@ -111,54 +111,54 @@ impl UpCountStat {
 // share it with the producer trait.
 #[derive(Clone, Debug)]
 pub struct UpStatOuter {
-    pub up_stat_wrap: Arc<Mutex<UpCountStat>>,
+    pub up_stat_wrap: Arc<std::sync::Mutex<UpCountStat>>,
 }
 
 impl UpStatOuter {
     // When an operation happens that we wish to record in Oximeter,
     // one of these methods will be called.  Each method will get the
     // correct field of UpCountStat to record the update.
-    pub async fn add_activation(&self) {
-        let mut ups = self.up_stat_wrap.lock().await;
+    pub fn add_activation(&self) {
+        let mut ups = self.up_stat_wrap.lock().unwrap();
         let datum = ups.activated_count.datum_mut();
         *datum += 1;
     }
-    pub async fn add_write(&self, bytes: i64) {
-        let mut ups = self.up_stat_wrap.lock().await;
+    pub fn add_write(&self, bytes: i64) {
+        let mut ups = self.up_stat_wrap.lock().unwrap();
         let datum = ups.write_bytes.datum_mut();
         *datum += bytes;
         let datum = ups.write_count.datum_mut();
         *datum += 1;
     }
-    pub async fn add_read(&self, bytes: i64) {
-        let mut ups = self.up_stat_wrap.lock().await;
+    pub fn add_read(&self, bytes: i64) {
+        let mut ups = self.up_stat_wrap.lock().unwrap();
         let datum = ups.read_bytes.datum_mut();
         *datum += bytes;
         let datum = ups.read_count.datum_mut();
         *datum += 1;
     }
-    pub async fn add_flush(&self) {
-        let mut ups = self.up_stat_wrap.lock().await;
+    pub fn add_flush(&self) {
+        let mut ups = self.up_stat_wrap.lock().unwrap();
         let datum = ups.flush_count.datum_mut();
         *datum += 1;
     }
-    pub async fn add_flush_close(&self) {
-        let mut ups = self.up_stat_wrap.lock().await;
+    pub fn add_flush_close(&self) {
+        let mut ups = self.up_stat_wrap.lock().unwrap();
         let datum = ups.flush_close_count.datum_mut();
         *datum += 1;
     }
-    pub async fn add_extent_repair(&self) {
-        let mut ups = self.up_stat_wrap.lock().await;
+    pub fn add_extent_repair(&self) {
+        let mut ups = self.up_stat_wrap.lock().unwrap();
         let datum = ups.extent_repair_count.datum_mut();
         *datum += 1;
     }
-    pub async fn add_extent_noop(&self) {
-        let mut ups = self.up_stat_wrap.lock().await;
+    pub fn add_extent_noop(&self) {
+        let mut ups = self.up_stat_wrap.lock().unwrap();
         let datum = ups.extent_noop_count.datum_mut();
         *datum += 1;
     }
-    pub async fn add_extent_reopen(&self) {
-        let mut ups = self.up_stat_wrap.lock().await;
+    pub fn add_extent_reopen(&self) {
+        let mut ups = self.up_stat_wrap.lock().unwrap();
         let datum = ups.extent_reopen_count.datum_mut();
         *datum += 1;
     }
@@ -173,9 +173,7 @@ impl Producer for UpStatOuter {
     fn produce(
         &mut self,
     ) -> Result<Box<dyn Iterator<Item = Sample> + 'static>, MetricsError> {
-        let ups = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(self.up_stat_wrap.lock())
-        });
+        let ups = self.up_stat_wrap.lock().unwrap();
 
         let name = &ups.stat_name;
         let data = vec![


### PR DESCRIPTION
Same as before – this is a POD type and only locked briefly.

(I'd ideally prefer using atomics, to avoid locking altogether, but that would require a larger refactoring)