### PR TITLE
Fix shadowing warning in downstairs

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -45,7 +45,7 @@ use region::Region;
 pub use admin::run_dropshot;
 pub use dump::dump_region;
 pub use dynamometer::*;
-pub use stats::*;
+pub use stats::{DsCountStat, DsStatOuter};
 
 fn deadline_secs(secs: u64) -> Instant {
     Instant::now()


### PR DESCRIPTION
Since the `rustc` updated (in #1039), we've been getting warnings about shadowing:
```
warning: private item shadows public glob re-export
  --> downstairs/src/lib.rs:11:15
   |
11 | use std::io::{Read, Write};
   |               ^^^^
   |
note: the name `Read` in the type namespace is supposed to be publicly re-exported here
  --> downstairs/src/lib.rs:48:9
   |
48 | pub use stats::*;
   |         ^^^^^^^^
note: but the private item here shadows it
  --> downstairs/src/lib.rs:11:15
   |
11 | use std::io::{Read, Write};
   |               ^^^^
   = note: `#[warn(hidden_glob_reexports)]` on by default

warning: private item shadows public glob re-export
  --> downstairs/src/lib.rs:11:21
   |
11 | use std::io::{Read, Write};
   |                     ^^^^^
   |
note: the name `Write` in the type namespace is supposed to be publicly re-exported here
  --> downstairs/src/lib.rs:48:9
   |
48 | pub use stats::*;
   |         ^^^^^^^^
note: but the private item here shadows it
  --> downstairs/src/lib.rs:11:21
   |
11 | use std::io::{Read, Write};
   |                     ^^^^^
```

#1058 fixes this for `crucible-upstairs`; this PR fixes it for `crucible-downstairs`