### PR TITLE
Add logger to `Guest`

### DIFF
--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -563,10 +563,10 @@ async fn main() -> Result<()> {
     };
 
     // TODO: volumes?
-    let guest = Arc::new(Guest::new());
+    let guest = Arc::new(Guest::new(None));
 
     let _join_handle =
-        up_main(crucible_opts, opt.gen, None, guest.clone(), None, None)?;
+        up_main(crucible_opts, opt.gen, None, guest.clone(), None)?;
     eprintln!("Crucible runtime is spawned");
 
     // IO time

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -668,7 +668,7 @@ async fn main() -> Result<()> {
      * We create this here instead of inside up_main() so we can use
      * the methods provided by guest to interact with Crucible.
      */
-    let guest = Arc::new(Guest::new());
+    let guest = Arc::new(Guest::new(None));
 
     let pr;
     if opt.metrics {
@@ -699,7 +699,7 @@ async fn main() -> Result<()> {
     }
 
     let _join_handle =
-        up_main(crucible_opts, opt.gen, None, guest.clone(), pr, None)?;
+        up_main(crucible_opts, opt.gen, None, guest.clone(), pr)?;
     println!("Crucible runtime is spawned");
 
     if let Workload::CliServer { listen, port } = opt.workload {

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -130,17 +130,11 @@ async fn main() -> Result<()> {
          * We create this here instead of inside up_main() so we can use
          * the methods provided by guest to interact with Crucible.
          */
-        let guest = Arc::new(Guest::new());
+        let guest = Arc::new(Guest::new(None));
 
         let gen: u64 = i as u64 + opt.gen;
-        let _join_handle = up_main(
-            crucible_opts.clone(),
-            gen,
-            None,
-            guest.clone(),
-            None,
-            None,
-        )?;
+        let _join_handle =
+            up_main(crucible_opts.clone(), gen, None, guest.clone(), None)?;
         println!("Crucible runtime is spawned");
 
         cpfs.push(crucible::CruciblePseudoFile::from(guest)?);

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -3068,10 +3068,10 @@ mod test {
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();
 
-        let guest = Arc::new(Guest::new());
+        let guest = Arc::new(Guest::new(None));
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None, None)?;
+        let _join_handle = up_main(opts, 1, None, gc, None)?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -3112,10 +3112,10 @@ mod test {
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();
 
-        let guest = Arc::new(Guest::new());
+        let guest = Arc::new(Guest::new(None));
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None, None)?;
+        let _join_handle = up_main(opts, 1, None, gc, None)?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -3147,10 +3147,10 @@ mod test {
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();
 
-        let guest = Arc::new(Guest::new());
-        let gc = guest.clone();
         let log = csl();
-        let _jh = up_main(opts, 1, None, gc, None, Some(log.clone()))?;
+        let guest = Arc::new(Guest::new(Some(log.clone())));
+        let gc = guest.clone();
+        let _jh = up_main(opts, 1, None, gc, None)?;
 
         guest.activate().await?;
 
@@ -3222,11 +3222,11 @@ mod test {
         let tds = TestDownstairsSet::small(true).await?;
         let opts = tds.opts();
 
-        let guest = Arc::new(Guest::new());
+        let guest = Arc::new(Guest::new(None));
         let gc = guest.clone();
 
         // Read-only Upstairs should return errors if writes are attempted.
-        let _join_handle = up_main(opts, 1, None, gc, None, None)?;
+        let _join_handle = up_main(opts, 1, None, gc, None)?;
 
         guest.activate().await?;
 
@@ -3255,10 +3255,10 @@ mod test {
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();
 
-        let guest = Arc::new(Guest::new());
-        let gc = guest.clone();
         let log = csl();
-        let _jh = up_main(opts, 1, None, gc, None, Some(log.clone()))?;
+        let guest = Arc::new(Guest::new(Some(log.clone())));
+        let gc = guest.clone();
+        let _jh = up_main(opts, 1, None, gc, None)?;
 
         guest.activate().await?;
 
@@ -3303,10 +3303,10 @@ mod test {
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();
 
-        let guest = Arc::new(Guest::new());
+        let guest = Arc::new(Guest::new(None));
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None, None)?;
+        let _join_handle = up_main(opts, 1, None, gc, None)?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -3376,10 +3376,10 @@ mod test {
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();
 
-        let guest = Arc::new(Guest::new());
+        let guest = Arc::new(Guest::new(None));
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None, None)?;
+        let _join_handle = up_main(opts, 1, None, gc, None)?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -3434,10 +3434,10 @@ mod test {
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();
 
-        let guest = Arc::new(Guest::new());
+        let guest = Arc::new(Guest::new(None));
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None, None)?;
+        let _join_handle = up_main(opts, 1, None, gc, None)?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -3493,10 +3493,10 @@ mod test {
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();
 
-        let guest = Arc::new(Guest::new());
+        let guest = Arc::new(Guest::new(None));
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None, None)?;
+        let _join_handle = up_main(opts, 1, None, gc, None)?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -3550,10 +3550,10 @@ mod test {
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();
 
-        let guest = Arc::new(Guest::new());
+        let guest = Arc::new(Guest::new(None));
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None, None)?;
+        let _join_handle = up_main(opts, 1, None, gc, None)?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -3607,10 +3607,10 @@ mod test {
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();
 
-        let guest = Arc::new(Guest::new());
+        let guest = Arc::new(Guest::new(None));
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None, None)?;
+        let _join_handle = up_main(opts, 1, None, gc, None)?;
 
         guest.activate().await?;
         guest.query_work_queue().await?;
@@ -3662,10 +3662,10 @@ mod test {
         let tds = TestDownstairsSet::small(false).await.unwrap();
         let opts = tds.opts();
 
-        let guest = Arc::new(Guest::new());
+        let guest = Arc::new(Guest::new(None));
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None, None).unwrap();
+        let _join_handle = up_main(opts, 1, None, gc, None).unwrap();
 
         guest.activate().await.unwrap();
 
@@ -3698,10 +3698,10 @@ mod test {
         let tds = TestDownstairsSet::small(false).await.unwrap();
         let opts = tds.opts();
 
-        let guest = Arc::new(Guest::new());
+        let guest = Arc::new(Guest::new(None));
         let gc = guest.clone();
 
-        let _join_handle = up_main(opts, 1, None, gc, None, None).unwrap();
+        let _join_handle = up_main(opts, 1, None, gc, None).unwrap();
 
         guest.activate().await.unwrap();
 

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -101,7 +101,7 @@ async fn main() -> Result<()> {
         std::process::exit(1);
     }));
 
-    let mut guest = Guest::new();
+    let mut guest = Guest::new(None);
 
     if let Some(iop_limit) = opt.iop_limit {
         guest.set_iop_limit(16 * 1024 * 1024, iop_limit);
@@ -113,7 +113,7 @@ async fn main() -> Result<()> {
 
     let guest = Arc::new(guest);
     let _join_handle =
-        up_main(crucible_opts, opt.gen, None, guest.clone(), None, None)?;
+        up_main(crucible_opts, opt.gen, None, guest.clone(), None)?;
     println!("Crucible runtime is spawned");
 
     guest.activate().await?;

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -91,10 +91,10 @@ async fn main() -> Result<()> {
      * We create this here instead of inside up_main() so we can use
      * the methods provided by guest to interact with Crucible.
      */
-    let guest = Arc::new(Guest::new());
+    let guest = Arc::new(Guest::new(None));
 
     let _join_handle =
-        up_main(crucible_opts, opt.gen, None, guest.clone(), None, None)?;
+        up_main(crucible_opts, opt.gen, None, guest.clone(), None)?;
     println!("Crucible runtime is spawned");
 
     // NBD server

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -522,7 +522,7 @@ pub(crate) mod protocol_test {
 
             // Configure our guest without queue backpressure, to speed up tests
             // which require triggering a timeout
-            let mut g = Guest::new();
+            let mut g = Guest::new(Some(log.clone()));
             g.backpressure_config.queue_max_delay = Duration::ZERO;
             let guest = Arc::new(g);
 
@@ -535,15 +535,8 @@ pub(crate) mod protocol_test {
                 ..Default::default()
             };
 
-            let join_handle = up_main(
-                crucible_opts,
-                1,
-                None,
-                guest.clone(),
-                None,
-                Some(log.new(o!("upstairs" => 1))),
-            )
-            .unwrap();
+            let join_handle =
+                up_main(crucible_opts, 1, None, guest.clone(), None).unwrap();
 
             let mut handles: Vec<JoinHandle<Result<()>>> = vec![];
 

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -23,9 +23,8 @@ pub(crate) fn make_upstairs() -> crate::upstairs::Upstairs {
         &opts,
         0,
         Some(def),
-        Arc::new(Guest::new()),
+        Arc::new(Guest::new(None)),
         None,
-        crucible_common::build_logger(),
     )
 }
 
@@ -46,9 +45,8 @@ pub(crate) fn make_encrypted_upstairs() -> crate::upstairs::Upstairs {
         &opts,
         0,
         Some(def),
-        Arc::new(Guest::new()),
+        Arc::new(Guest::new(None)),
         None,
-        crucible_common::build_logger(),
     )
 }
 
@@ -731,7 +729,7 @@ pub(crate) mod up_test {
 
     #[tokio::test]
     async fn test_no_iop_limit() -> Result<()> {
-        let guest = Guest::new();
+        let guest = Guest::new(None);
 
         assert_none_consumed!(&guest);
 
@@ -771,7 +769,7 @@ pub(crate) mod up_test {
 
     #[tokio::test]
     async fn test_set_iop_limit() -> Result<()> {
-        let mut guest = Guest::new();
+        let mut guest = Guest::new(None);
         guest.set_iop_limit(16000, 2);
 
         assert_none_consumed!(&guest);
@@ -826,7 +824,7 @@ pub(crate) mod up_test {
 
     #[tokio::test]
     async fn test_flush_does_not_consume_iops() -> Result<()> {
-        let mut guest = Guest::new();
+        let mut guest = Guest::new(None);
 
         // Set 0 as IOP limit
         guest.set_iop_limit(16000, 0);
@@ -859,7 +857,7 @@ pub(crate) mod up_test {
 
     #[tokio::test]
     async fn test_set_bw_limit() -> Result<()> {
-        let mut guest = Guest::new();
+        let mut guest = Guest::new(None);
         guest.set_bw_limit(1024 * 1024); // 1 KiB
 
         assert_none_consumed!(&guest);
@@ -914,7 +912,7 @@ pub(crate) mod up_test {
 
     #[tokio::test]
     async fn test_flush_does_not_consume_bw() -> Result<()> {
-        let mut guest = Guest::new();
+        let mut guest = Guest::new(None);
 
         // Set 0 as bandwidth limit
         guest.set_bw_limit(0);
@@ -947,7 +945,7 @@ pub(crate) mod up_test {
 
     #[tokio::test]
     async fn test_iop_and_bw_limit() -> Result<()> {
-        let mut guest = Guest::new();
+        let mut guest = Guest::new(None);
 
         guest.set_iop_limit(16384, 500); // 1 IOP is 16 KiB
         guest.set_bw_limit(6400 * 1024); // 16384 B * 400 = 6400 KiB/s
@@ -1065,7 +1063,7 @@ pub(crate) mod up_test {
     // Is it possible to submit an IO that will never be sent? It shouldn't be!
     #[tokio::test]
     async fn test_impossible_io() -> Result<()> {
-        let mut guest = Guest::new();
+        let mut guest = Guest::new(None);
 
         guest.set_iop_limit(1024 * 1024 / 2, 10); // 1 IOP is half a KiB
         guest.set_bw_limit(1024 * 1024); // 1 KiB

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -261,7 +261,6 @@ impl Upstairs {
         expected_region_def: Option<RegionDefinition>,
         guest: Arc<Guest>,
         tls_context: Option<Arc<crucible_common::x509::TLSContext>>,
-        log: Logger,
     ) -> Self {
         /*
          * XXX Make sure we have three and only three downstairs
@@ -302,7 +301,7 @@ impl Upstairs {
         };
 
         let session_id = Uuid::new_v4();
-        let log = log.new(o!("session_id" => session_id.to_string()));
+        let log = guest.log.new(o!("session_id" => session_id.to_string()));
         info!(log, "Crucible {} has session id: {}", uuid, session_id);
         info!(log, "Upstairs opts: {}", opt);
 
@@ -361,7 +360,13 @@ impl Upstairs {
 
         let log = crucible_common::build_logger();
 
-        Self::new(&opts, 0, ddef, Arc::new(Guest::default()), None, log)
+        Self::new(
+            &opts,
+            0,
+            ddef,
+            Arc::new(Guest::new(Some(log.clone()))),
+            None,
+        )
     }
 
     /// Runs the upstairs (forever)

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -168,7 +168,7 @@ impl Volume {
         producer_registry: Option<ProducerRegistry>,
     ) -> Result<(), CrucibleError> {
         let region_def = build_region_definition(&extent_info, &opts)?;
-        let guest = Arc::new(Guest::new());
+        let guest = Arc::new(Guest::new(Some(self.log.clone())));
 
         // Spawn crucible tasks
         let guest_clone = guest.clone();
@@ -179,7 +179,6 @@ impl Volume {
             Some(region_def),
             guest_clone,
             producer_registry,
-            Some(self.log.clone()),
         )?;
 
         self.add_subvolume(guest).await
@@ -1557,7 +1556,7 @@ mod test {
     fn test_single_block() -> Result<()> {
         let sub_volume = SubVolume {
             lba_range: 0..10,
-            block_io: Arc::new(Guest::new()),
+            block_io: Arc::new(Guest::new(Some(csl()))),
         };
 
         // Coverage inside region
@@ -1570,7 +1569,7 @@ mod test {
     fn test_single_sub_volume_lba_coverage() -> Result<()> {
         let sub_volume = SubVolume {
             lba_range: 0..2048,
-            block_io: Arc::new(Guest::new()),
+            block_io: Arc::new(Guest::new(Some(csl()))),
         };
 
         // Coverage inside region
@@ -1592,7 +1591,7 @@ mod test {
     fn test_single_sub_volume_lba_coverage_with_offset() -> Result<()> {
         let sub_volume = SubVolume {
             lba_range: 1024..2048,
-            block_io: Arc::new(Guest::new()),
+            block_io: Arc::new(Guest::new(Some(csl()))),
         };
 
         // No coverage before region


### PR DESCRIPTION
For reasons, we want to be able to log stuff from the `struct Guest` in the Crucible upstairs.

This PR adds a `log: Logger` member, then adjusts a bunch of APIs so that the same logger is passed to the `Upstairs` (to avoid interleaving of log messages).

To match existing behavior, `Guest::new` takes an `Option<Logger>` and calls `crucible_common::build_logger` if it is `None`.

The public API used by Propolis (`Volume::new`) is unchanged.