### PR TITLE
Don't check for a snapshot that's gone

### DIFF
--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -320,23 +320,6 @@ async fn region_delete_running_snapshot(
         }
     }
 
-    let snapshots = match rc.context().get_snapshots_for_region(&p.id) {
-        Ok(results) => results,
-        Err(e) => {
-            return Err(HttpError::for_internal_error(e.to_string()));
-        }
-    };
-
-    let snapshot_names: Vec<String> =
-        snapshots.iter().map(|s| s.name.clone()).collect();
-
-    if !snapshot_names.contains(&p.name) {
-        return Err(HttpError::for_not_found(
-            None,
-            format!("snapshot {:?} not found", p.name),
-        ));
-    }
-
     let request = model::DeleteRunningSnapshotRequest {
         id: p.id,
         name: p.name,


### PR DESCRIPTION
When Nexus is trying to delete its snapshots, it will send two calls to the agent: one to delete the read-only downstairs booted for a snapshot (called a "running snapshot" in the agent), and one to delete the snapshot itself. Multiple requests from a user(s) to delete a snapshot can queue up multiple identical snapshot-delete sagas that run one after each other. With the current agent this results in all snapshot-delete sagas after the first experiencing 404s during the DELETE call for a running snapshot, because the agent checks to see if the underlying snapshot exists before accepting that delete request.

Given that Nexus is calling

    DELETE /crucible/0/regions/{id}/snapshots/{name}/run

it seemed natural when writing the agent to return a 404 if the snapshot didn't exist: this is a nested path, and that's an invalid request if we're a traditional REST server. The agent isn't a traditional REST server though - because it is an external service that is contacted as part of sagas, there are additional requirements on it.

One of those requirements is idempotency: if a repeated request is submitted, then the agent's response should be identical to the first response. This PR changes that to extend further: the agent keeps enough state (serialized in crucible.json) to return an identical response even if the snapshot is gone, and even if the region is gone. It's able to do this because the agent does not currently remove records for deleted objects.