### PR TITLE
Clippy lints from new Rust version.

### DIFF
--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -246,7 +246,7 @@ impl DataFile {
         if let Some(r) = inner
             .running_snapshots
             .entry(request.id.clone())
-            .or_insert_with(BTreeMap::default)
+            .or_default()
             .get(&request.name)
         {
             return Ok(r.clone());

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -8,7 +8,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
 use std::fs::File;
-use std::io::{Read, Write};
+use std::io::{Read as IORead, Write as IOWrite};
 use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -722,9 +722,8 @@ impl Region {
             HashMap::new();
 
         for write in writes {
-            let extent_vec = batched_writes
-                .entry(write.eid as usize)
-                .or_default();
+            let extent_vec =
+                batched_writes.entry(write.eid as usize).or_default();
             extent_vec.push(write);
         }
 

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -724,7 +724,7 @@ impl Region {
         for write in writes {
             let extent_vec = batched_writes
                 .entry(write.eid as usize)
-                .or_insert_with(Vec::new);
+                .or_default();
             extent_vec.push(write);
         }
 
@@ -4183,7 +4183,7 @@ pub(crate) mod test {
         let (_dir, mut region, mut data) = prepare_random_region().await?;
 
         // Call region_write with a multiple disjoint large contiguous ranges
-        let writes = vec![
+        let writes = [
             prepare_writes(1..4, &mut data),
             prepare_writes(15..24, &mut data),
             prepare_writes(27..28, &mut data),
@@ -4202,7 +4202,7 @@ pub(crate) mod test {
         let (_dir, mut region, mut data) = prepare_random_region().await?;
 
         // Call region_write with a multiple disjoint non-contiguous ranges
-        let writes = vec![
+        let writes = [
             prepare_writes(0..1, &mut data),
             prepare_writes(14..15, &mut data),
             prepare_writes(19..20, &mut data),
@@ -4282,7 +4282,7 @@ pub(crate) mod test {
         let mut data: Vec<u8> = vec![0; region.def().total_size() as usize];
 
         // Call region_write with a multiple disjoint large contiguous ranges
-        let writes = vec![
+        let writes = [
             prepare_writes(1..4, &mut data),
             prepare_writes(15..24, &mut data),
             prepare_writes(27..28, &mut data),
@@ -4312,7 +4312,7 @@ pub(crate) mod test {
         let mut data: Vec<u8> = vec![0; region.def().total_size() as usize];
 
         // Call region_write with a multiple disjoint non-contiguous ranges
-        let writes = vec![
+        let writes = [
             prepare_writes(0..1, &mut data),
             prepare_writes(14..15, &mut data),
             prepare_writes(19..20, &mut data),

--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -25,7 +25,7 @@ pub struct FileServerContext {
     region_dir: PathBuf,
 }
 
-pub fn write_openapi<W: Write>(f: &mut W) -> Result<()> {
+pub fn write_openapi<W: IOWrite>(f: &mut W) -> Result<()> {
     let api = build_api();
     api.openapi("Downstairs Repair", "0.0.0").write(f)?;
     Ok(())

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -1264,7 +1264,7 @@ async fn region_create_test(
     //  an option to the test to allow it from the command line.
     //  Since the larger sizes can currently take minutes/hours, those
     //  are commented out as well.
-    let region_size = vec![
+    let region_size = [
         1024 * 1024 * 1024,        //   1 GiB
         1024 * 1024 * 1024 * 10,   //  10 GiB
         1024 * 1024 * 1024 * 100,  // 100 GiB
@@ -1277,7 +1277,7 @@ async fn region_create_test(
     // The list of blocks per extent file, in crucible: extent_size
     // XXX This is again some self selected interesting values.  Expect
     // these to change as we learn more.
-    let extent_size = vec![4096, 8192, 16384, 32768];
+    let extent_size = [4096, 8192, 16384, 32768];
 
     // This header is the same for both the regular and the long test.
     print!(

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -453,7 +453,7 @@ impl BlockMap {
     /// If such a range exists, returns its starting address (i.e. the key to
     /// look it up in [`self.addr_to_jobs`].
     fn find_split_location(&self, i: ImpactedAddr) -> Option<ImpactedAddr> {
-        match self.addr_to_jobs.range(..i).rev().next() {
+        match self.addr_to_jobs.range(..i).next_back() {
             Some((start, (end, _))) if i < *end => Some(*start),
             _ => None,
         }
@@ -466,8 +466,7 @@ impl BlockMap {
         let Some(mut pos) = self
             .addr_to_jobs
             .range(..r.start)
-            .rev()
-            .next()
+            .next_back()
             .map(|(start, _)| *start)
             .or_else(|| self.addr_to_jobs.first_key_value().map(|(k, _)| *k))
         else {
@@ -517,8 +516,7 @@ impl BlockMap {
         let start = self
             .addr_to_jobs
             .range(..=r.start)
-            .rev()
-            .next()
+            .next_back()
             .map(|(start, _)| *start)
             .unwrap_or(r.start);
         self.addr_to_jobs

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -616,10 +616,8 @@ pub(crate) mod protocol_test {
 
         let (_jh1, mut ds1_messages) =
             harness.ds1().await.spawn_message_receiver();
-        let (_jh2, mut ds2_messages) =
-            harness.ds2.spawn_message_receiver();
-        let (_jh3, mut ds3_messages) =
-            harness.ds3.spawn_message_receiver();
+        let (_jh2, mut ds2_messages) = harness.ds2.spawn_message_receiver();
+        let (_jh3, mut ds3_messages) = harness.ds3.spawn_message_receiver();
 
         for _ in 0..MAX_ACTIVE_COUNT {
             let harness = harness.clone();
@@ -821,10 +819,8 @@ pub(crate) mod protocol_test {
 
         let (jh1, mut ds1_messages) =
             harness.ds1().await.spawn_message_receiver();
-        let (_jh2, mut ds2_messages) =
-            harness.ds2.spawn_message_receiver();
-        let (_jh3, mut ds3_messages) =
-            harness.ds3.spawn_message_receiver();
+        let (_jh2, mut ds2_messages) = harness.ds2.spawn_message_receiver();
+        let (_jh3, mut ds3_messages) = harness.ds3.spawn_message_receiver();
 
         // Send a read
         {
@@ -896,10 +892,8 @@ pub(crate) mod protocol_test {
 
         let (jh1, mut ds1_messages) =
             harness.ds1().await.spawn_message_receiver();
-        let (_jh2, mut ds2_messages) =
-            harness.ds2.spawn_message_receiver();
-        let (_jh3, mut ds3_messages) =
-            harness.ds3.spawn_message_receiver();
+        let (_jh2, mut ds2_messages) = harness.ds2.spawn_message_receiver();
+        let (_jh3, mut ds3_messages) = harness.ds3.spawn_message_receiver();
 
         // Send 200 more than IO_OUTSTANDING_MAX jobs. Flow control will kick in
         // at MAX_ACTIVE_COUNT messages, so we need to be sending read responses
@@ -1934,10 +1928,8 @@ pub(crate) mod protocol_test {
 
         let (jh1, mut ds1_messages) =
             harness.ds1().await.spawn_message_receiver();
-        let (_jh2, mut ds2_messages) =
-            harness.ds2.spawn_message_receiver();
-        let (_jh3, mut ds3_messages) =
-            harness.ds3.spawn_message_receiver();
+        let (_jh2, mut ds2_messages) = harness.ds2.spawn_message_receiver();
+        let (_jh3, mut ds3_messages) = harness.ds3.spawn_message_receiver();
 
         // Send 200 more than IO_OUTSTANDING_MAX jobs. Flow control will kick in
         // at MAX_ACTIVE_COUNT messages, so we need to be sending read responses
@@ -2640,10 +2632,8 @@ pub(crate) mod protocol_test {
 
         let (jh1, mut ds1_messages) =
             harness.ds1().await.spawn_message_receiver();
-        let (_jh2, mut ds2_messages) =
-            harness.ds2.spawn_message_receiver();
-        let (_jh3, mut ds3_messages) =
-            harness.ds3.spawn_message_receiver();
+        let (_jh2, mut ds2_messages) = harness.ds2.spawn_message_receiver();
+        let (_jh3, mut ds3_messages) = harness.ds3.spawn_message_receiver();
 
         // Send 200 more than IO_OUTSTANDING_MAX jobs. Flow control will kick in
         // at MAX_ACTIVE_COUNT messages, so we need to be sending read responses

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -404,7 +404,7 @@ pub(crate) mod protocol_test {
 
         // Spawn a task to pull messages off the framed reader and put into a
         // channel
-        pub async fn spawn_message_receiver(
+        pub fn spawn_message_receiver(
             &self,
         ) -> (JoinHandle<()>, mpsc::Receiver<Message>) {
             let (tx, rx) = mpsc::channel(1000);
@@ -615,11 +615,11 @@ pub(crate) mod protocol_test {
         let harness = Arc::new(TestHarness::new().await?);
 
         let (_jh1, mut ds1_messages) =
-            harness.ds1().await.spawn_message_receiver().await;
+            harness.ds1().await.spawn_message_receiver();
         let (_jh2, mut ds2_messages) =
-            harness.ds2.spawn_message_receiver().await;
+            harness.ds2.spawn_message_receiver();
         let (_jh3, mut ds3_messages) =
-            harness.ds3.spawn_message_receiver().await;
+            harness.ds3.spawn_message_receiver();
 
         for _ in 0..MAX_ACTIVE_COUNT {
             let harness = harness.clone();
@@ -820,11 +820,11 @@ pub(crate) mod protocol_test {
         let harness = Arc::new(TestHarness::new().await?);
 
         let (jh1, mut ds1_messages) =
-            harness.ds1().await.spawn_message_receiver().await;
+            harness.ds1().await.spawn_message_receiver();
         let (_jh2, mut ds2_messages) =
-            harness.ds2.spawn_message_receiver().await;
+            harness.ds2.spawn_message_receiver();
         let (_jh3, mut ds3_messages) =
-            harness.ds3.spawn_message_receiver().await;
+            harness.ds3.spawn_message_receiver();
 
         // Send a read
         {
@@ -866,7 +866,7 @@ pub(crate) mod protocol_test {
         ds1.negotiate_start().await?;
         ds1.negotiate_step_last_flush(JobId(0)).await?;
 
-        let (_jh1, mut ds1_messages) = ds1.spawn_message_receiver().await;
+        let (_jh1, mut ds1_messages) = ds1.spawn_message_receiver();
 
         let mut ds1_message_second_time = None;
 
@@ -895,11 +895,11 @@ pub(crate) mod protocol_test {
         let harness = Arc::new(TestHarness::new().await?);
 
         let (jh1, mut ds1_messages) =
-            harness.ds1().await.spawn_message_receiver().await;
+            harness.ds1().await.spawn_message_receiver();
         let (_jh2, mut ds2_messages) =
-            harness.ds2.spawn_message_receiver().await;
+            harness.ds2.spawn_message_receiver();
         let (_jh3, mut ds3_messages) =
-            harness.ds3.spawn_message_receiver().await;
+            harness.ds3.spawn_message_receiver();
 
         // Send 200 more than IO_OUTSTANDING_MAX jobs. Flow control will kick in
         // at MAX_ACTIVE_COUNT messages, so we need to be sending read responses
@@ -1145,7 +1145,7 @@ pub(crate) mod protocol_test {
         ds1.negotiate_start().await?;
         ds1.negotiate_step_extent_versions_please().await?;
 
-        let (_jh1, mut ds1_messages) = ds1.spawn_message_receiver().await;
+        let (_jh1, mut ds1_messages) = ds1.spawn_message_receiver();
 
         // The Upstairs will start sending LiveRepair related work, which may be
         // out of order. Buffer some here.
@@ -1933,11 +1933,11 @@ pub(crate) mod protocol_test {
         let harness = Arc::new(TestHarness::new().await?);
 
         let (jh1, mut ds1_messages) =
-            harness.ds1().await.spawn_message_receiver().await;
+            harness.ds1().await.spawn_message_receiver();
         let (_jh2, mut ds2_messages) =
-            harness.ds2.spawn_message_receiver().await;
+            harness.ds2.spawn_message_receiver();
         let (_jh3, mut ds3_messages) =
-            harness.ds3.spawn_message_receiver().await;
+            harness.ds3.spawn_message_receiver();
 
         // Send 200 more than IO_OUTSTANDING_MAX jobs. Flow control will kick in
         // at MAX_ACTIVE_COUNT messages, so we need to be sending read responses
@@ -2189,7 +2189,7 @@ pub(crate) mod protocol_test {
         ds1.negotiate_start().await?;
         ds1.negotiate_step_extent_versions_please().await?;
 
-        let (_jh1, mut ds1_messages) = ds1.spawn_message_receiver().await;
+        let (_jh1, mut ds1_messages) = ds1.spawn_message_receiver();
 
         // The Upstairs will start sending LiveRepair related work, which may be
         // out of order. Buffer some here.
@@ -2445,7 +2445,7 @@ pub(crate) mod protocol_test {
         ds1.negotiate_step_extent_versions_please().await?;
 
         error!(harness.log, "ds1 spawn message receiver now!");
-        let (_jh1, mut ds1_messages) = ds1.spawn_message_receiver().await;
+        let (_jh1, mut ds1_messages) = ds1.spawn_message_receiver();
 
         // Continue faking for downstairs 2 and 3 - the work that was occuring
         // for extent 0 should finish before the Upstairs aborts the repair
@@ -2639,11 +2639,11 @@ pub(crate) mod protocol_test {
         let harness = Arc::new(TestHarness::new_ro().await?);
 
         let (jh1, mut ds1_messages) =
-            harness.ds1().await.spawn_message_receiver().await;
+            harness.ds1().await.spawn_message_receiver();
         let (_jh2, mut ds2_messages) =
-            harness.ds2.spawn_message_receiver().await;
+            harness.ds2.spawn_message_receiver();
         let (_jh3, mut ds3_messages) =
-            harness.ds3.spawn_message_receiver().await;
+            harness.ds3.spawn_message_receiver();
 
         // Send 200 more than IO_OUTSTANDING_MAX jobs. Flow control will kick in
         // at MAX_ACTIVE_COUNT messages, so we need to be sending read responses
@@ -2889,7 +2889,7 @@ pub(crate) mod protocol_test {
         ds1.negotiate_start().await?;
         ds1.negotiate_step_extent_versions_please().await?;
 
-        let (_jh1, mut ds1_messages) = ds1.spawn_message_receiver().await;
+        let (_jh1, mut ds1_messages) = ds1.spawn_message_receiver();
 
         // Wait for all three downstairs to be online before we send
         // our final read.

--- a/upstairs/src/impacted_blocks.rs
+++ b/upstairs/src/impacted_blocks.rs
@@ -1076,7 +1076,7 @@ mod test {
         point_d: (u64, u64),
     ) {
         // First we need to sort the points so we can use them correctly.
-        let mut sorted_points = vec![point_a, point_b, point_c, point_d];
+        let mut sorted_points = [point_a, point_b, point_c, point_d];
         sorted_points.sort();
         let (eid_a, block_a) = sorted_points[0];
         let (eid_b, block_b) = sorted_points[1];

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -8,7 +8,9 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::convert::TryFrom;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
-use std::io::{Read, Result as IOResult, Seek, SeekFrom, Write};
+use std::io::{
+    Read as IORead, Result as IOResult, Seek, SeekFrom, Write as IOWrite,
+};
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -7602,7 +7604,7 @@ impl Upstairs {
             }
         }
 
-        if new_client_id.is_some() {
+        if let Some(new_client_id) = new_client_id {
             // Our new downstairs already exists.
             if old_client_id.is_some() {
                 // New target is present, but old is present too, so this is not
@@ -7617,7 +7619,7 @@ impl Upstairs {
 
             // We don't really know if the "old" matches what was old,
             // as that info is gone to us now, so assume it was true.
-            match ds.clients[new_client_id.unwrap()].state {
+            match ds.clients[new_client_id].state {
                 DsState::Replacing
                 | DsState::Replaced
                 | DsState::LiveRepairReady

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -187,7 +187,7 @@ impl<T: BlockIO> CruciblePseudoFile<T> {
  * The Read + Write impls here translate arbitrary sized operations into
  * calls for the underlying Crucible API.
  */
-impl<T: BlockIO> Read for CruciblePseudoFile<T> {
+impl<T: BlockIO> IORead for CruciblePseudoFile<T> {
     fn read(&mut self, buf: &mut [u8]) -> IOResult<usize> {
         if !self.active {
             return Err(std::io::Error::new(
@@ -203,7 +203,7 @@ impl<T: BlockIO> Read for CruciblePseudoFile<T> {
     }
 }
 
-impl<T: BlockIO> Write for CruciblePseudoFile<T> {
+impl<T: BlockIO> IOWrite for CruciblePseudoFile<T> {
     fn write(&mut self, buf: &[u8]) -> IOResult<usize> {
         if !self.active {
             return Err(std::io::Error::new(

--- a/upstairs/src/stats.rs
+++ b/upstairs/src/stats.rs
@@ -19,7 +19,7 @@ pub struct Activated {
     pub count: Cumulative<i64>,
 }
 #[derive(Debug, Default, Copy, Clone, Metric)]
-pub struct Write {
+pub struct WriteCount {
     /// Count of region writes this upstairs has completed
     #[datum]
     pub count: Cumulative<i64>,
@@ -31,7 +31,7 @@ pub struct WriteBytes {
     pub count: Cumulative<i64>,
 }
 #[derive(Debug, Default, Copy, Clone, Metric)]
-pub struct Read {
+pub struct ReadCount {
     /// Count of region reads this upstairs has completed
     #[datum]
     pub count: Cumulative<i64>,
@@ -78,9 +78,9 @@ pub struct ExtentReopen {
 pub struct UpCountStat {
     stat_name: CrucibleUpstairs,
     activated_count: Activated,
-    write_count: Write,
+    write_count: WriteCount,
     write_bytes: WriteBytes,
-    read_count: Read,
+    read_count: ReadCount,
     read_bytes: ReadBytes,
     flush_count: Flush,
     flush_close_count: FlushClose,


### PR DESCRIPTION
Cleaned up a bunch of clippy lints that showed up after the new Rust version.

I left alone stuff that I think will go away after the big refactor, hopefully to east the
merge pain.