### PR TITLE
Don't hold the Downstairs lock while doing encryption

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -5951,33 +5951,7 @@ impl Upstairs {
             return Err(());
         }
 
-        /*
-         * Get the next ID for the guest work struct we will make at the
-         * end. This ID is also put into the IO struct we create that
-         * handles the operation(s) on the storage side.
-         */
-        let mut gw = self.guest.guest_work.lock().await;
-        let mut downstairs = self.downstairs.lock().await;
         let ddef = self.ddef.lock().await.get_def().unwrap();
-
-        // While we've got the lock, update our current backpressure
-        self.set_backpressure_with_downstairs(&downstairs);
-
-        /*
-         * Verify IO is in range for our region.  If not give up now and
-         * report error.
-         */
-        match ddef.validate_io(offset, data.len()) {
-            Ok(()) => {}
-            Err(e) => {
-                if let Some(req) = req {
-                    req.send_err(e);
-                }
-                return Err(());
-            }
-        }
-
-        self.set_flush_need();
 
         /*
          * Given the offset and buffer size, figure out what extent and
@@ -5989,26 +5963,6 @@ impl Upstairs {
             offset,
             Block::from_bytes(data.len(), &ddef),
         );
-
-        /*
-         * Grab this ID after extent_from_offset: in case of Err we don't
-         * want to create a gap in the IDs.
-         */
-        let gw_id: u64 = gw.next_gw_id();
-        if is_write_unwritten {
-            cdt::gw__write__unwritten__start!(|| (gw_id));
-        } else {
-            cdt::gw__write__start!(|| (gw_id));
-        }
-
-        // The impacted blocks may span our extent under repair.  If that's the
-        // case, then reserve repair jobs now (but do not enqueue them); this
-        // makes our dependencies correct.
-        downstairs.check_repair_ids_for_range(impacted_blocks);
-
-        // After reserving any LiveRepair IDs, go get one for this job.
-        // This is required to avoid circular dependencies.
-        let next_id = downstairs.next_id();
 
         let mut writes: Vec<crucible_protocol::Write> =
             Vec::with_capacity(impacted_blocks.len(&ddef));
@@ -6066,6 +6020,53 @@ impl Upstairs {
 
             cur_offset += byte_len;
         }
+
+        /*
+         * Get the next ID for the guest work struct we will make at the
+         * end. This ID is also put into the IO struct we create that
+         * handles the operation(s) on the storage side.
+         */
+        let mut gw = self.guest.guest_work.lock().await;
+        let mut downstairs = self.downstairs.lock().await;
+
+        // While we've got the lock, update our current backpressure
+        self.set_backpressure_with_downstairs(&downstairs);
+
+        /*
+         * Verify IO is in range for our region.  If not give up now and
+         * report error.
+         */
+        match ddef.validate_io(offset, data.len()) {
+            Ok(()) => {}
+            Err(e) => {
+                if let Some(req) = req {
+                    req.send_err(e);
+                }
+                return Err(());
+            }
+        }
+
+        self.set_flush_need();
+
+        /*
+         * Grab this ID after extent_from_offset: in case of Err we don't
+         * want to create a gap in the IDs.
+         */
+        let gw_id: u64 = gw.next_gw_id();
+        if is_write_unwritten {
+            cdt::gw__write__unwritten__start!(|| (gw_id));
+        } else {
+            cdt::gw__write__start!(|| (gw_id));
+        }
+
+        // The impacted blocks may span our extent under repair.  If that's the
+        // case, then reserve repair jobs now (but do not enqueue them); this
+        // makes our dependencies correct.
+        downstairs.check_repair_ids_for_range(impacted_blocks);
+
+        // After reserving any LiveRepair IDs, go get one for this job.
+        // This is required to avoid circular dependencies.
+        let next_id = downstairs.next_id();
 
         let wr = create_write_eob(
             &mut downstairs,


### PR DESCRIPTION
# Test setup
128 GiB disk, 64 KiB extents, 4K blocks, encrypted, running `fio` on an Alpine VM with the following script:

```toml
[global]
filename=/dev/nvme0n1
iodepth=25
ioengine=aio
time_based
runtime=60
numjobs=1
direct=1
stonewall=1

[randwrite-4K]
bs=4K
rw=randwrite

[randwrite-1M]
bs=1M
rw=randwrite

[randwrite-4M]
bs=4M
rw=randwrite
```

# Before
(`main` at da534e73380f3cc53ca0de073e1ea862ae32109b)
```
Run status group 0 (all jobs):
  WRITE: bw=16.1MiB/s (16.9MB/s), 16.1MiB/s-16.1MiB/s (16.9MB/s-16.9MB/s), io=967MiB (1014MB), run=60008-60008msec

Run status group 1 (all jobs):
  WRITE: bw=367MiB/s (385MB/s), 367MiB/s-367MiB/s (385MB/s-385MB/s), io=21.6GiB (23.1GB), run=60061-60061msec

Run status group 2 (all jobs):
  WRITE: bw=349MiB/s (365MB/s), 349MiB/s-349MiB/s (365MB/s-365MB/s), io=20.5GiB (22.0GB), run=60270-60270msec
```

# After
```
Run status group 0 (all jobs):
  WRITE: bw=15.1MiB/s (15.8MB/s), 15.1MiB/s-15.1MiB/s (15.8MB/s-15.8MB/s), io=904MiB (948MB), run=60036-60036msec

Run status group 1 (all jobs):
  WRITE: bw=457MiB/s (479MB/s), 457MiB/s-457MiB/s (479MB/s-479MB/s), io=26.8GiB (28.7GB), run=60045-60045msec

Run status group 2 (all jobs):
  WRITE: bw=499MiB/s (523MB/s), 499MiB/s-499MiB/s (523MB/s-523MB/s), io=29.3GiB (31.5GB), run=60190-60190msec
```

# Conclusion
![free real estate](https://media1.giphy.com/media/5wWf7GMbT1ZUGTDdTqM/giphy.gif)
