### PR TITLE
fix replace and takeover test

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1309,9 +1309,8 @@ where
                              */
                             info!(
                                 up.log,
-                                "[{}] upstairs guest_io_ready=TRUE, promote! session {}",
+                                "[{}] upstairs guest_io_ready=TRUE, promote!",
                                 up_coms.client_id,
-                                up.session_id,
                             );
                             self_promotion = true;
                             fw.send(Message::PromoteToActive {


### PR DESCRIPTION
A fix for https://github.com/oxidecomputer/crucible/issues/1037

Depending on timing, the 
`integration_test_volume_replace_downstairs_then_takeover` would behave differently,
making the results inconsistent.

These changes make the test more deterministic, and remove checks for things that
we can't guarantee will always happen.

Specifically,
Added a flush after the write, so the data is persisted to disk.
Removed the final check for the old upstairs being deactivated.
Removed a loop that served no purpose.

I ran this test (that would fail 100% of the time before) and have done 528 runs with 100% success.

Also, fixed a log message that was double printing `session_id`, unrelated to all this.