### PR TITLE
Reduce memcpy serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "base64",
+ "bincode",
  "bytes",
  "chrono",
  "crucible-client-types",
@@ -1092,6 +1093,7 @@ dependencies = [
  "num_enum",
  "schemars",
  "serde",
+ "strum_macros",
  "tokio-util",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ slog-term = { version = "2.9" }
 static_assertions = "1.1.0"
 statistical = "1.0.0"
 subprocess = "0.2.9"
+strum_macros = "0.25.3"
 tempfile = "3"
 test-strategy = "0.3.1"
 thiserror = "1"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -13,6 +13,7 @@ crucible-common.workspace = true
 num_enum.workspace = true
 schemars.workspace = true
 serde.workspace = true
+strum_macros.workspace = true
 tokio-util.workspace = true
 uuid.workspace = true
 crucible-workspace-hack.workspace = true

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -6,6 +6,7 @@ use anyhow::bail;
 use bytes::{Buf, BufMut, BytesMut};
 use num_enum::IntoPrimitive;
 use serde::{Deserialize, Serialize};
+use strum_macros::EnumDiscriminants;
 use tokio_util::codec::{Decoder, Encoder};
 use uuid::Uuid;
 
@@ -282,7 +283,10 @@ pub const CRUCIBLE_MESSAGE_VERSION: u32 = 5;
  * go do that right now before you forget.
  */
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(
+    Debug, PartialEq, Clone, Serialize, Deserialize, EnumDiscriminants,
+)]
+#[strum_discriminants(derive(Serialize))]
 #[repr(u16)]
 pub enum Message {
     /**
@@ -531,6 +535,8 @@ pub enum Message {
     /*
      * IO related
      */
+    // Message::Write must contain the same fields in the same order as
+    // RawMessage::Write which is used for zero-copy serialization.
     Write {
         upstairs_id: Uuid,
         session_id: Uuid,
@@ -580,6 +586,8 @@ pub enum Message {
         responses: Result<Vec<ReadResponse>, CrucibleError>,
     },
 
+    // Message::WriteUnwritten must contain the same fields in the same order as
+    // RawMessage::WriteUnwritten, which is used for zero-copy serialization.
     WriteUnwritten {
         upstairs_id: Uuid,
         session_id: Uuid,

--- a/upstairs/Cargo.toml
+++ b/upstairs/Cargo.toml
@@ -17,6 +17,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 async-recursion.workspace = true
 base64.workspace = true
+bincode.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 crucible-common.workspace = true

--- a/upstairs/src/deferred.rs
+++ b/upstairs/src/deferred.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 
 use crate::{
     upstairs::UpstairsConfig, BlockContext, BlockReq, BlockRes, ClientId,
-    ImpactedBlocks, Message,
+    ImpactedBlocks, Message, SerializedWrite,
 };
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use crucible_common::{integrity_hash, CrucibleError, RegionDefinition};
 use futures::{
     future::{ready, Either, Ready},
@@ -123,7 +123,11 @@ pub(crate) enum DeferredBlockReq {
 
 #[derive(Debug)]
 pub(crate) struct EncryptedWrite {
-    pub writes: Vec<crucible_protocol::Write>,
+    /// Raw data to be written, along with extra metadata
+    ///
+    /// This is equivalent to a pre-serialized `Vec<Write>`, but avoids
+    /// superfluous memory copies.
+    pub data: SerializedWrite,
     pub impacted_blocks: ImpactedBlocks,
     pub res: Option<BlockRes>,
     pub is_write_unwritten: bool,
@@ -132,37 +136,59 @@ pub(crate) struct EncryptedWrite {
 impl DeferredWrite {
     pub fn run(self) -> Option<EncryptedWrite> {
         // Build up all of the Write operations, encrypting data here
-        let mut writes: Vec<crucible_protocol::Write> =
-            Vec::with_capacity(self.impacted_blocks.len(&self.ddef));
+        let byte_len: usize = self.ddef.block_size() as usize;
+        let mut serialized = {
+            let block_count = self.impacted_blocks.blocks(&self.ddef).len();
+            // TODO I think is an overestimation?
+            let bytes_per_block =
+                byte_len + std::mem::size_of::<crucible_protocol::Write>();
+            BytesMut::with_capacity(
+                block_count * bytes_per_block + std::mem::size_of::<usize>(),
+            )
+        };
+
+        // First, serialize the length of the Vec<Write>
+        let num_blocks = self.impacted_blocks.blocks(&self.ddef).len();
+        serialized.extend(bincode::serialize(&num_blocks).unwrap());
+
+        // Metadata to store
+        let mut eids = Vec::with_capacity(num_blocks);
 
         let mut cur_offset: usize = 0;
-        let byte_len: usize = self.ddef.block_size() as usize;
         for (eid, offset) in self.impacted_blocks.blocks(&self.ddef) {
-            let (sub_data, encryption_context, hash) = if let Some(context) =
+            if eids.last().map(|e| *e != eid).unwrap_or(true) {
+                eids.push(eid);
+            }
+
+            // Write the header for this section
+            let header = bincode::serialize(&(eid, offset, byte_len)).unwrap();
+            serialized.extend(header);
+
+            // Copy over raw data, since we need exclusive ownership to mutate
+            // it (doing in-place encryption).
+            let pos = serialized.len();
+            serialized.extend_from_slice(
+                &self.data[cur_offset..(cur_offset + byte_len)],
+            );
+
+            let (encryption_context, hash) = if let Some(ctx) =
                 &self.cfg.encryption_context
             {
                 // Encrypt here
-                let mut mut_data = self
-                    .data
-                    .slice(cur_offset..(cur_offset + byte_len))
-                    .to_vec();
-
-                let (nonce, tag, hash) =
-                    match context.encrypt_in_place(&mut mut_data[..]) {
-                        Err(e) => {
-                            if let Some(res) = self.res {
-                                res.send_err(CrucibleError::EncryptionError(
-                                    e.to_string(),
-                                ));
-                            }
-                            return None;
+                let mut_data = &mut serialized[pos..];
+                let (nonce, tag, hash) = match ctx.encrypt_in_place(mut_data) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        if let Some(res) = self.res {
+                            res.send_err(CrucibleError::EncryptionError(
+                                e.to_string(),
+                            ));
                         }
-
-                        Ok(v) => v,
-                    };
+                        return None;
+                    }
+                };
 
                 (
-                    Bytes::copy_from_slice(&mut_data),
                     Some(crucible_protocol::EncryptionContext {
                         nonce: nonce.into(),
                         tag: tag.into(),
@@ -171,27 +197,31 @@ impl DeferredWrite {
                 )
             } else {
                 // Unencrypted
-                let sub_data =
-                    self.data.slice(cur_offset..(cur_offset + byte_len));
-                let hash = integrity_hash(&[&sub_data[..]]);
+                let hash = integrity_hash(&[&serialized[pos..]]);
 
-                (sub_data, None, hash)
+                (None, hash)
             };
 
-            writes.push(crucible_protocol::Write {
-                eid,
-                offset,
-                data: sub_data,
-                block_context: BlockContext {
-                    hash,
-                    encryption_context,
-                },
-            });
+            // Write the trailing data for this chunk
+            let trailer = bincode::serialize(&BlockContext {
+                hash,
+                encryption_context,
+            })
+            .unwrap();
+            serialized.extend(trailer);
 
             cur_offset += byte_len;
         }
+
+        let data = SerializedWrite {
+            data: serialized.freeze(),
+            num_blocks,
+            io_size_bytes: self.data.len(),
+            eids,
+        };
+
         Some(EncryptedWrite {
-            writes,
+            data,
             impacted_blocks: self.impacted_blocks,
             res: self.res,
             is_write_unwritten: self.is_write_unwritten,

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -1178,12 +1178,12 @@ pub(crate) mod up_test {
         if wu {
             IOop::WriteUnwritten {
                 dependencies: vec![],
-                writes,
+                data: SerializedWrite::from_writes(writes),
             }
         } else {
             IOop::Write {
                 dependencies: vec![],
-                writes,
+                data: SerializedWrite::from_writes(writes),
             }
         }
     }

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1492,7 +1492,7 @@ impl Upstairs {
         let next_id = self.downstairs.submit_write(
             gw_id,
             write.impacted_blocks,
-            write.writes,
+            write.data,
             write.is_write_unwritten,
         );
 


### PR DESCRIPTION
Right now, we copy data from a `BlockOp::Write/WriteUnwritten` into a `BytesMut` buffer, encrypt it in-place, then serialize it using `CrucibleEncoder`.  Serialization requires a *second* full copy of the data.  This is noticeable in our flamegraphs for large writes:

![before](https://github.com/oxidecomputer/crucible/assets/745333/901a8a68-578b-4824-8d37-ab0ccc73ec6a)
[interactive version](https://github.com/oxidecomputer/crucible/assets/745333/901a8a68-578b-4824-8d37-ab0ccc73ec6a)

This PR performs encryption and serialization simultaneously into a single buffer, saving us the unnecessary copy:

![after](https://github.com/oxidecomputer/crucible/assets/745333/e8720f2d-1ed8-4c86-b706-671fe28566de)
[interactive version](https://github.com/oxidecomputer/crucible/assets/745333/e8720f2d-1ed8-4c86-b706-671fe28566de)

This is a significant speedup for large writes.  Comparing against `main` (best of 2x runs), I see the following:

| Random write size | `main` | `reduce-memcpy-serialization` |
|-|-|-|
| 4K | 27.0 MiB/s | 27.1 MiB/s |
| 1M | 710 MiB/s | 861 MiB/s |
| 4M | 890 MiB/s | 969 MiB/s |

The implementation introduces new `IOop::SerializedWrite` and `IOop::SerializedWriteUnwritten` variants, which represent pre-serialized data.  Unlike normal `IOop`s (which are translated into the existing `enum Message`), these are translated into a new `RawMessage` type.  The serialization must be equivalent to the existing `Message::Write/WriteUnwritten` values; this is checked implicitly in our unit tests, which decode into the `Message` type.