### PR TITLE
Don't unwrap when we can't create a dataset

### DIFF
--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -453,11 +453,10 @@ impl DataFile {
     /**
      * Mark a particular region as failed to provision.
      */
-    pub fn fail(&self, id: &RegionId) {
+    pub fn fail(&self, id: &RegionId, nstate: State) {
         let mut inner = self.inner.lock().unwrap();
 
         let r = inner.regions.get_mut(id).unwrap();
-        let nstate = State::Failed;
         if r.state == nstate {
             return;
         }

--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -453,10 +453,11 @@ impl DataFile {
     /**
      * Mark a particular region as failed to provision.
      */
-    pub fn fail(&self, id: &RegionId, nstate: State) {
+    pub fn fail(&self, id: &RegionId) {
         let mut inner = self.inner.lock().unwrap();
 
         let r = inner.regions.get_mut(id).unwrap();
+        let nstate = State::Failed;
         if r.state == nstate {
             return;
         }
@@ -612,6 +613,7 @@ impl DataFile {
         let r = inner.regions.get_mut(id).unwrap();
         let nstate = State::Destroyed;
         match &r.state {
+            State::Requested => (),
             State::Tombstoned => (),
             x => bail!("region to destroy in weird state {:?}", x),
         }

--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -682,7 +682,7 @@ impl DataFile {
                  * - Already destroyed; no more work to do.
                  */
             }
-            State::Requested | State::Created => {
+            State::Requested | State::Created | State::Failed => {
                 /*
                  * Schedule the destruction of this region.
                  */
@@ -696,17 +696,6 @@ impl DataFile {
                 r.state = State::Tombstoned;
                 self.bell.notify_all();
                 self.store(inner);
-            }
-            State::Failed => {
-                /*
-                 * For now, this terminal state will preserve evidence for
-                 * investigation.
-                 */
-                bail!(
-                    "region {} failed to provision and cannot be \
-                    destroyed",
-                    r.id.0
-                );
             }
         }
 
@@ -773,7 +762,10 @@ impl DataFile {
         let region = region.unwrap();
 
         match region.state {
-            State::Requested | State::Destroyed | State::Tombstoned => {
+            State::Requested
+            | State::Destroyed
+            | State::Tombstoned
+            | State::Failed => {
                 // Either the region hasn't been created yet, or it has been
                 // destroyed or marked to be destroyed (both of which require
                 // that no snapshots exist). Return an empty list.
@@ -782,10 +774,6 @@ impl DataFile {
 
             State::Created => {
                 // proceed to next section
-            }
-
-            State::Failed => {
-                bail!("region.state is failed!");
             }
         }
 

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -206,7 +206,7 @@ impl ZFSDataset {
 
                 if i == 4 {
                     bail!(
-                        "zfs list mountpoint failed! out:{} err:{}",
+                        "zfs destroy dataset failed! out:{} err:{}",
                         out,
                         err
                     );
@@ -1589,15 +1589,7 @@ fn worker(
                                     &r.id.0,
                                     e,
                                 );
-                                if let Err(e) = df.destroyed(&r.id) {
-                                    error!(
-                                        log,
-                                        "Dataset {} destruction failed: {}",
-                                        &r.id.0,
-                                        e,
-                                    );
-                                    df.fail(&r.id);
-                                }
+                                df.fail(&r.id);
                                 break 'requested;
                             }
                         };
@@ -1699,7 +1691,7 @@ fn worker(
                                         r.id.0,
                                         e,
                                     );
-                                    df.fail(&r.id);
+                                    let _ = df.destroyed(&r.id);
                                     break 'tombstoned;
                                 }
                             };

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1128,7 +1128,7 @@ mod test {
         })?;
 
         // Pretend creating the region failed
-        harness.df.fail(&region_id);
+        harness.df.fail(&region_id, State::Failed);
 
         // Now call apply_smf
         harness.apply_smf()?;
@@ -1590,7 +1590,7 @@ fn worker(
                                     &r.id.0,
                                     e,
                                 );
-                                df.fail(&r.id);
+                                df.fail(&r.id, State::Tombstoned);
                                 break 'requested;
                             }
                         };
@@ -1604,7 +1604,7 @@ fn worker(
                                     &r.id.0,
                                     e,
                                 );
-                                df.fail(&r.id);
+                                df.fail(&r.id, State::Failed);
                                 break 'requested;
                             }
                         };
@@ -1631,7 +1631,7 @@ fn worker(
                                 log,
                                 "region {:?} create failed: {:?}", r.id.0, e
                             );
-                            df.fail(&r.id);
+                            df.fail(&r.id, State::Failed);
                         }
 
                         info!(log, "applying SMF actions post create...");
@@ -1660,7 +1660,7 @@ fn worker(
                                    &r.id.0,
                                    e,
                                 );
-                                df.fail(&r.id);
+                                df.fail(&r.id, State::Failed);
                                 break 'tombstoned;
                             }
                         };
@@ -1691,7 +1691,7 @@ fn worker(
                                         r.id.0,
                                         e,
                                     );
-                                    df.fail(&r.id);
+                                    df.fail(&r.id, State::Failed);
                                     break 'tombstoned;
                                 }
                             };
@@ -1705,7 +1705,7 @@ fn worker(
                                 log,
                                 "region {:?} destroy failed: {:?}", r.id.0, e
                             );
-                            df.fail(&r.id);
+                            df.fail(&r.id, State::Failed);
                         }
                     }
                     _ => {


### PR DESCRIPTION
If we can't create a dataset for a region, don't panic, just fail.

This removes all the `unwrap()` calls from the `worker` function.

Here is the log from the agent when a region creation fails:
```
21:58:17.488Z INFO crucible-agent (worker): Region size:53687091200 reservation:67108864000 quota:161061273600                                                      
21:58:17.505Z INFO crucible-agent (worker): zfs set reservation of 67108864000 for oxp_31bd71cd-4736-4a12-a387-9b74b050396f/crucible/regions/b3eec9cd-1152-4a50-aa4-8a87cd8c916a                                                                      
21:58:17.505Z INFO crucible-agent (worker): zfs set quota of 161061273600 for oxp_31bd71cd-4736-4a12-a387-9b74b050396f/crucible/regions/b3eec9cd-1152-4a50-aa41-8a87cd8c916a                                                                          
21:58:17.557Z ERRO crucible-agent (worker): Dataset b3eec9cd-1152-4a50-aa41-8a87cd8c916a creation failed: zfs create failed! out: err:cannot create 'oxp_31bd71cd-4736-4a12-a387-9b74b050396f/crucible/regions/b3eec9cd-1152-4a50-aa41-8a87cd8c916a': out of space                                                                      
21:58:17.557Z INFO crucible-agent (datafile): region b3eec9cd-1152-4a50-aa41-8a87cd8c916a state: Requested -> Destroyed                                             
21:58:17.792Z INFO crucible-agent (dropshot): request completed 
```