### PR TITLE
Fix tests and update log messages.

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -3140,8 +3140,6 @@ pub async fn start_downstairs(
         "Upstairs <-> Downstairs Message Version: {}", CRUCIBLE_MESSAGE_VERSION
     );
 
-    info!(log, "Using address: {:?}", local_addr);
-
     let repair_address = match address {
         IpAddr::V4(ipv4) => SocketAddr::new(std::net::IpAddr::V4(ipv4), rport),
         IpAddr::V6(ipv6) => SocketAddr::new(std::net::IpAddr::V6(ipv6), rport),

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -123,7 +123,7 @@ impl Region {
 
         let number_of_files_limit = match rlim.rlim_cur.cmp(&rlim.rlim_max) {
             std::cmp::Ordering::Less => {
-                info!(
+                debug!(
                     log,
                     "raising number of open files limit to from {} to {}",
                     rlim.rlim_cur,
@@ -143,7 +143,7 @@ impl Region {
             }
 
             Ordering::Equal => {
-                info!(
+                debug!(
                     log,
                     "current number of open files limit {} is already the maximum",
                     rlim.rlim_cur,
@@ -268,7 +268,9 @@ impl Region {
                 def.database_read_version(),
             );
         }
-        info!(log, "Database read version {}", def.database_read_version());
+        if verbose {
+            info!(log, "Database read version {}", def.database_read_version());
+        }
 
         if def.database_write_version()
             != crucible_common::DATABASE_WRITE_VERSION
@@ -279,11 +281,13 @@ impl Region {
                 def.database_write_version(),
             );
         }
-        info!(
-            log,
-            "Database write version {}",
-            def.database_write_version()
-        );
+        if verbose {
+            info!(
+                log,
+                "Database write version {}",
+                def.database_write_version()
+            );
+        }
 
         /*
          * Open every extent that presently exists.

--- a/tools/test_repair_perf.sh
+++ b/tools/test_repair_perf.sh
@@ -140,7 +140,7 @@ function repair_round() {
             "$ct" one "${args[@]}" \
                     -q -g "$gen" --verify-out alan \
                     --verify-in alan \
-                    --verify \
+                    --verify-at-start \
                     --retry-activate >> "$test_log" 2>&1
             result=$?
 

--- a/tools/test_restart_repair.sh
+++ b/tools/test_restart_repair.sh
@@ -97,6 +97,7 @@ export region_dir="./var"
 
 echo "" > ${loop_log}
 echo "starting $(date)" | tee ${loop_log}
+echo "" > ${test_log}
 echo "Tail $test_log for test output"
 echo "Tail $loop_log for summary output"
 echo "Tail $dsc_log for dsc outout"
@@ -210,8 +211,11 @@ while [[ $count -le $loops ]]; do
         rm -rf "$region_dir"/8830
         cp -R  "$region_dir"/8830.old "$region_dir"/8830
     fi
-    echo "$(date) regions moved, current dump output:" >> "$test_log"
-    cdump.sh >> "$test_log" 2>&1
+    echo "$(date) regions moved, current dump outputs:" >> "$test_log"
+    $cds dump --no-color -d "$region_dir"/8810 \
+        -d "$region_dir"/8820 \
+        -d "$region_dir"/8830 >> "$test_log" 2>&1
+
     echo "$(date) resume downstairs" >> "$test_log"
     bring_all_downstairs_online
 
@@ -225,7 +229,7 @@ while [[ $count -le $loops ]]; do
     "$ct" one "${args[@]}" \
             -q -g "$gen" --verify-out alan \
             --verify-in alan \
-            --verify \
+            --verify-at-start \
             --retry-activate >> "$test_log" 2>&1
     result=$?
     if [[ $result -ne 0 ]]; then


### PR DESCRIPTION
Fixed two tests that were using old args for crutest
and updated a test that was calling a local script that did not exist.

Updated the log messages printed during region open to only happen 
during a real downstairs startup and not during the dump subcommand.