### PR TITLE
report backpressure in upstairs_info dtrace probe

### DIFF
--- a/tools/dtrace/upstairs_info.d
+++ b/tools/dtrace/upstairs_info.d
@@ -18,11 +18,11 @@ tick-1s
 /show > 20/
 {
     printf("%17s %17s %17s", "DS STATE 0", "DS STATE 1", "DS STATE 2");
-    printf("  %4s %4s", "UPW", "DSW");
-    printf("  %4s %4s %4s", "NEW0", "NEW1", "NEW2");
-    printf("  %4s %4s %4s", "IP0", "IP1", "IP2");
-    printf("  %4s %4s %4s", "D0", "D1", "D2");
-    printf("  %4s %4s %4s", "S0", "S1", "S2");
+    printf("  %5s %5s %5s", "UPW", "DSW", "BAKPR");
+    printf("  %5s %5s %5s", "NEW0", "NEW1", "NEW2");
+    printf("  %5s %5s %5s", "IP0", "IP1", "IP2");
+    printf("  %5s %5s %5s", "D0", "D1", "D2");
+    printf("  %5s %5s %5s", "S0", "S1", "S2");
     printf("  %2s %2s %2s", "E0", "E1", "E2");
     printf("\n");
     show = 0;
@@ -42,40 +42,41 @@ crucible_upstairs*:::up-status
      * Work queue counts for Upstairs and Downstairs
      */
     printf(" ");
-    printf(" %4s", json(copyinstr(arg1), "ok.up_count"));
-    printf(" %4s", json(copyinstr(arg1), "ok.ds_count"));
+    printf(" %5s", json(copyinstr(arg1), "ok.up_count"));
+    printf(" %5s", json(copyinstr(arg1), "ok.ds_count"));
+    printf(" %5s", json(copyinstr(arg1), "ok.up_backpressure"));
 
     /*
      * New jobs on the work list for each downstairs
      */
     printf(" ");
-    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.new[0]"));
-    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.new[1]"));
-    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.new[2]"));
+    printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.new[0]"));
+    printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.new[1]"));
+    printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.new[2]"));
 
     /*
      * In progress jobs on the work list for each downstairs
      */
     printf(" ");
-    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.in_progress[0]"));
-    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.in_progress[1]"));
-    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.in_progress[2]"));
+    printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.in_progress[0]"));
+    printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.in_progress[1]"));
+    printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.in_progress[2]"));
 
     /*
      * Completed (done) jobs on the work list for each downstairs
      */
     printf(" ");
-    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.done[0]"));
-    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.done[1]"));
-    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.done[2]"));
+    printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.done[0]"));
+    printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.done[1]"));
+    printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.done[2]"));
 
     /*
      * Skipped jobs on the work list for each downstairs
      */
     printf(" ");
-    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.skipped[0]"));
-    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.skipped[1]"));
-    printf(" %4s", json(copyinstr(arg1), "ok.ds_io_count.skipped[2]"));
+    printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.skipped[0]"));
+    printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.skipped[1]"));
+    printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.skipped[2]"));
 
     /*
      * Jobs that are done with errors on the work list for each downstairs

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -5370,10 +5370,12 @@ impl Upstairs {
         let ds_flow_control = ds.flow_control;
         let ds_extents_repaired = ds.extents_repaired;
         let ds_extents_confirmed = ds.extents_confirmed;
+        let up_backpressure = self.guest.backpressure_us.load(Ordering::SeqCst);
 
         cdt::up__status!(|| {
             let arg = Arg {
                 up_count,
+                up_backpressure,
                 ds_count,
                 ds_state: ds_state.0,
                 ds_io_count,
@@ -9892,6 +9894,7 @@ async fn process_new_io(
 pub struct Arg {
     pub up_count: u32,
     pub ds_count: u32,
+    pub up_backpressure: u64,
     pub ds_state: [DsState; 3],
     pub ds_io_count: IOStateCount,
     pub ds_reconciled: usize,


### PR DESCRIPTION
also expand columns to %5s from %4s

as discussed in chat. thanks matt.