### PR TITLE
Log crucible opts on start, shuffle crutest structs

### DIFF
--- a/crucible-client-types/src/lib.rs
+++ b/crucible-client-types/src/lib.rs
@@ -81,15 +81,16 @@ impl std::fmt::Display for CrucibleOpts {
         write!(f, " Targets: {:?},", self.target)?;
         write!(f, " lossy: {:?},", self.lossy)?;
         write!(f, " flush_timeout: {:?},", self.flush_timeout)?;
-        write!(f, " read_only: {:?},", self.read_only)?;
         write!(f, " key populated: {}, ", self.key.is_some())?;
         write!(f, " cert_pem populated: {}, ", self.cert_pem.is_some())?;
         write!(f, " key_pem populated: {}, ", self.key_pem.is_some())?;
         write!(
             f,
-            " root_cert_pem populated: {}",
+            " root_cert_pem populated: {}, ",
             self.root_cert_pem.is_some()
         )?;
+        write!(f, " Control: {:?}, ", self.control)?;
+        write!(f, " read_only: {:?}", self.read_only)?;
         Ok(())
     }
 }

--- a/crucible-client-types/src/lib.rs
+++ b/crucible-client-types/src/lib.rs
@@ -3,6 +3,7 @@
 use base64::{engine, Engine};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::net::SocketAddr;
 use uuid::Uuid;
 
@@ -69,5 +70,26 @@ impl CrucibleOpts {
         } else {
             None
         }
+    }
+}
+
+/// Display the contents of CrucibleOpts, Only print if keys are populated,
+/// not what the actual contents are.
+impl std::fmt::Display for CrucibleOpts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Upstairs UUID: {},", self.id)?;
+        write!(f, " Targets: {:?},", self.target)?;
+        write!(f, " lossy: {:?},", self.lossy)?;
+        write!(f, " flush_timeout: {:?},", self.flush_timeout)?;
+        write!(f, " read_only: {:?},", self.read_only)?;
+        write!(f, " key populated: {}, ", self.key.is_some())?;
+        write!(f, " cert_pem populated: {}, ", self.cert_pem.is_some())?;
+        write!(f, " key_pem populated: {}, ", self.key_pem.is_some())?;
+        write!(
+            f,
+            " root_cert_pem populated: {}",
+            self.root_cert_pem.is_some()
+        )?;
+        Ok(())
     }
 }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -10134,6 +10134,11 @@ pub async fn up_main(
         "Upstairs <-> Downstairs Message Version: {}", CRUCIBLE_MESSAGE_VERSION
     );
 
+    info!(log, "Upstairs opts: {}", opt);
+    if let Some(rd) = region_def {
+        info!(log, "Using region definition {:?}", rd);
+    }
+
     /*
      * Build the Upstairs struct that we use to share data between
      * the different async tasks


### PR DESCRIPTION
Make crucible upstairs log what options it receives on startup. Don't actually print keys though, just print if they are present.

Updated crutest to have a read-only option to pass to crucible and put all the crutest options in abc order.