### PR TITLE
[workspace-hack] use workspace-dotted format and a patch directive

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -1,10 +1,12 @@
 # This file contains settings for `cargo hakari`.
 # See https://docs.rs/cargo-hakari/latest/cargo_hakari/config for a full list of options.
 
-hakari-package = "workspace-hack"
+hakari-package = "crucible-workspace-hack"
 
 # Format version for hakari's output. Version 4 requires cargo-hakari 0.9.22 or above.
 dep-format-version = "4"
+
+workspace-hack-line-style = "workspace-dotted"
 
 # Setting workspace.resolver = "2" in the root Cargo.toml is HIGHLY recommended.
 # Hakari works much better with the new feature resolver.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,9 +556,9 @@ dependencies = [
  "crucible",
  "crucible-control-client",
  "crucible-protocol",
+ "crucible-workspace-hack",
  "serde_json",
  "tokio",
- "workspace-hack",
 ]
 
 [[package]]
@@ -705,6 +705,7 @@ dependencies = [
  "crucible-client-types",
  "crucible-common",
  "crucible-protocol",
+ "crucible-workspace-hack",
  "dropshot",
  "expectorate",
  "futures",
@@ -739,7 +740,6 @@ dependencies = [
  "usdt",
  "uuid",
  "version_check",
- "workspace-hack",
 ]
 
 [[package]]
@@ -751,6 +751,7 @@ dependencies = [
  "clap",
  "crucible-common",
  "crucible-smf",
+ "crucible-workspace-hack",
  "dropshot",
  "expectorate",
  "futures",
@@ -768,7 +769,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "uuid",
- "workspace-hack",
 ]
 
 [[package]]
@@ -777,13 +777,13 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "chrono",
+ "crucible-workspace-hack",
  "percent-encoding",
  "progenitor",
  "reqwest",
  "schemars",
  "serde",
  "serde_json",
- "workspace-hack",
 ]
 
 [[package]]
@@ -791,11 +791,11 @@ name = "crucible-client-types"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.4",
+ "crucible-workspace-hack",
  "schemars",
  "serde",
  "serde_json",
  "uuid",
- "workspace-hack",
 ]
 
 [[package]]
@@ -804,6 +804,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "atty",
+ "crucible-workspace-hack",
  "nix",
  "rusqlite",
  "rustls-pemfile",
@@ -822,7 +823,6 @@ dependencies = [
  "twox-hash",
  "uuid",
  "vergen",
- "workspace-hack",
 ]
 
 [[package]]
@@ -830,13 +830,13 @@ name = "crucible-control-client"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "crucible-workspace-hack",
  "percent-encoding",
  "progenitor",
  "reqwest",
  "schemars",
  "serde",
  "serde_json",
- "workspace-hack",
 ]
 
 [[package]]
@@ -851,6 +851,7 @@ dependencies = [
  "crucible",
  "crucible-common",
  "crucible-protocol",
+ "crucible-workspace-hack",
  "dropshot",
  "expectorate",
  "futures",
@@ -895,7 +896,6 @@ dependencies = [
  "usdt",
  "uuid",
  "version_check",
- "workspace-hack",
 ]
 
 [[package]]
@@ -907,6 +907,7 @@ dependencies = [
  "clap",
  "crucible",
  "crucible-common",
+ "crucible-workspace-hack",
  "opentelemetry 0.20.0",
  "opentelemetry-jaeger",
  "rand 0.8.5",
@@ -914,7 +915,6 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
- "workspace-hack",
 ]
 
 [[package]]
@@ -929,6 +929,7 @@ dependencies = [
  "crucible-downstairs",
  "crucible-pantry",
  "crucible-pantry-client",
+ "crucible-workspace-hack",
  "futures",
  "futures-core",
  "hex",
@@ -945,7 +946,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "uuid",
- "workspace-hack",
 ]
 
 [[package]]
@@ -958,6 +958,7 @@ dependencies = [
  "crucible",
  "crucible-common",
  "crucible-protocol",
+ "crucible-workspace-hack",
  "futures",
  "futures-core",
  "nbd",
@@ -967,7 +968,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml 0.8.0",
- "workspace-hack",
 ]
 
 [[package]]
@@ -975,9 +975,9 @@ name = "crucible-package"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "crucible-workspace-hack",
  "omicron-zone-package",
  "tokio",
- "workspace-hack",
 ]
 
 [[package]]
@@ -991,6 +991,7 @@ dependencies = [
  "crucible",
  "crucible-common",
  "crucible-smf",
+ "crucible-workspace-hack",
  "dropshot",
  "expectorate",
  "futures",
@@ -1009,7 +1010,6 @@ dependencies = [
  "subprocess",
  "tokio",
  "uuid",
- "workspace-hack",
 ]
 
 [[package]]
@@ -1018,6 +1018,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "chrono",
+ "crucible-workspace-hack",
  "percent-encoding",
  "progenitor",
  "reqwest",
@@ -1025,7 +1026,6 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid",
- "workspace-hack",
 ]
 
 [[package]]
