### PR TITLE
Buffer should destructure to Vec when single-referenced

### DIFF
--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -180,7 +180,7 @@ async fn cmd_read<T: BlockIO>(
         // So say we have an offset of 5. we're misaligned by 5 bytes, so we
         // read 5 bytes we don't need. we skip those 5 bytes then write
         // the rest to the output
-        let bytes = buffer.as_vec().await;
+        let bytes = buffer.into_vec().unwrap();
         output.write_all(
             &bytes[offset_misalignment as usize
                 ..(offset_misalignment + alignment_bytes) as usize],
@@ -314,7 +314,7 @@ async fn write_remainder_and_finalize<'a, T: BlockIO>(
         crucible.read(uflow_offset, uflow_r_buf.clone()).await?;
 
         // Copy it into w_buf
-        let r_bytes = uflow_r_buf.as_vec().await;
+        let r_bytes = uflow_r_buf.into_vec().unwrap();
         w_buf[n_read..n_read + uflow_backfill]
             .copy_from_slice(&r_bytes[uflow_remainder as usize..]);
 
@@ -400,7 +400,7 @@ async fn cmd_write<T: BlockIO>(
         let offset = Block::new(block_idx, native_block_size.trailing_zeros());
         crucible.read(offset, buffer.clone()).await?;
 
-        let mut w_vec = buffer.as_vec().await.clone();
+        let mut w_vec = buffer.into_vec().unwrap();
         // Write our data into the buffer
         let bytes_read = input.read(
             &mut w_vec[offset_misalignment as usize

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -224,13 +224,12 @@ async fn cli_read(
     let offset = Block::new(block_index as u64, ri.block_size.trailing_zeros());
     let length: usize = size * ri.block_size as usize;
 
-    let vec: Vec<u8> = vec![255; length];
-    let data = crucible::Buffer::from_vec(vec);
+    let data = crucible::Buffer::from_vec(vec![255; length]);
 
     println!("Read  at block {:5}, len:{:7}", offset.value, data.len());
     guest.read(offset, data.clone()).await?;
 
-    let mut dl = data.as_vec().await.to_vec();
+    let mut dl = data.into_vec().unwrap();
     match validate_vec(
         dl.clone(),
         block_index,

--- a/pantry/src/pantry.rs
+++ b/pantry/src/pantry.rs
@@ -298,8 +298,7 @@ impl PantryEntry {
             .read_from_byte_offset(offset, buffer.clone())
             .await?;
 
-        let response = buffer.as_vec().await;
-        Ok(response.clone())
+        Ok(buffer.into_vec().unwrap())
     }
 
     pub async fn scrub(&self) -> Result<(), CrucibleError> {
@@ -341,7 +340,7 @@ impl PantryEntry {
                 .read_from_byte_offset(start, data.clone())
                 .await?;
 
-            hasher.update(&*data.as_vec().await);
+            hasher.update(&data.into_vec().unwrap())
         }
 
         let digest = hex::encode(hasher.finalize());

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2505,8 +2505,8 @@ impl Drop for Guest {
     fn drop(&mut self) {
         // Any BlockReqs or GuestWork which remains pending on this Guest when
         // it is dropped should be issued an error completion.  This avoids
-        // dropping BlockRes BlockRes instances prior to completion (which
-        // results in a panic).
+        // dropping BlockRes instances prior to completion (which results in a
+        // panic).
 
         self.reqs.get_mut().drain(..).for_each(|req| {
             req.res.send_err(CrucibleError::GenericError(

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1590,6 +1590,18 @@ impl Buffer {
         Buffer::from_vec(vec)
     }
 
+    /// Attempt to extract the underlying `Vec<u8>` bearing buffered data.
+    ///
+    /// Will succeed if no other references (clones) to the Buffer exist,
+    /// otherwise will return the Buffer as it still exists.
+    pub fn into_vec(self) -> Result<Vec<u8>, Self> {
+        let Buffer { len, data, owned } = self;
+        match Arc::try_unwrap(data) {
+            Ok(buf) => Ok(buf.into_inner()),
+            Err(data) => Err(Buffer { len, data, owned }),
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.len
     }
@@ -1884,7 +1896,7 @@ impl GtoS {
         assert!(!self.completed.is_empty());
 
         for ds_id in &self.completed {
-            if let Some(guest_buffer) = self.guest_buffers.get_mut(ds_id) {
+            if let Some(guest_buffer) = self.guest_buffers.remove(ds_id) {
                 let mut offset = 0;
                 let mut vec = guest_buffer.as_vec().await;
                 let mut owned_vec = guest_buffer.owned_vec().await;

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -945,7 +945,7 @@ impl Upstairs {
                     "{} request to activate upstairs already going active",
                     self.cfg.upstairs_id
                 );
-                res.send_err(CrucibleError::UpstairsDeactivating);
+                res.send_err(CrucibleError::UpstairsAlreadyActive);
             }
             UpstairsState::Deactivating(..) => {
                 warn!(


### PR DESCRIPTION
Until now, Buffer offered no means of extracting the internal `Vec<u8>` when, say, a Volume::read() operation had completed.  This made it impossible for Crucible consumers to reuse the `Vec` buffer, forcing an otherwise unnecessary allocation.

There are a few other changes I believe need to be made before consumers like Propolis can start reusing their buffer `Vec`, rather than reallocating after every request, but I believe this is a step in the right direction for that.