### PR TITLE
Use regions_dataset path for apply_smf

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1532,8 +1532,8 @@ fn worker(
         Ok(regions_dataset_path) => regions_dataset_path,
         Err(e) => {
             panic!(
-               "Cannot get regions_dataset_path for {:?}: {}",
-               regions_dataset, e,
+                "Cannot get regions_dataset_path for {:?}: {}",
+                regions_dataset, e,
             );
         }
     };


### PR DESCRIPTION
`apply_smf`'s `dataset` argument is meant to be for the regions dataset,
not the specific region dataset.
    
Additionally, panic if regions_dataset.path() returns Err: the agent
requires a valid regions dataset and path to work.

Fixes #999