### PR TITLE
Support multiple downstairs operations in GtoS

### DIFF
--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -756,7 +756,7 @@ async fn show_extent_block(
                     if depth < ctxs.len() {
                         if let Some(ec) = ctxs[depth] {
                             nonces.push(&ec.nonce);
-                            hex::encode(&ec.nonce)
+                            hex::encode(ec.nonce)
                         } else {
                             all_same_len = false;
                             "".to_string()
@@ -815,7 +815,7 @@ async fn show_extent_block(
                     if depth < ctxs.len() {
                         if let Some(ec) = ctxs[depth] {
                             tags.push(&ec.tag);
-                            hex::encode(&ec.tag)
+                            hex::encode(ec.tag)
                         } else {
                             all_same_len = false;
                             "".to_string()

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -5841,10 +5841,7 @@ impl Upstairs {
             extent_under_repair,
         );
 
-        let mut sub = HashMap::new();
-        sub.insert(next_id, 0);
-
-        let new_gtos = GtoS::new(sub, Vec::new(), None, HashMap::new(), req);
+        let new_gtos = GtoS::new(next_id, None, req);
         gw.active.insert(gw_id, new_gtos);
 
         cdt::up__to__ds__flush__start!(|| (gw_id));
@@ -6008,13 +6005,10 @@ impl Upstairs {
             is_write_unwritten,
         );
 
-        let mut sub = HashMap::new();
-        sub.insert(next_id, 0); // XXX does value here matter?
-
         /*
          * New work created, add to the guest_work HM
          */
-        let new_gtos = GtoS::new(sub, Vec::new(), None, HashMap::new(), req);
+        let new_gtos = GtoS::new(next_id, None, req);
         {
             gw.active.insert(gw_id, new_gtos);
         }
@@ -6111,10 +6105,6 @@ impl Upstairs {
             requests.push(ReadRequest { eid, offset });
         }
 
-        let mut sub = HashMap::new();
-
-        sub.insert(next_id, 0); // XXX does this value matter?
-
         let wr = create_read_eob(
             &mut downstairs,
             next_id,
@@ -6129,9 +6119,7 @@ impl Upstairs {
          * downstairs lists. We don't want to miss a completion from
          * downstairs.
          */
-        assert!(!sub.is_empty());
-        let new_gtos =
-            GtoS::new(sub, Vec::new(), Some(data), HashMap::new(), req);
+        let new_gtos = GtoS::new(next_id, Some(data), req);
         {
             gw.active.insert(gw_id, new_gtos);
         }
@@ -8614,31 +8602,26 @@ async fn test_return_iops() {
 #[derive(Debug)]
 struct GtoS {
     /*
-     * Jobs we have submitted (or will soon submit) to the storage side
-     * of the upstairs process to send on to the downstairs.
-     * The key for the hashmap is the ds_id number in the hashmap for
-     * downstairs work. The value is the buffer size of the operation in
-     * blocks.
+     * Jobs we have submitted to the storage side of the upstairs process to
+     * send on to the downstairs.  The key is the ds_id number in the hashmap
+     * for downstairs work.
      */
-    submitted: HashMap<JobId, u64>,
+    submitted: HashSet<JobId>,
     completed: Vec<JobId>,
 
     /*
-     * This buffer is provided by the guest request. If this is a read,
+     * These buffers are provided by the guest request. If this is a read,
      * data will be written here.
      */
-    guest_buffer: Option<Buffer>,
+    guest_buffers: HashMap<JobId, Buffer>,
 
     /*
      * When we have an IO between the guest and crucible, it's possible
      * it will be broken into two smaller requests if the range happens
      * to cross an extent boundary. This hashmap is a list of those
      * buffers with the key being the downstairs request ID.
-     *
-     * Data moving in/out of this buffer will be encrypted or decrypted
-     * depending on the operation.
      */
-    downstairs_buffer: HashMap<JobId, Vec<ReadResponse>>,
+    downstairs_responses: HashMap<JobId, Vec<ReadResponse>>,
 
     /*
      * Notify the caller waiting on the job to finish.
@@ -8653,18 +8636,36 @@ struct GtoS {
 }
 
 impl GtoS {
+    /// Create a new GtoS object where one Guest IO request maps to one
+    /// downstairs operation.
     pub fn new(
-        submitted: HashMap<JobId, u64>,
-        completed: Vec<JobId>,
+        ds_id: JobId,
         guest_buffer: Option<Buffer>,
-        downstairs_buffer: HashMap<JobId, Vec<ReadResponse>>,
+        req: Option<BlockReq>,
+    ) -> GtoS {
+        let mut submitted = HashSet::new();
+        submitted.insert(ds_id);
+
+        let mut guest_buffers = HashMap::new();
+        if let Some(guest_buffer) = guest_buffer {
+            guest_buffers.insert(ds_id, guest_buffer);
+        }
+
+        GtoS::new_bulk(submitted, guest_buffers, req)
+    }
+
+    /// Create a new GtoS object where one Guest IO request maps to many
+    /// downstairs operations.
+    pub fn new_bulk(
+        submitted: HashSet<JobId>,
+        guest_buffers: HashMap<JobId, Buffer>,
         req: Option<BlockReq>,
     ) -> GtoS {
         GtoS {
             submitted,
-            completed,
-            guest_buffer,
-            downstairs_buffer,
+            completed: Vec::new(),
+            guest_buffers,
+            downstairs_responses: HashMap::new(),
             req,
         }
     }
@@ -8676,16 +8677,22 @@ impl GtoS {
      */
     #[instrument]
     async fn transfer(&mut self) {
-        if let Some(guest_buffer) = &mut self.guest_buffer {
-            self.completed.sort_unstable();
-            assert!(!self.completed.is_empty());
+        assert!(!self.completed.is_empty());
 
-            let mut offset = 0;
-            let mut vec = guest_buffer.as_vec().await;
-            let mut owned_vec = guest_buffer.owned_vec().await;
+        for ds_id in &self.completed {
+            if let Some(guest_buffer) = self.guest_buffers.get_mut(ds_id) {
+                let mut offset = 0;
+                let mut vec = guest_buffer.as_vec().await;
+                let mut owned_vec = guest_buffer.owned_vec().await;
 
-            for ds_id in self.completed.iter() {
-                let responses = self.downstairs_buffer.remove(ds_id).unwrap();
+                /*
+                 * Should this panic?  If the caller is requesting a transfer,
+                 * the guest_buffer should exist. If it does not exist, then
+                 * either there is a real problem, or the operation was a write
+                 * or flush and why are we requesting a transfer for those.
+                 */
+                let responses =
+                    self.downstairs_responses.remove(ds_id).unwrap();
 
                 for response in responses {
                     // Copy over into guest memory.
@@ -8703,14 +8710,6 @@ impl GtoS {
                     }
                 }
             }
-        } else {
-            /*
-             * Should this panic?  If the caller is requesting a transfer,
-             * the guest_buffer should exist. If it does not exist, then
-             * either there is a real problem, or the operation was a write
-             * or flush and why are we requesting a transfer for those.
-             */
-            panic!("No guest buffer, no copy");
         }
     }
 
@@ -8774,7 +8773,7 @@ impl GuestWork {
      * we may not be done yet. When the required number of completions have
      * arrived from all the downstairs jobs we created, then we
      * can move forward with finishing up the guest work operation.
-     * This may include moving/decrypting data buffers from completed reads.
+     * This may include moving data buffers from completed reads.
      */
     #[instrument]
     async fn gw_ds_complete(
@@ -8789,14 +8788,15 @@ impl GuestWork {
          * A gw_id that already finished and results were sent back to
          * the guest could still have an outstanding ds_id.
          */
-        if let Some(mut gtos_job) = self.active.remove(&gw_id) {
+        let mut gtos_job_done = false;
+        if let Some(gtos_job) = self.active.get_mut(&gw_id) {
             /*
              * If the ds_id is on the submitted list, then we will take it
              * off and, if it is a read, add the read result
              * buffer to the gtos job structure for later
              * copying.
              */
-            if gtos_job.submitted.remove(&ds_id).is_some() {
+            if gtos_job.submitted.remove(&ds_id) {
                 if let Some(data) = data {
                     /*
                      * The first read buffer will become the source for the
@@ -8804,7 +8804,10 @@ impl GuestWork {
                      * combined with other buffers if the upstairs request
                      * required multiple jobs.
                      */
-                    if gtos_job.downstairs_buffer.insert(ds_id, data).is_some()
+                    if gtos_job
+                        .downstairs_responses
+                        .insert(ds_id, data)
+                        .is_some()
                     {
                         /*
                          * Only the first successful read should fill the
@@ -8829,26 +8832,39 @@ impl GuestWork {
                 );
             }
 
-            /*
-             * Copy (if present) read data back to the guest buffer they
-             * provided to us, and notify any waiters.
-             */
-            assert!(gtos_job.submitted.is_empty());
-            if result.is_ok() && gtos_job.guest_buffer.is_some() {
-                gtos_job.transfer().await;
+            if gtos_job.submitted.is_empty() {
+                gtos_job_done = true;
             }
-
-            gtos_job.notify(result);
-
-            self.completed.push(gw_id);
         } else {
             /*
              * XXX This is just so I can see if ever does happen.
              */
-            panic!(
-                "gw_id {} from removed job {} not on active list",
-                gw_id, ds_id
-            );
+            panic!("gw_id {} for job {} not on active list", gw_id, ds_id);
+        }
+
+        if gtos_job_done {
+            if let Some(mut gtos_job) = self.active.remove(&gw_id) {
+                /*
+                 * Copy (if present) read data back to the guest buffer they
+                 * provided to us, and notify any waiters.
+                 */
+
+                if result.is_ok() && !gtos_job.guest_buffers.is_empty() {
+                    gtos_job.transfer().await;
+                }
+
+                gtos_job.notify(result);
+
+                self.completed.push(gw_id);
+            } else {
+                /*
+                 * XXX This is just so I can see if ever does happen.
+                 */
+                panic!(
+                    "gw_id {} remove for job {} not on active list",
+                    gw_id, ds_id
+                );
+            }
         }
     }
 }

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -591,16 +591,12 @@ fn create_and_enqueue_reopen_io(
     let reopen_io =
         create_reopen_io(eid as usize, reopen_id, deps, gw_reopen_id);
 
-    let mut sub = HashMap::new();
-    sub.insert(reopen_id, 0);
-
     cdt::gw__reopen__start!(|| (gw_reopen_id, eid));
     let (send, recv) = oneshot::channel();
     let op = BlockOp::RepairOp;
     let reopen_br = BlockReq::new(op, send);
     let reopen_brw = BlockReqWaiter::new(recv);
-    let new_gtos =
-        GtoS::new(sub, Vec::new(), None, HashMap::new(), Some(reopen_br));
+    let new_gtos = GtoS::new(reopen_id, None, Some(reopen_br));
     {
         gw.active.insert(gw_reopen_id, new_gtos);
     }
@@ -633,16 +629,12 @@ fn create_and_enqueue_close_io(
         repair.to_vec(),
     );
 
-    let mut sub = HashMap::new();
-    sub.insert(close_id, 0);
-
     cdt::gw__close__start!(|| (gw_close_id, eid));
     let (send, recv) = oneshot::channel();
     let op = BlockOp::RepairOp;
     let close_br = BlockReq::new(op, send);
     let close_brw = BlockReqWaiter::new(recv);
-    let new_gtos =
-        GtoS::new(sub, Vec::new(), None, HashMap::new(), Some(close_br));
+    let new_gtos = GtoS::new(close_id, None, Some(close_br));
     {
         gw.active.insert(gw_close_id, new_gtos);
     }
@@ -671,16 +663,12 @@ fn create_and_enqueue_repair_io(
         repair,
     );
 
-    let mut sub = HashMap::new();
-    sub.insert(repair_id, 0);
-
     cdt::gw__repair__start!(|| (gw_repair_id, eid));
     let (send, recv) = oneshot::channel();
     let op = BlockOp::RepairOp;
     let repair_br = BlockReq::new(op, send);
     let repair_brw = BlockReqWaiter::new(recv);
-    let new_gtos =
-        GtoS::new(sub, Vec::new(), None, HashMap::new(), Some(repair_br));
+    let new_gtos = GtoS::new(repair_id, None, Some(repair_br));
     {
         gw.active.insert(gw_repair_id, new_gtos);
     }
@@ -697,16 +685,12 @@ fn create_and_enqueue_noop_io(
 ) -> block_req::BlockReqWaiter {
     let nio = create_noop_io(noop_id, deps, gw_noop_id);
 
-    let mut sub = HashMap::new();
-    sub.insert(noop_id, 0);
-
     cdt::gw__noop__start!(|| (gw_noop_id));
     let (send, recv) = oneshot::channel();
     let op = BlockOp::RepairOp;
     let noop_br = BlockReq::new(op, send);
     let noop_brw = BlockReqWaiter::new(recv);
-    let new_gtos =
-        GtoS::new(sub, Vec::new(), None, HashMap::new(), Some(noop_br));
+    let new_gtos = GtoS::new(noop_id, None, Some(noop_br));
     {
         gw.active.insert(gw_noop_id, new_gtos);
     }
@@ -3171,15 +3155,11 @@ pub mod repair_test {
             vec![ClientId::new(1)], // repair
         );
 
-        let mut sub = HashMap::new();
-        sub.insert(repair_ids.close_id, 0);
-
         let (send, recv) = oneshot::channel();
         let op = BlockOp::RepairOp;
         let close_br = BlockReq::new(op, send);
         let _close_brw = BlockReqWaiter::new(recv);
-        let new_gtos =
-            GtoS::new(sub, Vec::new(), None, HashMap::new(), Some(close_br));
+        let new_gtos = GtoS::new(repair_ids.close_id, None, Some(close_br));
         {
             gw.active.insert(gw_close_id, new_gtos);
         }

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -1865,9 +1865,7 @@ pub(crate) mod up_test {
             is_write_unwritten,
         );
 
-        let mut sub = HashMap::new();
-        sub.insert(next_id, 0);
-        let new_gtos = GtoS::new(sub, Vec::new(), None, HashMap::new(), None);
+        let new_gtos = GtoS::new(next_id, None, None);
         {
             gw.active.insert(gw_id, new_gtos);
         }
@@ -1960,9 +1958,7 @@ pub(crate) mod up_test {
             is_write_unwritten,
         );
 
-        let mut sub = HashMap::new();
-        sub.insert(next_id, 0);
-        let new_gtos = GtoS::new(sub, Vec::new(), None, HashMap::new(), None);
+        let new_gtos = GtoS::new(next_id, None, None);
         {
             gw.active.insert(gw_id, new_gtos);
         }
@@ -2042,9 +2038,7 @@ pub(crate) mod up_test {
             is_write_unwritten,
         );
 
-        let mut sub = HashMap::new();
-        sub.insert(next_id, 0);
-        let new_gtos = GtoS::new(sub, Vec::new(), None, HashMap::new(), None);
+        let new_gtos = GtoS::new(next_id, None, None);
         {
             gw.active.insert(gw_id, new_gtos);
         }
@@ -2129,9 +2123,7 @@ pub(crate) mod up_test {
             None, None,
         );
 
-        let mut sub = HashMap::new();
-        sub.insert(next_id, 0);
-        let new_gtos = GtoS::new(sub, Vec::new(), None, HashMap::new(), None);
+        let new_gtos = GtoS::new(next_id, None, None);
         {
             gw.active.insert(gw_id, new_gtos);
         }
@@ -2210,9 +2202,7 @@ pub(crate) mod up_test {
             None, None,
         );
 
-        let mut sub = HashMap::new();
-        sub.insert(next_id, 0);
-        let new_gtos = GtoS::new(sub, Vec::new(), None, HashMap::new(), None);
+        let new_gtos = GtoS::new(next_id, None, None);
         {
             gw.active.insert(gw_id, new_gtos);
         }
@@ -2278,9 +2268,7 @@ pub(crate) mod up_test {
             None, None,
         );
 
-        let mut sub = HashMap::new();
-        sub.insert(next_id, 0);
-        let new_gtos = GtoS::new(sub, Vec::new(), None, HashMap::new(), None);
+        let new_gtos = GtoS::new(next_id, None, None);
         {
             gw.active.insert(gw_id, new_gtos);
         }
@@ -9000,5 +8988,86 @@ pub(crate) mod up_test {
 
         // assert write depends on just the flush
         assert_eq!(jobs[2].work.deps(), &[jobs[1].ds_id]); // op 2
+    }
+
+    // Test that multiple GtoS downstairs jobs work
+    #[tokio::test]
+    async fn test_multiple_gtos_bulk_read_read() {
+        let up = Upstairs::test_default(None);
+        up.set_active().await.unwrap();
+        for cid in ClientId::iter() {
+            up.ds_transition(cid, DsState::WaitActive).await;
+            up.ds_transition(cid, DsState::WaitQuorum).await;
+            up.ds_transition(cid, DsState::Active).await;
+        }
+
+        let mut gw = up.guest.guest_work.lock().await;
+
+        let gw_id = 12345;
+
+        // Create two reads
+        let first_id = JobId(1010);
+        let second_id = JobId(1011);
+
+        let mut data_buffers = HashMap::new();
+        data_buffers.insert(first_id, Buffer::new(512));
+        data_buffers.insert(second_id, Buffer::new(512));
+
+        let mut sub = HashSet::new();
+        sub.insert(first_id);
+        sub.insert(second_id);
+
+        let guest_job = GtoS::new_bulk(sub, data_buffers.clone(), None);
+
+        gw.active.insert(gw_id, guest_job);
+
+        let mut first_response_data = BytesMut::with_capacity(512);
+        first_response_data.resize(512, 0u8);
+        thread_rng().fill(&mut first_response_data[..]);
+        let first_read_response_hash =
+            integrity_hash(&[&first_response_data[..]]);
+
+        let mut second_response_data = BytesMut::with_capacity(512);
+        second_response_data.resize(512, 0u8);
+        thread_rng().fill(&mut second_response_data[..]);
+        let second_read_response_hash =
+            integrity_hash(&[&second_response_data[..]]);
+
+        let first_response = Some(vec![ReadResponse {
+            eid: 0,
+            offset: Block::new_512(0),
+            data: first_response_data.clone(),
+            block_contexts: vec![BlockContext {
+                hash: first_read_response_hash,
+                encryption_context: None,
+            }],
+        }]);
+
+        let second_response = Some(vec![ReadResponse {
+            eid: 0,
+            offset: Block::new_512(0),
+            data: second_response_data.clone(),
+            block_contexts: vec![BlockContext {
+                hash: second_read_response_hash,
+                encryption_context: None,
+            }],
+        }]);
+
+        gw.gw_ds_complete(gw_id, first_id, first_response, Ok(()), &up.log)
+            .await;
+        assert!(!gw.completed.contains(&gw_id));
+
+        gw.gw_ds_complete(gw_id, second_id, second_response, Ok(()), &up.log)
+            .await;
+        assert!(gw.completed.contains(&gw_id));
+
+        assert_eq!(
+            *data_buffers.get(&first_id).unwrap().as_vec().await,
+            first_response_data.to_vec()
+        );
+        assert_eq!(
+            *data_buffers.get(&second_id).unwrap().as_vec().await,
+            second_response_data.to_vec()
+        );
     }
 }


### PR DESCRIPTION
GtoS' purpose is to map the Guest IO request to the downstairs operations required to fulfill it. Part of the work to implement and test guest initiated bulk operations involved using GtoS with many downstairs operations instead of just one, and this required changing GtoS' struct plus fixing `transfer` and `gw_ds_complete` to actually support multiple reads.  Those changes, along with a few quality of life improvements, were pulled out into this commit.