@@ -1036,23 +1036,77 @@ dependencies = [
  "bincode",
  "bytes",
  "crucible-common",
+ "crucible-workspace-hack",
  "num_enum",
  "schemars",
  "serde",
  "tokio-util",
  "uuid",
- "workspace-hack",
 ]
 
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
 dependencies = [
+ "crucible-workspace-hack",
  "libc",
  "num-derive",
  "num-traits",
  "thiserror",
- "workspace-hack",
+]
+
+[[package]]
+name = "crucible-workspace-hack"
+version = "0.1.0"
+dependencies = [
+ "bitflags 2.3.3",
+ "bytes",
+ "cc",
+ "chrono",
+ "console",
+ "crossbeam-utils",
+ "crypto-common",
+ "digest 0.10.6",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-sink",
+ "futures-util",
+ "getrandom",
+ "hashbrown 0.12.3",
+ "hex",
+ "hyper",
+ "indexmap 1.9.3",
+ "libc",
+ "log",
+ "mio",
+ "num-traits",
+ "once_cell",
+ "openapiv3",
+ "parking_lot",
+ "phf_shared 0.11.1",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "reqwest",
+ "rustls",
+ "schemars",
+ "semver 1.0.18",
+ "serde",
+ "slog",
+ "syn 1.0.107",
+ "syn 2.0.23",
+ "time 0.3.23",
+ "time-macros",
+ "tokio",
+ "tokio-util",
+ "toml_datetime",
+ "toml_edit 0.19.12",
+ "tracing",
+ "tracing-core",
+ "usdt",
+ "uuid",
 ]
 
 [[package]]
@@ -1065,6 +1119,7 @@ dependencies = [
  "crucible",
  "crucible-common",
  "crucible-protocol",
+ "crucible-workspace-hack",
  "futures",
  "futures-core",
  "ringbuffer",
@@ -1075,7 +1130,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml 0.8.0",
- "workspace-hack",
 ]
 
 [[package]]
@@ -1090,6 +1144,7 @@ dependencies = [
  "crucible",
  "crucible-common",
  "crucible-protocol",
+ "crucible-workspace-hack",
  "csv",
  "dropshot",
  "dsc-client",
@@ -1113,7 +1168,6 @@ dependencies = [
  "tokio-util",
  "toml 0.8.0",
  "uuid",
- "workspace-hack",
 ]
 
 [[package]]
@@ -1344,6 +1398,7 @@ dependencies = [
  "anyhow",
  "byte-unit",
  "clap",
+ "crucible-workspace-hack",
  "csv",
  "dropshot",
  "dsc-client",
@@ -1358,7 +1413,6 @@ dependencies = [
  "statistical",
  "tempfile",
  "tokio",
- "workspace-hack",
 ]
 
 [[package]]
@@ -1366,13 +1420,13 @@ name = "dsc-client"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "crucible-workspace-hack",
  "percent-encoding",
  "progenitor",
  "reqwest",
  "schemars",
  "serde",
  "serde_json",
- "workspace-hack",
 ]
 
 [[package]]
@@ -2235,11 +2289,11 @@ dependencies = [
  "clap",
  "crucible",
  "crucible-common",
+ "crucible-workspace-hack",
  "rand 0.8.5",
  "statistical",
  "tokio",
  "uuid",
- "workspace-hack",
 ]
 
 [[package]]
@@ -3565,13 +3619,13 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "chrono",
+ "crucible-workspace-hack",
  "percent-encoding",
  "progenitor",
  "reqwest",
  "schemars",
  "serde",
  "serde_json",
- "workspace-hack",
 ]
 
 [[package]]
