### PR TITLE
Better backpressure

### DIFF
--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -485,9 +485,7 @@ pub(crate) mod protocol_test {
 
             // Configure our guest without backpressure, to speed up tests which
             // require triggering a timeout
-            let mut g = Guest::new();
-            g.backpressure_config.max_delay = Duration::ZERO;
-            let guest = Arc::new(g);
+            let guest = Arc::new(Guest::new());
 
             let crucible_opts = CrucibleOpts {
                 id: Uuid::new_v4(),

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -483,9 +483,11 @@ pub(crate) mod protocol_test {
                 ds3.set_read_only();
             }
 
-            // Configure our guest without backpressure, to speed up tests which
-            // require triggering a timeout
-            let guest = Arc::new(Guest::new());
+            // Configure our guest without queue backpressure, to speed up tests
+            // which require triggering a timeout
+            let mut g = Guest::new();
+            g.backpressure_config.queue_max_delay = Duration::ZERO;
+            let guest = Arc::new(g);
 
             let crucible_opts = CrucibleOpts {
                 id: Uuid::new_v4(),

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -8964,6 +8964,14 @@ pub struct Guest {
 
     /// Backpressure configuration, as a starting point and max delay
     backpressure_config: BackpressureConfig,
+
+    /// Lock held during backpressure delay
+    ///
+    /// Without this lock, multiple tasks could submit jobs to the upstairs and
+    /// wait in parallel, which defeats the purpose of backpressure (since you
+    /// could send arbitrarily many jobs at high speed by sending them from
+    /// different tasks).
+    backpressure_lock: Mutex<()>,
 }
 
 /// Configuration for host-side backpressure
@@ -9008,12 +9016,13 @@ impl Guest {
             bw_limit: None,
 
             block_size: AtomicU64::new(0),
-            backpressure_us: AtomicU64::new(0),
 
+            backpressure_us: AtomicU64::new(0),
             backpressure_config: BackpressureConfig {
                 start: 0.5,
                 max_delay: Duration::from_millis(5),
             },
+            backpressure_lock: Mutex::new(()),
         }
     }
 
@@ -9046,7 +9055,9 @@ impl Guest {
         let bp =
             Duration::from_micros(self.backpressure_us.load(Ordering::SeqCst));
         if bp > Duration::ZERO {
+            let _guard = self.backpressure_lock.lock().await;
             tokio::time::sleep(bp).await;
+            drop(_guard);
         }
 
         self.reqs.lock().await.push_back(BlockReq::new(op, send));

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -9035,13 +9035,13 @@ pub struct Guest {
 ///
 /// Backpressure adds an artificial delay to host write messages (which are
 /// otherwise acked immediately, before actually being complete).  The delay is
-/// varied based on "number of write bytes outstanding", using a quadratic
-/// weight parameterized here.
+/// varied based on two metrics:
 ///
-/// To be precise, backpressure delay in usec is given by
-/// ```
-/// ((bytes - start) * scale)**2
-/// ```
+/// - number of write bytes outstanding
+/// - queue length as a fraction (where 1.0 is full)
+///
+/// These two metrics are used for quadratic backpressure, picking the larger of
+/// the two delays.
 #[derive(Copy, Clone, Debug)]
 struct BackpressureConfig {
     /// When should backpressure start (in bytes)?

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -4804,7 +4804,8 @@ impl Downstairs {
                 match &job.work {
                     IOop::Write { writes, .. }
                     | IOop::WriteUnwritten { writes, .. } => {
-                        self.write_bytes_outstanding
+                        self.write_bytes_outstanding = self
+                            .write_bytes_outstanding
                             .checked_sub(
                                 writes
                                     .iter()

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -3728,10 +3728,8 @@ impl Downstairs {
         match &io.work {
             IOop::Write { writes, .. }
             | IOop::WriteUnwritten { writes, .. } => {
-                if let Some(f) = writes.get(0) {
-                    self.write_bytes_outstanding +=
-                        writes.iter().map(|w| w.data.len() as u64).sum::<u64>();
-                }
+                self.write_bytes_outstanding +=
+                    writes.iter().map(|w| w.data.len() as u64).sum::<u64>();
             }
             _ => (),
         };

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2858,6 +2858,17 @@ struct Downstairs {
      */
     ds_skipped_jobs: ClientData<HashSet<JobId>>,
 
+    /// The number of write bytes that haven't finished yet
+    ///
+    /// This is used to configure backpressure to the host, because writes
+    /// (uniquely) will return before actually being completed by a Downstairs
+    /// and can clog up the queues.
+    ///
+    /// It is stored in the Downstairs because from the perspective of the
+    /// Upstairs, writes complete immediately; only the Downstairs is actually
+    /// tracking the pending jobs.
+    write_bytes_outstanding: u64,
+
     /**
      * The next Job ID this Upstairs should use for downstairs work.
      */
@@ -3017,6 +3028,7 @@ impl Downstairs {
             ds_active: ActiveJobs::new(),
             ds_new: ClientData::new(BTreeSet::new()),
             ds_skipped_jobs: ClientData::new(HashSet::new()),
+            write_bytes_outstanding: 0,
             completed: AllocRingBuffer::new(2048),
             completed_jobs: AllocRingBuffer::new(8),
             next_id: JobId(1000),
@@ -3710,6 +3722,19 @@ impl Downstairs {
                 }
             }
         }
+
+        // If this is a write (which will be fast-acked), increment our byte
+        // counter for backpressure calculations.
+        match &io.work {
+            IOop::Write { writes, .. }
+            | IOop::WriteUnwritten { writes, .. } => {
+                if let Some(f) = writes.get(0) {
+                    self.write_bytes_outstanding += writes.len() as u64
+                        * f.offset.block_size_in_bytes() as u64;
+                }
+            }
+            _ => (),
+        };
 
         // Puts the IO onto the downstairs work queue.
         let ds_id = io.ds_id;
@@ -4776,7 +4801,22 @@ impl Downstairs {
             }
             // Now that we've collected jobs to retire, remove them from the map
             for &id in &retired {
-                let _ = self.ds_active.remove(&id);
+                let job = self.ds_active.remove(&id);
+                // Update pending bytes when this job is retired
+                match &job.work {
+                    IOop::Write { writes, .. }
+                    | IOop::WriteUnwritten { writes, .. } => {
+                        if let Some(f) = writes.get(0) {
+                            self.write_bytes_outstanding
+                                .checked_sub(
+                                    writes.len() as u64
+                                        * f.offset.block_size_in_bytes() as u64,
+                                )
+                                .unwrap();
+                        }
+                    }
+                    _ => (),
+                }
             }
 
             debug!(self.log, "[rc] retire {} clears {:?}", ds_id, retired);
@@ -5858,6 +5898,10 @@ impl Upstairs {
         cdt::up__to__ds__flush__start!(|| (gw_id));
         downstairs.enqueue(fl, ds_done_tx).await;
 
+        // While we've got the lock, update our current backpressure
+        self.guest
+            .set_backpressure(downstairs.write_bytes_outstanding);
+
         Ok(())
     }
 
@@ -5902,6 +5946,10 @@ impl Upstairs {
         let mut gw = self.guest.guest_work.lock().await;
         let mut downstairs = self.downstairs.lock().await;
         let ddef = self.ddef.lock().await.get_def().unwrap();
+
+        // While we've got the lock, update our current backpressure
+        self.guest
+            .set_backpressure(downstairs.write_bytes_outstanding);
 
         /*
          * Verify IO is in range for our region.  If not give up now and
@@ -8959,7 +9007,7 @@ pub struct Guest {
     /// it can be read from a `&self` reference.
     block_size: AtomicU64,
 
-    /// Backpressure is implemented as a delay on host operations
+    /// Backpressure is implemented as a delay on host write operations
     backpressure_us: AtomicU64,
 
     /// Backpressure configuration, as a starting point and max delay
@@ -8976,12 +9024,21 @@ pub struct Guest {
 
 /// Configuration for host-side backpressure
 ///
-/// Backpressure adds an artificial delay to host messages to maintain the
-/// downstairs queue at a particular length.
+/// Backpressure adds an artificial delay to host write messages (which are
+/// otherwise acked immediately, before actually being complete).  The delay is
+/// varied based on "number of write bytes outstanding", using a quadratic
+/// weight parameterized here.
+///
+/// To be precise, backpressure delay in usec is given by
+/// ```
+/// ((bytes - start) * scale)**2
+/// ```
 #[derive(Copy, Clone, Debug)]
 struct BackpressureConfig {
-    start: f32,
-    max_delay: Duration,
+    /// When should backpressure start (in bytes)?
+    start: u64,
+    /// Scale for quadratic backpressure
+    scale: f64,
 }
 
 /*
@@ -9019,8 +9076,8 @@ impl Guest {
 
             backpressure_us: AtomicU64::new(0),
             backpressure_config: BackpressureConfig {
-                start: 0.5,
-                max_delay: Duration::from_millis(5),
+                start: 1024u64.pow(3), // 1 GiB
+                scale: 9.3e-11,        // Delay for 10ms at 1 GB of extra bytes
             },
             backpressure_lock: Mutex::new(()),
         }
@@ -9052,14 +9109,6 @@ impl Guest {
     async fn send(&self, op: BlockOp) -> BlockReqWaiter {
         let (send, recv) = oneshot::channel();
 
-        let bp =
-            Duration::from_micros(self.backpressure_us.load(Ordering::SeqCst));
-        if bp > Duration::ZERO {
-            let _guard = self.backpressure_lock.lock().await;
-            tokio::time::sleep(bp).await;
-            drop(_guard);
-        }
-
         self.reqs.lock().await.push_back(BlockReq::new(op, send));
         self.notify.notify_one();
 
@@ -9080,18 +9129,15 @@ impl Guest {
     }
 
     /// Set `self.backpressure_us` based on outstanding IO ratio
-    fn set_backpressure(&self, ratio: f32) {
-        // Check to see if the number of outstanding IOs (between
+    fn set_backpressure(&self, bytes: u64) {
+        // Check to see if the number of outstanding write bytes (between
         // the upstairs and downstairs) is particularly high.  If so,
         // apply some backpressure by delaying host operations, with a
         // quadratically-increasing delay.
-        let d = self.backpressure_config.max_delay.mul_f32(
-            ((ratio - self.backpressure_config.start).max(0.0)
-                / (1.0 - self.backpressure_config.start))
-                .powf(2.0),
-        );
-        self.backpressure_us
-            .store(d.as_micros() as u64, Ordering::SeqCst);
+        let d = (bytes.saturating_sub(self.backpressure_config.start) as f64
+            * self.backpressure_config.scale)
+            .powf(2.0);
+        self.backpressure_us.store(d as u64, Ordering::SeqCst);
     }
 
     /*
@@ -9259,6 +9305,16 @@ impl Guest {
         println!("The guest has finished waiting for activation with:{}", gen);
         Ok(())
     }
+
+    async fn backpressure_sleep(&self) {
+        let bp =
+            Duration::from_micros(self.backpressure_us.load(Ordering::SeqCst));
+        if bp > Duration::ZERO {
+            let _guard = self.backpressure_lock.lock().await;
+            tokio::time::sleep(bp).await;
+            drop(_guard);
+        }
+    }
 }
 
 #[async_trait]
@@ -9362,6 +9418,8 @@ impl BlockIO for Guest {
             return Ok(());
         }
         let wio = BlockOp::Write { offset, data };
+
+        self.backpressure_sleep().await;
         Ok(self.send(wio).await.wait().await?)
     }
 
@@ -9384,6 +9442,8 @@ impl BlockIO for Guest {
             return Ok(());
         }
         let wio = BlockOp::WriteUnwritten { offset, data };
+
+        self.backpressure_sleep().await;
         Ok(self.send(wio).await.wait().await?)
     }
 
@@ -9617,21 +9677,17 @@ async fn up_ds_listen(up: &Arc<Upstairs>, mut ds_done_rx: mpsc::Receiver<()>) {
 ///
 /// Returns a ratio indicating how close the worst downstairs is to exceeding
 /// the IOP limit; 1.0 means the worst downstairs is at the limit.
-async fn gone_too_long(
-    up: &Arc<Upstairs>,
-    ds_done_tx: mpsc::Sender<()>,
-) -> f32 {
+async fn gone_too_long(up: &Arc<Upstairs>, ds_done_tx: mpsc::Sender<()>) {
     let active = up.active.lock().await;
     let up_state = active.up_state;
     // If we are not active, then just exit.
     if up_state != UpState::Active {
-        return 0.0;
+        return;
     }
     let mut ds = up.downstairs.lock().await;
     drop(active);
 
     let mut notify_guest = false;
-    let mut dsw_max = 0;
     for cid in ClientId::iter() {
         // Only downstairs in these states are checked.
         match ds.ds_state[cid] {
@@ -9640,7 +9696,6 @@ async fn gone_too_long(
             | DsState::Offline
             | DsState::Replay => {
                 let work_count = ds.total_live_work(cid);
-                dsw_max = dsw_max.max(work_count);
                 if work_count > IO_OUTSTANDING_MAX {
                     warn!(
                         up.log,
@@ -9678,7 +9733,6 @@ async fn gone_too_long(
             }
         }
     }
-    dsw_max as f32 / IO_OUTSTANDING_MAX as f32
 }
 
 /**
@@ -10104,9 +10158,8 @@ async fn up_listen(
                 process_new_io(up, &dst, req, &mut lastcast).await;
 
                 // Check how many outstanding downstairs jobs remain in the
-                // queue, and adjust guest backpressure accordingly.
-                let ratio = gone_too_long(up, dst[0].ds_done_tx.clone()).await;
-                up.guest.set_backpressure(ratio);
+                // queue, and adjust fail any downstairs that's not responding
+                gone_too_long(up, dst[0].ds_done_tx.clone()).await;
             }
             _ = sleep_until(repair_check_interval), if repair_check => {
                 match check_for_repair(up, &dst).await {


### PR DESCRIPTION
This PR makes a few changes to backpressure:
- Backpressure delays are only applied to writes.  Every other guest operation actually waits for the operation to finish, which serves as built-in backpressure (because longer operations will stall the guest for longer)
- The backpressure delay now requires holding a `tokio::sync::Mutex`.  This fixes an issue where _N_ tasks could submit writes simultaneously, which defeated the previous backpressure implementation
- The delay is now computed as the max of two values:
  - The current implementation, which is based on DSW queue length
  - A new delay based on write bytes in flight
- The latter prevents a host from queueing up too many _large writes_, which don't take much space in the queue but take a long time to execute – in some cases, long enough that the host will kick out the disk (#902)

Running `fio` tests in a VM with writes of various sizes, we see that
- small writes are limited by queue length (the black line shows where queue length backpressure kicks in)
- larger writes stabilize with fewer writes in the queue, due to the bytes-in-flight limitation

<img width="576" alt="Screenshot 2023-10-06 at 1 29 56 PM" src="https://github.com/oxidecomputer/crucible/assets/745333/7d352d4d-4da1-4d78-8224-5c591ff01ca7">
