### PR TITLE
Lock the Downstairs less

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -3128,10 +3128,16 @@ impl Downstairs {
             && !self.ds_skipped_jobs[client_id].is_empty()
     }
 
-    // Given a client ID that is undergoing LiveRepair, go through the list
-    // of dependencies and remove any jobs that this downstairs has already
-    // skipped, as the downstairs on the other side will not have received
-    // these IOs.
+    /// Given a client ID that is undergoing LiveRepair, go through the list
+    /// of dependencies and remove any jobs that this downstairs has already
+    /// skipped, as the downstairs on the other side will not have received
+    /// these IOs.
+    ///
+    /// First off, any job that was "skipped" should not be a dependency for
+    /// this specific downstairs.  In addition, any job that happened before
+    /// the skipped jobs that was marked as "Done" should also be removed, as
+    /// there will be no replay here and we are basically rebuilding this
+    /// downstairs from other downstairs.
     fn remove_dep_if_live_repair(
         &mut self,
         client_id: ClientId,


### PR DESCRIPTION
Right now, we lock the `downstairs: Mutex<Downstairs>` _many times_ per message:

```
 count   | usec | frame
---------|------|--------
  365898 |   27 | Upstairs::live_repair_dep_check::{{closure}}::h2a5eb9ef1869029d+0x97
   60960 |    1 | Upstairs::submit_flush::{{closure}}::hd26902ffce1cbf52+0x67b
   61006 |    0 | Upstairs::submit_write::{{closure}}::h0483f246c30e462f+0xa47
  365898 |    1 | cmd_loop::{{closure}}::{{closure}}::hac611f6d010d3f3a
  365898 |   22 | io_send::{{closure}}::hbe101b43c688bc9f+0x1e06
  182880 |   23 | io_send::{{closure}}::hbe101b43c688bc9f+0x2cea
  365898 |   10 | io_send::{{closure}}::hbe101b43c688bc9f+0x613
  365898 |    2 | process_message::{{closure}}::he56b83ef659423b5+0xd1e
  121931 |    0 | up_listen::{{closure}}::h4933810dd8126016
  243932 |   12 | up_main::{{closure}}::{{closure}}::h0d4dafbe6380f5b8
```

This PR consolidates `in_progress` and `live_repair_dep_check`, removing one lock per write and two locks per flush:

```
 count   | usec | frame
---------|------|--------
   23342 |    0 | Upstairs::submit_flush::{{closure}}::hd26902ffce1cbf52+0x67b
   23391 |    0 | Upstairs::submit_write::{{closure}}::h0483f246c30e462f+0xa47
  140196 |    1 | cmd_loop::{{closure}}::{{closure}}::hac611f6d010d3f3a
  140199 |   11 | io_send::{{closure}}::hd1ba0ad80a942e83+0x55c
  140199 |   31 | io_send::{{closure}}::hd1ba0ad80a942e83+0xf77
  140196 |    3 | process_message::{{closure}}::he56b83ef659423b5+0xd1e
   46727 |    1 | up_listen::{{closure}}::h4933810dd8126016
   93464 |   17 | up_main::{{closure}}::{{closure}}::h0d4dafbe6380f5b8
```
(don't compare `count`-to-`count`, since the number of jobs is different; look at counts relative to `submit_flush/write`)

Alas, this has no VM-visible performance impact (when running `pgbench`).