@@ -5634,60 +5688,6 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "workspace-hack"
-version = "0.1.0"
-dependencies = [
- "bitflags 2.3.3",
- "bytes",
- "cc",
- "chrono",
- "console",
- "crossbeam-utils",
- "crypto-common",
- "digest 0.10.6",
- "either",
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-sink",
- "futures-util",
- "getrandom",
- "hashbrown 0.12.3",
- "hex",
- "hyper",
- "indexmap 1.9.3",
- "libc",
- "log",
- "mio",
- "num-traits",
- "once_cell",
- "openapiv3",
- "parking_lot",
- "phf_shared 0.11.1",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
- "reqwest",
- "rustls",
- "schemars",
- "semver 1.0.18",
- "serde",
- "slog",
- "syn 1.0.107",
- "syn 2.0.23",
- "time 0.3.23",
- "time-macros",
- "tokio",
- "tokio-util",
- "toml_datetime",
- "toml_edit 0.19.12",
- "tracing",
- "tracing-core",
- "usdt",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ chrono = { version = "0.4", features = [ "serde" ] }
 clap = { version = "4.4", features = ["derive", "env", "wrap_help"] }
 clearscreen = "2.0.1"
 crossterm = { version = "0.27.0" }
+crucible-workspace-hack = "0.1.0"  # see [patch.crates-io.crucible-workspace-hack] for more
 csv = "1.2.2"
 expectorate = "1.0.7"
 futures = "0.3"
@@ -126,3 +127,10 @@ repair-client = { path = "./repair-client" }
 
 [profile.dev]
 panic = 'abort'
+
+# Using the workspace-hack via this patch directive means that it only applies
+# while building within this workspace. If another workspace imports a crate
+# from here via a git dependency, it will not have the workspace-hack applied
+# to it.
+[patch.crates-io.crucible-workspace-hack]
+path = "workspace-hack"

--- a/agent-client/Cargo.toml
+++ b/agent-client/Cargo.toml
@@ -13,5 +13,4 @@ reqwest.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
-
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/agent-client/Cargo.toml
+++ b/agent-client/Cargo.toml
@@ -13,4 +13,4 @@ reqwest.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -21,7 +21,7 @@ serde_json.workspace = true
 slog.workspace = true
 tokio.workspace = true
 uuid.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -21,7 +21,7 @@ serde_json.workspace = true
 slog.workspace = true
 tokio.workspace = true
 uuid.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/cmon/Cargo.toml
+++ b/cmon/Cargo.toml
@@ -12,4 +12,4 @@ crucible-control-client.workspace = true
 crucible-protocol.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true

--- a/cmon/Cargo.toml
+++ b/cmon/Cargo.toml
@@ -12,4 +12,4 @@ crucible-control-client.workspace = true
 crucible-protocol.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -25,7 +25,7 @@ tokio-rustls.workspace = true
 toml.workspace = true
 twox-hash.workspace = true
 uuid.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true
 
 [build-dependencies]
 vergen = { version = "8.2", features = ["cargo", "git", "git2", "rustc" ] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -25,7 +25,7 @@ tokio-rustls.workspace = true
 toml.workspace = true
 twox-hash.workspace = true
 uuid.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [build-dependencies]
 vergen = { version = "8.2", features = ["cargo", "git", "git2", "rustc" ] }

--- a/control-client/Cargo.toml
+++ b/control-client/Cargo.toml
@@ -12,5 +12,4 @@ reqwest.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
-
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/control-client/Cargo.toml
+++ b/control-client/Cargo.toml
@@ -12,4 +12,4 @@ reqwest.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true

--- a/crucible-client-types/Cargo.toml
+++ b/crucible-client-types/Cargo.toml
@@ -9,4 +9,4 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crucible-client-types/Cargo.toml
+++ b/crucible-client-types/Cargo.toml
@@ -9,4 +9,4 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true

--- a/crudd/Cargo.toml
+++ b/crudd/Cargo.toml
@@ -22,4 +22,4 @@ signal-hook.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
 toml.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crudd/Cargo.toml
+++ b/crudd/Cargo.toml
@@ -22,4 +22,4 @@ signal-hook.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
 toml.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true

--- a/crutest/Cargo.toml
+++ b/crutest/Cargo.toml
@@ -37,4 +37,4 @@ tokio-util.workspace = true
 tokio.workspace = true
 toml.workspace = true
 uuid.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/crutest/Cargo.toml
+++ b/crutest/Cargo.toml
@@ -37,4 +37,4 @@ tokio-util.workspace = true
 tokio.workspace = true
 toml.workspace = true
 uuid.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -53,7 +53,7 @@ tracing-subscriber.workspace = true
 tracing.workspace = true
 usdt.workspace = true
 uuid.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -53,7 +53,7 @@ tracing-subscriber.workspace = true
 tracing.workspace = true
 usdt.workspace = true
 uuid.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/dsc-client/Cargo.toml
+++ b/dsc-client/Cargo.toml
@@ -12,4 +12,4 @@ reqwest.workspace = true
 schemars.workspace = true
 serde_json.workspace = true
 serde.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true

--- a/dsc-client/Cargo.toml
+++ b/dsc-client/Cargo.toml
@@ -12,5 +12,4 @@ reqwest.workspace = true
 schemars.workspace = true
 serde_json.workspace = true
 serde.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
-
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -17,7 +17,7 @@ schemars.workspace = true
 serde.workspace = true
 statistical.workspace = true
 tokio.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -17,7 +17,7 @@ schemars.workspace = true
 serde.workspace = true
 statistical.workspace = true
 tokio.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/hammer/Cargo.toml
+++ b/hammer/Cargo.toml
@@ -19,4 +19,4 @@ opentelemetry-jaeger.workspace = true
 tracing-subscriber.workspace = true
 tracing-opentelemetry.workspace = true
 uuid.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/hammer/Cargo.toml
+++ b/hammer/Cargo.toml
@@ -19,4 +19,4 @@ opentelemetry-jaeger.workspace = true
 tracing-subscriber.workspace = true
 tracing-opentelemetry.workspace = true
 uuid.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -38,4 +38,4 @@ tokio.workspace = true
 uuid.workspace = true
 
 [dependencies]
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -38,4 +38,4 @@ tokio.workspace = true
 uuid.workspace = true
 
 [dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/measure_iops/Cargo.toml
+++ b/measure_iops/Cargo.toml
@@ -14,4 +14,4 @@ rand.workspace = true
 tokio.workspace = true
 statistical.workspace = true
 uuid.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/measure_iops/Cargo.toml
+++ b/measure_iops/Cargo.toml
@@ -14,4 +14,4 @@ rand.workspace = true
 tokio.workspace = true
 statistical.workspace = true
 uuid.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true

--- a/nbd_server/Cargo.toml
+++ b/nbd_server/Cargo.toml
@@ -21,4 +21,4 @@ serde_json.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
 toml.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/nbd_server/Cargo.toml
+++ b/nbd_server/Cargo.toml
@@ -21,4 +21,4 @@ serde_json.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
 toml.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 anyhow.workspace = true
 omicron-zone-package.workspace = true
 tokio.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 anyhow.workspace = true
 omicron-zone-package.workspace = true
 tokio.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/pantry-client/Cargo.toml
+++ b/pantry-client/Cargo.toml
@@ -14,4 +14,4 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true

--- a/pantry-client/Cargo.toml
+++ b/pantry-client/Cargo.toml
@@ -14,5 +14,4 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
-
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/pantry/Cargo.toml
+++ b/pantry/Cargo.toml
@@ -26,7 +26,7 @@ uuid.workspace = true
 reqwest.workspace = true
 hex.workspace = true
 sha2.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/pantry/Cargo.toml
+++ b/pantry/Cargo.toml
@@ -26,7 +26,7 @@ uuid.workspace = true
 reqwest.workspace = true
 hex.workspace = true
 sha2.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -15,4 +15,4 @@ schemars.workspace = true
 serde.workspace = true
 tokio-util.workspace = true
 uuid.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -15,4 +15,4 @@ schemars.workspace = true
 serde.workspace = true
 tokio-util.workspace = true
 uuid.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/repair-client/Cargo.toml
+++ b/repair-client/Cargo.toml
@@ -13,5 +13,4 @@ reqwest.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
-
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/repair-client/Cargo.toml
+++ b/repair-client/Cargo.toml
@@ -13,4 +13,4 @@ reqwest.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true

--- a/smf/Cargo.toml
+++ b/smf/Cargo.toml
@@ -8,4 +8,4 @@ libc.workspace = true
 thiserror.workspace = true
 num-traits.workspace = true
 num-derive.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true

--- a/smf/Cargo.toml
+++ b/smf/Cargo.toml
@@ -8,4 +8,4 @@ libc.workspace = true
 thiserror.workspace = true
 num-traits.workspace = true
 num-derive.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/upstairs/Cargo.toml
+++ b/upstairs/Cargo.toml
@@ -49,7 +49,7 @@ uuid.workspace = true
 aes-gcm-siv.workspace = true
 rand_chacha.workspace = true
 reqwest.workspace = true
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/upstairs/Cargo.toml
+++ b/upstairs/Cargo.toml
@@ -49,7 +49,7 @@ uuid.workspace = true
 aes-gcm-siv.workspace = true
 rand_chacha.workspace = true
 reqwest.workspace = true
-crucible-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+crucible-workspace-hack.workspace = true
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -3,7 +3,7 @@
 #     cargo hakari generate
 
 [package]
-name = "workspace-hack"
+name = "crucible-workspace-hack"
 version = "0.1.0"
 description = "workspace-hack package, managed by hakari"
 # You can choose to publish this crate: see https://docs.rs/cargo-hakari/latest/cargo_hakari/publishing.


### PR DESCRIPTION
Similar to https://github.com/oxidecomputer/omicron/pull/4197, this PR
has two changes:

1. Switch to the workspace-dotted format (`.workspace = true`) for
   uniformity with the rest of crucible. This is new in cargo-hakari
   0.9.28.

2. Use a patch directive, which means that the workspace-hack only
   applies while building within this workspace. If another workspace
   imports a crate from here via a git dependency, it will not have the
   workspace-hack applied to it (instead, it will use [this empty crate](https://crates.io/crates/crucible-workspace-hack)
   on crates.io). Thanks so much to @pfmooney for this
   suggestion!
