### PR TITLE
Abort a live repair

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -953,12 +953,10 @@ where
      */
     while job_channel_rx.recv().await.is_some() {
         // Add a little time to completion for this operation.
-        /*
         if ads.lock().await.lossy && random() && random() {
             info!(ads.lock().await.log, "[lossy] sleeping 1 second");
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
-        */
 
         if !ads.lock().await.is_active(upstairs_connection) {
             // We are not an active downstairs, wait until we are
@@ -2177,9 +2175,6 @@ impl Downstairs {
                 } else {
                     self.region.close_extent(*extent).await
                 };
-                if self.lossy {
-                    panic!("ZZZ EC");
-                }
                 debug!(
                     self.log,
                     "JustClose :{} extent {} deps:{:?} res:{}",
@@ -2208,9 +2203,6 @@ impl Downstairs {
                     error!(self.log, "Upstairs inactive error");
                     Err(CrucibleError::UpstairsInactive)
                 } else {
-                    if self.lossy {
-                        panic!("ZZZ EFC");
-                    }
                     // If flush fails, return that result.
                     // Else, if close fails, return that result.
                     // Else, return the f/g/d from the close.
@@ -2254,9 +2246,6 @@ impl Downstairs {
                 source_repair_address,
                 repair_downstairs: _,
             } => {
-                if self.lossy {
-                    panic!("ZZZ ELR");
-                }
                 debug!(
                     self.log,
                     "ExtentLiveRepair: extent {} sra:{:?}",
@@ -2291,9 +2280,6 @@ impl Downstairs {
                 dependencies,
                 extent,
             } => {
-                if self.lossy {
-                    panic!("ZZZ ELR");
-                }
                 let result = if !self.is_active(job.upstairs_connection) {
                     error!(self.log, "Upstairs inactive error");
                     Err(CrucibleError::UpstairsInactive)

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -953,10 +953,12 @@ where
      */
     while job_channel_rx.recv().await.is_some() {
         // Add a little time to completion for this operation.
+        /*
         if ads.lock().await.lossy && random() && random() {
             info!(ads.lock().await.log, "[lossy] sleeping 1 second");
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
+        */
 
         if !ads.lock().await.is_active(upstairs_connection) {
             // We are not an active downstairs, wait until we are
@@ -2175,6 +2177,9 @@ impl Downstairs {
                 } else {
                     self.region.close_extent(*extent).await
                 };
+                if self.lossy {
+                    panic!("ZZZ EC");
+                }
                 debug!(
                     self.log,
                     "JustClose :{} extent {} deps:{:?} res:{}",
@@ -2203,6 +2208,9 @@ impl Downstairs {
                     error!(self.log, "Upstairs inactive error");
                     Err(CrucibleError::UpstairsInactive)
                 } else {
+                    if self.lossy {
+                        panic!("ZZZ EFC");
+                    }
                     // If flush fails, return that result.
                     // Else, if close fails, return that result.
                     // Else, return the f/g/d from the close.
@@ -2246,6 +2254,9 @@ impl Downstairs {
                 source_repair_address,
                 repair_downstairs: _,
             } => {
+                if self.lossy {
+                    panic!("ZZZ ELR");
+                }
                 debug!(
                     self.log,
                     "ExtentLiveRepair: extent {} sra:{:?}",
@@ -2280,6 +2291,9 @@ impl Downstairs {
                 dependencies,
                 extent,
             } => {
+                if self.lossy {
+                    panic!("ZZZ ELR");
+                }
                 let result = if !self.is_active(job.upstairs_connection) {
                     error!(self.log, "Upstairs inactive error");
                     Err(CrucibleError::UpstairsInactive)

--- a/openapi/crucible-control.json
+++ b/openapi/crucible-control.json
@@ -74,7 +74,9 @@
         "enum": [
           "NotAcked",
           "AckReady",
-          "Acked"
+          "Acked",
+          "AbortReady",
+          "Aborted"
         ]
       },
       "DownstairsWork": {

--- a/tools/test_fail_live_repair.sh
+++ b/tools/test_fail_live_repair.sh
@@ -21,11 +21,11 @@ function ctrl_c() {
     echo "Stopping at your request"
     if ps -p "$dsc_pid" ; then
         ${dsc} cmd shutdown
-        # wait "$dsc_pid"
+        wait "$dsc_pid"
     fi
     if ps -p "$crutest_pid" ; then
         kill "$crutest_pid"
-        # wait "$crutest_pid"
+        wait "$crutest_pid"
     fi
     exit 1
 }

--- a/tools/test_nightly.sh
+++ b/tools/test_nightly.sh
@@ -14,6 +14,17 @@ ROOT=$(cd "$(dirname "$0")/.." && pwd)
 export BINDIR=${BINDIR:-$ROOT/target/release}
 
 echo "Nightly starts at $(date)" | tee "$output_file"
+echo "$(date) LiveRepairFail start" >> "$output_file"
+banner LRFail
+./tools/test_fail_live_repair.sh -l 40
+res=$?
+if [[ "$res" -eq 0 ]]; then
+    echo "$(date) LiveRepairFail pass" >> "$output_file"
+else
+    echo "$(date) LiveRepairFail failed with: $res" >> "$output_file"
+    (( err += 1 ))
+fi
+
 echo "$(date) hammer start" >> "$output_file"
 banner hammer
 ./tools/hammer_loop.sh -l 200

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -3001,9 +3001,9 @@ struct Downstairs {
     repair_min_id: Option<JobId>,
 
     /**
-     * When repairing, this will be the used to indicate to a running
-     * repair task needs to stop waiting for an answer from repair work
-     * and abort the repair.
+     * When repairing, this will be used to indicate to a running repair
+     * task needs to stop waiting for an answer from repair work and abort
+     * the repair.
      */
     repair_stop: Option<mpsc::Sender<bool>>,
 
@@ -3121,7 +3121,7 @@ impl Downstairs {
             && job.ack_status != AckStatus::Acked
         {
             job.ack_status = AckStatus::AbortReady;
-            warn!(self.log, "[{client_id}] Job {ds_id} AbortReady AAA");
+            warn!(self.log, "[{client_id}] Job {ds_id} AbortReady");
         }
     }
 


### PR DESCRIPTION
A fix for [issue 968](https://github.com/oxidecomputer/crucible/issues/968)
A live repair can get stuck waiting on a channel that will never respond.

There is a window of time when the repair task has sent a repair job to
all three downstairs and is waiting for a response that all three downstairs
have handled that operation.  If the two good downstairs respond, then the third
downstairs disconnects before answering, the live repair task has no way of knowing
and will wait forever for an answer to a job that will never come.
If the downstairs that disconnects comes back, it will attempt to enter LiveRepair, but
will be blocked as a LiveRepair is in progress.

This PR adds a few things,
A new channel that LiveRepair will listen on that can be used to signal an abort.
A new `AckState`: `Aborted`
A new `LiveRepair` `RepairCheck`: `RepairAborted`

The "test_fail_live_repair.sh" was fixed to test this scenario.

The "test_fail_live_repair.sh" was added to the nightly test list.