### PR TITLE
Optimize requeue during flow control conditions

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -738,9 +738,14 @@ where
         if active_count > MAX_ACTIVE_COUNT {
             ds.flow_control[client_id] += 1;
             return Ok(true);
+        } else {
+            let n = MAX_ACTIVE_COUNT - active_count;
+            let (new_work, flow_control) = ds.new_work(client_id, n)
+            if flow_control {
+                ds.flow_control[client_id] += 1;
+            }
+            (new_work, flow_control)
         }
-        let n = MAX_ACTIVE_COUNT - active_count;
-        ds.new_work(client_id, n)
     };
 
     /*

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -740,7 +740,7 @@ where
             return Ok(true);
         } else {
             let n = MAX_ACTIVE_COUNT - active_count;
-            let (new_work, flow_control) = ds.new_work(client_id, n)
+            let (new_work, flow_control) = ds.new_work(client_id, n);
             if flow_control {
                 ds.flow_control[client_id] += 1;
             }


### PR DESCRIPTION
In `io_send`, we move the entire `new_work` array out of `Downstairs`, start as many items as we can (limited by `MAX_ACTIVE_COUNT`), then put any remaining items back.  The `Downstairs` isn't locked, so new jobs can also be added while we're processing the last batch.

During heavy streaming write workloads, this becomes problematic: many new jobs have been added, we didn't manage to enqueue many old jobs, so we have to merge two large `BTreeSet<JobId>`'s.  This is clearly visible in the flamegraph:

<img width="957" alt="Screenshot 2023-09-26 at 12 24 37 PM" src="https://github.com/oxidecomputer/crucible/assets/745333/35a711c3-ef2c-4400-9b2b-863725cbe050">

This PR changes the logic to instead **only remove as many jobs as we have room for**.  This removes `requeue_work` entirely, and is a significant speedup in `rwrite` workloads (running on a Gimlet with the downstairs on 3 separate U.2s).

Before (`main`, `b4c0da1fc`):
```
    TEST SECONDS COUNT DPTH    IOPS    MEAN     P95     P99      MAX    ES    EC
 rwrites    4.11 30000    1 7294.58 0.00014 0.00037 0.00076  0.02760 16384   640
 rwrites    4.49 30000    1 6687.63 0.00015 0.00039 0.00068  0.03045 16384   640
 rwrites    4.05 30000    1 7398.96 0.00014 0.00038 0.00075  0.03177 16384  1280
 rwrites    4.35 30000    1 6896.55 0.00014 0.00043 0.00081  0.04575 16384  1280
```

After (`optimize-requeue`, `f4c99f94`):
```
    TEST SECONDS COUNT DPTH    IOPS    MEAN     P95     P99      MAX    ES    EC
 rwrites    3.00 30000    1 10010.46 0.00010 0.00014 0.00020  0.09465 16384   640
 rwrites    2.85 30000    1 10511.38 0.00010 0.00014 0.00020  0.03723 16384   640
 rwrites    2.98 30000    1 10074.01 0.00010 0.00014 0.00020  0.03751 16384  1280
 rwrites    2.98 30000    1 10058.42 0.00010 0.00015 0.00023  0.03239 16384  1280
```

Note that there is a subtle change in logic here: the new code doesn't check whether jobs will be skipped when deciding how many to take from `ds_new`.  In other words, it's more pessimistic: if rate-limiting allows for 10 new jobs, and we have 20 in the queue – but the first 10 are skipped – it will take the first 10, not all 20.

(I think this is fine, because jobs are only skipped on rare occasions, but am open to objections)