### PR TITLE
Add timeout and failure data collection of replay job

### DIFF
--- a/.github/buildomat/jobs/build.sh
+++ b/.github/buildomat/jobs/build.sh
@@ -38,7 +38,9 @@ for t in crucible-downstairs crucible-hammer crutest dsc; do
 done
 
 mkdir -p /work/scripts
-for s in tools/test_live_repair.sh tools/test_repair.sh tools/test_up.sh tools/test_ds.sh tools/test_replay.sh ; do
+for s in tools/test_live_repair.sh tools/test_repair.sh tools/test_up.sh \
+  tools/test_ds.sh tools/test_replay.sh tools/dtrace/upstairs_info.d \
+  tools/dtrace/perf-downstairs-tick.d; do
 	cp "$s" /work/scripts/
 done
 

--- a/.github/buildomat/jobs/test-replay.sh
+++ b/.github/buildomat/jobs/test-replay.sh
@@ -46,8 +46,8 @@ export BINDIR=/var/tmp/bins
 banner setup
 
 echo "Setup self timeout"
-# First, test that, after 3 minutes a timeout fires and collects data.
-jobpid=$$; (sleep $(( 3 * 60 )); ps -ef; zfs list;kill $jobpid) &
+# Three hours should be enough
+jobpid=$$; (sleep 10800; ps -ef; zfs list;kill $jobpid) &
 
 echo "Setup debug logging"
 mkdir /tmp/debug

--- a/.github/buildomat/jobs/test-replay.sh
+++ b/.github/buildomat/jobs/test-replay.sh
@@ -7,7 +7,7 @@
 #:	"/tmp/*.txt",
 #:	"/tmp/*.log",
 #:	"%/tmp/debug/*.txt",
-#:	"/tmp/dsc/*.txt",
+#:	"%/tmp/dsc/*.txt",
 #:	"/tmp/core.*",
 #: ]
 #: skip_clone = true
@@ -57,7 +57,8 @@ prstat -d d -mLc 1 > /tmp/debug/prstat.txt 2>&1 &
 iostat -T d -xn 1 > /tmp/debug/iostat.txt 2>&1 &
 mpstat -T d 1 > /tmp/debug/mpstat.txt 2>&1 &
 vmstat -T d -p 1 < /dev/null > /tmp/debug/paging.txt 2>&1 &
-pfexec dtrace -Z -s $input/scripts/perf-downstairs-tick.d > /tmp/debug/dtrace.txt 2>&1 &
+pfexec dtrace -Z -s $input/scripts/perf-downstairs-tick.d > /tmp/debug/perf.txt 2>&1 &
+pfexec dtrace -Z -s $input/scripts/upstairs-info.d > /tmp/debug/upinfo.txt 2>&1 &
 
 banner replay
 ptime -m bash "$input/scripts/test_replay.sh"


### PR DESCRIPTION
Add a timeout (currently 3 hours) to  `test-replay`
If the timeout is hit, we should gather some data
