### PR TITLE
Add raw file backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-staticfile",
+ "itertools 0.11.0",
  "libc",
  "mime_guess",
  "nix",

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -395,7 +395,10 @@ impl From<CrucibleError> for dropshot::HttpError {
             | CrucibleError::SubvolumeSizeMismatch
             | CrucibleError::UpstairsAlreadyActive
             | CrucibleError::UpstairsDeactivating
-            | CrucibleError::UuidMismatch => {
+            | CrucibleError::UuidMismatch
+            | CrucibleError::MissingContextSlot(..)
+            | CrucibleError::BadMetadata(..)
+            | CrucibleError::BadContextSlot(..) => {
                 dropshot::HttpError::for_internal_error(e.to_string())
             }
         }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -146,6 +146,15 @@ pub enum CrucibleError {
 
     #[error("Invalid downstairs replace {0}")]
     ReplaceRequestInvalid(String),
+
+    #[error("missing context slot for block {0}")]
+    MissingContextSlot(u64),
+
+    #[error("metadata deserialization failed: {0}")]
+    BadMetadata(String),
+
+    #[error("context slot deserialization failed: {0}")]
+    BadContextSlot(String),
 }
 
 impl From<std::io::Error> for CrucibleError {

--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -274,7 +274,7 @@ impl RegionDefinition {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Clone, Debug, PartialEq)]
 pub struct RegionOptions {
     /**
      * The size of each block in bytes.  Must be a power of 2, minimum 512.

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -22,6 +22,7 @@ hex.workspace = true
 http.workspace = true
 hyper-staticfile.workspace = true
 hyper.workspace = true
+itertools.workspace = true
 libc.workspace = true
 mime_guess.workspace = true
 nix.workspace = true

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -70,3 +70,4 @@ version_check = "0.9.4"
 asm = ["usdt/asm"]
 default = []
 zfs_snapshot = []
+integration-tests = [] # Enables creating SQLite volumes

--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -367,7 +367,7 @@ impl Extent {
 
             // Compute supplemental data from the SQLite extent
             let mut inner = extent_inner_sqlite::SqliteInner::open(
-                &path, def, number, read_only, log,
+                dir, def, number, read_only, log,
             )?;
             let ctxs = inner.export_contexts()?;
             let dirty = inner.dirty()?;
@@ -423,12 +423,12 @@ impl Extent {
             if has_sqlite {
                 assert!(read_only || force_sqlite_backend);
                 let inner = extent_inner_sqlite::SqliteInner::open(
-                    &path, def, number, read_only, log,
+                    dir, def, number, read_only, log,
                 )?;
                 Box::new(inner)
             } else {
                 let inner = extent_inner_raw::RawInner::open(
-                    &path, def, number, read_only, log,
+                    dir, def, number, read_only, log,
                 )?;
                 Box::new(inner)
             }

--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -655,7 +655,7 @@ pub(crate) fn move_replacement_extent<P: AsRef<Path>>(
     sync_path(&original_file, log)?;
 
     // We distinguish between SQLite-backend and raw-file extents based on the
-    // presence of the `000.db` file.  We should never do live migration across
+    // presence of the `.db` file.  We should never do live migration across
     // different extent formats; in fact, we should never live-migrate
     // SQLite-backed extents at all, but must still handle the case of
     // unfinished migrations.

--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -362,7 +362,16 @@ impl Extent {
                 let mut inner = extent_inner_sqlite::SqliteInner::open(
                     &path, def, number, read_only, log,
                 )?;
-                inner.export_meta_and_context()?
+                let ctxs = inner.export_contexts()?;
+                let dirty = inner.dirty()?;
+                let flush_number = inner.flush_number()?;
+                let gen_number = inner.gen_number()?;
+                extent_inner_raw::RawInner::import(
+                    ctxs,
+                    dirty,
+                    flush_number,
+                    gen_number,
+                )?
             };
             // Append the new raw data, then sync the file to disk
             {

--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -332,8 +332,7 @@ impl Extent {
         //        .db file)
         //      - Open the extent using our existing SQLite extent code
         //      - Using standard extent APIs, find the metadata and encryption
-        //        context for each block. Encode this in the new raw file format
-        //        (as a Vec<u8>)
+        //        context for each block. Append this to the existing data file.
         //      - Close the (SQLite) extent
         //      - Open the extent data file in append mode, and append the new
         //        raw metadata + block contexts to the end of the file.

--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -125,7 +125,7 @@ pub struct ExtentMeta {
 /// This is no longer used when creating new extents, but we support opening
 /// existing SQLite-based extents because snapshot images are on read-only
 /// volumes, so we can't migrate them.
-#[allow(dead_code)] // used in unit test
+#[cfg(test)] // This constant is only actually used in unit tests
 pub const EXTENT_META_SQLITE: u32 = 1;
 
 /// Extent version for raw-file-backed metadata

--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -125,7 +125,7 @@ pub struct ExtentMeta {
 /// This is no longer used when creating new extents, but we support opening
 /// existing SQLite-based extents because snapshot images are on read-only
 /// volumes, so we can't migrate them.
-#[cfg(test)] // This constant is only actually used in unit tests
+#[cfg(any(test, feature = "integration-tests"))]
 pub const EXTENT_META_SQLITE: u32 = 1;
 
 /// Extent version for raw-file-backed metadata
@@ -497,7 +497,7 @@ impl Extent {
     /// Identical to `create`, but using the SQLite backend
     ///
     /// This is only allowed in unit tests
-    #[cfg(test)]
+    #[cfg(any(test, feature = "integration-tests"))]
     pub fn create_sqlite(
         dir: &Path,
         def: &RegionDefinition,

--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -401,10 +401,12 @@ impl Extent {
         }
 
         // Pick the format for the downstairs files.  In most cases, we will be
-        // using the raw extent format, but for read-only snapshots, we're stuck
-        // with the SQLite backend.
+        // using the raw extent format, but for older read-only snapshots that
+        // were constructed using the SQLite backend, we have to keep them
+        // as-is.
         let inner: Box<dyn ExtentInner> = {
             if has_sqlite {
+                assert!(read_only);
                 let inner = extent_inner_sqlite::SqliteInner::open(
                     &path, def, number, read_only, log,
                 )?;

--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -252,6 +252,7 @@ pub fn completed_dir<P: AsRef<Path>>(dir: P, number: u32) -> PathBuf {
         .with_extension("completed")
 }
 
+/// Produce a `PathBuf` for the SQLite-to-raw migration directory
 pub fn migrate_dir<P: AsRef<Path>>(dir: P, number: u32) -> PathBuf {
     extent_dir(dir, number)
         .join(extent_file_name(number, ExtentType::Data))
@@ -369,9 +370,9 @@ impl Extent {
             has_sqlite = false;
         }
 
-        // Pick the format for the downstairs files
-        //
-        // Right now, this only supports SQLite-flavored Downstairs
+        // Pick the format for the downstairs files.  In most cases, we will be
+        // using the raw extent format, but for read-only snapshots, we're stuck
+        // with the SQLite backend.
         let inner: Box<dyn ExtentInner> = {
             if has_sqlite {
                 let inner = extent_inner_sqlite::SqliteInner::open(

--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -275,7 +275,6 @@ impl Extent {
 
     /**
      * Open an existing extent file at the location requested.
-     * Read in the metadata from the first block of the file.
      */
     pub fn open(
         dir: &Path,

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -619,12 +619,13 @@ impl RawInner {
 
     /// Constructs a new `Inner` object from files that already exist on disk
     pub fn open(
-        path: &Path,
+        dir: &Path,
         def: &RegionDefinition,
         extent_number: u32,
         read_only: bool,
         log: &Logger,
     ) -> Result<Self> {
+        let path = extent_path(dir, extent_number);
         let extent_size = def.extent_size();
         let layout = RawLayout::new(extent_size);
         let size = layout.file_size();
@@ -633,7 +634,7 @@ impl RawInner {
          * Open the extent file and verify the size is as we expect.
          */
         let file =
-            match OpenOptions::new().read(true).write(!read_only).open(path) {
+            match OpenOptions::new().read(true).write(!read_only).open(&path) {
                 Err(e) => {
                     error!(
                         log,

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -857,9 +857,10 @@ impl RawInner {
         let mut writes = 0u64;
         for (slot, group) in block_contexts
             .iter()
-            .group_by(|block_context|
-            // We'll be writing to the inactive slot
-            !self.active_context[block_context.block as usize])
+            .group_by(|block_context| {
+                // We'll be writing to the inactive slot
+                !self.active_context[block_context.block as usize]
+            })
             .into_iter()
         {
             let mut group = group.peekable();

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -1154,6 +1154,11 @@ impl RawLayout {
         }
     }
 
+    /// Sets the dirty flag in the file true
+    ///
+    /// This unconditionally writes to the file; to avoid extra syscalls, it
+    /// would be wise to cache this at a higher level and only write if it has
+    /// changed.
     fn set_dirty(&self, file: &File) -> Result<(), CrucibleError> {
         let offset = self.metadata_offset();
         nix::sys::uio::pwrite(file.as_raw_fd(), &[1u8], offset as i64)

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -16,7 +16,7 @@ use slog::{error, Logger};
 
 use std::collections::HashSet;
 use std::fs::{File, OpenOptions};
-use std::io::{IoSliceMut, Read, Seek, SeekFrom};
+use std::io::{BufReader, IoSliceMut, Read, Seek, SeekFrom};
 use std::os::fd::AsRawFd;
 use std::path::Path;
 
@@ -75,8 +75,8 @@ pub struct RawInner {
     /// Extent size, in blocks
     extent_size: Block,
 
-    /// Is the `ping` or `pong` context slot active?
-    active_context: Vec<ActiveContext>,
+    /// Is the `A` or `B` context slot active, on a per-block basis?
+    active_context: Vec<ContextSlot>,
 
     /// Local cache for the `dirty` value
     ///
@@ -98,18 +98,19 @@ pub struct RawInner {
 }
 
 #[derive(Copy, Clone, Debug)]
-enum ActiveContext {
-    /// There is no active context for the given block
-    Empty,
+enum ContextSlot {
+    A,
+    B,
+}
 
-    /// The active context for the given block is unknown
-    ///
-    /// We set the context to this state before a write, so that if the write
-    /// fails, we rehash the file contents to get back to a known state.
-    Unknown,
-
-    /// The active context is stored in the given slot
-    Slot(bool),
+impl std::ops::Not for ContextSlot {
+    type Output = Self;
+    fn not(self) -> Self {
+        match self {
+            ContextSlot::A => ContextSlot::B,
+            ContextSlot::B => ContextSlot::A,
+        }
+    }
 }
 
 impl ExtentInner for RawInner {
@@ -251,12 +252,6 @@ impl ExtentInner for RawInner {
                     on_disk_hash,
                 })?;
             pending_slots.push(Some(next_slot));
-
-            // Until the write lands, we can't trust the context slot and must
-            // rehash it if requested.  This assignment is overwritten after the
-            // write finishes.
-            self.active_context[write.offset.value as usize] =
-                ActiveContext::Unknown;
         }
 
         cdt::extent__write__raw__context__insert__done!(|| {
@@ -284,36 +279,24 @@ impl ExtentInner for RawInner {
             (job_id.0, self.extent_number, writes.len() as u64)
         });
 
-        // Now, batch writes into iovecs and use pwritev to write them all out.
-        let mut batched_pwritev = BatchedPwritev::new(
-            self.file.as_raw_fd(),
-            writes.len(),
-            self.extent_size.block_size_in_bytes().into(),
-            iov_max,
-        );
+        let r = self.write_inner(writes, &writes_to_skip, iov_max);
 
-        for write in writes {
-            let block = write.offset.value;
-
-            // TODO, can this be `only_write_unwritten &&
-            // write_to_skip.contains()`?
-            if writes_to_skip.contains(&block) {
-                debug_assert!(only_write_unwritten);
-                batched_pwritev.perform_writes()?;
-                continue;
+        if r.is_err() {
+            for write in writes.iter() {
+                let block = write.offset.value;
+                if !writes_to_skip.contains(&block) {
+                    // Try to recompute the context slot from the file.  If this
+                    // fails, then we _really_ can't recover, so bail out
+                    // unceremoniously.
+                    self.recompute_slot_from_file(block).unwrap();
+                }
             }
-
-            batched_pwritev.add_write(write)?;
-        }
-
-        // Write any remaining data
-        batched_pwritev.perform_writes()?;
-
-        // Now that writes have gone through, update our active context slots
-        for (write, new_slot) in writes.iter().zip(pending_slots) {
-            if let Some(slot) = new_slot {
-                self.active_context[write.offset.value as usize] =
-                    ActiveContext::Slot(slot);
+        } else {
+            // Now that writes have gone through, update active context slots
+            for (write, new_slot) in writes.iter().zip(pending_slots) {
+                if let Some(slot) = new_slot {
+                    self.active_context[write.offset.value as usize] = slot;
+                }
             }
         }
 
@@ -481,8 +464,7 @@ impl ExtentInner for RawInner {
     ) -> Result<(), CrucibleError> {
         self.set_dirty()?;
         let new_slot = self.set_block_context(block_context)?;
-        self.active_context[block_context.block as usize] =
-            ActiveContext::Slot(new_slot);
+        self.active_context[block_context.block as usize] = new_slot;
         Ok(())
     }
 
@@ -525,7 +507,7 @@ impl RawInner {
             extent_size: def.extent_size(),
             extent_number,
             active_context: vec![
-                ActiveContext::Empty;
+                ContextSlot::A; // both slots are empty, so this is fine
                 def.extent_size().value as usize
             ],
             context_slot_synched_at: vec![
@@ -557,7 +539,8 @@ impl RawInner {
         read_only: bool,
         log: &Logger,
     ) -> Result<Self> {
-        let bcount = def.extent_size().value;
+        let extent_size = def.extent_size();
+        let bcount = extent_size.value;
         let size = def.block_size().checked_mul(bcount).unwrap()
             + BLOCK_CONTEXT_SLOT_SIZE_BYTES * bcount * 2
             + BLOCK_META_SIZE_BYTES;
@@ -565,7 +548,7 @@ impl RawInner {
         /*
          * Open the extent file and verify the size is as we expect.
          */
-        let mut file =
+        let file =
             match OpenOptions::new().read(true).write(!read_only).open(path) {
                 Err(e) => {
                     error!(
@@ -592,32 +575,81 @@ impl RawInner {
 
         // Just in case, let's be very sure that the file on disk is what it
         // should be
-        if let Err(e) = file.sync_all() {
-            return Err(CrucibleError::IoError(format!(
-                "extent {extent_number}:
+        if !read_only {
+            if let Err(e) = file.sync_all() {
+                return Err(CrucibleError::IoError(format!(
+                    "extent {extent_number}:
                  fsync 1 failure during initial rehash: {e:?}",
-            ))
-            .into());
+                ))
+                .into());
+            }
         }
 
-        file.seek(SeekFrom::Start(Self::meta_offset_from_extent_size(
-            def.extent_size(),
-        )))?;
-        let mut dirty = [0u8];
-        file.read_exact(&mut dirty)?;
-        let dirty = match dirty[0] {
-            0 => false,
-            1 => true,
-            i => bail!("invalid dirty value: {i}"),
+        // Now, we'll compute which context slots are active in the file!  We
+        // start by reading + hashing the file, then compare those hashes
+        // against values in the context slots.  This is equivalent to
+        // `recompute_slot_from_file`, but reads the file in bulk for
+        // efficiency.
+
+        // Buffer the file so we don't spend all day waiting on syscalls
+        let mut file_buffered = BufReader::with_capacity(64 * 1024, &file);
+
+        let block_hashes = {
+            let mut block_hashes =
+                Vec::with_capacity(extent_size.value as usize);
+
+            // Stream the contents of the file and rehash them.
+            let mut buf = vec![0; extent_size.block_size_in_bytes() as usize];
+            for _block in 0..extent_size.value as usize {
+                file_buffered.read_exact(&mut buf)?;
+                block_hashes.push(integrity_hash(&[&buf]));
+            }
+            block_hashes
+        };
+
+        let dirty = {
+            let mut meta_buf = [0u8; BLOCK_META_SIZE_BYTES as usize];
+            file_buffered.read_exact(&mut meta_buf)?;
+            match meta_buf[0] {
+                0 => false,
+                1 => true,
+                i => bail!("invalid dirty value: {i}"),
+            }
+        };
+
+        // Now, read context data from the file and assign slots
+        let active_context = {
+            let mut buf = vec![0u8; BLOCK_CONTEXT_SLOT_SIZE_BYTES as usize];
+            let mut active_context = vec![];
+            for (block, hash) in block_hashes.into_iter().enumerate() {
+                let mut matching_slot = None;
+                let mut empty_slot = None;
+                for slot in [ContextSlot::A, ContextSlot::B] {
+                    file_buffered.read_exact(&mut buf)?;
+                    let context: Option<OnDiskDownstairsBlockContext> =
+                        bincode::deserialize(&buf)?;
+                    if let Some(context) = context {
+                        if context.on_disk_hash == hash {
+                            matching_slot = Some(slot);
+                        }
+                    } else if empty_slot.is_none() {
+                        empty_slot = Some(slot);
+                    }
+                }
+                let value = matching_slot.or(empty_slot).ok_or(
+                    CrucibleError::IoError(format!(
+                        "no slot found for {block}"
+                    )),
+                )?;
+                active_context.push(value);
+            }
+            active_context
         };
 
         Ok(Self {
             file,
             // Lazy initialization of which context slot is active
-            active_context: vec![
-                ActiveContext::Unknown;
-                def.extent_size().value as usize
-            ],
+            active_context,
             dirty,
             extent_number,
             extent_size: def.extent_size(),
@@ -639,45 +671,55 @@ impl RawInner {
         Ok(())
     }
 
-    /// Looks up the current context slot for the given block
+    /// Updates `self.active_context[block]` based on data read from the file
     ///
-    /// If the slot is currently unknown, rehashes the block and picks one of
-    /// the two slots, storing it locally.
-    fn get_block_context_slot(&mut self, block: usize) -> Result<Option<bool>> {
-        match self.active_context[block] {
-            ActiveContext::Empty => Ok(None),
-            ActiveContext::Slot(b) => Ok(Some(b)),
-            ActiveContext::Unknown => {
-                let block_size = self.extent_size.block_size_in_bytes();
-                let mut buf = vec![0; block_size as usize];
-                self.file
-                    .seek(SeekFrom::Start(block_size as u64 * block as u64))?;
-                self.file.read_exact(&mut buf)?;
-                let hash = integrity_hash(&[&buf]);
+    /// This returns an error if neither context slot matches the block data,
+    /// which should never happen (even during error conditions or after a
+    /// crash).
+    ///
+    /// We expect to call this function rarely, so it does not attempt to
+    /// minimize the number of syscalls it executes.
+    fn recompute_slot_from_file(
+        &mut self,
+        block: u64,
+    ) -> Result<(), CrucibleError> {
+        // Read the block data itself:
+        let block_size = self.extent_size.block_size_in_bytes();
+        let mut buf = vec![0; block_size as usize];
+        self.file.seek(SeekFrom::Start(block_size as u64 * block))?;
+        self.file.read_exact(&mut buf)?;
+        let hash = integrity_hash(&[&buf]);
 
-                self.file.seek(SeekFrom::Start(
-                    self.context_slot_offset(block as u64, false),
-                ))?;
-                let mut buf = vec![0; BLOCK_CONTEXT_SLOT_SIZE_BYTES as usize];
-                let mut found = None;
-                for slot in 0..2 {
-                    self.file.read_exact(&mut buf)?;
-                    let context: Option<OnDiskDownstairsBlockContext> =
-                        bincode::deserialize(&buf)?;
-                    if let Some(context) = context {
-                        if context.on_disk_hash == hash {
-                            self.active_context[block] =
-                                ActiveContext::Slot(slot != 0);
-                            found = Some(slot != 0);
-                        }
-                    }
+        // Then, read the slot data and decide if either slot
+        // (1) is present and
+        // (2) has a matching hash
+        let mut buf = [0; BLOCK_CONTEXT_SLOT_SIZE_BYTES as usize];
+        let mut matching_slot = None;
+        let mut empty_slot = None;
+        for slot in [ContextSlot::A, ContextSlot::B] {
+            // TODO: is `pread` faster than seek + read_exact?
+            self.file
+                .seek(SeekFrom::Start(self.context_slot_offset(block, slot)))?;
+            self.file.read_exact(&mut buf)?;
+            let context: Option<OnDiskDownstairsBlockContext> =
+                bincode::deserialize(&buf).map_err(|e| {
+                    CrucibleError::IoError(format!(
+                        "context deserialization failed: {e:?}"
+                    ))
+                })?;
+            if let Some(context) = context {
+                if context.on_disk_hash == hash {
+                    matching_slot = Some(slot);
                 }
-                if found.is_none() {
-                    self.active_context[block] = ActiveContext::Empty;
-                }
-                Ok(found)
+            } else if empty_slot.is_none() {
+                empty_slot = Some(slot);
             }
         }
+        let value = matching_slot.or(empty_slot).ok_or(
+            CrucibleError::IoError(format!("no slot found for {block}")),
+        )?;
+        self.active_context[block as usize] = value;
+        Ok(())
     }
 
     /// Writes the inactive block context slot
@@ -686,10 +728,10 @@ impl RawInner {
     fn set_block_context(
         &mut self,
         block_context: &DownstairsBlockContext,
-    ) -> Result<bool> {
+    ) -> Result<ContextSlot> {
         let block = block_context.block as usize;
         // Select the inactive slot
-        let slot = !self.get_block_context_slot(block)?.unwrap_or(true);
+        let slot = !self.active_context[block];
 
         // If the context slot that we're about to write into hasn't been
         // synched to disk yet, we must sync it first.  This prevents subtle
@@ -742,7 +784,7 @@ impl RawInner {
     /// Contexts slots are located after block data in the extent file.  There
     /// are two context slots per block.  We use a ping-pong strategy to ensure
     /// that one of them is always valid (i.e. matching the data in the file).
-    fn context_slot_offset(&self, block: u64, slot: bool) -> u64 {
+    fn context_slot_offset(&self, block: u64, slot: ContextSlot) -> u64 {
         self.extent_size.block_size_in_bytes() as u64 * self.extent_size.value
             + BLOCK_META_SIZE_BYTES
             + (block * 2 + slot as u64) * BLOCK_CONTEXT_SLOT_SIZE_BYTES
@@ -763,9 +805,7 @@ impl RawInner {
         &mut self,
         block: u64,
     ) -> Result<Option<DownstairsBlockContext>> {
-        let Some(slot) = self.get_block_context_slot(block as usize)? else {
-            return Ok(None);
-        };
+        let slot = self.active_context[block as usize];
         let offset = self.context_slot_offset(block, slot);
         let mut buf = [0u8; BLOCK_CONTEXT_SLOT_SIZE_BYTES as usize];
         nix::sys::uio::pread(self.file.as_raw_fd(), &mut buf, offset as i64)
@@ -813,6 +853,32 @@ impl RawInner {
             out.push(ctx);
         }
         Ok(out)
+    }
+
+    fn write_inner(
+        &self,
+        writes: &[&crucible_protocol::Write],
+        writes_to_skip: &HashSet<u64>,
+        iov_max: usize,
+    ) -> Result<(), CrucibleError> {
+        // Now, batch writes into iovecs and use pwritev to write them all out.
+        let mut batched_pwritev = BatchedPwritev::new(
+            self.file.as_raw_fd(),
+            writes.len(),
+            self.extent_size.block_size_in_bytes().into(),
+            iov_max,
+        );
+
+        for write in writes {
+            if !writes_to_skip.contains(&write.offset.value) {
+                batched_pwritev.add_write(write)?;
+            }
+        }
+
+        // Write any remaining data
+        batched_pwritev.perform_writes()?;
+
+        Ok(())
     }
 }
 

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -541,6 +541,8 @@ impl RawInner {
     ) -> Result<(), CrucibleError> {
         let layout = RawLayout::new(def.extent_size());
         let block_count = layout.block_count() as usize;
+        assert_eq!(block_count, def.extent_size().value as usize);
+        assert_eq!(block_count, ctxs.len());
 
         file.set_len(layout.file_size())?;
         layout.write_context_slots_contiguous(

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -55,12 +55,12 @@ pub const BLOCK_META_SIZE_BYTES: u64 = 64;
 ///
 /// The file is structured as follows:
 /// - Block data, structured as `block_size` × `extent_size`
-/// - Block contexts (for encryption).  Each block index (in the range
-///   `0..extent_size`) has two context slots; we use a ping-pong strategy when
-///   writing to ensure that one slot is always valid.  Each slot is
 /// - [`BLOCK_META_SIZE_BYTES`], which contains an [`OnDiskMeta`] serialized
 ///   using `bincode`.  The first byte of this range is `dirty`, serialized as a
 ///   `u8` (where `1` is dirty and `0` is clean).
+/// - Block contexts (for encryption).  Each block index (in the range
+///   `0..extent_size`) has two context slots; we use a ping-pong strategy when
+///   writing to ensure that one slot is always valid.  Each slot is
 ///   [`BLOCK_CONTEXT_SLOT_SIZE_BYTES`] in size, so this region is
 ///   `BLOCK_CONTEXT_SLOT_SIZE_BYTES * extent_size * 2` bytes in total.  The
 ///   slots contain an `Option<OnDiskDownstairsBlockContext>`, serialized using
@@ -510,8 +510,8 @@ impl RawInner {
         let path = extent_path(dir, extent_number);
         let bcount = def.extent_size().value;
         let size = def.block_size().checked_mul(bcount).unwrap()
-            + BLOCK_CONTEXT_SLOT_SIZE_BYTES * bcount * 2
-            + BLOCK_META_SIZE_BYTES;
+            + BLOCK_META_SIZE_BYTES
+            + BLOCK_CONTEXT_SLOT_SIZE_BYTES * bcount * 2;
 
         mkdir_for_file(&path)?;
         let mut file = OpenOptions::new()

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -1053,6 +1053,8 @@ impl RawInner {
         // We track the number of A vs B slots, as well as the range covered by
         // the slots.  It's that range that we'll need to read + write, so we
         // want to pick whichever slot does less work.
+        assert!(!self.dirty); // This can only be called after a flush!
+
         #[derive(Copy, Clone)]
         struct Counter {
             count: usize,

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -781,13 +781,15 @@ impl RawInner {
 
     /// Returns the byte offset of the given context slot
     ///
-    /// Contexts slots are located after block data in the extent file.  There
-    /// are two context slots per block.  We use a ping-pong strategy to ensure
-    /// that one of them is always valid (i.e. matching the data in the file).
+    /// Contexts slots are located after block and meta data in the extent file.
+    /// There are two context slots arrays, each of which contains one context
+    /// slot per block.  We use a ping-pong strategy to ensure that one of them
+    /// is always valid (i.e. matching the data in the file).
     fn context_slot_offset(&self, block: u64, slot: ContextSlot) -> u64 {
         self.extent_size.block_size_in_bytes() as u64 * self.extent_size.value
             + BLOCK_META_SIZE_BYTES
-            + (block * 2 + slot as u64) * BLOCK_CONTEXT_SLOT_SIZE_BYTES
+            + (self.extent_size.value * slot as u64 + block)
+                * BLOCK_CONTEXT_SLOT_SIZE_BYTES
     }
 
     /// Returns the byte offset of the metadata region

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -1013,6 +1013,14 @@ impl RawInner {
             for block in counter.min_block..=counter.max_block {
                 self.active_context[block as usize] = !copy_from;
             }
+            // At this point, the `dirty` bit is not set, but values in
+            // `self.active_context` disagree with the active context slot
+            // stored in the file.  Normally, this is bad: if we crashed and
+            // reloaded the file from disk right at this moment, we'd end up
+            // with different values in `self.active_context`.  In this case,
+            // though, it's okay: the values that have changed have the **same
+            // data** in both context slots, so it would still be a valid state
+            // for the file.
         }
         r.map(|_| ())
     }

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -424,10 +424,6 @@ impl ExtentInner for RawInner {
             req_run_start += n_contiguous_requests;
         }
 
-        cdt::extent__read__done!(|| {
-            (job_id.0, self.extent_number, requests.len() as u64)
-        });
-
         Ok(())
     }
 

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -44,13 +44,13 @@ pub struct OnDiskMeta {
 ///
 /// This must be large enough to fit an `Option<OnDiskDownstairsBlockContext>`
 /// serialized using `bincode`.
-pub const BLOCK_CONTEXT_SLOT_SIZE_BYTES: u64 = 64;
+pub const BLOCK_CONTEXT_SLOT_SIZE_BYTES: u64 = 48;
 
 /// Size of metadata region
 ///
 /// This must be large enough to contain an `OnDiskMeta` serialized using
 /// `bincode`.
-pub const BLOCK_META_SIZE_BYTES: u64 = 64;
+pub const BLOCK_META_SIZE_BYTES: u64 = 32;
 
 /// `RawInner` is a wrapper around a [`std::fs::File`] representing an extent
 ///

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -835,7 +835,7 @@ impl RawInner {
         &mut self,
         block_contexts: &[DownstairsBlockContext],
     ) -> Result<(), CrucibleError> {
-        // If any of these block contexts will be overwriting an unsyched
+        // If any of these block contexts will be overwriting an unsynched
         // context slot, then we insert a sync here.
         let needs_sync = block_contexts.iter().any(|block_context| {
             let block = block_context.block as usize;

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -1,0 +1,1329 @@
+// Copyright 2023 Oxide Computer Company
+use crate::{
+    cdt, crucible_bail,
+    extent::{
+        check_input, extent_path, DownstairsBlockContext, ExtentInner,
+        EXTENT_META_RAW,
+    },
+    integrity_hash, mkdir_for_file,
+    region::{BatchedPwritev, JobOrReconciliationId},
+    Block, BlockContext, CrucibleError, JobId, ReadResponse, RegionDefinition,
+};
+
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+use slog::{error, Logger};
+
+use std::collections::HashSet;
+use std::fs::{File, OpenOptions};
+use std::io::{IoSliceMut, Read, Seek, SeekFrom};
+use std::os::fd::AsRawFd;
+use std::path::Path;
+
+/// Equivalent to `DownstairsBlockContext`, but without one's own block number
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OnDiskDownstairsBlockContext {
+    pub block_context: BlockContext,
+    pub on_disk_hash: u64,
+}
+
+/// Equivalent to `ExtentMeta`, but ordered for efficient on-disk serialization
+///
+/// In particular, the `dirty` byte is first, so it's easy to read at a known
+/// offset within the file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OnDiskMeta {
+    pub dirty: bool,
+    pub gen_number: u64,
+    pub flush_number: u64,
+    pub ext_version: u32,
+}
+
+/// Size of backup data
+///
+/// This must be large enough to contain an `Option<DownstairsBlockContext>`
+/// serialized using `bincode`.
+pub const BLOCK_CONTEXT_SLOT_SIZE_BYTES: u64 = 64;
+
+/// Size of metadata region
+///
+/// This must be large enough to contain an `OnDiskMeta` serialized using
+/// `bincode`.
+pub const BLOCK_META_SIZE_BYTES: u64 = 64;
+
+/// `RawInner` is a wrapper around a [`std::fs::File`] representing an extent
+///
+/// The file is structured as follows:
+/// - Block data, structured as `block_size` × `extent_size`
+/// - Block contexts (for encryption).  Each block index (in the range
+///   `0..extent_size`) has two context slots; we use a ping-pong strategy when
+///   writing to ensure that one slot is always valid.  Each slot is
+/// - [`BLOCK_META_SIZE_BYTES`], which contains an [`OnDiskMeta`] serialized
+///   using `bincode`.  The first byte of this range is `dirty`, serialized as a
+///   `u8` (where `1` is dirty and `0` is clean).
+///   [`BLOCK_CONTEXT_SLOT_SIZE_BYTES`] in size, so this region is
+///   `BLOCK_CONTEXT_SLOT_SIZE_BYTES * extent_size * 2` bytes in total.  The
+///   slots contain an `Option<OnDiskDownstairsBlockContext>`, serialized using
+///   `bincode`.
+#[derive(Debug)]
+pub struct RawInner {
+    file: File,
+
+    /// Our extent number
+    extent_number: u32,
+
+    /// Extent size, in blocks
+    extent_size: Block,
+
+    /// Is the `ping` or `pong` context slot active?
+    active_context: Vec<ActiveContext>,
+
+    /// Local cache for the `dirty` value
+    ///
+    /// This allows us to only write the flag when the value changes
+    dirty: bool,
+
+    /// Monotonically increasing sync index
+    ///
+    /// This is unrelated to `flush_number` or `gen_number`; it's purely
+    /// internal to this data structure and is transient.  We use this value to
+    /// determine whether a context slot has been persisted to disk or not.
+    sync_index: u64,
+
+    /// The value of `sync_index` when the current value of a context slot was
+    /// synched to disk.  When the value of a context slot changes, the value in
+    /// this array is set to `self.sync_index + 1` indicates that the slot has
+    /// not yet been synched.
+    context_slot_synched_at: Vec<[u64; 2]>,
+}
+
+#[derive(Copy, Clone, Debug)]
+enum ActiveContext {
+    /// There is no active context for the given block
+    Empty,
+
+    /// The active context for the given block is unknown
+    ///
+    /// We set the context to this state before a write, so that if the write
+    /// fails, we rehash the file contents to get back to a known state.
+    Unknown,
+
+    /// The active context is stored in the given slot
+    Slot(bool),
+}
+
+impl ExtentInner for RawInner {
+    fn flush_number(&self) -> Result<u64, CrucibleError> {
+        self.get_metadata().map(|v| v.flush_number)
+    }
+
+    fn gen_number(&self) -> Result<u64, CrucibleError> {
+        self.get_metadata().map(|v| v.gen_number)
+    }
+
+    fn dirty(&self) -> Result<bool, CrucibleError> {
+        Ok(self.dirty)
+    }
+
+    fn write(
+        &mut self,
+        job_id: JobId,
+        writes: &[&crucible_protocol::Write],
+        only_write_unwritten: bool,
+        iov_max: usize,
+    ) -> Result<(), CrucibleError> {
+        /*
+         * In order to be crash consistent, perform the following steps in
+         * order:
+         *
+         * 1) set the dirty bit
+         * 2) for each write:
+         *   a) write out encryption context and hashes first
+         *   b) write out extent data second
+         *
+         * If encryption context is written after the extent data, a crash or
+         * interruption before extent data is written would potentially leave
+         * data on the disk that cannot be decrypted.
+         *
+         * If hash is written after extent data, same thing - a crash or
+         * interruption would leave data on disk that would fail the
+         * integrity hash check.
+         *
+         * Note that writing extent data here does not assume that it is
+         * durably on disk - the only guarantee of that is returning
+         * ok from fsync. The data is only potentially on disk and
+         * this depends on operating system implementation.
+         *
+         * To minimize the performance hit of sending many transactions to the
+         * filesystem, as much as possible is written at the same time. This
+         * means multiple loops are required. The steps now look like:
+         *
+         * 1) set the dirty bit
+         * 2) gather and write all encryption contexts + hashes
+         * 3) write all extent data
+         *
+         * If "only_write_unwritten" is true, then we only issue a write for
+         * a block if that block has not been written to yet.  Note
+         * that we can have a write that is "sparse" if the range of
+         * blocks it contains has a mix of written an unwritten
+         * blocks.
+         *
+         * We define a block being written to or not has if that block has
+         * `Some(...)` with a matching checksum serialized into a context slot
+         * or not. So it is required that a written block has a checksum.
+         */
+
+        // If `only_write_written`, we need to skip writing to blocks that
+        // already contain data. We'll first query the metadata to see which
+        // blocks have hashes
+        let mut writes_to_skip = HashSet::new();
+        if only_write_unwritten {
+            cdt::extent__write__get__hashes__start!(|| {
+                (job_id.0, self.extent_number, writes.len() as u64)
+            });
+            let mut write_run_start = 0;
+            while write_run_start < writes.len() {
+                let first_write = writes[write_run_start];
+
+                // Starting from the first write in the potential run, we scan
+                // forward until we find a write with a block that isn't
+                // contiguous with the request before it. Since we're counting
+                // pairs, and the number of pairs is one less than the number of
+                // writes, we need to add 1 to get our actual run length.
+                let n_contiguous_writes = writes[write_run_start..]
+                    .windows(2)
+                    .take_while(|wr_pair| {
+                        wr_pair[0].offset.value + 1 == wr_pair[1].offset.value
+                    })
+                    .count()
+                    + 1;
+
+                // Query hashes for the write range.
+                let block_contexts = self.get_block_contexts(
+                    first_write.offset.value,
+                    n_contiguous_writes as u64,
+                )?;
+
+                for (i, block_contexts) in block_contexts.iter().enumerate() {
+                    if block_contexts.is_some() {
+                        let _ = writes_to_skip
+                            .insert(i as u64 + first_write.offset.value);
+                    }
+                }
+
+                write_run_start += n_contiguous_writes;
+            }
+            cdt::extent__write__get__hashes__done!(|| {
+                (job_id.0, self.extent_number, writes.len() as u64)
+            });
+
+            if writes_to_skip.len() == writes.len() {
+                // Nothing to do
+                return Ok(());
+            }
+        }
+
+        self.set_dirty()?;
+
+        // Write all the metadata to the raw file, at the end
+        //
+        // TODO right now we're including the integrity_hash() time in the
+        // measured time.  Is it small enough to be ignored?
+        cdt::extent__write__raw__context__insert__start!(|| {
+            (job_id.0, self.extent_number, writes.len() as u64)
+        });
+
+        let mut pending_slots = vec![];
+        for write in writes {
+            if writes_to_skip.contains(&write.offset.value) {
+                pending_slots.push(None);
+                continue;
+            }
+
+            // TODO it would be nice if we could profile what % of time we're
+            // spending on hashes locally vs writing to disk
+            let on_disk_hash = integrity_hash(&[&write.data[..]]);
+
+            let next_slot =
+                self.set_block_context(&DownstairsBlockContext {
+                    block_context: write.block_context,
+                    block: write.offset.value,
+                    on_disk_hash,
+                })?;
+            pending_slots.push(Some(next_slot));
+
+            // Until the write lands, we can't trust the context slot and must
+            // rehash it if requested.  This assignment is overwritten after the
+            // write finishes.
+            self.active_context[write.offset.value as usize] =
+                ActiveContext::Unknown;
+        }
+
+        cdt::extent__write__raw__context__insert__done!(|| {
+            (job_id.0, self.extent_number, writes.len() as u64)
+        });
+
+        // PERFORMANCE TODO:
+        //
+        // Something worth considering for small writes is that, based on
+        // my memory of conversations we had with propolis folks about what
+        // OSes expect out of an NVMe driver, I believe our contract with the
+        // upstairs doesn't require us to have the writes inside the file
+        // until after a flush() returns. If that is indeed true, we could
+        // buffer a certain amount of writes, only actually writing that
+        // buffer when either a flush is issued or the buffer exceeds some
+        // set size (based on our memory constraints). This would have
+        // benefits on any workload that frequently writes to the same block
+        // between flushes, would have benefits for small contiguous writes
+        // issued over multiple write commands by letting us batch them into
+        // a larger write, and (speculation) may benefit non-contiguous writes
+        // by cutting down the number of metadata writes. But, it introduces
+        // complexity. The time spent implementing that would probably better be
+        // spent switching to aio or something like that.
+        cdt::extent__write__file__start!(|| {
+            (job_id.0, self.extent_number, writes.len() as u64)
+        });
+
+        // Now, batch writes into iovecs and use pwritev to write them all out.
+        let mut batched_pwritev = BatchedPwritev::new(
+            self.file.as_raw_fd(),
+            writes.len(),
+            self.extent_size.block_size_in_bytes().into(),
+            iov_max,
+        );
+
+        for write in writes {
+            let block = write.offset.value;
+
+            // TODO, can this be `only_write_unwritten &&
+            // write_to_skip.contains()`?
+            if writes_to_skip.contains(&block) {
+                debug_assert!(only_write_unwritten);
+                batched_pwritev.perform_writes()?;
+                continue;
+            }
+
+            batched_pwritev.add_write(write)?;
+        }
+
+        // Write any remaining data
+        batched_pwritev.perform_writes()?;
+
+        // Now that writes have gone through, update our active context slots
+        for (write, new_slot) in writes.iter().zip(pending_slots) {
+            if let Some(slot) = new_slot {
+                self.active_context[write.offset.value as usize] =
+                    ActiveContext::Slot(slot);
+            }
+        }
+
+        cdt::extent__write__file__done!(|| {
+            (job_id.0, self.extent_number, writes.len() as u64)
+        });
+
+        Ok(())
+    }
+
+    fn read(
+        &mut self,
+        job_id: JobId,
+        requests: &[&crucible_protocol::ReadRequest],
+        responses: &mut Vec<crucible_protocol::ReadResponse>,
+        iov_max: usize,
+    ) -> Result<(), CrucibleError> {
+        // This code batches up operations for contiguous regions of
+        // ReadRequests, so we can perform larger read syscalls queries. This
+        // significantly improves read throughput.
+
+        // Keep track of the index of the first request in any contiguous run
+        // of requests. Of course, a "contiguous run" might just be a single
+        // request.
+        let mut req_run_start = 0;
+        let block_size = self.extent_size.block_size_in_bytes();
+        while req_run_start < requests.len() {
+            let first_req = requests[req_run_start];
+
+            // Starting from the first request in the potential run, we scan
+            // forward until we find a request with a block that isn't
+            // contiguous with the request before it. Since we're counting
+            // pairs, and the number of pairs is one less than the number of
+            // requests, we need to add 1 to get our actual run length.
+            let mut n_contiguous_requests = 1;
+
+            for request_window in requests[req_run_start..].windows(2) {
+                if (request_window[0].offset.value + 1
+                    == request_window[1].offset.value)
+                    && ((n_contiguous_requests + 1) < iov_max)
+                {
+                    n_contiguous_requests += 1;
+                } else {
+                    break;
+                }
+            }
+
+            // Create our responses and push them into the output. While we're
+            // at it, check for overflows.
+            let resp_run_start = responses.len();
+            let mut iovecs = Vec::with_capacity(n_contiguous_requests);
+            for req in requests[req_run_start..][..n_contiguous_requests].iter()
+            {
+                let resp = ReadResponse::from_request(req, block_size as usize);
+                check_input(self.extent_size, req.offset, &resp.data)?;
+                responses.push(resp);
+            }
+
+            // Create what amounts to an iovec for each response data buffer.
+            for resp in
+                &mut responses[resp_run_start..][..n_contiguous_requests]
+            {
+                iovecs.push(IoSliceMut::new(&mut resp.data[..]));
+            }
+
+            // Finally we get to read the actual data. That's why we're here
+            cdt::extent__read__file__start!(|| {
+                (job_id.0, self.extent_number, n_contiguous_requests as u64)
+            });
+
+            nix::sys::uio::preadv(
+                self.file.as_raw_fd(),
+                &mut iovecs,
+                first_req.offset.value as i64 * block_size as i64,
+            )
+            .map_err(|e| CrucibleError::IoError(e.to_string()))?;
+
+            cdt::extent__read__file__done!(|| {
+                (job_id.0, self.extent_number, n_contiguous_requests as u64)
+            });
+
+            // Query the block metadata
+            cdt::extent__read__get__contexts__start!(|| {
+                (job_id.0, self.extent_number, n_contiguous_requests as u64)
+            });
+            let block_contexts = self.get_block_contexts(
+                first_req.offset.value,
+                n_contiguous_requests as u64,
+            )?;
+            cdt::extent__read__get__contexts__done!(|| {
+                (job_id.0, self.extent_number, n_contiguous_requests as u64)
+            });
+
+            // Now it's time to put block contexts into the responses.
+            // We use into_iter here to move values out of enc_ctxts/hashes,
+            // avoiding a clone(). For code consistency, we use iters for the
+            // response and data chunks too. These iters will be the same length
+            // (equal to n_contiguous_requests) so zipping is fine
+            let resp_iter =
+                responses[resp_run_start..][..n_contiguous_requests].iter_mut();
+            let ctx_iter = block_contexts.into_iter();
+
+            for (resp, r_ctx) in resp_iter.zip(ctx_iter) {
+                resp.block_contexts =
+                    r_ctx.into_iter().map(|x| x.block_context).collect();
+            }
+
+            req_run_start += n_contiguous_requests;
+        }
+
+        cdt::extent__read__done!(|| {
+            (job_id.0, self.extent_number, requests.len() as u64)
+        });
+
+        Ok(())
+    }
+
+    fn flush(
+        &mut self,
+        new_flush: u64,
+        new_gen: u64,
+        job_id: JobOrReconciliationId,
+    ) -> Result<(), CrucibleError> {
+        if !self.dirty()? {
+            /*
+             * If we have made no writes to this extent since the last flush,
+             * we do not need to update the extent on disk
+             */
+            return Ok(());
+        }
+
+        // We put all of our metadata updates into a single write to make this
+        // operation atomic.
+        self.set_flush_number(new_flush, new_gen)?;
+
+        // Now, we fsync to ensure data is flushed to disk.  It's okay to crash
+        // before this point, because setting the flush number is atomic.
+        cdt::extent__flush__file__start!(|| {
+            (job_id.get(), self.extent_number, 0)
+        });
+        if let Err(e) = self.file.sync_all() {
+            /*
+             * XXX Retry?  Mark extent as broken?
+             */
+            crucible_bail!(
+                IoError,
+                "extent {}: fsync 1 failure: {:?}",
+                self.extent_number,
+                e
+            );
+        }
+        self.sync_index += 1;
+        cdt::extent__flush__file__done!(|| {
+            (job_id.get(), self.extent_number, 0)
+        });
+
+        // Finally, reset the file's seek offset to 0
+        self.file.seek(SeekFrom::Start(0))?;
+
+        cdt::extent__flush__done!(|| { (job_id.get(), self.extent_number, 0) });
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn set_dirty_and_block_context(
+        &mut self,
+        block_context: &DownstairsBlockContext,
+    ) -> Result<(), CrucibleError> {
+        self.set_dirty()?;
+        let new_slot = self.set_block_context(block_context)?;
+        self.active_context[block_context.block as usize] =
+            ActiveContext::Slot(new_slot);
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn get_block_contexts(
+        &mut self,
+        block: u64,
+        count: u64,
+    ) -> Result<Vec<Vec<DownstairsBlockContext>>, CrucibleError> {
+        let out = RawInner::get_block_contexts(self, block, count)?;
+        Ok(out.into_iter().map(|v| v.into_iter().collect()).collect())
+    }
+}
+
+impl RawInner {
+    pub fn create(
+        dir: &Path,
+        def: &RegionDefinition,
+        extent_number: u32,
+    ) -> Result<Self> {
+        let path = extent_path(dir, extent_number);
+        let bcount = def.extent_size().value;
+        let size = def.block_size().checked_mul(bcount).unwrap()
+            + BLOCK_CONTEXT_SLOT_SIZE_BYTES * bcount * 2
+            + BLOCK_META_SIZE_BYTES;
+
+        mkdir_for_file(&path)?;
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)?;
+
+        // All 0s are fine for everything except extent version in the metadata
+        file.set_len(size)?;
+        file.seek(SeekFrom::Start(0))?;
+        let mut out = Self {
+            file,
+            dirty: false,
+            extent_size: def.extent_size(),
+            extent_number,
+            active_context: vec![
+                ActiveContext::Empty;
+                def.extent_size().value as usize
+            ],
+            context_slot_synched_at: vec![
+                [0, 0];
+                def.extent_size().value as usize
+            ],
+            sync_index: 0,
+        };
+        // Setting the flush number also writes the extent version, since
+        // they're serialized together in the same block.
+        out.set_flush_number(0, 0)?;
+
+        // Sync the file to disk, to avoid any questions
+        if let Err(e) = out.file.sync_all() {
+            return Err(CrucibleError::IoError(format!(
+                "extent {}: fsync 1 failure during initial sync: {e:?}",
+                out.extent_number,
+            ))
+            .into());
+        }
+        Ok(out)
+    }
+
+    /// Constructs a new `Inner` object from files that already exist on disk
+    pub fn open(
+        path: &Path,
+        def: &RegionDefinition,
+        extent_number: u32,
+        read_only: bool,
+        log: &Logger,
+    ) -> Result<Self> {
+        let bcount = def.extent_size().value;
+        let size = def.block_size().checked_mul(bcount).unwrap()
+            + BLOCK_CONTEXT_SLOT_SIZE_BYTES * bcount * 2
+            + BLOCK_META_SIZE_BYTES;
+
+        /*
+         * Open the extent file and verify the size is as we expect.
+         */
+        let mut file =
+            match OpenOptions::new().read(true).write(!read_only).open(path) {
+                Err(e) => {
+                    error!(
+                        log,
+                        "Open of {path:?} for extent#{extent_number} \
+                         returned: {e}",
+                    );
+                    bail!(
+                        "Open of {path:?} for extent#{extent_number} \
+                         returned: {e}",
+                    );
+                }
+                Ok(f) => {
+                    let cur_size = f.metadata().unwrap().len();
+                    if size != cur_size {
+                        bail!(
+                            "File size {size:?} does not match \
+                             expected {cur_size:?}",
+                        );
+                    }
+                    f
+                }
+            };
+
+        // Just in case, let's be very sure that the file on disk is what it
+        // should be
+        if let Err(e) = file.sync_all() {
+            return Err(CrucibleError::IoError(format!(
+                "extent {extent_number}:
+                 fsync 1 failure during initial rehash: {e:?}",
+            ))
+            .into());
+        }
+
+        file.seek(SeekFrom::Start(Self::meta_offset_from_extent_size(
+            def.extent_size(),
+        )))?;
+        let mut dirty = [0u8];
+        file.read_exact(&mut dirty)?;
+        let dirty = match dirty[0] {
+            0 => false,
+            1 => true,
+            i => bail!("invalid dirty value: {i}"),
+        };
+
+        Ok(Self {
+            file,
+            // Lazy initialization of which context slot is active
+            active_context: vec![
+                ActiveContext::Unknown;
+                def.extent_size().value as usize
+            ],
+            dirty,
+            extent_number,
+            extent_size: def.extent_size(),
+            context_slot_synched_at: vec![
+                [0, 0];
+                def.extent_size().value as usize
+            ],
+            sync_index: 0,
+        })
+    }
+
+    fn set_dirty(&mut self) -> Result<(), CrucibleError> {
+        if !self.dirty {
+            let offset = self.meta_offset();
+            nix::sys::uio::pwrite(self.file.as_raw_fd(), &[1u8], offset as i64)
+                .map_err(|e| CrucibleError::IoError(e.to_string()))?;
+            self.dirty = true;
+        }
+        Ok(())
+    }
+
+    /// Looks up the current context slot for the given block
+    ///
+    /// If the slot is currently unknown, rehashes the block and picks one of
+    /// the two slots, storing it locally.
+    fn get_block_context_slot(&mut self, block: usize) -> Result<Option<bool>> {
+        match self.active_context[block] {
+            ActiveContext::Empty => Ok(None),
+            ActiveContext::Slot(b) => Ok(Some(b)),
+            ActiveContext::Unknown => {
+                let block_size = self.extent_size.block_size_in_bytes();
+                let mut buf = vec![0; block_size as usize];
+                self.file
+                    .seek(SeekFrom::Start(block_size as u64 * block as u64))?;
+                self.file.read_exact(&mut buf)?;
+                let hash = integrity_hash(&[&buf]);
+
+                self.file.seek(SeekFrom::Start(
+                    self.context_slot_offset(block as u64, false),
+                ))?;
+                let mut buf = vec![0; BLOCK_CONTEXT_SLOT_SIZE_BYTES as usize];
+                let mut found = None;
+                for slot in 0..2 {
+                    self.file.read_exact(&mut buf)?;
+                    let context: Option<OnDiskDownstairsBlockContext> =
+                        bincode::deserialize(&buf)?;
+                    if let Some(context) = context {
+                        if context.on_disk_hash == hash {
+                            self.active_context[block] =
+                                ActiveContext::Slot(slot != 0);
+                            found = Some(slot != 0);
+                        }
+                    }
+                }
+                if found.is_none() {
+                    self.active_context[block] = ActiveContext::Empty;
+                }
+                Ok(found)
+            }
+        }
+    }
+
+    /// Writes the inactive block context slot
+    ///
+    /// Returns the new slot which should be marked as active after the write
+    fn set_block_context(
+        &mut self,
+        block_context: &DownstairsBlockContext,
+    ) -> Result<bool> {
+        let block = block_context.block as usize;
+        // Select the inactive slot
+        let slot = !self.get_block_context_slot(block)?.unwrap_or(true);
+
+        // If the context slot that we're about to write into hasn't been
+        // synched to disk yet, we must sync it first.  This prevents subtle
+        // ordering issues!
+        let last_sync = &mut self.context_slot_synched_at[block][slot as usize];
+        if *last_sync > self.sync_index {
+            assert_eq!(*last_sync, self.sync_index + 1);
+            if let Err(e) = self.file.sync_all() {
+                return Err(CrucibleError::IoError(format!(
+                    "extent {}: fsync 1 failure: {:?}",
+                    self.extent_number, e
+                ))
+                .into());
+            }
+            self.sync_index += 1;
+        }
+        // The given slot is about to be newly unsynched, because we're going to
+        // write to it below.
+        *last_sync = self.sync_index + 1;
+
+        let offset = self.context_slot_offset(block_context.block, slot);
+
+        // Serialize into a local buffer, then write into the inactive slot
+        let mut buf = [0u8; BLOCK_CONTEXT_SLOT_SIZE_BYTES as usize];
+        let d = OnDiskDownstairsBlockContext {
+            block_context: block_context.block_context,
+            on_disk_hash: block_context.on_disk_hash,
+        };
+        bincode::serialize_into(buf.as_mut_slice(), &Some(d))?;
+        nix::sys::uio::pwrite(self.file.as_raw_fd(), &buf, offset as i64)
+            .map_err(|e| CrucibleError::IoError(e.to_string()))?;
+
+        // Return the just-written slot; it's the caller's responsibility to
+        // select it as active once data is written.
+        Ok(slot)
+    }
+
+    fn get_metadata(&self) -> Result<OnDiskMeta, CrucibleError> {
+        let mut buf = [0u8; BLOCK_META_SIZE_BYTES as usize];
+        let offset = self.meta_offset();
+        nix::sys::uio::pread(self.file.as_raw_fd(), &mut buf, offset as i64)
+            .map_err(|e| CrucibleError::IoError(e.to_string()))?;
+        let out: OnDiskMeta = bincode::deserialize(&buf)
+            .map_err(|e| CrucibleError::IoError(e.to_string()))?;
+        Ok(out)
+    }
+
+    /// Returns the byte offset of the given context slot
+    ///
+    /// Contexts slots are located after block data in the extent file.  There
+    /// are two context slots per block.  We use a ping-pong strategy to ensure
+    /// that one of them is always valid (i.e. matching the data in the file).
+    fn context_slot_offset(&self, block: u64, slot: bool) -> u64 {
+        self.extent_size.block_size_in_bytes() as u64 * self.extent_size.value
+            + BLOCK_META_SIZE_BYTES
+            + (block * 2 + slot as u64) * BLOCK_CONTEXT_SLOT_SIZE_BYTES
+    }
+
+    /// Returns the byte offset of the metadata region
+    ///
+    /// The resulting offset points to serialized [`OnDiskMeta`] data.
+    fn meta_offset(&self) -> u64 {
+        Self::meta_offset_from_extent_size(self.extent_size)
+    }
+
+    fn meta_offset_from_extent_size(extent_size: Block) -> u64 {
+        extent_size.block_size_in_bytes() as u64 * extent_size.value
+    }
+
+    fn get_block_context(
+        &mut self,
+        block: u64,
+    ) -> Result<Option<DownstairsBlockContext>> {
+        let Some(slot) = self.get_block_context_slot(block as usize)? else {
+            return Ok(None);
+        };
+        let offset = self.context_slot_offset(block, slot);
+        let mut buf = [0u8; BLOCK_CONTEXT_SLOT_SIZE_BYTES as usize];
+        nix::sys::uio::pread(self.file.as_raw_fd(), &mut buf, offset as i64)
+            .map_err(|e| CrucibleError::IoError(e.to_string()))?;
+        let out: Option<OnDiskDownstairsBlockContext> =
+            bincode::deserialize(&buf)?;
+        let out = out.map(|c| DownstairsBlockContext {
+            block,
+            block_context: c.block_context,
+            on_disk_hash: c.on_disk_hash,
+        });
+
+        Ok(out)
+    }
+
+    /// Update the flush number, generation number, and clear the dirty bit
+    fn set_flush_number(&mut self, new_flush: u64, new_gen: u64) -> Result<()> {
+        let d = OnDiskMeta {
+            dirty: false,
+            flush_number: new_flush,
+            gen_number: new_gen,
+            ext_version: EXTENT_META_RAW,
+        };
+        // Byte 0 is the dirty byte
+        let mut buf = [0u8; BLOCK_META_SIZE_BYTES as usize];
+
+        bincode::serialize_into(buf.as_mut_slice(), &d)?;
+        let offset = self.meta_offset();
+        nix::sys::uio::pwrite(self.file.as_raw_fd(), &buf, offset as i64)
+            .map_err(|e| CrucibleError::IoError(e.to_string()))?;
+        self.dirty = false;
+
+        Ok(())
+    }
+
+    /// Returns the valid block contexts (or `None`) for the given block range
+    fn get_block_contexts(
+        &mut self,
+        block: u64,
+        count: u64,
+    ) -> Result<Vec<Option<DownstairsBlockContext>>> {
+        let mut out = vec![];
+        for i in block..block + count {
+            let ctx = self.get_block_context(i)?;
+            out.push(ctx);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bytes::{Bytes, BytesMut};
+    use crucible_protocol::EncryptionContext;
+    use crucible_protocol::ReadRequest;
+    use rand::Rng;
+    use tempfile::tempdir;
+
+    const IOV_MAX_TEST: usize = 1000;
+
+    fn new_region_definition() -> RegionDefinition {
+        let opt = crate::region::test::new_region_options();
+        RegionDefinition::from_options(&opt).unwrap()
+    }
+
+    #[tokio::test]
+    async fn encryption_context() -> Result<()> {
+        let dir = tempdir()?;
+        let mut inner =
+            RawInner::create(dir.as_ref(), &new_region_definition(), 0)
+                .unwrap();
+
+        // Encryption context for blocks 0 and 1 should start blank
+
+        assert!(inner.get_block_contexts(0, 1)?[0].is_none());
+        assert!(inner.get_block_contexts(1, 1)?[0].is_none());
+
+        // Set and verify block 0's context
+        inner.set_dirty_and_block_context(&DownstairsBlockContext {
+            block_context: BlockContext {
+                encryption_context: Some(EncryptionContext {
+                    nonce: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                    tag: [
+                        4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+                        19,
+                    ],
+                }),
+                hash: 123,
+            },
+            block: 0,
+            on_disk_hash: 456,
+        })?;
+
+        let ctxs = inner.get_block_contexts(0, 1)?;
+        let ctx = ctxs[0].as_ref().unwrap();
+        assert_eq!(
+            ctx.block_context.encryption_context.unwrap().nonce,
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        );
+        assert_eq!(
+            ctx.block_context.encryption_context.unwrap().tag,
+            [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+        );
+        assert_eq!(ctx.block_context.hash, 123);
+        assert_eq!(ctx.on_disk_hash, 456);
+
+        // Block 1 should still be blank
+        assert!(inner.get_block_contexts(1, 1)?[0].is_none());
+
+        // Set and verify a new context for block 0
+        let blob1 = rand::thread_rng().gen::<[u8; 12]>();
+        let blob2 = rand::thread_rng().gen::<[u8; 16]>();
+
+        // Set and verify block 0's context
+        inner.set_dirty_and_block_context(&DownstairsBlockContext {
+            block_context: BlockContext {
+                encryption_context: Some(EncryptionContext {
+                    nonce: blob1,
+                    tag: blob2,
+                }),
+                hash: 1024,
+            },
+            block: 0,
+            on_disk_hash: 65536,
+        })?;
+
+        let ctxs = inner.get_block_contexts(0, 1)?;
+        let ctx = ctxs[0].as_ref().unwrap();
+
+        // Second context was appended
+        assert_eq!(ctx.block_context.encryption_context.unwrap().nonce, blob1);
+        assert_eq!(ctx.block_context.encryption_context.unwrap().tag, blob2);
+        assert_eq!(ctx.block_context.hash, 1024);
+        assert_eq!(ctx.on_disk_hash, 65536);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn multiple_context() -> Result<()> {
+        let dir = tempdir()?;
+        let mut inner =
+            RawInner::create(dir.as_ref(), &new_region_definition(), 0)
+                .unwrap();
+
+        // Encryption context for blocks 0 and 1 should start blank
+
+        assert!(inner.get_block_contexts(0, 1)?[0].is_none());
+        assert!(inner.get_block_contexts(1, 1)?[0].is_none());
+
+        // Set block 0's and 1's context and dirty flag
+        inner.set_dirty_and_block_context(&DownstairsBlockContext {
+            block_context: BlockContext {
+                encryption_context: Some(EncryptionContext {
+                    nonce: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                    tag: [
+                        4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+                        19,
+                    ],
+                }),
+                hash: 123,
+            },
+            block: 0,
+            on_disk_hash: 456,
+        })?;
+        inner.set_dirty_and_block_context(&DownstairsBlockContext {
+            block_context: BlockContext {
+                encryption_context: Some(EncryptionContext {
+                    nonce: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                    tag: [8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+                }),
+                hash: 9999,
+            },
+            block: 1,
+            on_disk_hash: 1234567890,
+        })?;
+
+        // Verify block 0's context
+        let ctxs = inner.get_block_contexts(0, 1)?;
+        let ctx = ctxs[0].as_ref().unwrap();
+        assert_eq!(
+            ctx.block_context.encryption_context.unwrap().nonce,
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        );
+        assert_eq!(
+            ctx.block_context.encryption_context.unwrap().tag,
+            [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+        );
+        assert_eq!(ctx.block_context.hash, 123);
+        assert_eq!(ctx.on_disk_hash, 456);
+
+        // Verify block 1's context
+        let ctxs = inner.get_block_contexts(1, 1)?;
+        let ctx = ctxs[0].as_ref().unwrap();
+
+        assert_eq!(
+            ctx.block_context.encryption_context.unwrap().nonce,
+            [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        );
+        assert_eq!(
+            ctx.block_context.encryption_context.unwrap().tag,
+            [8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+        );
+        assert_eq!(ctx.block_context.hash, 9999);
+        assert_eq!(ctx.on_disk_hash, 1234567890);
+
+        // Return both block 0's and block 1's context, and verify
+
+        let ctxs = inner.get_block_contexts(0, 2)?;
+        let ctx = ctxs[0].as_ref().unwrap();
+        assert_eq!(
+            ctx.block_context.encryption_context.unwrap().nonce,
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        );
+        assert_eq!(
+            ctx.block_context.encryption_context.unwrap().tag,
+            [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+        );
+        assert_eq!(ctx.block_context.hash, 123);
+        assert_eq!(ctx.on_disk_hash, 456);
+
+        let ctx = ctxs[1].as_ref().unwrap();
+        assert_eq!(
+            ctx.block_context.encryption_context.unwrap().nonce,
+            [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        );
+        assert_eq!(
+            ctx.block_context.encryption_context.unwrap().tag,
+            [8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+        );
+        assert_eq!(ctx.block_context.hash, 9999);
+        assert_eq!(ctx.on_disk_hash, 1234567890);
+
+        // Append a whole bunch of block context rows
+        for i in 0..10 {
+            inner.set_dirty_and_block_context(&DownstairsBlockContext {
+                block_context: BlockContext {
+                    encryption_context: Some(EncryptionContext {
+                        nonce: rand::thread_rng().gen::<[u8; 12]>(),
+                        tag: rand::thread_rng().gen::<[u8; 16]>(),
+                    }),
+                    hash: rand::thread_rng().gen::<u64>(),
+                },
+                block: 0,
+                on_disk_hash: i,
+            })?;
+            inner.set_dirty_and_block_context(&DownstairsBlockContext {
+                block_context: BlockContext {
+                    encryption_context: Some(EncryptionContext {
+                        nonce: rand::thread_rng().gen::<[u8; 12]>(),
+                        tag: rand::thread_rng().gen::<[u8; 16]>(),
+                    }),
+                    hash: rand::thread_rng().gen::<u64>(),
+                },
+                block: 1,
+                on_disk_hash: i,
+            })?;
+        }
+
+        let ctxs = inner.get_block_contexts(0, 2)?;
+
+        assert!(ctxs[0].is_some());
+        assert_eq!(ctxs[0].as_ref().unwrap().on_disk_hash, 9);
+
+        assert!(ctxs[1].is_some());
+        assert_eq!(ctxs[1].as_ref().unwrap().on_disk_hash, 9);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_unwritten_without_flush() -> Result<()> {
+        let dir = tempdir()?;
+        let mut inner =
+            RawInner::create(dir.as_ref(), &new_region_definition(), 0)
+                .unwrap();
+
+        // Write a block, but don't flush.
+        let data = Bytes::from(vec![0x55; 512]);
+        let hash = integrity_hash(&[&data[..]]);
+        let write = crucible_protocol::Write {
+            eid: 0,
+            offset: Block::new_512(0),
+            data,
+            block_context: BlockContext {
+                encryption_context: None,
+                hash,
+            },
+        };
+        inner.write(JobId(10), &[&write], false, IOV_MAX_TEST)?;
+
+        // The context should be in place, though we haven't flushed yet
+
+        // Therefore, we expect that write_unwritten to the first block won't
+        // do anything.
+        {
+            let data = Bytes::from(vec![0x66; 512]);
+            let hash = integrity_hash(&[&data[..]]);
+            let block_context = BlockContext {
+                encryption_context: None,
+                hash,
+            };
+            let write = crucible_protocol::Write {
+                eid: 0,
+                offset: Block::new_512(0),
+                data: data.clone(),
+                block_context,
+            };
+            inner.write(JobId(20), &[&write], true, IOV_MAX_TEST)?;
+
+            let mut resp = Vec::new();
+            let read = ReadRequest {
+                eid: 0,
+                offset: Block::new_512(0),
+            };
+            inner.read(JobId(21), &[&read], &mut resp, IOV_MAX_TEST)?;
+
+            // We should not get back our data, because block 0 was written.
+            assert_ne!(
+                resp,
+                vec![ReadResponse {
+                    eid: 0,
+                    offset: Block::new_512(0),
+                    data: BytesMut::from(data.as_ref()),
+                    block_contexts: vec![block_context]
+                }]
+            );
+        }
+
+        // But, writing to the second block still should!
+        {
+            let data = Bytes::from(vec![0x66; 512]);
+            let hash = integrity_hash(&[&data[..]]);
+            let block_context = BlockContext {
+                encryption_context: None,
+                hash,
+            };
+            let write = crucible_protocol::Write {
+                eid: 0,
+                offset: Block::new_512(1),
+                data: data.clone(),
+                block_context,
+            };
+            inner.write(JobId(30), &[&write], true, IOV_MAX_TEST)?;
+
+            let mut resp = Vec::new();
+            let read = ReadRequest {
+                eid: 0,
+                offset: Block::new_512(1),
+            };
+            inner.read(JobId(31), &[&read], &mut resp, IOV_MAX_TEST)?;
+
+            // We should get back our data! Block 1 was never written.
+            assert_eq!(
+                resp,
+                vec![ReadResponse {
+                    eid: 0,
+                    offset: Block::new_512(1),
+                    data: BytesMut::from(data.as_ref()),
+                    block_contexts: vec![block_context]
+                }]
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_auto_sync() -> Result<()> {
+        let dir = tempdir()?;
+        let mut inner =
+            RawInner::create(dir.as_ref(), &new_region_definition(), 0)
+                .unwrap();
+
+        // Write a block, but don't flush.
+        let data = Bytes::from(vec![0x55; 512]);
+        let hash = integrity_hash(&[&data[..]]);
+        let write = crucible_protocol::Write {
+            eid: 0,
+            offset: Block::new_512(0),
+            data,
+            block_context: BlockContext {
+                encryption_context: None,
+                hash,
+            },
+        };
+        // The context should be written to slot 0
+        inner.write(JobId(10), &[&write], false, IOV_MAX_TEST)?;
+        assert_eq!(inner.sync_index, 0);
+
+        // The context should be written to slot 1
+        inner.write(JobId(11), &[&write], false, IOV_MAX_TEST)?;
+        assert_eq!(inner.sync_index, 0);
+
+        // The context should be written to slot 0, forcing a sync
+        inner.write(JobId(12), &[&write], false, IOV_MAX_TEST)?;
+        assert_eq!(inner.sync_index, 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_auto_sync_flush() -> Result<()> {
+        let dir = tempdir()?;
+        let mut inner =
+            RawInner::create(dir.as_ref(), &new_region_definition(), 0)
+                .unwrap();
+
+        // Write a block, but don't flush.
+        let data = Bytes::from(vec![0x55; 512]);
+        let hash = integrity_hash(&[&data[..]]);
+        let write = crucible_protocol::Write {
+            eid: 0,
+            offset: Block::new_512(0),
+            data,
+            block_context: BlockContext {
+                encryption_context: None,
+                hash,
+            },
+        };
+        // The context should be written to slot 0
+        inner.write(JobId(10), &[&write], false, IOV_MAX_TEST)?;
+        assert_eq!(inner.sync_index, 0);
+
+        // Flush, which should bump the sync number (marking slot 0 as synched)
+        inner.flush(12, 12, JobId(11).into())?;
+
+        // The context should be written to slot 1
+        inner.write(JobId(11), &[&write], false, IOV_MAX_TEST)?;
+        assert_eq!(inner.sync_index, 1);
+
+        // The context should be written to slot 0
+        inner.write(JobId(12), &[&write], false, IOV_MAX_TEST)?;
+        assert_eq!(inner.sync_index, 1);
+
+        // The context should be written to slot 1, forcing a sync
+        inner.write(JobId(12), &[&write], false, IOV_MAX_TEST)?;
+        assert_eq!(inner.sync_index, 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_auto_sync_flush_2() -> Result<()> {
+        let dir = tempdir()?;
+        let mut inner =
+            RawInner::create(dir.as_ref(), &new_region_definition(), 0)
+                .unwrap();
+
+        // Write a block, but don't flush.
+        let data = Bytes::from(vec![0x55; 512]);
+        let hash = integrity_hash(&[&data[..]]);
+        let write = crucible_protocol::Write {
+            eid: 0,
+            offset: Block::new_512(0),
+            data,
+            block_context: BlockContext {
+                encryption_context: None,
+                hash,
+            },
+        };
+        // The context should be written to slot 0
+        inner.write(JobId(10), &[&write], false, IOV_MAX_TEST)?;
+        assert_eq!(inner.sync_index, 0);
+
+        // The context should be written to slot 1
+        inner.write(JobId(11), &[&write], false, IOV_MAX_TEST)?;
+        assert_eq!(inner.sync_index, 0);
+
+        // Flush, which should bump the sync number (marking slot 0 as synched)
+        inner.flush(12, 12, JobId(11).into())?;
+
+        // The context should be written to slot 0
+        inner.write(JobId(12), &[&write], false, IOV_MAX_TEST)?;
+        assert_eq!(inner.sync_index, 1);
+
+        // The context should be written to slot 1
+        inner.write(JobId(12), &[&write], false, IOV_MAX_TEST)?;
+        assert_eq!(inner.sync_index, 1);
+
+        // The context should be written to slot 0, forcing a sync
+        inner.write(JobId(12), &[&write], false, IOV_MAX_TEST)?;
+        assert_eq!(inner.sync_index, 2);
+
+        Ok(())
+    }
+
+    /// If a write successfully put a context into a context slot, but it never
+    /// actually got the data onto the disk, that block should revert back to
+    /// being "unwritten". After all, the data never was truly written.
+    ///
+    /// This test is very similar to test_region_open_removes_partial_writes.
+    #[test]
+    fn test_reopen_marks_blocks_unwritten_if_data_never_hit_disk() -> Result<()>
+    {
+        let dir = tempdir()?;
+        let mut inner =
+            RawInner::create(dir.as_ref(), &new_region_definition(), 0)
+                .unwrap();
+
+        // Partial write, the data never hits disk, but there's a context
+        // in the DB and the dirty flag is set.
+        inner.set_dirty_and_block_context(&DownstairsBlockContext {
+            block_context: BlockContext {
+                encryption_context: None,
+                hash: 1024,
+            },
+            block: 0,
+            on_disk_hash: 65536,
+        })?;
+        drop(inner);
+
+        // Reopen, which should note that the hash doesn't match on-disk values
+        // and decide that block 0 is unwritten.
+        let mut inner =
+            RawInner::create(dir.as_ref(), &new_region_definition(), 0)
+                .unwrap();
+
+        // Writing to block 0 should succeed with only_write_unwritten
+        {
+            let data = Bytes::from(vec![0x66; 512]);
+            let hash = integrity_hash(&[&data[..]]);
+            let block_context = BlockContext {
+                encryption_context: None,
+                hash,
+            };
+            let write = crucible_protocol::Write {
+                eid: 0,
+                offset: Block::new_512(0),
+                data: data.clone(),
+                block_context,
+            };
+            inner.write(JobId(30), &[&write], true, IOV_MAX_TEST)?;
+
+            let mut resp = Vec::new();
+            let read = ReadRequest {
+                eid: 0,
+                offset: Block::new_512(0),
+            };
+            inner.read(JobId(31), &[&read], &mut resp, IOV_MAX_TEST)?;
+
+            // We should get back our data! Block 1 was never written.
+            assert_eq!(
+                resp,
+                vec![ReadResponse {
+                    eid: 0,
+                    offset: Block::new_512(0),
+                    data: BytesMut::from(data.as_ref()),
+                    block_contexts: vec![block_context]
+                }]
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -1471,6 +1471,7 @@ impl RawLayout {
             });
         }
         assert_eq!(active_context.len(), self.block_count() as usize);
+        self.buf.set(buf);
         Ok(active_context)
     }
 }

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -1248,11 +1248,7 @@ impl RawLayout {
                 block_context: b.block_context,
                 on_disk_hash: b.on_disk_hash,
             });
-            bincode::serialize_into(&mut buf[n..], &d).map_err(|e| {
-                CrucibleError::IoError(format!(
-                    "could not serialize context: {e}"
-                ))
-            })?;
+            bincode::serialize_into(&mut buf[n..], &d).unwrap();
         }
         let offset = self.context_slot_offset(block_start, slot);
         nix::sys::uio::pwrite(file.as_raw_fd(), &buf, offset as i64)
@@ -1321,7 +1317,7 @@ impl RawLayout {
             ext_version: EXTENT_META_RAW,
         };
         let mut meta = [0u8; BLOCK_META_SIZE_BYTES as usize];
-        bincode::serialize_into(meta.as_mut_slice(), &d)?;
+        bincode::serialize_into(meta.as_mut_slice(), &d).unwrap();
         buf.extend(meta);
 
         let offset = self.active_context_offset();

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -1317,6 +1317,10 @@ impl RawLayout {
     /// Write out the active context array and metadata section of the file
     ///
     /// This is done in a single write, so it should be atomic.
+    ///
+    /// # Panics
+    /// `active_context.len()` must match `self.block_count()`, and the function
+    /// will panic otherwise.
     fn write_active_context_and_metadata(
         &self,
         file: &File,
@@ -1325,6 +1329,8 @@ impl RawLayout {
         flush_number: u64,
         gen_number: u64,
     ) -> Result<(), CrucibleError> {
+        assert_eq!(active_context.len(), self.block_count() as usize);
+
         // Serialize bitpacked active slot values
         let mut buf = self.buf.take();
         buf.clear();

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -42,7 +42,7 @@ pub struct OnDiskMeta {
 
 /// Size of backup data
 ///
-/// This must be large enough to contain an `Option<DownstairsBlockContext>`
+/// This must be large enough to fit an `Option<OnDiskDownstairsBlockContext>`
 /// serialized using `bincode`.
 pub const BLOCK_CONTEXT_SLOT_SIZE_BYTES: u64 = 64;
 
@@ -1459,5 +1459,30 @@ mod test {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn test_serialized_sizes() {
+        let c = OnDiskDownstairsBlockContext {
+            block_context: BlockContext {
+                hash: u64::MAX,
+                encryption_context: Some(EncryptionContext {
+                    nonce: [0xFF; 12],
+                    tag: [0xFF; 16],
+                }),
+            },
+            on_disk_hash: u64::MAX,
+        };
+        let mut ctx_buf = [0u8; BLOCK_CONTEXT_SLOT_SIZE_BYTES as usize];
+        bincode::serialize_into(ctx_buf.as_mut_slice(), &Some(c)).unwrap();
+
+        let m = OnDiskMeta {
+            dirty: true,
+            gen_number: u64::MAX,
+            flush_number: u64::MAX,
+            ext_version: u32::MAX,
+        };
+        let mut meta_buf = [0u8; BLOCK_META_SIZE_BYTES as usize];
+        bincode::serialize_into(meta_buf.as_mut_slice(), &Some(m)).unwrap();
     }
 }

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -518,13 +518,14 @@ impl SqliteInner {
         let ctxs = self.get_block_contexts(0, self.extent_size.value)?;
         let needs_rehash = ctxs.iter().any(|c| c.len() > 1);
 
-        if needs_rehash {
+        let ctxs = if needs_rehash {
             // Clean up stale hashes.  After this is done, each block should
             // have either 0 or 1 contexts.
             self.fully_rehash_and_clean_all_stale_contexts(true)?;
-        }
-
-        let ctxs = self.get_block_contexts(0, self.extent_size.value)?;
+            self.get_block_contexts(0, self.extent_size.value)?
+        } else {
+            ctxs
+        };
 
         use crate::{
             extent::EXTENT_META_RAW,

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -534,7 +534,7 @@ impl SqliteInner {
             },
         };
 
-        // Record the metadata region, which will be right after raw block data
+        // Record the metadata section, which will be right after raw block data
         let dirty = self.dirty()?;
         let flush_number = self.flush_number()?;
         let gen_number = self.gen_number()?;

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -593,7 +593,7 @@ impl SqliteInner {
     // We should never create a new SQLite-backed extent in production code,
     // because we should be using raw extents everywhere.  However, we'll create
     // them during tests to check that our automatic migration system works.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "integration-tests"))]
     pub fn create(
         dir: &Path,
         def: &RegionDefinition,

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -548,6 +548,12 @@ impl SqliteInner {
         bincode::serialize_into(buf.as_mut_slice(), &meta)
             .map_err(|e| CrucibleError::IoError(e.to_string()))?;
 
+        // Add bitpacked data indicating which slot is active; this is always A
+        buf.extend(
+            std::iter::repeat(0)
+                .take((self.extent_size.value as usize + 7) / 8),
+        );
+
         // Put the context data after the metadata, all in slot A
         for c in ctxs {
             let ctx = match c.len() {

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -868,7 +868,9 @@ impl SqliteInner {
         };
         // Clean out any irrelevant block contexts, which may be present
         // if downstairs crashed between a write() and a flush().
-        out.fully_rehash_and_clean_all_stale_contexts(false)?;
+        if !read_only {
+            out.fully_rehash_and_clean_all_stale_contexts(false)?;
+        }
         Ok(out)
     }
 

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -548,7 +548,10 @@ impl SqliteInner {
         bincode::serialize_into(meta_buf.as_mut_slice(), &meta)
             .map_err(|e| CrucibleError::IoError(e.to_string()))?;
 
-        let mut buf = vec![];
+        let mut buf = Vec::with_capacity(
+            BLOCK_META_SIZE_BYTES as usize
+                + ctxs.len() * 2 * BLOCK_CONTEXT_SLOT_SIZE_BYTES as usize,
+        );
         buf.extend(meta_buf);
 
         // Put the context data after the metadata

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -37,6 +37,7 @@ pub mod region;
 pub mod repair;
 mod stats;
 
+mod extent_inner_raw;
 mod extent_inner_sqlite;
 
 use region::Region;
@@ -443,6 +444,18 @@ pub mod cdt {
         job_id: u64,
         extent_id: u32,
         n_blocks: u64,
+    ) {
+    }
+    fn extent__write__raw__context__insert__start(
+        job_id: u64,
+        extent_id: u32,
+        extent_size: u64,
+    ) {
+    }
+    fn extent__write__raw__context__insert__done(
+        _job_id: u64,
+        _extent_id: u32,
+        extent_size: u64,
     ) {
     }
     fn extent__read__start(job_id: u64, extent_id: u32, n_blocks: u64) {}

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -477,6 +477,11 @@ pub mod cdt {
 
     fn extent__context__truncate__start(n_deletions: u64) {}
     fn extent__context__truncate__done() {}
+    fn extent__set__block__contexts__write__count(
+        extent_id: u32,
+        n_blocks: u64,
+    ) {
+    }
     fn submit__el__close__done(_: u64) {}
     fn submit__el__flush__close__done(_: u64) {}
     fn submit__el__repair__done(_: u64) {}

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1986,7 +1986,7 @@ pub(crate) mod test {
         // write everything to disk).
         let extent_file = extent_path(&dir, 1);
         let mut inner = extent_inner_sqlite::SqliteInner::open(
-            &extent_file,
+            dir.path(),
             &ddef,
             1,
             false,

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1884,7 +1884,7 @@ pub(crate) mod test {
         // Manually calculate the migration from extent 1
         let extent_file = extent_path(&dir, 1);
         let mut inner = extent_inner_sqlite::SqliteInner::open(
-            &extent_file,
+            dir.path(),
             &ddef,
             1,
             false,

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -27,7 +27,7 @@ use crate::extent::{
 };
 
 /**
- * Validate a list of sorted repair files.
+ * Validate the repair file.
  *
  * There is only one repair file: the raw file itself (which also contains
  * structured context and metadata at the end).

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1869,7 +1869,7 @@ pub(crate) mod test {
             .await?;
         drop(region);
 
-        // Calculate the migration from extent 1
+        // Manually calculate the migration from extent 1
         let extent_file = extent_path(&dir, 1);
         let exported = {
             let mut inner = extent_inner_sqlite::SqliteInner::open(
@@ -1879,7 +1879,17 @@ pub(crate) mod test {
                 false,
                 &log,
             )?;
-            inner.export_meta_and_context()?
+            use crate::extent::ExtentInner;
+            let ctxs = inner.export_contexts()?;
+            let dirty = inner.dirty()?;
+            let flush_number = inner.flush_number()?;
+            let gen_number = inner.gen_number()?;
+            extent_inner_raw::RawInner::import(
+                ctxs,
+                dirty,
+                flush_number,
+                gen_number,
+            )?
         };
 
         {

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1600,9 +1600,8 @@ pub(crate) mod test {
     async fn reopen_extent_cleanup_replay_short() -> Result<()> {
         // test move_replacement_extent(), create a copy dir, populate it
         // and let the reopen do the work.  This time we make sure our
-        // copy dir only has extent data and .db files, and not .db-shm
-        // nor .db-wal.  Verify these files are delete from the original
-        // extent after the reopen has cleaned them up.
+        // copy dir only has the extent data file.
+
         // Create the region, make three extents
         let dir = tempdir()?;
         let mut region =
@@ -1942,6 +1941,15 @@ pub(crate) mod test {
         let good_files: Vec<String> = vec!["001".to_string()];
 
         assert!(!validate_repair_files(2, &good_files));
+    }
+
+    #[test]
+    fn validate_repair_files_old() {
+        // Old extent files
+        let good_files: Vec<String> =
+            vec!["001".to_string(), "001.db".to_string()];
+
+        assert!(!validate_repair_files(1, &good_files));
     }
 
     #[tokio::test]

--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -226,12 +226,7 @@ fn extent_file_list(
     eid: u32,
 ) -> Result<Vec<String>, HttpError> {
     let mut files = Vec::new();
-    let possible_files = vec![
-        (extent_file_name(eid, ExtentType::Data), true),
-        (extent_file_name(eid, ExtentType::Db), true),
-        (extent_file_name(eid, ExtentType::DbShm), false),
-        (extent_file_name(eid, ExtentType::DbWal), false),
-    ];
+    let possible_files = vec![(extent_file_name(eid, ExtentType::Data), true)];
 
     for (file, required) in possible_files.into_iter() {
         let mut fullname = extent_dir.clone();
@@ -282,7 +277,7 @@ mod test {
         let ed = extent_dir(&dir, 1);
         let mut ex_files = extent_file_list(ed, 1).unwrap();
         ex_files.sort();
-        let expected = vec!["001", "001.db", "001.db-shm", "001.db-wal"];
+        let expected = vec!["001"];
         println!("files: {:?}", ex_files);
         assert_eq!(ex_files, expected);
 
@@ -290,42 +285,11 @@ mod test {
     }
 
     #[tokio::test]
-    async fn extent_expected_files_short() -> Result<()> {
+    async fn extent_expected_files_with_close() -> Result<()> {
         // Verify that the list of files returned for an extent matches
         // what we expect. In this case we expect the extent data file and
-        // the .db file, but not the .db-shm or .db-wal database files.
-        let dir = tempdir()?;
-        let mut region =
-            Region::create(&dir, new_region_options(), csl()).await?;
-        region.extend(3).await?;
-
-        // Determine the directory and name for expected extent files.
-        let extent_dir = extent_dir(&dir, 1);
-
-        // Delete db-wal and db-shm
-        let mut rm_file = extent_dir.clone();
-        rm_file.push(extent_file_name(1, ExtentType::Data));
-        rm_file.set_extension("db-wal");
-        std::fs::remove_file(&rm_file).unwrap();
-        rm_file.set_extension("db-shm");
-        std::fs::remove_file(rm_file).unwrap();
-
-        let mut ex_files = extent_file_list(extent_dir, 1).unwrap();
-        ex_files.sort();
-        let expected = vec!["001", "001.db"];
-        println!("files: {:?}", ex_files);
-        assert_eq!(ex_files, expected);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn extent_expected_files_short_with_close() -> Result<()> {
-        // Verify that the list of files returned for an extent matches
-        // what we expect. In this case we expect the extent data file and
-        // the .db file, but not the .db-shm or .db-wal database files.
-        // We close the extent here first, and on illumos that behaves
-        // a little different than elsewhere.
+        // nothing else. We close the extent here first, and on illumos that
+        // behaves a little different than elsewhere.
         let dir = tempdir()?;
         let mut region =
             Region::create(&dir, new_region_options(), csl()).await?;
@@ -336,18 +300,9 @@ mod test {
         // Determine the directory and name for expected extent files.
         let extent_dir = extent_dir(&dir, 1);
 
-        // Delete db-wal and db-shm.  On illumos the close of the extent
-        // may remove these for us, so we ignore errors on the removal.
-        let mut rm_file = extent_dir.clone();
-        rm_file.push(extent_file_name(1, ExtentType::Data));
-        rm_file.set_extension("db-wal");
-        let _ = std::fs::remove_file(&rm_file);
-        rm_file.set_extension("db-shm");
-        let _ = std::fs::remove_file(rm_file);
-
         let mut ex_files = extent_file_list(extent_dir, 1).unwrap();
         ex_files.sort();
-        let expected = vec!["001", "001.db"];
+        let expected = vec!["001"];
         println!("files: {:?}", ex_files);
         assert_eq!(ex_files, expected);
 
@@ -356,29 +311,6 @@ mod test {
 
     #[tokio::test]
     async fn extent_expected_files_fail() -> Result<()> {
-        // Verify that we get an error if the expected extent.db file
-        // is missing.
-        let dir = tempdir()?;
-        let mut region =
-            Region::create(&dir, new_region_options(), csl()).await?;
-        region.extend(3).await?;
-
-        // Determine the directory and name for expected extent files.
-        let extent_dir = extent_dir(&dir, 2);
-
-        // Delete db
-        let mut rm_file = extent_dir.clone();
-        rm_file.push(extent_file_name(2, ExtentType::Data));
-        rm_file.set_extension("db");
-        std::fs::remove_file(&rm_file).unwrap();
-
-        assert!(extent_file_list(extent_dir, 2).is_err());
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn extent_expected_files_fail_two() -> Result<()> {
         // Verify that we get an error if the expected extent file
         // is missing.
         let dir = tempdir()?;
@@ -389,7 +321,7 @@ mod test {
         // Determine the directory and name for expected extent files.
         let extent_dir = extent_dir(&dir, 1);
 
-        // Delete db
+        // Delete the extent file
         let mut rm_file = extent_dir.clone();
         rm_file.push(extent_file_name(1, ExtentType::Data));
         std::fs::remove_file(&rm_file).unwrap();

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -16,7 +16,7 @@ bytes.workspace = true
 crucible-client-types.workspace = true
 # importantly, don't use features = ["zfs_snapshot"] here, this will cause
 # cleanup issues!
-crucible-downstairs.workspace = true
+crucible-downstairs = { workspace = true, features = ["integration-tests"] }
 crucible-pantry-client.workspace = true
 crucible-pantry.workspace = true
 crucible.workspace = true

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -2320,20 +2320,6 @@ mod test {
         let mut test_downstairs_set =
             TestDownstairsSet::small_sqlite(false).await?;
         // This must be a SQLite extent!
-        println!(
-            "{:?}",
-            test_downstairs_set
-                .downstairs1
-                .tempdir
-                .path()
-                .join("00/000/000.db")
-        );
-        let out = std::process::Command::new("tree")
-            .arg(test_downstairs_set.downstairs1.tempdir.path())
-            .output()
-            .expect("failed to execute process");
-        println!("{}", std::str::from_utf8(&out.stdout).unwrap());
-
         assert!(test_downstairs_set
             .downstairs1
             .tempdir
@@ -2524,20 +2510,6 @@ mod test {
         let mut test_downstairs_set =
             TestDownstairsSet::small_sqlite(false).await?;
         // This must be a SQLite extent!
-        println!(
-            "{:?}",
-            test_downstairs_set
-                .downstairs1
-                .tempdir
-                .path()
-                .join("00/000/000.db")
-        );
-        let out = std::process::Command::new("tree")
-            .arg(test_downstairs_set.downstairs1.tempdir.path())
-            .output()
-            .expect("failed to execute process");
-        println!("{}", std::str::from_utf8(&out.stdout).unwrap());
-
         assert!(test_downstairs_set
             .downstairs1
             .tempdir

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -44,30 +44,35 @@ mod test {
             blocks_per_extent: u64,
             extent_count: u32,
             problematic: bool,
+            backend: Backend,
         ) -> Result<Self> {
             let tempdir = tempfile::Builder::new()
                 .prefix(&"downstairs-")
                 .rand_bytes(8)
                 .tempdir()?;
 
-            let _region = create_region(
-                512, /* block_size */
+            let _region = create_region_with_backend(
                 tempdir.path().to_path_buf(),
-                blocks_per_extent,
+                Block {
+                    value: blocks_per_extent,
+                    shift: 9,
+                },
                 extent_count.into(),
                 Uuid::new_v4(),
                 encrypted,
+                backend,
                 csl(),
             )
             .await?;
 
-            let downstairs = build_downstairs_for_region(
+            let downstairs = build_downstairs_for_region_with_backend(
                 tempdir.path(),
                 problematic, /* lossy */
                 problematic, /* read errors */
                 problematic, /* write errors */
                 problematic, /* flush errors */
                 read_only,
+                backend,
                 Some(csl()),
             )
             .await?;
@@ -191,6 +196,7 @@ mod test {
                 blocks_per_extent,
                 extent_count,
                 problematic,
+                Backend::RawFile,
             )
             .await?;
             let downstairs2 = TestDownstairs::new(
@@ -200,6 +206,7 @@ mod test {
                 blocks_per_extent,
                 extent_count,
                 problematic,
+                Backend::RawFile,
             )
             .await?;
             let downstairs3 = TestDownstairs::new(
@@ -209,6 +216,7 @@ mod test {
                 blocks_per_extent,
                 extent_count,
                 problematic,
+                Backend::RawFile,
             )
             .await?;
 
@@ -281,6 +289,7 @@ mod test {
                 self.blocks_per_extent,
                 self.extent_count,
                 false,
+                Backend::RawFile,
             )
             .await
         }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -150,6 +150,24 @@ mod test {
                 blocks_per_extent,
                 extent_count,
                 false,
+                Backend::RawFile,
+            )
+            .await
+        }
+
+        /// Spin off three SQLite downstairs, with a 5120b region
+        pub async fn small_sqlite(
+            read_only: bool,
+        ) -> Result<TestDownstairsSet> {
+            // 5 * 2 * 512 = 5120b
+            let blocks_per_extent = 5;
+            let extent_count = 2;
+            TestDownstairsSet::new_with_flag(
+                read_only,
+                blocks_per_extent,
+                extent_count,
+                false,
+                Backend::SQLite,
             )
             .await
         }
@@ -164,6 +182,7 @@ mod test {
                 blocks_per_extent,
                 extent_count,
                 false,
+                Backend::RawFile,
             )
             .await
         }
@@ -178,6 +197,7 @@ mod test {
                 blocks_per_extent,
                 extent_count,
                 true, // problematic
+                Backend::RawFile,
             )
             .await
         }
@@ -188,6 +208,7 @@ mod test {
             blocks_per_extent: u64,
             extent_count: u32,
             problematic: bool,
+            backend: Backend,
         ) -> Result<TestDownstairsSet> {
             let downstairs1 = TestDownstairs::new(
                 "127.0.0.1".parse()?,
@@ -196,7 +217,7 @@ mod test {
                 blocks_per_extent,
                 extent_count,
                 problematic,
-                Backend::RawFile,
+                backend,
             )
             .await?;
             let downstairs2 = TestDownstairs::new(
@@ -206,7 +227,7 @@ mod test {
                 blocks_per_extent,
                 extent_count,
                 problematic,
-                Backend::RawFile,
+                backend,
             )
             .await?;
             let downstairs3 = TestDownstairs::new(
@@ -216,7 +237,7 @@ mod test {
                 blocks_per_extent,
                 extent_count,
                 problematic,
-                Backend::RawFile,
+                backend,
             )
             .await?;
 
@@ -2169,6 +2190,210 @@ mod test {
         let top_layer_tds = TestDownstairsSet::small(false).await?;
         let top_layer_opts = top_layer_tds.opts();
         let bottom_layer_opts = test_downstairs_set.opts();
+
+        let vcr: VolumeConstructionRequest =
+            VolumeConstructionRequest::Volume {
+                id: Uuid::new_v4(),
+                block_size: BLOCK_SIZE as u64,
+                sub_volumes: vec![VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: top_layer_tds.blocks_per_extent(),
+                    extent_count: top_layer_tds.extent_count(),
+                    opts: top_layer_opts,
+                    gen: 3,
+                }],
+                read_only_parent: Some(Box::new(
+                    VolumeConstructionRequest::Volume {
+                        id: Uuid::new_v4(),
+                        block_size: BLOCK_SIZE as u64,
+                        sub_volumes: vec![VolumeConstructionRequest::Region {
+                            block_size: BLOCK_SIZE as u64,
+                            blocks_per_extent: test_downstairs_set
+                                .blocks_per_extent(),
+                            extent_count: test_downstairs_set.extent_count(),
+                            opts: bottom_layer_opts,
+                            gen: 3,
+                        }],
+                        read_only_parent: None,
+                    },
+                )),
+            };
+
+        let volume = Volume::construct(vcr, None, csl()).await?;
+        volume.activate().await?;
+
+        // Validate that source blocks originally come from the read-only parent
+        {
+            let buffer = Buffer::new(volume.total_size().await? as usize);
+            volume
+                .read(
+                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                    buffer.clone(),
+                )
+                .await?;
+
+            assert_eq!(*buffer.as_vec().await, random_buffer);
+        }
+
+        // Validate a flush works
+        volume.flush(None).await?;
+
+        // Write one block of 0x00 in, validate with a read
+        volume
+            .write(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![0u8; BLOCK_SIZE]),
+            )
+            .await?;
+
+        {
+            let buffer = Buffer::new(volume.total_size().await? as usize);
+            volume
+                .read(
+                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                    buffer.clone(),
+                )
+                .await?;
+
+            let buffer_vec = buffer.as_vec().await;
+
+            assert_eq!(buffer_vec[..BLOCK_SIZE], vec![0u8; BLOCK_SIZE]);
+            assert_eq!(buffer_vec[BLOCK_SIZE..], random_buffer[BLOCK_SIZE..]);
+        }
+
+        // Validate a flush still works
+        volume.flush(None).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn integration_test_sqlite_backed_vol() -> Result<()> {
+        // Test using an old SQLite backend as a read-only parent.
+
+        const BLOCK_SIZE: usize = 512;
+
+        // boot three downstairs, write some data to them, then change to
+        // read-only.
+        let mut test_downstairs_set =
+            TestDownstairsSet::small_sqlite(false).await?;
+        // This must be a SQLite extent!
+        println!(
+            "{:?}",
+            test_downstairs_set
+                .downstairs1
+                .tempdir
+                .path()
+                .join("00/000/000.db")
+        );
+        let out = std::process::Command::new("tree")
+            .arg(test_downstairs_set.downstairs1.tempdir.path())
+            .output()
+            .expect("failed to execute process");
+        println!("{}", std::str::from_utf8(&out.stdout).unwrap());
+
+        assert!(test_downstairs_set
+            .downstairs1
+            .tempdir
+            .path()
+            .join("00/000/000.db")
+            .exists());
+
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
+        volume
+            .add_subvolume_create_guest(
+                test_downstairs_set.opts(),
+                volume::RegionExtentInfo {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: test_downstairs_set.blocks_per_extent(),
+                    extent_count: test_downstairs_set.extent_count(),
+                },
+                1,
+                None,
+            )
+            .await?;
+
+        volume.activate().await?;
+
+        let random_buffer = {
+            let mut random_buffer =
+                vec![0u8; volume.total_size().await? as usize];
+            rand::thread_rng().fill(&mut random_buffer[..]);
+            random_buffer
+        };
+
+        volume
+            .write(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(random_buffer.clone()),
+            )
+            .await?;
+
+        volume.deactivate().await?;
+
+        drop(volume);
+
+        test_downstairs_set.reboot_read_only().await?;
+        // This must still be a SQLite backend!
+        assert!(test_downstairs_set
+            .downstairs1
+            .tempdir
+            .path()
+            .join("00/000/000.db")
+            .exists());
+
+        // Validate that this now accepts reads and flushes, but rejects writes
+        {
+            let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
+            volume
+                .add_subvolume_create_guest(
+                    test_downstairs_set.opts(),
+                    volume::RegionExtentInfo {
+                        block_size: BLOCK_SIZE as u64,
+                        blocks_per_extent: test_downstairs_set
+                            .blocks_per_extent(),
+                        extent_count: test_downstairs_set.extent_count(),
+                    },
+                    2,
+                    None,
+                )
+                .await?;
+
+            volume.activate().await?;
+
+            let buffer = Buffer::new(volume.total_size().await? as usize);
+            volume
+                .read(
+                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                    buffer.clone(),
+                )
+                .await?;
+
+            assert_eq!(*buffer.as_vec().await, random_buffer);
+
+            assert!(volume
+                .write(
+                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                    Bytes::from(vec![0u8; BLOCK_SIZE]),
+                )
+                .await
+                .is_err());
+
+            volume.flush(None).await?;
+        }
+
+        // create a new volume, layering a new set of downstairs on top of the
+        // read-only one we just (re)booted
+        let top_layer_tds = TestDownstairsSet::small(false).await?;
+        let top_layer_opts = top_layer_tds.opts();
+        let bottom_layer_opts = test_downstairs_set.opts();
+        // The new volume is **not** using the SQLite backend!
+        assert!(!top_layer_tds
+            .downstairs1
+            .tempdir
+            .path()
+            .join("00/000/000.db")
+            .exists());
 
         let vcr: VolumeConstructionRequest =
             VolumeConstructionRequest::Volume {

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -2501,12 +2501,10 @@ mod test {
 
     #[tokio::test]
     async fn integration_test_sqlite_migration() -> Result<()> {
-        // Test using an old SQLite backend as a read-only parent.
-
         const BLOCK_SIZE: usize = 512;
 
-        // boot three downstairs, write some data to them, then change to
-        // read-only.
+        // boot three downstairs, write some data to them, then reopen as
+        // read-write (which will automatically migrate the extent)
         let mut test_downstairs_set =
             TestDownstairsSet::small_sqlite(false).await?;
         // This must be a SQLite extent!

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -241,6 +241,12 @@ pub struct SnapshotDetails {
 #[repr(u32)]
 #[derive(IntoPrimitive)]
 pub enum MessageVersion {
+    /// Switched to raw file extents
+    ///
+    /// The message format remains the same, but live repair between SQLite and
+    /// raw file extents is not possible.
+    V5 = 5,
+
     /// Added ErrorReport
     V4 = 4,
 
@@ -255,7 +261,7 @@ pub enum MessageVersion {
 }
 impl MessageVersion {
     pub const fn current() -> Self {
-        Self::V4
+        Self::V5
     }
 }
 
@@ -264,7 +270,7 @@ impl MessageVersion {
  * This, along with the MessageVersion enum above should be updated whenever
  * changes are made to the Message enum below.
  */
-pub const CRUCIBLE_MESSAGE_VERSION: u32 = 4;
+pub const CRUCIBLE_MESSAGE_VERSION: u32 = 5;
 
 /*
  * If you add or change the Message enum, you must also increment the

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -157,7 +157,7 @@ impl ReadResponse {
 }
 
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BlockContext {
     /// If this is a non-encrypted write, then the integrity hasher has the
     /// data as an input:
@@ -183,7 +183,7 @@ pub struct BlockContext {
 }
 
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct EncryptionContext {
     pub nonce: [u8; 12],
     pub tag: [u8; 16],


### PR DESCRIPTION
This PR adds a new backend for Crucible Downstairs extent files: a single on-disk file.  The on-disk file includes the raw block contents, a small metadata block, and two slots per block for storing encryption context.

By alternating between slots, we get the same crash consistency behavior as the SQLite database, but with many fewer syncs – we only need to add a `fsync` call if we're about to overwrite a context slot that hasn't yet been synched to disk, i.e. someone has written the same block 3x in a row without a flush.

The new backend implements the same `trait ExtentInner` as the SQLite backend, introduced in #982 .  This means that it's _mostly_ seamless, although I had to tweak a few small things around the edges.

Though this is a change to the on-disk format, we maintain support for existing (SQLite-based) volumes.  Existing volumes fall into two categories, which we handle differently:

- Snapshots are stored on read-only filesystems, so we can't mess with them.  We keep the old `SqliteInner` implementation around and use it in this case.
- Volumes that _aren't_ read-only are migrated from SQLite to raw extent files when they are opened.  ~The migration uses the same strategy as live repair:~
    - ~Creating a separate staging directory and staging new files in there~
    - ~Renaming that directory (to `.migrate` in this case) once everything is staged~
    - ~Copying from the `.migrate` directory if it's present on startup~
    - EDIT: the migration uses a new strategy; see [this comment](https://github.com/oxidecomputer/crucible/pull/991#issuecomment-1753266674)

To simplify the implementation, this change requires a whole-rack update.  Specifically, live repair between SQLite extents and raw file extents is not possible!  We have bumped the `CRUCIBLE_MESSAGE_VERSION` to prevent the system from trying such a thing (though the message format remains identical).

One subtle point: we still have to support `.replace` directories with SQLite files, because a live repair of an older extent could have been interrupted before the system update!