### PR TITLE
Read only downstairs can skip Live Repair

### DIFF
--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -2628,7 +2628,10 @@ mod test {
         }
 
         // Old volume is no longer active
-        assert!(!volume.query_is_active().await?);
+        while volume.query_is_active().await? {
+            println!("Waiting for old volume to deactivate");
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
 
         // Read back what we wrote.
         let buffer = Buffer::new(new_volume.total_size().await? as usize);

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -77,6 +77,7 @@ pub(crate) mod protocol_test {
         _repair_listener: TcpListener,
         repair_addr: SocketAddr,
         uuid: Uuid,
+        read_only: bool,
 
         extent_count: u32,
         extent_size: Block,
@@ -124,6 +125,7 @@ pub(crate) mod protocol_test {
                 _repair_listener: repair_listener,
                 repair_addr,
                 uuid: Uuid::new_v4(),
+                read_only: false,
 
                 extent_count: 10,
                 extent_size: Block::new_512(10),
@@ -132,6 +134,10 @@ pub(crate) mod protocol_test {
                 flush_numbers: vec![0u64; 10],
                 dirty_bits: vec![false; 10],
             }
+        }
+
+        pub fn set_read_only(&mut self) {
+            self.read_only = true;
         }
 
         pub async fn into_connected_downstairs(self) -> ConnectedDownstairs {
@@ -201,11 +207,15 @@ pub(crate) mod protocol_test {
                     upstairs_id: _,
                     session_id: _,
                     gen: _,
-                    read_only: _,
+                    read_only,
                     encrypted: _,
                     alternate_versions: _,
                 } => {
-                    info!(self.inner.log, "negotiate packet {:?}", packet);
+                    info!(self.inner.log, "negotiate packet {:?} (upstairs read-only {})", packet, read_only);
+
+                    if *read_only != self.inner.read_only {
+                        bail!("read only mismatch!");
+                    }
 
                     self.fw
                         .lock()
@@ -448,11 +458,25 @@ pub(crate) mod protocol_test {
 
     impl TestHarness {
         pub async fn new() -> Result<TestHarness> {
+            Self::new_(false).await
+        }
+
+        pub async fn new_ro() -> Result<TestHarness> {
+            Self::new_(true).await
+        }
+
+        async fn new_(read_only: bool) -> Result<TestHarness> {
             let log = csl();
 
-            let ds1 = Downstairs::new(log.new(o!("downstairs" => 1))).await;
-            let ds2 = Downstairs::new(log.new(o!("downstairs" => 2))).await;
-            let ds3 = Downstairs::new(log.new(o!("downstairs" => 3))).await;
+            let mut ds1 = Downstairs::new(log.new(o!("downstairs" => 1))).await;
+            let mut ds2 = Downstairs::new(log.new(o!("downstairs" => 2))).await;
+            let mut ds3 = Downstairs::new(log.new(o!("downstairs" => 3))).await;
+
+            if read_only {
+                ds1.set_read_only();
+                ds2.set_read_only();
+                ds3.set_read_only();
+            }
 
             // Configure our guest without backpressure, to speed up tests which
             // require triggering a timeout
@@ -464,6 +488,7 @@ pub(crate) mod protocol_test {
                 id: Uuid::new_v4(),
                 target: vec![ds1.local_addr, ds2.local_addr, ds3.local_addr],
                 flush_timeout: Some(86400.0),
+                read_only,
 
                 ..Default::default()
             };
@@ -2597,6 +2622,306 @@ pub(crate) mod protocol_test {
             ds1_messages.recv().await.unwrap(),
             Message::ExtentLiveReopen { extent_id: 0, .. },
         ));
+
+        Ok(())
+    }
+
+    /// Test that after giving up on a downstairs, setting it to faulted, and
+    /// letting it reconnect, live repair does *not* occur if the upstairs is
+    /// configured read-only.
+    #[tokio::test]
+    async fn test_no_read_only_live_repair() -> Result<()> {
+        let harness = Arc::new(TestHarness::new_ro().await?);
+
+        let (jh1, mut ds1_messages) =
+            harness.ds1().await.spawn_message_receiver().await;
+        let (_jh2, mut ds2_messages) =
+            harness.ds2.spawn_message_receiver().await;
+        let (_jh3, mut ds3_messages) =
+            harness.ds3.spawn_message_receiver().await;
+
+        // Send 200 more than IO_OUTSTANDING_MAX jobs. Flow control will kick in
+        // at MAX_ACTIVE_COUNT messages, so we need to be sending read responses
+        // while reads are being sent. After IO_OUTSTANDING_MAX jobs, the
+        // Upstairs will set ds1 to faulted, and send it no more work.
+        const NUM_JOBS: usize = IO_OUTSTANDING_MAX + 200;
+        let mut job_ids = Vec::with_capacity(NUM_JOBS);
+
+        for i in 0..NUM_JOBS {
+            {
+                let harness = harness.clone();
+
+                // We must tokio::spawn here because `read` will wait for the
+                // response to come back before returning
+                tokio::spawn(async move {
+                    let buffer = Buffer::new(512);
+                    harness
+                        .guest
+                        .read(Block::new_512(0), buffer)
+                        .await
+                        .unwrap();
+                });
+            }
+
+            if i < MAX_ACTIVE_COUNT {
+                // Before flow control kicks in, assert we're seeing the read
+                // requests
+                bail_assert!(matches!(
+                    ds1_messages.recv().await.unwrap(),
+                    Message::ReadRequest { .. },
+                ));
+            } else {
+                // After flow control kicks in, we shouldn't see any more
+                // messages
+                match ds1_messages.try_recv() {
+                    Err(TryRecvError::Empty) => {}
+                    Err(TryRecvError::Disconnected) => {}
+                    x => {
+                        info!(
+                            harness.log,
+                            "Read {i} should return EMPTY, but we got:{:?}", x
+                        );
+
+                        bail!(
+                            "Read {i} should return EMPTY, but we got:{:?}",
+                            x
+                        );
+                    }
+                }
+            }
+
+            match ds2_messages.recv().await.unwrap() {
+                Message::ReadRequest { job_id, .. } => {
+                    // Record the job ids of the read requests
+                    job_ids.push(job_id);
+                }
+
+                _ => bail!("saw non read request!"),
+            }
+
+            bail_assert!(matches!(
+                ds3_messages.recv().await.unwrap(),
+                Message::ReadRequest { .. },
+            ));
+
+            // Respond with read responses for downstairs 2 and 3
+            harness
+                .ds2
+                .fw
+                .lock()
+                .await
+                .send(Message::ReadResponse {
+                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
+                    session_id: harness
+                        .ds2
+                        .upstairs_session_id
+                        .lock()
+                        .await
+                        .unwrap(),
+                    job_id: job_ids[i],
+                    responses: Ok(vec![make_blank_read_response()]),
+                })
+                .await
+                .unwrap();
+
+            harness
+                .ds3
+                .fw
+                .lock()
+                .await
+                .send(Message::ReadResponse {
+                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
+                    session_id: harness
+                        .ds3
+                        .upstairs_session_id
+                        .lock()
+                        .await
+                        .unwrap(),
+                    job_id: job_ids[i],
+                    responses: Ok(vec![make_blank_read_response()]),
+                })
+                .await
+                .unwrap();
+        }
+
+        // Confirm that's all the Upstairs sent us (only ds2 and ds3) - with the
+        // flush_timeout set to 24 hours, we shouldn't see anything else
+        bail_assert!(matches!(
+            ds2_messages.try_recv(),
+            Err(TryRecvError::Empty)
+        ));
+        bail_assert!(matches!(
+            ds3_messages.try_recv(),
+            Err(TryRecvError::Empty)
+        ));
+
+        // Flush to clean out skipped jobs
+        {
+            let jh = {
+                let harness = harness.clone();
+
+                // We must tokio::spawn here because `flush` will wait for the
+                // response to come back before returning
+                tokio::spawn(async move {
+                    harness.guest.flush(None).await.unwrap();
+                })
+            };
+
+            let flush_job_id = match ds2_messages.recv().await.unwrap() {
+                Message::Flush { job_id, .. } => job_id,
+
+                _ => bail!("saw non flush ack!"),
+            };
+
+            bail_assert!(matches!(
+                ds3_messages.recv().await.unwrap(),
+                Message::Flush { .. },
+            ));
+
+            harness
+                .ds2
+                .fw
+                .lock()
+                .await
+                .send(Message::FlushAck {
+                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
+                    session_id: harness
+                        .ds2
+                        .upstairs_session_id
+                        .lock()
+                        .await
+                        .unwrap(),
+                    job_id: flush_job_id,
+                    result: Ok(()),
+                })
+                .await
+                .unwrap();
+
+            harness
+                .ds3
+                .fw
+                .lock()
+                .await
+                .send(Message::FlushAck {
+                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
+                    session_id: harness
+                        .ds3
+                        .upstairs_session_id
+                        .lock()
+                        .await
+                        .unwrap(),
+                    job_id: flush_job_id,
+                    result: Ok(()),
+                })
+                .await
+                .unwrap();
+
+            // Wait for the flush to come back
+            jh.await.unwrap();
+        }
+
+        // Send ds1 responses for the jobs it saw
+        for (i, job_id) in job_ids.iter().enumerate().take(MAX_ACTIVE_COUNT) {
+            match harness
+                .ds1()
+                .await
+                .fw
+                .lock()
+                .await
+                .send(Message::ReadResponse {
+                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
+                    session_id: harness
+                        .ds1()
+                        .await
+                        .upstairs_session_id
+                        .lock()
+                        .await
+                        .unwrap(),
+                    job_id: *job_id,
+                    responses: Ok(vec![make_blank_read_response()]),
+                })
+                .await
+            {
+                Ok(()) => {}
+                Err(e) => {
+                    // We should be able to send a few, but at some point
+                    // the Upstairs will disconnect us.
+                    error!(
+                        harness.log,
+                        "could not send read response for job {} = {}: {}",
+                        i,
+                        job_id,
+                        e
+                    );
+                    break;
+                }
+            }
+        }
+
+        // Assert the Upstairs isn't sending ds1 more work, because it is
+        // Faulted
+        let v = ds1_messages.try_recv();
+        match v {
+            // We're either disconnected, or the queue is empty.
+            Err(TryRecvError::Empty) | Err(TryRecvError::Disconnected) => {
+                // This is expected, continue on
+            }
+
+            _ => {
+                // Any other error (or success!) is unexpected
+                bail!("try_recv returned {:?}", v);
+            }
+        }
+
+        // Reconnect ds1
+        drop(ds1_messages);
+        jh1.abort();
+
+        let ds1 = harness.take_ds1().await;
+        let ds1 = ds1.close();
+        let ds1 = ds1.into_connected_downstairs().await;
+
+        ds1.negotiate_start().await?;
+        ds1.negotiate_step_extent_versions_please().await?;
+
+        let (_jh1, mut ds1_messages) = ds1.spawn_message_receiver().await;
+
+        // The read should be served as normal
+        {
+            error!(harness.log, "submitting final read!");
+
+            {
+                let harness = harness.clone();
+
+                // We must tokio::spawn here because `read` will wait for the
+                // response to come back before returning
+                tokio::spawn(async move {
+                    let buffer = Buffer::new(512);
+                    harness
+                        .guest
+                        .read(Block::new_512(0), buffer)
+                        .await
+                        .unwrap();
+                });
+            }
+
+            // All downstairs should see it
+
+            bail_assert!(matches!(
+                ds1_messages.recv().await.unwrap(),
+                Message::ReadRequest { .. },
+            ));
+
+            bail_assert!(matches!(
+                ds2_messages.recv().await.unwrap(),
+                Message::ReadRequest { .. },
+            ));
+
+            bail_assert!(matches!(
+                ds3_messages.recv().await.unwrap(),
+                Message::ReadRequest { .. },
+            ));
+        }
 
         Ok(())
     }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2939,7 +2939,7 @@ struct Downstairs {
      * Times we skipped repairing a downstairs because we are running
      * as read_only.
      */
-    rop_lr_skipped: ClientData<usize>,
+    ro_lr_skipped: ClientData<usize>,
 
     /**
      * Extent limit, if set, indicates the extent where LiveRepair has already
@@ -3025,7 +3025,7 @@ impl Downstairs {
             extents_confirmed: ClientData::new(0),
             live_repair_completed: ClientData::new(0),
             live_repair_aborted: ClientData::new(0),
-            rop_lr_skipped: ClientData::new(0),
+            ro_lr_skipped: ClientData::new(0),
             extent_limit: ClientMap::new(),
             repair_job_ids: BTreeMap::new(),
             repair_min_id: None,
@@ -5370,7 +5370,7 @@ impl Upstairs {
         let ds_flow_control = ds.flow_control;
         let ds_extents_repaired = ds.extents_repaired;
         let ds_extents_confirmed = ds.extents_confirmed;
-        let ds_rop_lr_skipped = ds.rop_lr_skipped;
+        let ds_ro_lr_skipped = ds.ro_lr_skipped;
 
         cdt::up__status!(|| {
             let arg = Arg {
@@ -5387,7 +5387,7 @@ impl Upstairs {
                 ds_flow_control: ds_flow_control.0,
                 ds_extents_repaired: ds_extents_repaired.0,
                 ds_extents_confirmed: ds_extents_confirmed.0,
-                ds_rop_lr_skipped: ds_rop_lr_skipped.0,
+                ds_ro_lr_skipped: ds_ro_lr_skipped.0,
             };
             (msg, arg)
         });
@@ -9922,7 +9922,7 @@ pub struct Arg {
     /// Times we have live confirmed  an extent on this downstairs.
     pub ds_extents_confirmed: [usize; 3],
     /// Times we skipped repairing a downstairs because we are read_only.
-    pub ds_rop_lr_skipped: [usize; 3],
+    pub ds_ro_lr_skipped: [usize; 3],
 }
 
 /**

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -6316,6 +6316,9 @@ impl Upstairs {
                     | DsState::Replay
                     | DsState::Repair
                     | DsState::LiveRepair => {} // Okay
+
+                    DsState::LiveRepairReady if self.read_only => {} // Okay
+
                     _ => {
                         panic!(
                             "[{}] {} Invalid transition: {:?} -> {:?}",

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2936,6 +2936,12 @@ struct Downstairs {
     live_repair_aborted: ClientData<usize>,
 
     /**
+     * Times we skipped repairing a downstairs because we are running
+     * as read_only.
+     */
+    rop_lr_skipped: ClientData<usize>,
+
+    /**
      * Extent limit, if set, indicates the extent where LiveRepair has already
      * submitted, or possibly even already finished the LiveRepair of this
      * extent. If you are changing this value, it must happen at the same
@@ -3019,6 +3025,7 @@ impl Downstairs {
             extents_confirmed: ClientData::new(0),
             live_repair_completed: ClientData::new(0),
             live_repair_aborted: ClientData::new(0),
+            rop_lr_skipped: ClientData::new(0),
             extent_limit: ClientMap::new(),
             repair_job_ids: BTreeMap::new(),
             repair_min_id: None,
@@ -5363,6 +5370,7 @@ impl Upstairs {
         let ds_flow_control = ds.flow_control;
         let ds_extents_repaired = ds.extents_repaired;
         let ds_extents_confirmed = ds.extents_confirmed;
+        let ds_rop_lr_skipped = ds.rop_lr_skipped;
 
         cdt::up__status!(|| {
             let arg = Arg {
@@ -5379,6 +5387,7 @@ impl Upstairs {
                 ds_flow_control: ds_flow_control.0,
                 ds_extents_repaired: ds_extents_repaired.0,
                 ds_extents_confirmed: ds_extents_confirmed.0,
+                ds_rop_lr_skipped: ds_rop_lr_skipped.0,
             };
             (msg, arg)
         });
@@ -9883,19 +9892,34 @@ async fn process_new_io(
  */
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Arg {
+    /// Jobs on the upstairs guest work queue.
     pub up_count: u32,
+    /// Jobs on the downstairs work queue.
     pub ds_count: u32,
+    /// State of a downstairs
     pub ds_state: [DsState; 3],
+    /// Counters for each state of a downstairs job.
     pub ds_io_count: IOStateCount,
+    /// Extents repaired during initial reconciliation.
     pub ds_reconciled: usize,
+    /// Extents still needing repair during initial reconciliation.
     pub ds_reconcile_needed: usize,
+    /// Times we have completed a LiveRepair on a downstairs.
     pub ds_live_repair_completed: [usize; 3],
+    /// Times we aborted a LiveRepair on a downstairs.
     pub ds_live_repair_aborted: [usize; 3],
+    /// Times the upstairs has connected to a downstairs.
     pub ds_connected: [usize; 3],
+    /// Times this downstairs has been replaced.
     pub ds_replaced: [usize; 3],
+    /// Times flow control has been enabled on this downstairs.
     pub ds_flow_control: [usize; 3],
+    /// Times we have live repaired an extent on this downstairs.
     pub ds_extents_repaired: [usize; 3],
+    /// Times we have live confirmed  an extent on this downstairs.
     pub ds_extents_confirmed: [usize; 3],
+    /// Times we skipped repairing a downstairs because we are read_only.
+    pub ds_rop_lr_skipped: [usize; 3],
 }
 
 /**

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -124,7 +124,7 @@ pub async fn check_for_repair(
                     cid,
                     DsState::Active,
                 );
-                ds.rop_lr_skipped[cid] += 1;
+                ds.ro_lr_skipped[cid] += 1;
             }
         }
 


### PR DESCRIPTION
Don't bother trying to live repair a read only downstairs.  If we find a read only downstairs was kicked out for being gone to long, we just let it back in, as a read only region can have no changes, so there should be nothing to repair.

This is literally the code you put into chat last week.
Or, was it Monday? 

I'm trying to come up with a simple test for this without having to do a bunch of work
spinning up real downstairs, but I'm not coming up with any good ideas.