### PR TITLE
Change guest work id from `u64` -> `GuestWorkId`

### DIFF
--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -1353,8 +1353,8 @@ impl DownstairsClient {
                         job.read_response_hashes = read_response_hashes;
                         assert!(!job.acked);
                         ackable = true;
-                        debug!(self.log, "Read AckReady {}", job.ds_id);
-                        cdt::up__to__ds__read__done!(|| job.guest_id);
+                        debug!(self.log, "Read AckReady {}", job.ds_id.0);
+                        cdt::up__to__ds__read__done!(|| job.guest_id.0);
                     } else {
                         /*
                          * If another job has finished already, we can
@@ -1385,7 +1385,7 @@ impl DownstairsClient {
                     assert!(extent_info.is_none());
                     if jobs_completed_ok == 2 {
                         ackable = true;
-                        cdt::up__to__ds__write__done!(|| job.guest_id);
+                        cdt::up__to__ds__write__done!(|| job.guest_id.0);
                     }
                 }
                 IOop::WriteUnwritten { .. } => {
@@ -1393,9 +1393,9 @@ impl DownstairsClient {
                     assert!(extent_info.is_none());
                     if jobs_completed_ok == 2 {
                         ackable = true;
-                        cdt::up__to__ds__write__unwritten__done!(
-                            || job.guest_id
-                        );
+                        cdt::up__to__ds__write__unwritten__done!(|| job
+                            .guest_id
+                            .0);
                     }
                 }
                 IOop::Flush {
@@ -1420,7 +1420,7 @@ impl DownstairsClient {
 
                     if jobs_completed_ok == ack_at_num_jobs {
                         ackable = true;
-                        cdt::up__to__ds__flush__done!(|| job.guest_id);
+                        cdt::up__to__ds__flush__done!(|| job.guest_id.0);
                         if deactivate {
                             debug!(self.log, "deactivate flush {ds_id} done");
                         }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -856,7 +856,7 @@ impl std::fmt::Display for DsState {
 struct DownstairsIO {
     ds_id: JobId, // This MUST match our hashmap index
 
-    guest_id: u64, // The hahsmap ID from the parent guest work.
+    guest_id: GuestWorkId, // The hashmap ID from the parent guest work.
     work: IOop,
 
     /// Map of work status, tracked on a per-client basis
@@ -1959,6 +1959,19 @@ impl GtoS {
     }
 }
 
+/// Strongly-typed ID for guest work (stored in the [`GuestWork`] map)
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct GuestWorkId(pub u64);
+
+impl std::fmt::Display for GuestWorkId {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> Result<(), std::fmt::Error> {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
 /**
  * This structure keeps track of work that Crucible has accepted from the
  * "Guest", aka, Propolis.
@@ -1975,16 +1988,16 @@ impl GtoS {
  */
 #[derive(Debug)]
 struct GuestWork {
-    active: HashMap<u64, GtoS>,
+    active: HashMap<GuestWorkId, GtoS>,
     next_gw_id: u64,
-    completed: AllocRingBuffer<u64>,
+    completed: AllocRingBuffer<GuestWorkId>,
 }
 
 impl GuestWork {
-    fn next_gw_id(&mut self) -> u64 {
+    fn next_gw_id(&mut self) -> GuestWorkId {
         let id = self.next_gw_id;
         self.next_gw_id += 1;
-        id
+        GuestWorkId(id)
     }
 
     /*
@@ -2004,7 +2017,7 @@ impl GuestWork {
     #[instrument]
     async fn gw_ds_complete(
         &mut self,
-        gw_id: u64,
+        gw_id: GuestWorkId,
         ds_id: JobId,
         data: Option<Vec<ReadResponse>>,
         result: Result<(), CrucibleError>,
@@ -2846,7 +2859,7 @@ pub async fn up_main(
 async fn show_guest_work(guest: &Arc<Guest>) -> usize {
     println!("Guest work:  Active and Completed Jobs:");
     let gw = guest.guest_work.lock().await;
-    let mut kvec: Vec<u64> = gw.active.keys().cloned().collect::<Vec<u64>>();
+    let mut kvec: Vec<_> = gw.active.keys().cloned().collect();
     kvec.sort_unstable();
     for id in kvec.iter() {
         let job = gw.active.get(id).unwrap();

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -1220,7 +1220,7 @@ pub(crate) mod up_test {
 
         let mut gw = up.guest.guest_work.lock().await;
 
-        let gw_id = 12345;
+        let gw_id = GuestWorkId(12345);
 
         // Create two reads
         let first_id = JobId(1010);
@@ -1293,7 +1293,7 @@ pub(crate) mod up_test {
         // Regular happy path
         let job = DownstairsIO {
             ds_id: JobId(1),
-            guest_id: 1,
+            guest_id: GuestWorkId(1),
             work: IOop::Read {
                 dependencies: vec![],
                 requests: vec![],
@@ -1318,7 +1318,7 @@ pub(crate) mod up_test {
         // Mismatch!
         let job = DownstairsIO {
             ds_id: JobId(1),
-            guest_id: 1,
+            guest_id: GuestWorkId(1),
             work: IOop::Read {
                 dependencies: vec![],
                 requests: vec![],
@@ -1343,7 +1343,7 @@ pub(crate) mod up_test {
         // Length mismatch
         let job = DownstairsIO {
             ds_id: JobId(1),
-            guest_id: 1,
+            guest_id: GuestWorkId(1),
             work: IOop::Read {
                 dependencies: vec![],
                 requests: vec![],
@@ -1367,7 +1367,7 @@ pub(crate) mod up_test {
 
         let job = DownstairsIO {
             ds_id: JobId(1),
-            guest_id: 1,
+            guest_id: GuestWorkId(1),
             work: IOop::Read {
                 dependencies: vec![],
                 requests: vec![],

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1020,8 +1020,8 @@ impl Upstairs {
          * should be flushed at the next flush ID.
          */
         let mut gw = self.guest.guest_work.lock().await;
-        let gw_id: u64 = gw.next_gw_id();
-        cdt::gw__flush__start!(|| (gw_id));
+        let gw_id = gw.next_gw_id();
+        cdt::gw__flush__start!(|| (gw_id.0));
 
         if snapshot_details.is_some() {
             info!(self.log, "flush with snap requested");
@@ -1032,7 +1032,7 @@ impl Upstairs {
         let new_gtos = GtoS::new(next_id, None, res);
         gw.active.insert(gw_id, new_gtos);
 
-        cdt::up__to__ds__flush__start!(|| (gw_id));
+        cdt::up__to__ds__flush__start!(|| (gw_id.0));
     }
 
     /// Submits a read job to the downstairs
@@ -1110,8 +1110,8 @@ impl Upstairs {
          * Grab this ID after extent_from_offset: in case of Err we don't
          * want to create a gap in the IDs.
          */
-        let gw_id: u64 = gw.next_gw_id();
-        cdt::gw__read__start!(|| (gw_id));
+        let gw_id = gw.next_gw_id();
+        cdt::gw__read__start!(|| (gw_id.0));
 
         let next_id = self.downstairs.submit_read(gw_id, impacted_blocks, ddef);
 
@@ -1122,7 +1122,7 @@ impl Upstairs {
         let new_gtos = GtoS::new(next_id, Some(data), res);
         gw.active.insert(gw_id, new_gtos);
 
-        cdt::up__to__ds__read__start!(|| (gw_id));
+        cdt::up__to__ds__read__start!(|| (gw_id.0));
     }
 
     /// Submits a new write job to the upstairs
@@ -1268,11 +1268,11 @@ impl Upstairs {
          * Grab this ID after extent_from_offset: in case of Err we don't
          * want to create a gap in the IDs.
          */
-        let gw_id: u64 = gw.next_gw_id();
+        let gw_id = gw.next_gw_id();
         if is_write_unwritten {
-            cdt::gw__write__unwritten__start!(|| (gw_id));
+            cdt::gw__write__unwritten__start!(|| (gw_id.0));
         } else {
-            cdt::gw__write__start!(|| (gw_id));
+            cdt::gw__write__start!(|| (gw_id.0));
         }
 
         let next_id = self.downstairs.submit_write(
@@ -1287,9 +1287,9 @@ impl Upstairs {
         gw.active.insert(gw_id, new_gtos);
 
         if is_write_unwritten {
-            cdt::up__to__ds__write__unwritten__start!(|| (gw_id));
+            cdt::up__to__ds__write__unwritten__start!(|| (gw_id.0));
         } else {
-            cdt::up__to__ds__write__start!(|| (gw_id));
+            cdt::up__to__ds__write__start!(|| (gw_id.0));
         }
     }
 


### PR DESCRIPTION
The long-delayed fourth PR in the "use wrapper types instead of `u64`" series!

Previous episodes include

- https://github.com/oxidecomputer/crucible/pull/919
- https://github.com/oxidecomputer/crucible/pull/925
- https://github.com/oxidecomputer/crucible/pull/928

This is purely mechanical, with no logic or (external) API changes.
