### PR TITLE
Buffer should destructure to Vec when single-referenced

### DIFF
--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -180,7 +180,7 @@ async fn cmd_read<T: BlockIO>(
         // So say we have an offset of 5. we're misaligned by 5 bytes, so we
         // read 5 bytes we don't need. we skip those 5 bytes then write
         // the rest to the output
-        let bytes = buffer.as_vec().await;
+        let bytes = buffer.into_vec().unwrap();
         output.write_all(
             &bytes[offset_misalignment as usize
                 ..(offset_misalignment + alignment_bytes) as usize],
@@ -314,7 +314,7 @@ async fn write_remainder_and_finalize<'a, T: BlockIO>(
         crucible.read(uflow_offset, uflow_r_buf.clone()).await?;
 
         // Copy it into w_buf
-        let r_bytes = uflow_r_buf.as_vec().await;
+        let r_bytes = uflow_r_buf.into_vec().unwrap();
         w_buf[n_read..n_read + uflow_backfill]
             .copy_from_slice(&r_bytes[uflow_remainder as usize..]);
 
@@ -400,7 +400,7 @@ async fn cmd_write<T: BlockIO>(
         let offset = Block::new(block_idx, native_block_size.trailing_zeros());
         crucible.read(offset, buffer.clone()).await?;
 
-        let mut w_vec = buffer.as_vec().await.clone();
+        let mut w_vec = buffer.into_vec().unwrap();
         // Write our data into the buffer
         let bytes_read = input.read(
             &mut w_vec[offset_misalignment as usize

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -224,13 +224,12 @@ async fn cli_read(
     let offset = Block::new(block_index as u64, ri.block_size.trailing_zeros());
     let length: usize = size * ri.block_size as usize;
 
-    let vec: Vec<u8> = vec![255; length];
-    let data = crucible::Buffer::from_vec(vec);
+    let data = crucible::Buffer::from_vec(vec![255; length]);
 
     println!("Read  at block {:5}, len:{:7}", offset.value, data.len());
     guest.read(offset, data.clone()).await?;
 
-    let mut dl = data.as_vec().await.to_vec();
+    let mut dl = data.into_vec().unwrap();
     match validate_vec(
         dl.clone(),
         block_index,

--- a/pantry/src/pantry.rs
+++ b/pantry/src/pantry.rs
@@ -298,8 +298,7 @@ impl PantryEntry {
             .read_from_byte_offset(offset, buffer.clone())
             .await?;
 
-        let response = buffer.as_vec().await;
-        Ok(response.clone())
+        Ok(buffer.into_vec().unwrap())
     }
 
     pub async fn scrub(&self) -> Result<(), CrucibleError> {
@@ -341,7 +340,7 @@ impl PantryEntry {
                 .read_from_byte_offset(start, data.clone())
                 .await?;
 
-            hasher.update(&*data.as_vec().await);
+            hasher.update(&data.into_vec().unwrap())
         }
 
         let digest = hex::encode(hasher.finalize());

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -409,7 +409,7 @@ impl Volume {
                 // TODO: Nexus needs to know about this failure.
                 self.write_unwritten(
                     Block::new(offset, bs.trailing_zeros()),
-                    Bytes::from(buffer.as_vec().await.clone()),
+                    Bytes::from(buffer.into_vec().unwrap()),
                 )
                 .await?;
 
@@ -1831,7 +1831,7 @@ mod test {
         let buffer = Buffer::new(4096);
         disk.read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
-        assert_eq!(*buffer.as_vec().await, vec![0; 4096]);
+        assert_eq!(buffer.into_vec().unwrap(), vec![0; 4096]);
 
         // Write ones to second block
         disk.write(
@@ -1856,7 +1856,7 @@ mod test {
         let mut expected = vec![0; 512];
         expected.extend(vec![1; 512]);
         expected.extend(vec![0; 4096 - 1024]);
-        assert_eq!(*buffer.as_vec().await, expected);
+        assert_eq!(buffer.into_vec().unwrap(), expected);
 
         // Write twos to first block
         disk.write(
@@ -1873,7 +1873,7 @@ mod test {
         let mut expected = vec![2; 512];
         expected.extend(vec![1; 512]);
         expected.extend(vec![0; 4096 - 1024]);
-        assert_eq!(*buffer.as_vec().await, expected);
+        assert_eq!(buffer.into_vec().unwrap(), expected);
 
         // Write sevens to third and fourth blocks
         disk.write(
@@ -1899,7 +1899,7 @@ mod test {
         expected.extend(vec![7; 1024]);
         expected.extend(vec![8; 1024]);
         expected.extend(vec![0; 1024]);
-        assert_eq!(*buffer.as_vec().await, expected);
+        assert_eq!(buffer.into_vec().unwrap(), expected);
 
         Ok(())
     }
@@ -1939,7 +1939,7 @@ mod test {
         let mut expected = vec![read_only_parent_init_value; 512 * 4];
         expected.extend(vec![0x00; 512 * 4]);
 
-        assert_eq!(*buffer.as_vec().await, expected);
+        assert_eq!(buffer.into_vec().unwrap(), expected);
 
         // If the parent volume has data, it should be returned. Write ones to
         // the first block of the parent:
@@ -1964,7 +1964,7 @@ mod test {
         expected.extend(vec![read_only_parent_init_value; 512 * 3]);
         expected.extend(vec![0x00; 512 * 4]); // <- from subvolume, still "-"
 
-        assert_eq!(*buffer.as_vec().await, expected);
+        assert_eq!(buffer.into_vec().unwrap(), expected);
 
         // If the volume is written to and it doesn't overlap, still return the
         // parent data. Write twos to the volume:
@@ -1991,7 +1991,7 @@ mod test {
             let mut expected = vec![1; 512];
             expected.extend(vec![read_only_parent_init_value; 2048 - 512]);
 
-            assert_eq!(*buffer.as_vec().await, expected);
+            assert_eq!(buffer.into_vec().unwrap(), expected);
         }
 
         // Read whole volume and verify
@@ -2005,7 +2005,7 @@ mod test {
         expected.extend(vec![read_only_parent_init_value; 512]);
         expected.extend(vec![0x00; 512 * 4]); // <- from subvolume, still "-"
 
-        assert_eq!(*buffer.as_vec().await, expected);
+        assert_eq!(buffer.into_vec().unwrap(), expected);
 
         // If the volume is written to and it does overlap, return the volume
         // data. Write threes to the volume:
@@ -2032,7 +2032,7 @@ mod test {
             let mut expected = vec![1; 512];
             expected.extend(vec![read_only_parent_init_value; 2048 - 512]);
 
-            assert_eq!(*buffer.as_vec().await, expected);
+            assert_eq!(buffer.into_vec().unwrap(), expected);
         }
 
         // Read whole volume and verify
@@ -2046,7 +2046,7 @@ mod test {
         expected.extend(vec![read_only_parent_init_value; 512]);
         expected.extend(vec![0x00; 512 * 4]); // <- from subvolume, still "-"
 
-        assert_eq!(*buffer.as_vec().await, expected);
+        assert_eq!(buffer.into_vec().unwrap(), expected);
 
         // If the whole parent is now written to, only the last block should be
         // returned. Write fours to the parent
@@ -2071,7 +2071,7 @@ mod test {
         expected.extend(vec![4; 512]);
         expected.extend(vec![0x00; 512 * 4]); // <- from subvolume, still "-"
 
-        assert_eq!(*buffer.as_vec().await, expected);
+        assert_eq!(buffer.into_vec().unwrap(), expected);
 
         // If the parent goes away, then the sub volume data should still be
         // readable.
@@ -2088,7 +2088,7 @@ mod test {
         expected.extend(vec![0; 512]); // <- was previously from parent, now "-"
         expected.extend(vec![0x00; 512 * 4]); // <- from subvolume, still "-"
 
-        assert_eq!(*buffer.as_vec().await, expected);
+        assert_eq!(buffer.into_vec().unwrap(), expected);
 
         // Write to the whole volume. There's no more read-only parent (it was
         // dropped above)
@@ -2104,7 +2104,7 @@ mod test {
             .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())
             .await?;
 
-        assert_eq!(*buffer.as_vec().await, vec![9; 4096]);
+        assert_eq!(buffer.into_vec().unwrap(), vec![9; 4096]);
 
         Ok(())
     }
@@ -2385,7 +2385,7 @@ mod test {
 
         let expected = vec![128; 2048];
 
-        assert_eq!(*buffer.as_vec().await, expected);
+        assert_eq!(buffer.into_vec().unwrap(), expected);
 
         Ok(())
     }
@@ -2499,7 +2499,7 @@ mod test {
                 )
                 .await?;
 
-            assert_eq!(vec![0x55; BLOCK_SIZE * 10], *buffer.as_vec().await);
+            assert_eq!(vec![0x55; BLOCK_SIZE * 10], buffer.into_vec().unwrap());
 
             volume
                 .write(
@@ -2516,7 +2516,7 @@ mod test {
                 )
                 .await?;
 
-            assert_eq!(vec![0xFF; BLOCK_SIZE * 10], *buffer.as_vec().await);
+            assert_eq!(vec![0xFF; BLOCK_SIZE * 10], buffer.into_vec().unwrap());
         }
 
         // Create the same volume, verify data was written
@@ -2530,7 +2530,7 @@ mod test {
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
 
-        assert_eq!(vec![0xFF; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0xFF; BLOCK_SIZE * 10], buffer.into_vec().unwrap());
 
         Ok(())
     }
@@ -2558,7 +2558,7 @@ mod test {
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
 
-        assert_eq!(vec![0x55; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0x55; BLOCK_SIZE * 10], buffer.into_vec().unwrap());
 
         let mut parent_volume = Volume::new(BLOCK_SIZE as u64, csl());
         parent_volume.add_subvolume(parent).await?;
@@ -2592,7 +2592,7 @@ mod test {
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
 
-        assert_eq!(vec![0x55; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0x55; BLOCK_SIZE * 10], buffer.into_vec().unwrap());
 
         // Write over whole volume
         volume
@@ -2608,7 +2608,7 @@ mod test {
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
 
-        assert_eq!(vec![0xFF; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0xFF; BLOCK_SIZE * 10], buffer.into_vec().unwrap());
 
         Ok(())
     }
@@ -2642,7 +2642,7 @@ mod test {
             .await
             .unwrap();
 
-        assert_eq!(vec![0x0; BLOCK_SIZE], *buffer.as_vec().await);
+        assert_eq!(vec![0x0; BLOCK_SIZE], buffer.into_vec().unwrap());
 
         let buffer = Buffer::new(BLOCK_SIZE);
         volume
@@ -2650,7 +2650,7 @@ mod test {
             .await
             .unwrap();
 
-        assert_eq!(vec![0x5; BLOCK_SIZE], *buffer.as_vec().await);
+        assert_eq!(vec![0x5; BLOCK_SIZE], buffer.into_vec().unwrap());
     }
 
     // Test that blocks are correctly returned during read-only parent +
@@ -2680,7 +2680,7 @@ mod test {
             .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())
             .await?;
 
-        assert_eq!(vec![11; block_size * 5], *buffer.as_vec().await);
+        assert_eq!(vec![11; block_size * 5], buffer.into_vec().unwrap());
 
         // Create a volume out of this parent and the argument subvolume parts
         let mut volume = Volume::new(block_size as u64, csl());
@@ -2703,7 +2703,7 @@ mod test {
 
         let mut expected = vec![11; block_size * 5];
         expected.extend(vec![0x00; block_size * 5]);
-        assert_eq!(expected, *buffer.as_vec().await);
+        assert_eq!(expected, buffer.into_vec().unwrap());
 
         // One big write!
         volume
@@ -2719,7 +2719,7 @@ mod test {
             .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())
             .await?;
 
-        assert_eq!(vec![55; block_size * 10], *buffer.as_vec().await);
+        assert_eq!(vec![55; block_size * 10], buffer.into_vec().unwrap());
 
         Ok(())
     }


### PR DESCRIPTION
Until now, Buffer offered no means of extracting the internal `Vec<u8>` when, say, a Volume::read() operation had completed.  This made it impossible for Crucible consumers to reuse the `Vec` buffer, forcing an otherwise unnecessary allocation.