### PR TITLE
Make guest work queue async

### DIFF
--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -571,10 +571,10 @@ async fn main() -> Result<()> {
     };
 
     // TODO: volumes?
-    let guest = Arc::new(Guest::new(None));
+    let (guest, io) = Guest::new(None);
+    let guest = Arc::new(guest);
 
-    let _join_handle =
-        up_main(crucible_opts, opt.gen, None, guest.clone(), None)?;
+    let _join_handle = up_main(crucible_opts, opt.gen, None, io, None)?;
     eprintln!("Crucible runtime is spawned");
 
     // IO time

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -668,7 +668,8 @@ async fn main() -> Result<()> {
      * We create this here instead of inside up_main() so we can use
      * the methods provided by guest to interact with Crucible.
      */
-    let guest = Arc::new(Guest::new(None));
+    let (guest, io) = Guest::new(None);
+    let guest = Arc::new(guest);
 
     let pr;
     if opt.metrics {
@@ -698,8 +699,7 @@ async fn main() -> Result<()> {
         pr = None;
     }
 
-    let _join_handle =
-        up_main(crucible_opts, opt.gen, None, guest.clone(), pr)?;
+    let _join_handle = up_main(crucible_opts, opt.gen, None, io, pr)?;
     println!("Crucible runtime is spawned");
 
     if let Workload::CliServer { listen, port } = opt.workload {

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -1,7 +1,6 @@
 // Copyright 2023 Oxide Computer Company
 
 use std::net::SocketAddr;
-use std::sync::Arc;
 
 use anyhow::{bail, Result};
 use clap::Parser;
@@ -130,11 +129,10 @@ async fn main() -> Result<()> {
          * We create this here instead of inside up_main() so we can use
          * the methods provided by guest to interact with Crucible.
          */
-        let guest = Arc::new(Guest::new(None));
+        let (guest, io) = Guest::new(None);
 
         let gen: u64 = i as u64 + opt.gen;
-        let _join_handle =
-            up_main(crucible_opts.clone(), gen, None, guest.clone(), None)?;
+        let _join_handle = up_main(crucible_opts.clone(), gen, None, io, None)?;
         println!("Crucible runtime is spawned");
 
         cpfs.push(crucible::CruciblePseudoFile::from(guest)?);

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -101,19 +101,19 @@ async fn main() -> Result<()> {
         std::process::exit(1);
     }));
 
-    let mut guest = Guest::new(None);
+    let (guest, mut io) = Guest::new(None);
+    let guest = Arc::new(guest);
 
     if let Some(iop_limit) = opt.iop_limit {
-        guest.set_iop_limit(16 * 1024 * 1024, iop_limit);
+        io.set_iop_limit(16 * 1024 * 1024, iop_limit);
     }
 
     if let Some(bw_limit) = opt.bw_limit_in_bytes {
-        guest.set_bw_limit(bw_limit);
+        io.set_bw_limit(bw_limit);
     }
 
     let guest = Arc::new(guest);
-    let _join_handle =
-        up_main(crucible_opts, opt.gen, None, guest.clone(), None)?;
+    let _join_handle = up_main(crucible_opts, opt.gen, None, io, None)?;
     println!("Crucible runtime is spawned");
 
     guest.activate().await?;

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -1,6 +1,5 @@
 // Copyright 2021 Oxide Computer Company
 use std::net::SocketAddr;
-use std::sync::Arc;
 
 use anyhow::{bail, Result};
 use clap::Parser;
@@ -91,10 +90,9 @@ async fn main() -> Result<()> {
      * We create this here instead of inside up_main() so we can use
      * the methods provided by guest to interact with Crucible.
      */
-    let guest = Arc::new(Guest::new(None));
+    let (guest, io) = Guest::new(None);
 
-    let _join_handle =
-        up_main(crucible_opts, opt.gen, None, guest.clone(), None)?;
+    let _join_handle = up_main(crucible_opts, opt.gen, None, io, None)?;
     println!("Crucible runtime is spawned");
 
     // NBD server

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -2311,7 +2311,12 @@ async fn client_run(
     .await;
 
     warn!(log, "client task is sending Done({r:?})");
-    tx.send(ClientResponse::Done(r)).await.unwrap();
+    if tx.send(ClientResponse::Done(r)).await.is_err() {
+        warn!(
+            log,
+            "client task could not reply to main task; shutting down?"
+        );
+    }
     while let Some(v) = rx.recv().await {
         warn!(log, "exiting client task is ignoring message {v:?}");
     }

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -522,8 +522,8 @@ pub(crate) mod protocol_test {
 
             // Configure our guest without queue backpressure, to speed up tests
             // which require triggering a timeout
-            let mut g = Guest::new(Some(log.clone()));
-            g.backpressure_config.queue_max_delay = Duration::ZERO;
+            let (g, mut io) = Guest::new(Some(log.clone()));
+            io.backpressure_config.queue_max_delay = Duration::ZERO;
             let guest = Arc::new(g);
 
             let crucible_opts = CrucibleOpts {
@@ -536,7 +536,7 @@ pub(crate) mod protocol_test {
             };
 
             let join_handle =
-                up_main(crucible_opts, 1, None, guest.clone(), None).unwrap();
+                up_main(crucible_opts, 1, None, io, None).unwrap();
 
             let mut handles: Vec<JoinHandle<Result<()>>> = vec![];
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::mutex_atomic)]
 
 use std::clone::Clone;
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::io::{Read as _, Result as IOResult, Seek, SeekFrom, Write as _};
@@ -25,7 +25,7 @@ use ringbuffer::{AllocRingBuffer, RingBuffer};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slog::{error, info, o, warn, Logger};
-use tokio::sync::{mpsc, oneshot, Mutex, Notify, RwLock};
+use tokio::sync::{mpsc, oneshot, Mutex, RwLock};
 use tokio::time::Instant;
 use tracing::{instrument, span, Level};
 use usdt::register_probes;
@@ -73,7 +73,7 @@ use async_trait::async_trait;
 mod client;
 mod downstairs;
 mod upstairs;
-use crate::upstairs::UpCounters;
+use upstairs::{UpCounters, UpstairsAction};
 
 // Max number of outstanding IOs between the upstairs and the downstairs
 // before we give up and mark that downstairs faulted.
@@ -2076,6 +2076,10 @@ struct GuestWork {
 }
 
 impl GuestWork {
+    fn is_empty(&self) -> bool {
+        self.active.is_empty()
+    }
+
     fn next_gw_id(&mut self) -> GuestWorkId {
         let id = self.next_gw_id;
         self.next_gw_id += 1;
@@ -2134,76 +2138,18 @@ impl Default for GuestWork {
     }
 }
 
-/**
- * This is the structure we use to keep track of work passed into crucible
- * from the "Guest".
- *
- * Requests from the guest are put into the reqs VecDeque initially.
- *
- * A task on the Crucible side will receive a notification that a new
- * operation has landed on the reqs queue and will take action:
- *
- * * Pop the request off the reqs queue.
- *
- * * Copy (and optionally encrypt) any data buffers provided to us by the
- *   Guest.
- *
- * * Create one or more downstairs DownstairsIO structures.
- *
- * * Create a GtoS tracking structure with the id's for each downstairs task
- *   and the read result buffer if required.
- *
- * * Add the GtoS struct to the in GuestWork active work hashmap.
- *
- * * Put all the DownstairsIO structures on the downstairs work queue.
- *
- * * Send notification to the upstairs tasks that there is new work.
- *
- * Work here will be added to storage side queues and the responses will
- * be waited on and processed when they arrive.
- *
- * This structure and operations on in handle the translation between
- * outside requests and internal upstairs structures and work queues.
- */
+/// IO handles used by the guest uses to pass work into Crucible proper
+///
+/// This data structure is the counterpart to the [`GuestIoHandle`], which
+/// receives work from the guest and is exclusively owned by the
+/// [`upstairs::Upstairs`]
+///
+/// Requests from the guest are put into the `req_tx` queue by the guest, and
+/// received by the [`GuestIoHandle::req_rx`] side.
 #[derive(Debug)]
 pub struct Guest {
-    /*
-     * New requests from outside go onto this VecDeque. The notify is how
-     * the submission task tells the listening task that new work has been
-     * added.
-     */
-    reqs: Mutex<VecDeque<BlockReq>>,
-    notify: Notify,
-
-    /*
-     * When the crucible listening task has noticed a new IO request, it
-     * will pull it from the reqs queue and create an GuestWork struct
-     * as well as convert the new IO request into the matching
-     * downstairs request(s). Each new GuestWork request will get a
-     * unique gw_id, which is also the index for that operation into the
-     * hashmap.
-     *
-     * It is during this process that data will encrypted. For a read, the
-     * data is decrypted back to the guest provided buffer after all the
-     * required downstairs operations are completed.
-     */
-    guest_work: Mutex<GuestWork>,
-
-    /*
-     * Setting an IOP limit means that the rate at which block reqs are
-     * pulled off will be limited. No setting means they are sent right
-     * away.
-     */
-    iop_tokens: std::sync::Mutex<usize>,
-    bytes_per_iop: Option<usize>,
-    iop_limit: Option<usize>,
-
-    /*
-     * Setting a bandwidth limit will also limit the rate at which block
-     * reqs are pulled off the queue.
-     */
-    bw_tokens: std::sync::Mutex<usize>, // bytes
-    bw_limit: Option<usize>,            // bytes per second
+    /// New requests from outside go into this queue
+    req_tx: mpsc::Sender<BlockReq>,
 
     /// Local cache for block size
     ///
@@ -2213,10 +2159,10 @@ pub struct Guest {
     block_size: AtomicU64,
 
     /// Backpressure is implemented as a delay on host write operations
-    backpressure_us: AtomicU64,
-
-    /// Backpressure configuration, as a starting point and max delay
-    backpressure_config: BackpressureConfig,
+    ///
+    /// It is stored in an `Arc` so that the `GuestIoHandle` can update it from
+    /// the IO task.
+    backpressure_us: Arc<AtomicU64>,
 
     /// Lock held during backpressure delay
     ///
@@ -2258,66 +2204,62 @@ struct BackpressureConfig {
  * These methods are how to add or checking for new work on the Guest struct
  */
 impl Guest {
-    pub fn new(log: Option<Logger>) -> Guest {
+    pub fn new(log: Option<Logger>) -> (Guest, GuestIoHandle) {
         let log = log.unwrap_or_else(build_logger);
-        Guest {
-            /*
-             * Incoming I/O requests are added to this queue.
-             */
-            reqs: Mutex::new(VecDeque::new()),
-            notify: Notify::new(),
-            /*
-             * The active hashmap is for in-flight I/O operations
-             * that we have taken off the incoming queue, but we have not
-             * received the response from downstairs.
-             * Note that a single IO from outside may have multiple I/O
-             * requests that need to finish before we can complete that IO.
-             */
-            guest_work: Mutex::new(GuestWork {
+
+        // The channel size is chosen arbitrarily here.  The `req_rx` side
+        // is running independently and will constantly be processing messages,
+        // so we don't expect the queue to become full.  The `req_tx` side is
+        // only ever used in `Guest::send`, which waits for acknowledgement from
+        // the other side of the queue; there are no places where we put stuff
+        // into the queue without awaiting a response.
+        //
+        // Together, these facts mean that the queue should remain relatively
+        // small.  The exception is if someone spawns a zillion tasks, all of
+        // which call `Guest` APIs simultaneously.  In that case, having the
+        // queue be full will just look like another source of backpressure (and
+        // will in fact be invisible to the caller, since they can't distinguish
+        // time spent waiting for the queue versus time spent in Upstairs code).
+        let (req_tx, req_rx) = mpsc::channel(500);
+
+        let backpressure_us = Arc::new(AtomicU64::new(0));
+        let limits = GuestLimits {
+            iop_limit: None,
+            bw_limit: None,
+        };
+        let io = GuestIoHandle {
+            req_rx,
+            req_head: None,
+            req_limited: false,
+            limits,
+
+            guest_work: GuestWork {
                 active: HashMap::new(), // GtoS
                 next_gw_id: 1,
                 completed: AllocRingBuffer::new(2048),
-            }),
+            },
 
-            iop_tokens: std::sync::Mutex::new(0),
-            bytes_per_iop: None,
-            iop_limit: None,
-
-            bw_tokens: std::sync::Mutex::new(0),
-            bw_limit: None,
-
-            block_size: AtomicU64::new(0),
-
-            backpressure_us: AtomicU64::new(0),
+            iop_tokens: 0,
+            bw_tokens: 0,
+            backpressure_us: backpressure_us.clone(),
             backpressure_config: BackpressureConfig {
                 bytes_start: 1024u64.pow(3), // Start at 1 GiB
                 bytes_scale: 9.3e-8,         // Delay of 10ms at 2 GiB in-flight
                 queue_start: 0.05,
                 queue_max_delay: Duration::from_millis(5),
             },
+            log: log.clone(),
+        };
+        let guest = Guest {
+            req_tx,
+
+            block_size: AtomicU64::new(0),
+
+            backpressure_us,
             backpressure_lock: Mutex::new(()),
             log,
-        }
-    }
-
-    pub fn set_iop_limit(&mut self, bytes_per_iop: usize, limit: usize) {
-        self.bytes_per_iop = Some(bytes_per_iop);
-        self.iop_limit = Some(limit);
-    }
-
-    /*
-     * Return IOPs per second
-     */
-    pub fn get_iop_limit(&self) -> Option<usize> {
-        self.iop_limit
-    }
-
-    pub fn set_bw_limit(&mut self, bytes_per_second: usize) {
-        self.bw_limit = Some(bytes_per_second);
-    }
-
-    pub fn get_bw_limit(&self) -> Option<usize> {
-        self.bw_limit
+        };
+        (guest, io)
     }
 
     /*
@@ -2325,178 +2267,21 @@ impl Guest {
      */
     async fn send(&self, op: BlockOp) -> BlockReqWaiter {
         let (brw, res) = BlockReqWaiter::pair();
-        self.reqs.lock().await.push_back(BlockReq { op, res });
-        self.notify.notify_one();
-
+        if let Err(e) = self.req_tx.send(BlockReq { op, res }).await {
+            // This could happen during shutdown, if the up_main task is
+            // destroyed while the Guest is still trying to do work.
+            //
+            // If this happens, then the BlockReqWaiter will immediately return
+            // with CrucibleError::RecvDisconnected (since the oneshot::Sender
+            // will have been dropped into the void).
+            warn!(self.log, "failed to send op to guest: {e}");
+        }
         brw
     }
 
     async fn send_and_wait(&self, op: BlockOp) -> BlockReqReply {
         let brw = self.send(op).await;
         brw.wait(&self.log).await
-    }
-
-    /*
-     * A crucible task will listen for new work using this.
-     */
-    async fn recv(&self) -> BlockReq {
-        loop {
-            if let Some(req) = self.consume_req().await {
-                return req;
-            }
-
-            self.notify.notified().await;
-        }
-    }
-
-    /// Set `self.backpressure_us` based on outstanding IO ratio
-    fn set_backpressure(&self, bytes: u64, ratio: f64) {
-        // Check to see if the number of outstanding write bytes (between
-        // the upstairs and downstairs) is particularly high.  If so,
-        // apply some backpressure by delaying host operations, with a
-        // quadratically-increasing delay.
-        let d1 = (bytes.saturating_sub(self.backpressure_config.bytes_start)
-            as f64
-            * self.backpressure_config.bytes_scale)
-            .powf(2.0) as u64;
-
-        // Compute an alternate delay based on queue length
-        let d2 = self
-            .backpressure_config
-            .queue_max_delay
-            .mul_f64(
-                ((ratio - self.backpressure_config.queue_start).max(0.0)
-                    / (1.0 - self.backpressure_config.queue_start))
-                    .powf(2.0),
-            )
-            .as_micros() as u64;
-        self.backpressure_us.store(d1.max(d2), Ordering::SeqCst);
-    }
-
-    /*
-     * Consume one request off queue if it is under the IOP limit and the BW
-     * limit. This function must be cancel safe (due to it being used in a
-     * `tokio::select!` arm) so it is split into two parts: the first async part
-     * grabs all the necessary tokio Mutexes, and the second sync part does the
-     * actual work with the mutex guards.
-     */
-    async fn consume_req(&self) -> Option<BlockReq> {
-        let mut reqs = self.reqs.lock().await;
-        let mut bw_tokens = self.bw_tokens.lock().unwrap();
-        let mut iop_tokens = self.iop_tokens.lock().unwrap();
-
-        self.consume_req_locked(&mut reqs, &mut bw_tokens, &mut iop_tokens)
-
-        // IMPORTANT: there must be no await points after `consume_req_locked`
-        // has popped a BlockReq off the VecDeque! The function could be
-        // cancelled and would **drop** that BlockReq as a result.
-    }
-
-    fn consume_req_locked(
-        &self,
-        reqs: &mut VecDeque<BlockReq>,
-        bw_tokens: &mut usize,
-        iop_tokens: &mut usize,
-    ) -> Option<BlockReq> {
-        // TODO exposing queue depth here would be a good metric for disk
-        // contention
-
-        // Check if no requests are queued
-        if reqs.is_empty() {
-            return None;
-        }
-
-        let req_ref: &BlockReq = reqs.front().unwrap();
-
-        // Check if we can consume right away
-        let iop_limit_applies =
-            self.iop_limit.is_some() && req_ref.op.consumes_iops();
-        let bw_limit_applies =
-            self.bw_limit.is_some() && req_ref.op.sz().is_some();
-
-        if !iop_limit_applies && !bw_limit_applies {
-            return Some(reqs.pop_front().unwrap());
-        }
-
-        // Check bandwidth limit before IOP limit, but make sure only to consume
-        // tokens if both checks pass!
-
-        let mut bw_check_ok = true;
-        let mut iop_check_ok = true;
-
-        // When checking tokens vs the limit, do not check by checking if adding
-        // the block request's values to the applicable limit: this would create
-        // a scenario where a large IO enough would stall the pipeline (see
-        // test_impossible_io). Instead, check if the limits are already
-        // reached.
-
-        if let Some(bw_limit) = self.bw_limit {
-            if req_ref.op.sz().is_some() && *bw_tokens >= bw_limit {
-                bw_check_ok = false;
-            }
-        }
-
-        if let Some(iop_limit) = self.iop_limit {
-            let bytes_per_iops = self.bytes_per_iop.unwrap();
-            if req_ref.op.iops(bytes_per_iops).is_some()
-                && *iop_tokens >= iop_limit
-            {
-                iop_check_ok = false;
-            }
-        }
-
-        // If both checks pass, consume appropriate resources and return the
-        // block req
-        if bw_check_ok && iop_check_ok {
-            if self.bw_limit.is_some() {
-                if let Some(sz) = req_ref.op.sz() {
-                    *bw_tokens += sz;
-                }
-            }
-
-            if self.iop_limit.is_some() {
-                let bytes_per_iops = self.bytes_per_iop.unwrap();
-                if let Some(req_iops) = req_ref.op.iops(bytes_per_iops) {
-                    *iop_tokens += req_iops;
-                }
-            }
-
-            return Some(reqs.pop_front().unwrap());
-        }
-
-        // Otherwise, don't consume this block req
-        None
-    }
-
-    /*
-     * IOPs are IO operations per second, so leak tokens to allow that
-     * through.
-     */
-    pub fn leak_iop_tokens(&self, tokens: usize) {
-        let mut iop_tokens = self.iop_tokens.lock().unwrap();
-
-        if tokens > *iop_tokens {
-            *iop_tokens = 0;
-        } else {
-            *iop_tokens -= tokens;
-        }
-
-        // Notify to wake up recv now that there may be room.
-        self.notify.notify_one();
-    }
-
-    // Leak bytes from bandwidth tokens
-    pub fn leak_bw_tokens(&self, bytes: usize) {
-        let mut bw_tokens = self.bw_tokens.lock().unwrap();
-
-        if bytes > *bw_tokens {
-            *bw_tokens = 0;
-        } else {
-            *bw_tokens -= bytes;
-        }
-
-        // Notify to wake up recv now that there may be room.
-        self.notify.notify_one();
     }
 
     pub async fn query_extent_size(&self) -> Result<Block, CrucibleError> {
@@ -2768,6 +2553,228 @@ impl BlockIO for Guest {
     }
 }
 
+/// Configuration for iops-per-second limiting
+#[derive(Copy, Clone, Debug)]
+pub struct IopLimit {
+    bytes_per_iop: usize,
+    iop_limit: usize,
+}
+
+/// Configuration for guest limits
+#[derive(Copy, Clone, Debug)]
+pub struct GuestLimits {
+    iop_limit: Option<IopLimit>,
+    bw_limit: Option<usize>,
+}
+
+/// Handle for receiving requests from the guest
+///
+/// This is the counterpart to the [`Guest`], which sends requests.  It includes
+/// the receiving side of the request queue, along with infrastructure for
+/// bandwidth and IOP limiting.
+///
+/// In addition, it contains information about the mapping from guest to
+/// downstairs data structures, in the form of the [`GuestWork`] map.
+///
+/// The life-cycle of a request is roughly the following:
+///
+/// * Pop the request off the reqs queue.
+///
+/// * Copy (and optionally encrypt) any data buffers provided to us by the
+///   Guest.
+///
+/// * Create one or more downstairs DownstairsIO structures.
+///
+/// * Create a GtoS tracking structure with the id's for each downstairs task
+///   and the read result buffer if required.
+///
+/// * Add the GtoS struct to the in GuestWork active work hashmap.
+///
+/// * Put all the DownstairsIO structures on the downstairs work queue
+///
+/// * Wait for them to complete, then notify the guest through oneshot channels
+pub struct GuestIoHandle {
+    /// Queue to receive new blockreqs
+    req_rx: mpsc::Receiver<BlockReq>,
+
+    /// Guest IO and bandwidth limits
+    limits: GuestLimits,
+
+    /// `BlockReq` that is at the head of the queue
+    ///
+    /// If a `BlockReq` was pulled from the queue but couldn't be used due to
+    /// IOP or bandwidth limiting, it's stored here instead (and we check this
+    /// before awaiting the queue).
+    req_head: Option<BlockReq>,
+
+    /// Are we currently IOP or bandwidth limited?
+    ///
+    /// If so, we don't return anything in `recv()`
+    req_limited: bool,
+
+    /// Current number of IOP tokens
+    iop_tokens: usize,
+
+    /// Current backpressure (shared with the `Guest`)
+    backpressure_us: Arc<AtomicU64>,
+
+    /// Backpressure configuration, as a starting point and max delay
+    backpressure_config: BackpressureConfig,
+
+    /// Bandwidth tokens (in bytes)
+    bw_tokens: usize,
+
+    /// Active work from the guest
+    ///
+    /// When the crucible listening task has noticed a new IO request, it
+    /// will pull it from the reqs queue and create an GuestWork struct
+    /// as well as convert the new IO request into the matching
+    /// downstairs request(s). Each new GuestWork request will get a
+    /// unique gw_id, which is also the index for that operation into the
+    /// hashmap.
+    ///
+    /// It is during this process that data will encrypted. For a read, the
+    /// data is decrypted back to the guest provided buffer after all the
+    /// required downstairs operations are completed.
+    guest_work: GuestWork,
+
+    /// Log handle, mainly to pass it into the [`Upstairs`]
+    log: Logger,
+}
+
+impl GuestIoHandle {
+    /// Leak IOPs tokens
+    fn leak_iop_tokens(&mut self, tokens: usize) {
+        self.iop_tokens = self.iop_tokens.saturating_sub(tokens);
+        self.req_limited = false;
+    }
+
+    /// Leak bytes from bandwidth tokens
+    fn leak_bw_tokens(&mut self, bytes: usize) {
+        self.bw_tokens = self.bw_tokens.saturating_sub(bytes);
+        self.req_limited = false;
+    }
+
+    /// Listen for new work
+    ///
+    /// This will wait forever if we are currently IOP / BW limited; otherwise,
+    /// it will return the next value from the `BlockReq` queue.
+    ///
+    /// To avoid being stuck forever, this function should be called as **a
+    /// branch** of a `select!` statement that _also_ includes at least one
+    /// timeout; we should use that timeout to periodically service the IOP / BW
+    /// token counters, which will unblock the `GuestIoHandle` in future calls.
+    async fn recv(&mut self) -> UpstairsAction {
+        let req = if self.req_limited {
+            futures::future::pending().await
+        } else if let Some(req) = self.req_head.take() {
+            req
+        } else if let Some(req) = self.req_rx.recv().await {
+            // NOTE: once we take this req from the queue, we must be cancel
+            // safe!  In other words, we cannot yield until either (1) returning
+            // the req or (2) storing it in self.req_head for safe-keeping.
+            req
+        } else {
+            warn!(self.log, "Guest handle has been dropped");
+            return UpstairsAction::GuestDropped;
+        };
+
+        // Check if we can consume right away
+        let iop_limit_applies =
+            self.limits.iop_limit.is_some() && req.op.consumes_iops();
+        let bw_limit_applies =
+            self.limits.bw_limit.is_some() && req.op.sz().is_some();
+
+        if !iop_limit_applies && !bw_limit_applies {
+            return UpstairsAction::Guest(req);
+        }
+
+        // Check bandwidth limit before IOP limit, but make sure only to consume
+        // tokens if both checks pass!
+
+        let mut bw_check_ok = true;
+        let mut iop_check_ok = true;
+
+        // When checking tokens vs the limit, do not check by checking if adding
+        // the block request's values to the applicable limit: this would create
+        // a scenario where a large IO enough would stall the pipeline (see
+        // test_impossible_io). Instead, check if the limits are already
+        // reached.
+
+        if let Some(bw_limit) = self.limits.bw_limit {
+            if req.op.sz().is_some() && self.bw_tokens >= bw_limit {
+                bw_check_ok = false;
+            }
+        }
+
+        if let Some(iop_limit_cfg) = &self.limits.iop_limit {
+            let bytes_per_iops = iop_limit_cfg.bytes_per_iop;
+            if req.op.iops(bytes_per_iops).is_some()
+                && self.iop_tokens >= iop_limit_cfg.iop_limit
+            {
+                iop_check_ok = false;
+            }
+        }
+
+        // If both checks pass, consume appropriate resources and return the
+        // block req
+        if bw_check_ok && iop_check_ok {
+            if self.limits.bw_limit.is_some() {
+                if let Some(sz) = req.op.sz() {
+                    self.bw_tokens += sz;
+                }
+            }
+
+            if let Some(cfg) = &self.limits.iop_limit {
+                if let Some(req_iops) = req.op.iops(cfg.bytes_per_iop) {
+                    self.iop_tokens += req_iops;
+                }
+            }
+
+            UpstairsAction::Guest(req)
+        } else {
+            assert!(self.req_head.is_none());
+            self.req_head = Some(req);
+            futures::future::pending().await
+        }
+    }
+
+    /// Set `self.backpressure_us` based on outstanding IO ratio
+    fn set_backpressure(&self, bytes: u64, ratio: f64) {
+        // Check to see if the number of outstanding write bytes (between
+        // the upstairs and downstairs) is particularly high.  If so,
+        // apply some backpressure by delaying host operations, with a
+        // quadratically-increasing delay.
+        let d1 = (bytes.saturating_sub(self.backpressure_config.bytes_start)
+            as f64
+            * self.backpressure_config.bytes_scale)
+            .powf(2.0) as u64;
+
+        // Compute an alternate delay based on queue length
+        let d2 = self
+            .backpressure_config
+            .queue_max_delay
+            .mul_f64(
+                ((ratio - self.backpressure_config.queue_start).max(0.0)
+                    / (1.0 - self.backpressure_config.queue_start))
+                    .powf(2.0),
+            )
+            .as_micros() as u64;
+        self.backpressure_us.store(d1.max(d2), Ordering::SeqCst);
+    }
+
+    pub fn set_iop_limit(&mut self, bytes_per_iop: usize, limit: usize) {
+        self.limits.iop_limit = Some(IopLimit {
+            bytes_per_iop,
+            iop_limit: limit,
+        });
+    }
+
+    pub fn set_bw_limit(&mut self, bytes_per_second: usize) {
+        self.limits.bw_limit = Some(bytes_per_second);
+    }
+}
+
 /*
  * Work Queue Counts, for debug ShowWork IO type
  */
@@ -2829,7 +2836,7 @@ pub fn up_main(
     opt: CrucibleOpts,
     gen: u64,
     region_def: Option<RegionDefinition>,
-    guest: Arc<Guest>,
+    guest: GuestIoHandle,
     producer_registry: Option<ProducerRegistry>,
 ) -> Result<tokio::task::JoinHandle<()>> {
     register_probes().unwrap();
@@ -2899,9 +2906,9 @@ pub fn up_main(
  * printing for each guest_work. It will be much more dense, but require
  * holding both locks for the duration.
  */
-async fn show_guest_work(guest: &Arc<Guest>) -> usize {
+fn show_guest_work(guest: &GuestIoHandle) -> usize {
     println!("Guest work:  Active and Completed Jobs:");
-    let gw = guest.guest_work.lock().await;
+    let gw = &guest.guest_work;
     let mut kvec: Vec<_> = gw.active.keys().cloned().collect();
     kvec.sort_unstable();
     for id in kvec.iter() {

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -1095,8 +1095,8 @@ pub mod repair_test {
         }
     }
 
-    #[tokio::test]
-    async fn test_reserve_extent_repair_ids() {
+    #[test]
+    fn test_reserve_extent_repair_ids() {
         // Verify that we can reserve extent IDs for repair work, and they
         // are allocated as expected.
         let mut up = create_test_upstairs();
@@ -1110,10 +1110,8 @@ pub mod repair_test {
         let client = &mut up.downstairs.clients[ClientId::new(1)];
         client.checked_state_transition(&up.state, DsState::Faulted);
         client.checked_state_transition(&up.state, DsState::LiveRepairReady);
-        up.on_repair_check().await;
+        up.on_repair_check();
         assert!(up.downstairs.live_repair_in_progress());
-
-        tokio::time::sleep(Duration::from_secs(1)).await;
         assert_eq!(up.downstairs.last_repair_extent(), Some(0));
 
         // We should have reserved ids 1000 -> 1003
@@ -1169,19 +1167,16 @@ pub mod repair_test {
             Block::new_512(0),
             Bytes::from(vec![0xff; 512]),
             false,
-        )
-        .await;
+        );
 
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
-            .await;
+        up.submit_dummy_read(Block::new_512(0), Buffer::new(1, 512));
 
         // WriteUnwritten
         up.submit_dummy_write(
             Block::new_512(0),
             Bytes::from(vec![0xff; 512]),
             true,
-        )
-        .await;
+        );
 
         // All clients should send the jobs (no skipped)
         for ids in [JobId(1008), JobId(1009), JobId(1010)] {
@@ -1207,19 +1202,16 @@ pub mod repair_test {
             Block::new_512(0),
             Bytes::from(vec![0xff; 512]),
             false,
-        )
-        .await;
+        );
 
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
-            .await;
+        up.submit_dummy_read(Block::new_512(0), Buffer::new(1, 512));
 
         // WriteUnwritten
         up.submit_dummy_write(
             Block::new_512(0),
             Bytes::from(vec![0xff; 512]),
             true,
-        )
-        .await;
+        );
 
         // All clients should send the jobs (no skipped)
         for ids in [JobId(1004), JobId(1005), JobId(1006)] {
@@ -1241,19 +1233,16 @@ pub mod repair_test {
             Block::new_512(3),
             Bytes::from(vec![0xff; 512]),
             false,
-        )
-        .await;
+        );
 
-        up.submit_dummy_read(Block::new_512(3), Buffer::new(1, 512))
-            .await;
+        up.submit_dummy_read(Block::new_512(3), Buffer::new(1, 512));
 
         // WriteUnwritten
         up.submit_dummy_write(
             Block::new_512(3),
             Bytes::from(vec![0xff; 512]),
             true,
-        )
-        .await;
+        );
 
         // Client 0 and 2 will send the jobs
         for ids in [JobId(1004), JobId(1005), JobId(1006)] {
@@ -1326,19 +1315,16 @@ pub mod repair_test {
             Block::new_512(0),
             Bytes::from(vec![0xff; 512 * 9]),
             false,
-        )
-        .await;
+        );
 
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(9, 512))
-            .await;
+        up.submit_dummy_read(Block::new_512(0), Buffer::new(9, 512));
 
         // WriteUnwritten
         up.submit_dummy_write(
             Block::new_512(0),
             Bytes::from(vec![0xff; 512 * 9]),
             true,
-        )
-        .await;
+        );
 
         // All clients should send the jobs (no skipped)
         // The future repair we had to reserve for extent 2 will have
@@ -1392,11 +1378,10 @@ pub mod repair_test {
         finish_live_repair(&mut up, 1000).await;
 
         // Our default extent size is 3, so 9 blocks will span 3 extents
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(9, 512))
-            .await;
+        up.submit_dummy_read(Block::new_512(0), Buffer::new(9, 512));
 
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-        up.show_all_work().await;
+        up.show_all_work();
 
         // All clients should send the jobs (no skipped)
         // The future repair we had to reserve for extent 2 will have
@@ -1457,8 +1442,7 @@ pub mod repair_test {
             Block::new_512(0),
             Bytes::from(vec![0xff; 512 * 9]),
             false,
-        )
-        .await;
+        );
 
         // All clients should send the jobs (no skipped)
         // The future repair we had to reserve for extent 2 will have
@@ -1522,8 +1506,7 @@ pub mod repair_test {
             Block::new_512(0),
             Bytes::from(vec![0xff; 512 * 9]),
             false,
-        )
-        .await;
+        );
 
         // Verify that the future repair jobs were added to our IOs
         // dependency list.

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -70,7 +70,7 @@ impl IOSpan {
     #[instrument(skip(block_io))]
     pub async fn read_affected_blocks_from_volume<T: BlockIO>(
         &mut self,
-        block_io: &Arc<T>,
+        block_io: &T,
     ) -> Result<(), CrucibleError> {
         block_io
             .read(
@@ -88,7 +88,7 @@ impl IOSpan {
     #[instrument(skip(block_io))]
     pub async fn write_affected_blocks_to_volume<T: BlockIO>(
         self,
-        block_io: &Arc<T>,
+        block_io: &T,
     ) -> Result<(), CrucibleError> {
         block_io
             .write(
@@ -180,7 +180,7 @@ impl IOSpan {
  */
 pub struct CruciblePseudoFile<T: BlockIO> {
     active: bool,
-    block_io: Arc<T>,
+    block_io: T,
     offset: u64,
     sz: u64,
     block_size: u64,
@@ -189,7 +189,7 @@ pub struct CruciblePseudoFile<T: BlockIO> {
 }
 
 impl<T: BlockIO> CruciblePseudoFile<T> {
-    pub fn from(block_io: Arc<T>) -> Result<Self, CrucibleError> {
+    pub fn from(block_io: T) -> Result<Self, CrucibleError> {
         Ok(CruciblePseudoFile {
             active: false,
             block_io,
@@ -403,11 +403,11 @@ mod test {
     async fn test_pseudo_file_sane() -> Result<()> {
         const BLOCK_SIZE: usize = 512;
 
-        let in_memory = Arc::new(InMemoryBlockIO::new(
+        let in_memory = InMemoryBlockIO::new(
             Uuid::new_v4(),
             BLOCK_SIZE as u64,
             1024 * 1024,
-        ));
+        );
         let mut cpf = CruciblePseudoFile::from(in_memory)?;
         cpf.activate().await?;
 
@@ -440,11 +440,11 @@ mod test {
     async fn test_pseudo_file_hammer() -> Result<()> {
         const BLOCK_SIZE: usize = 512;
 
-        let in_memory = Arc::new(InMemoryBlockIO::new(
+        let in_memory = InMemoryBlockIO::new(
             Uuid::new_v4(),
             BLOCK_SIZE as u64,
             1024 * 1024,
-        ));
+        );
         let mut cpf = CruciblePseudoFile::from(in_memory)?;
         cpf.activate().await?;
 


### PR DESCRIPTION
The upstairs `struct Guest` is currently used in at least two different tasks:
- The guest uses the `trait BlockIO` to push requests into a queue (protected by a `tokio::sync::Mutex`).  There can be multiple tasks sharing an `Arc<Guest>` here, e.g. 8x in Propolis.
- The `struct Upstairs` pulls requests from that queue in the `up_main` event loop

This PR splits the `Guest` into two separate `structs`, which are **owned** (not shared) by their respective tasks:
- `Guest` (same name as before) implements `BlockIO` and is used by the guest task to send new jobs
- `GuestIoHandle` (new!) is used by the `struct Upstairs` and receives those jobs

The two halves communicate via a `tokio::sync::mpsc` queue, removing the previous combination of `tokio::sync::Mutex<VecDeque<BlockReq>> + tokio::sync::Notify`

It's still possible to share a `Guest` by wrapping it in an `Arc`, just like before.

As a side effect of removing the `tokio::sync::Mutex`, many functions become synchronous; don't be alarmed by the LOC  in this PR, since they're mostly mechanical.

I don't see any performance changes here (alas), but I think it's still worthwhile: it simplifies our code and helps set up a future consolidation of backpressure logic.