### PR TITLE
Allow crutest cli to be quiet on generic test

### DIFF
--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -126,6 +126,9 @@ enum CliCommand {
         /// Number of IOs to execute
         #[clap(long, short, default_value = "5000", action)]
         count: usize,
+        /// Print out IOs as we send them
+        #[clap(long, short, default_value = "false", action)]
+        quiet: bool,
     },
     /// Request region information
     Info,
@@ -493,8 +496,8 @@ async fn cmd_to_msg(
         CliCommand::Flush => {
             fw.send(CliMessage::Flush).await?;
         }
-        CliCommand::Generic { count } => {
-            fw.send(CliMessage::Generic(count)).await?;
+        CliCommand::Generic { count, quiet } => {
+            fw.send(CliMessage::Generic(count, quiet)).await?;
         }
         CliCommand::IsActive => {
             fw.send(CliMessage::IsActive).await?;
@@ -811,7 +814,7 @@ async fn process_cli_command(
                 .await
             }
         }
-        CliMessage::Generic(count) => {
+        CliMessage::Generic(count, quiet) => {
             if ri.write_log.is_empty() {
                 fw.send(CliMessage::Error(CrucibleError::GenericError(
                     "Info not initialized".to_string(),
@@ -819,7 +822,7 @@ async fn process_cli_command(
                 .await
             } else {
                 let mut wtq = WhenToQuit::Count { count };
-                match generic_workload(guest, &mut wtq, ri, false).await {
+                match generic_workload(guest, &mut wtq, ri, quiet).await {
                     Ok(_) => fw.send(CliMessage::DoneOk).await,
                     Err(e) => {
                         let msg = format!("{}", e);

--- a/crutest/src/protocol.rs
+++ b/crutest/src/protocol.rs
@@ -33,7 +33,7 @@ pub enum CliMessage {
     // Run the fill test.
     Fill(bool),
     Flush,
-    Generic(usize),
+    Generic(usize, bool),
     Info(u64, u64, u64),
     InfoPlease,
     IsActive,
@@ -296,7 +296,7 @@ mod tests {
 
     #[test]
     fn rt_generic() -> Result<()> {
-        let input = CliMessage::Generic(2);
+        let input = CliMessage::Generic(2, true);
         assert_eq!(input, round_trip(&input)?);
         Ok(())
     }


### PR DESCRIPTION
Add an option to the crutest cli to run the generic test but not display IO output.