### PR TITLE
Make Buffer track per-block (not per-byte) ownership

### DIFF
--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -258,7 +258,7 @@ async fn cmd_read<T: BlockIO>(
         // let block_remainder = remainder % native_block_size;
         // round up
         let blocks = (remainder + native_block_size - 1) / native_block_size;
-        let buffer = Buffer::new(blocks, native_block_size as usize);
+        let buffer = Buffer::new(blocks as usize, native_block_size as usize);
         let block_idx = (cmd_count * opt.iocmd_block_count) + block_offset;
         let offset = Block::new(block_idx, native_block_size.trailing_zeros());
         crucible.read(offset, buffer.clone()).await?;

--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -171,8 +171,7 @@ async fn cmd_read<T: BlockIO>(
         cmp::min(num_bytes, native_block_size - offset_misalignment);
     if offset_misalignment != 0 {
         // Read the full block
-        let bs = native_block_size as usize;
-        let buffer = Buffer::new(bs, bs);
+        let buffer = Buffer::new(1, native_block_size as usize);
         let block_idx = opt.byte_offset / native_block_size;
         let offset = Block::new(block_idx, native_block_size.trailing_zeros());
         crucible.read(offset, buffer.clone()).await?;
@@ -217,7 +216,7 @@ async fn cmd_read<T: BlockIO>(
         // Send the read command with whichever buffer is at the back of the
         // queue. We re-use the buffers to avoid lots of allocations
         let w_buf = Buffer::new(
-            (opt.iocmd_block_count * native_block_size) as usize,
+            opt.iocmd_block_count as usize,
             native_block_size as usize,
         );
         let w_future = crucible.read(offset, w_buf.clone());
@@ -259,10 +258,7 @@ async fn cmd_read<T: BlockIO>(
         // let block_remainder = remainder % native_block_size;
         // round up
         let blocks = (remainder + native_block_size - 1) / native_block_size;
-        let buffer = Buffer::new(
-            (blocks * native_block_size) as usize,
-            native_block_size as usize,
-        );
+        let buffer = Buffer::new(blocks, native_block_size as usize);
         let block_idx = (cmd_count * opt.iocmd_block_count) + block_offset;
         let offset = Block::new(block_idx, native_block_size.trailing_zeros());
         crucible.read(offset, buffer.clone()).await?;
@@ -316,8 +312,7 @@ async fn write_remainder_and_finalize<'a, T: BlockIO>(
             offset.value + uflow_blocks,
             native_block_size.trailing_zeros(),
         );
-        let bs = native_block_size as usize;
-        let uflow_r_buf = Buffer::new(bs, bs);
+        let uflow_r_buf = Buffer::new(1, native_block_size as usize);
         crucible.read(uflow_offset, uflow_r_buf.clone()).await?;
 
         // Copy it into w_buf
@@ -402,8 +397,7 @@ async fn cmd_write<T: BlockIO>(
         // We need to read-modify-write here.
 
         // Read the full block
-        let bs = native_block_size as usize;
-        let buffer = Buffer::new(bs, bs);
+        let buffer = Buffer::new(1, native_block_size as usize);
         let block_idx = opt.byte_offset / native_block_size;
         let offset = Block::new(block_idx, native_block_size.trailing_zeros());
         crucible.read(offset, buffer.clone()).await?;

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -222,10 +222,7 @@ async fn cli_read(
      * Convert offset to its byte value.
      */
     let offset = Block::new(block_index as u64, ri.block_size.trailing_zeros());
-    let length: usize = size * ri.block_size as usize;
-
-    let data =
-        crucible::Buffer::from_vec(vec![255; length], ri.block_size as usize);
+    let data = crucible::Buffer::repeat(255, size, ri.block_size as usize);
 
     println!("Read  at block {:5}, len:{:7}", offset.value, data.len());
     guest.read(offset, data.clone()).await?;

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -224,7 +224,8 @@ async fn cli_read(
     let offset = Block::new(block_index as u64, ri.block_size.trailing_zeros());
     let length: usize = size * ri.block_size as usize;
 
-    let data = crucible::Buffer::from_vec(vec![255; length]);
+    let data =
+        crucible::Buffer::from_vec(vec![255; length], ri.block_size as usize);
 
     println!("Read  at block {:5}, len:{:7}", offset.value, data.len());
     guest.read(offset, data.clone()).await?;

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -1121,7 +1121,10 @@ async fn verify_volume(
         };
 
         let length: usize = next_io_blocks * ri.block_size as usize;
-        let data = crucible::Buffer::from_vec(vec![255; length]);
+        let data = crucible::Buffer::from_vec(
+            vec![255; length],
+            ri.block_size as usize,
+        );
         guest.read(offset, data.clone()).await?;
 
         let dl = data.into_vec().unwrap();
@@ -1360,7 +1363,10 @@ async fn balloon_workload(
             guest.flush(None).await?;
 
             let length: usize = size * ri.block_size as usize;
-            let data = crucible::Buffer::from_vec(vec![255; length]);
+            let data = crucible::Buffer::from_vec(
+                vec![255; length],
+                ri.block_size as usize,
+            );
             guest.read(offset, data.clone()).await?;
 
             let dl = data.into_vec().unwrap();
@@ -1577,7 +1583,10 @@ async fn generic_workload(
             } else {
                 // Read (+ verify)
                 let length: usize = size * ri.block_size as usize;
-                let data = crucible::Buffer::from_vec(vec![255; length]);
+                let data = crucible::Buffer::from_vec(
+                    vec![255; length],
+                    ri.block_size as usize,
+                );
                 if !quiet {
                     match wtq {
                         WhenToQuit::Count { count } => {
@@ -2064,8 +2073,9 @@ async fn perf_workload(
             )
         })
         .collect();
-    let read_buffers: Vec<Buffer> =
-        (0..io_depth).map(|_| Buffer::new(io_size)).collect();
+    let read_buffers: Vec<Buffer> = (0..io_depth)
+        .map(|_| Buffer::new(io_size, ri.block_size as usize))
+        .collect();
 
     let es = ri.extent_size.value;
     let ec = ri.total_blocks as u64 / es;
@@ -2214,7 +2224,8 @@ async fn one_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
     guest.write(offset, data).await?;
 
     let length: usize = size * ri.block_size as usize;
-    let data = crucible::Buffer::from_vec(vec![255; length]);
+    let data =
+        crucible::Buffer::from_vec(vec![255; length], ri.block_size as usize);
 
     println!("Read  at block {:5}, len:{:7}", offset.value, data.len());
     guest.read(offset, data.clone()).await?;
@@ -2368,7 +2379,10 @@ async fn write_flush_read_workload(
         guest.flush(None).await?;
 
         let length: usize = size * ri.block_size as usize;
-        let data = crucible::Buffer::from_vec(vec![255; length]);
+        let data = crucible::Buffer::from_vec(
+            vec![255; length],
+            ri.block_size as usize,
+        );
         guest.read(offset, data.clone()).await?;
 
         let dl = data.into_vec().unwrap();
@@ -2529,7 +2543,10 @@ async fn repair_workload(
             } else {
                 // Read
                 let length: usize = size * ri.block_size as usize;
-                let data = crucible::Buffer::from_vec(vec![255; length]);
+                let data = crucible::Buffer::from_vec(
+                    vec![255; length],
+                    ri.block_size as usize,
+                );
                 println!(
                     "{:>0width$}/{:>0width$} Read  \
                     block {:>bw$}  len {:>sw$}",
@@ -2609,7 +2626,10 @@ async fn demo_workload(
             } else {
                 // Read
                 let length: usize = size * ri.block_size as usize;
-                let data = crucible::Buffer::from_vec(vec![255; length]);
+                let data = crucible::Buffer::from_vec(
+                    vec![255; length],
+                    ri.block_size as usize,
+                );
 
                 let future = guest.read(offset, data);
                 futureslist.push(future);
@@ -2670,7 +2690,8 @@ async fn span_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
     guest.flush(None).await?;
 
     let length: usize = 2 * ri.block_size as usize;
-    let data = crucible::Buffer::from_vec(vec![99; length]);
+    let data =
+        crucible::Buffer::from_vec(vec![99; length], ri.block_size as usize);
 
     println!("Sending a read spanning two extents");
     guest.read(offset, data.clone()).await?;
@@ -2710,7 +2731,10 @@ async fn big_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
         guest.flush(None).await?;
 
         let length: usize = ri.block_size as usize;
-        let data = crucible::Buffer::from_vec(vec![255; length]);
+        let data = crucible::Buffer::from_vec(
+            vec![255; length],
+            ri.block_size as usize,
+        );
         guest.read(offset, data.clone()).await?;
 
         let dl = data.into_vec().unwrap();
@@ -2839,8 +2863,10 @@ async fn dep_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
                 let future = guest.write_to_byte_offset(my_offset, data);
                 futureslist.push(future);
             } else {
-                let data =
-                    crucible::Buffer::from_vec(vec![0; ri.block_size as usize]);
+                let data = crucible::Buffer::from_vec(
+                    vec![0; ri.block_size as usize],
+                    ri.block_size as usize,
+                );
 
                 println!(
                     "Loop:{} send read  {} @ offset:{} len:{}",

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -397,7 +397,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are zero on init
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -413,7 +413,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -449,7 +449,7 @@ mod test {
         volume.activate().await?;
 
         // A read of zero length does not error.
-        let buffer = Buffer::new(0);
+        let buffer = Buffer::new(0, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -499,7 +499,7 @@ mod test {
             )
             .await?;
 
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         in_memory_data
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -524,7 +524,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 11 on init
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -549,7 +549,7 @@ mod test {
         }
 
         // Verify parent wasn't written to
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         in_memory_data
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -557,7 +557,7 @@ mod test {
         assert_eq!(vec![11; BLOCK_SIZE * 10], *buffer.as_vec().await);
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -588,7 +588,7 @@ mod test {
             )
             .await?;
 
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         in_memory_data
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -624,7 +624,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 11 on init
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -640,7 +640,7 @@ mod test {
             .await?;
 
         // Verify parent wasn't written to
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         in_memory_data
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -648,7 +648,7 @@ mod test {
         assert_eq!(vec![11; BLOCK_SIZE * 10], *buffer.as_vec().await);
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -709,7 +709,7 @@ mod test {
         volume.activate().await?;
 
         // Read one block: should be all 0xff
-        let buffer = Buffer::new(BLOCK_SIZE);
+        let buffer = Buffer::new(BLOCK_SIZE, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -725,7 +725,7 @@ mod test {
             .await?;
 
         // Read one block: should be all 0x01
-        let buffer = Buffer::new(BLOCK_SIZE);
+        let buffer = Buffer::new(BLOCK_SIZE, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -762,7 +762,7 @@ mod test {
         volume.activate().await?;
 
         // Read one block: should be all 0x00
-        let buffer = Buffer::new(BLOCK_SIZE);
+        let buffer = Buffer::new(BLOCK_SIZE, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -818,7 +818,7 @@ mod test {
             .await?;
 
         // Read volume, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -834,7 +834,7 @@ mod test {
             .await?;
 
         // Read volume, verify original contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -889,7 +889,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -905,7 +905,7 @@ mod test {
             .await?;
 
         // Read volume, verify original contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -970,7 +970,7 @@ mod test {
             .await?;
 
         // Read and verify
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1048,7 +1048,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(full_volume_size);
+        let buffer = Buffer::new(full_volume_size, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1064,7 +1064,7 @@ mod test {
             .await?;
 
         // Read volume, verify original contents
-        let buffer = Buffer::new(full_volume_size);
+        let buffer = Buffer::new(full_volume_size, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1135,7 +1135,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 2);
+        let buffer = Buffer::new(BLOCK_SIZE * 2, BLOCK_SIZE);
         volume
             .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1154,7 +1154,7 @@ mod test {
 
         // Read full volume, verify first write_unwritten still valid, but the
         // other blocks of the 2nd write_unwritten are updated.
-        let buffer = Buffer::new(full_volume_size);
+        let buffer = Buffer::new(full_volume_size, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1261,7 +1261,7 @@ mod test {
             .await?;
 
         // Read full volume
-        let buffer = Buffer::new(full_volume_size);
+        let buffer = Buffer::new(full_volume_size, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1320,7 +1320,7 @@ mod test {
             .await?;
 
         // Read back in_memory, verify 1s
-        let buffer = Buffer::new(BLOCK_SIZE * 5);
+        let buffer = Buffer::new(BLOCK_SIZE * 5, BLOCK_SIZE);
         in_memory_data
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1345,7 +1345,7 @@ mod test {
         volume.activate().await?;
 
         // Verify parent contents in one read
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1364,7 +1364,7 @@ mod test {
         }
 
         // Verify volume contents in one read
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1425,7 +1425,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 11 at startup
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1446,7 +1446,7 @@ mod test {
             .await?;
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1508,7 +1508,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents of RO parent are 1s at startup
-        let buffer = Buffer::new(BLOCK_SIZE * 5);
+        let buffer = Buffer::new(BLOCK_SIZE * 5, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1516,7 +1516,7 @@ mod test {
         assert_eq!(vec![11; BLOCK_SIZE * 5], *buffer.as_vec().await);
 
         // Verify contents of blocks 5-10 are zero.
-        let buffer = Buffer::new(BLOCK_SIZE * 5);
+        let buffer = Buffer::new(BLOCK_SIZE * 5, BLOCK_SIZE);
         volume
             .read(Block::new(5, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1537,7 +1537,7 @@ mod test {
             .await?;
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1633,7 +1633,7 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1707,7 +1707,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 11 at startup
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1726,7 +1726,7 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1823,7 +1823,7 @@ mod test {
             .await?;
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 2);
+        let buffer = Buffer::new(BLOCK_SIZE * 2, BLOCK_SIZE);
         volume
             .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1842,7 +1842,7 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read full volume
-        let buffer = Buffer::new(BLOCK_SIZE * 20);
+        let buffer = Buffer::new(BLOCK_SIZE * 20, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1950,7 +1950,7 @@ mod test {
             .await?;
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 2);
+        let buffer = Buffer::new(BLOCK_SIZE * 2, BLOCK_SIZE);
         volume
             .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1979,7 +1979,7 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read full volume
-        let buffer = Buffer::new(BLOCK_SIZE * 20);
+        let buffer = Buffer::new(BLOCK_SIZE * 20, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -2053,14 +2053,14 @@ mod test {
         volume2.activate().await?;
 
         // Read one block: should be all 0x00
-        let buffer = Buffer::new(BLOCK_SIZE);
+        let buffer = Buffer::new(BLOCK_SIZE, BLOCK_SIZE);
         volume1
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
 
         assert_eq!(vec![0x00; BLOCK_SIZE], *buffer.as_vec().await);
 
-        let buffer = Buffer::new(BLOCK_SIZE);
+        let buffer = Buffer::new(BLOCK_SIZE, BLOCK_SIZE);
         volume2
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -2106,7 +2106,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 00 at startup
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -2125,7 +2125,7 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -2206,7 +2206,8 @@ mod test {
 
             volume.activate().await?;
 
-            let buffer = Buffer::new(volume.total_size().await? as usize);
+            let buffer =
+                Buffer::new(volume.total_size().await? as usize, BLOCK_SIZE);
             volume
                 .read(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
@@ -2266,7 +2267,8 @@ mod test {
 
         // Validate that source blocks originally come from the read-only parent
         {
-            let buffer = Buffer::new(volume.total_size().await? as usize);
+            let buffer =
+                Buffer::new(volume.total_size().await? as usize, BLOCK_SIZE);
             volume
                 .read(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
@@ -2289,7 +2291,8 @@ mod test {
             .await?;
 
         {
-            let buffer = Buffer::new(volume.total_size().await? as usize);
+            let buffer =
+                Buffer::new(volume.total_size().await? as usize, BLOCK_SIZE);
             volume
                 .read(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
@@ -2389,7 +2392,8 @@ mod test {
 
             volume.activate().await?;
 
-            let buffer = Buffer::new(volume.total_size().await? as usize);
+            let buffer =
+                Buffer::new(volume.total_size().await? as usize, BLOCK_SIZE);
             volume
                 .read(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
@@ -2456,7 +2460,8 @@ mod test {
 
         // Validate that source blocks originally come from the read-only parent
         {
-            let buffer = Buffer::new(volume.total_size().await? as usize);
+            let buffer =
+                Buffer::new(volume.total_size().await? as usize, BLOCK_SIZE);
             volume
                 .read(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
@@ -2479,7 +2484,8 @@ mod test {
             .await?;
 
         {
-            let buffer = Buffer::new(volume.total_size().await? as usize);
+            let buffer =
+                Buffer::new(volume.total_size().await? as usize, BLOCK_SIZE);
             volume
                 .read(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
@@ -2574,7 +2580,8 @@ mod test {
 
         volume.activate().await?;
         // Validate that source blocks are the same
-        let buffer = Buffer::new(volume.total_size().await? as usize);
+        let buffer =
+            Buffer::new(volume.total_size().await? as usize, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -2664,7 +2671,8 @@ mod test {
         }
 
         // Read back what we wrote.
-        let buffer = Buffer::new(volume.total_size().await? as usize);
+        let buffer =
+            Buffer::new(volume.total_size().await? as usize, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -2973,7 +2981,8 @@ mod test {
         }
 
         // Read back what we wrote.
-        let buffer = Buffer::new(new_volume.total_size().await? as usize);
+        let buffer =
+            Buffer::new(new_volume.total_size().await? as usize, BLOCK_SIZE);
         new_volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3037,7 +3046,7 @@ mod test {
             }
 
             for (i, random_buffer) in chunks {
-                let buffer = Buffer::new(CHUNK_SIZE);
+                let buffer = Buffer::new(CHUNK_SIZE, BLOCK_SIZE);
                 volume
                     .read(
                         Block::new(i as u64, BLOCK_SIZE.trailing_zeros()),
@@ -3077,7 +3086,7 @@ mod test {
         guest.query_work_queue().await?;
 
         // Verify contents are zero on init
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3093,7 +3102,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3121,7 +3130,7 @@ mod test {
         guest.query_work_queue().await?;
 
         // Read of length 0
-        let buffer = Buffer::new(0);
+        let buffer = Buffer::new(0, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3204,7 +3213,7 @@ mod test {
         }
 
         // Read back our block post replacement, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3320,7 +3329,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3336,7 +3345,7 @@ mod test {
             .await?;
 
         // Read back the same blocks.
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3353,7 +3362,7 @@ mod test {
             .await?;
 
         // Read back the same blocks.
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3402,7 +3411,7 @@ mod test {
             .await?;
 
         // Read back the first block.
-        let buffer = Buffer::new(BLOCK_SIZE);
+        let buffer = Buffer::new(BLOCK_SIZE, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3411,7 +3420,7 @@ mod test {
         assert_eq!(vec![0x55_u8; BLOCK_SIZE], *buffer.as_vec().await);
 
         // Read back the next two blocks.
-        let buffer = Buffer::new(BLOCK_SIZE * 2);
+        let buffer = Buffer::new(BLOCK_SIZE * 2, BLOCK_SIZE);
         guest
             .read(Block::new(1, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3460,7 +3469,7 @@ mod test {
             .await?;
 
         // Read back the all three blocks.
-        let buffer = Buffer::new(BLOCK_SIZE * 3);
+        let buffer = Buffer::new(BLOCK_SIZE * 3, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3519,7 +3528,7 @@ mod test {
             .await?;
 
         // Read back the all three blocks.
-        let buffer = Buffer::new(BLOCK_SIZE * 3);
+        let buffer = Buffer::new(BLOCK_SIZE * 3, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3576,7 +3585,7 @@ mod test {
             .await?;
 
         // Read back both blocks
-        let buffer = Buffer::new(BLOCK_SIZE * 2);
+        let buffer = Buffer::new(BLOCK_SIZE * 2, BLOCK_SIZE);
         guest
             .read(Block::new(4, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3633,7 +3642,7 @@ mod test {
             .await?;
 
         // Read back both blocks
-        let buffer = Buffer::new(BLOCK_SIZE * 2);
+        let buffer = Buffer::new(BLOCK_SIZE * 2, BLOCK_SIZE);
         guest
             .read(Block::new(4, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3680,7 +3689,7 @@ mod test {
         assert!(res.is_err());
 
         // Read a block past the end of the extent
-        let buffer = Buffer::new(BLOCK_SIZE);
+        let buffer = Buffer::new(BLOCK_SIZE, BLOCK_SIZE);
         let res = guest
             .read(Block::new(11, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await;
@@ -3716,7 +3725,7 @@ mod test {
         assert!(res.is_err());
 
         // Read a block with buffer that extends past the end of the region
-        let buffer = Buffer::new(BLOCK_SIZE * 2);
+        let buffer = Buffer::new(BLOCK_SIZE * 2, BLOCK_SIZE);
         let res = guest
             .read(Block::new(10, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await;
@@ -3868,7 +3877,7 @@ mod test {
         let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let buffer = Buffer::new(bytes.len());
+        let buffer = Buffer::new(bytes.len(), BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await
@@ -3979,7 +3988,7 @@ mod test {
                 .unwrap();
             volume.activate().await.unwrap();
 
-            let buffer = Buffer::new(5120);
+            let buffer = Buffer::new(5120, BLOCK_SIZE);
             volume
                 .read(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
@@ -4034,7 +4043,7 @@ mod test {
         let volume = Volume::construct(vcr, None, log.clone()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let buffer = Buffer::new(5120);
+        let buffer = Buffer::new(5120, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await
@@ -4112,7 +4121,7 @@ mod test {
         let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let buffer = Buffer::new(5120);
+        let buffer = Buffer::new(5120, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await
@@ -4175,8 +4184,10 @@ mod test {
         let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let buffer =
-            Buffer::new(crucible_pantry::pantry::PantryEntry::MAX_CHUNK_SIZE);
+        let buffer = Buffer::new(
+            crucible_pantry::pantry::PantryEntry::MAX_CHUNK_SIZE,
+            BLOCK_SIZE,
+        );
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await
@@ -4313,7 +4324,7 @@ mod test {
             let volume = Volume::construct(vcr, None, csl()).await.unwrap();
             volume.activate().await.unwrap();
 
-            let buffer = Buffer::new(data.len());
+            let buffer = Buffer::new(data.len(), BLOCK_SIZE);
             volume
                 .read(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
@@ -4411,7 +4422,7 @@ mod test {
         let volume = Volume::construct(vcr, None, log.clone()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let buffer = Buffer::new(data.len());
+        let buffer = Buffer::new(data.len(), BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await
@@ -4902,7 +4913,7 @@ mod test {
             .unwrap();
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await
@@ -4942,7 +4953,7 @@ mod test {
         info!(log, "Replace VCR now: {:?}", replacement);
         volume.target_replace(original, replacement).await.unwrap();
         info!(log, "send read now");
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
+        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -397,7 +397,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are zero on init
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -413,7 +413,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -499,7 +499,7 @@ mod test {
             )
             .await?;
 
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         in_memory_data
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -524,7 +524,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 11 on init
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -549,7 +549,7 @@ mod test {
         }
 
         // Verify parent wasn't written to
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         in_memory_data
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -557,7 +557,7 @@ mod test {
         assert_eq!(vec![11; BLOCK_SIZE * 10], *buffer.as_vec().await);
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -588,7 +588,7 @@ mod test {
             )
             .await?;
 
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         in_memory_data
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -624,7 +624,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 11 on init
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -640,7 +640,7 @@ mod test {
             .await?;
 
         // Verify parent wasn't written to
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         in_memory_data
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -648,7 +648,7 @@ mod test {
         assert_eq!(vec![11; BLOCK_SIZE * 10], *buffer.as_vec().await);
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -709,7 +709,7 @@ mod test {
         volume.activate().await?;
 
         // Read one block: should be all 0xff
-        let buffer = Buffer::new(BLOCK_SIZE, BLOCK_SIZE);
+        let buffer = Buffer::new(1, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -725,7 +725,7 @@ mod test {
             .await?;
 
         // Read one block: should be all 0x01
-        let buffer = Buffer::new(BLOCK_SIZE, BLOCK_SIZE);
+        let buffer = Buffer::new(1, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -762,7 +762,7 @@ mod test {
         volume.activate().await?;
 
         // Read one block: should be all 0x00
-        let buffer = Buffer::new(BLOCK_SIZE, BLOCK_SIZE);
+        let buffer = Buffer::new(1, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -818,7 +818,7 @@ mod test {
             .await?;
 
         // Read volume, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -834,7 +834,7 @@ mod test {
             .await?;
 
         // Read volume, verify original contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -889,7 +889,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -905,7 +905,7 @@ mod test {
             .await?;
 
         // Read volume, verify original contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -970,7 +970,7 @@ mod test {
             .await?;
 
         // Read and verify
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1038,7 +1038,8 @@ mod test {
 
         volume.activate().await?;
 
-        let full_volume_size = BLOCK_SIZE * 20;
+        let full_volume_blocks = 20;
+        let full_volume_size = BLOCK_SIZE * full_volume_blocks;
         // Write data in
         volume
             .write_unwritten(
@@ -1048,7 +1049,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(full_volume_size, BLOCK_SIZE);
+        let buffer = Buffer::new(full_volume_blocks, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1064,7 +1065,7 @@ mod test {
             .await?;
 
         // Read volume, verify original contents
-        let buffer = Buffer::new(full_volume_size, BLOCK_SIZE);
+        let buffer = Buffer::new(full_volume_blocks, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1123,7 +1124,8 @@ mod test {
         let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
         volume.activate().await?;
-        let full_volume_size = BLOCK_SIZE * 20;
+        let full_volume_blocks = 20;
+        let full_volume_size = BLOCK_SIZE * full_volume_blocks;
 
         // Write data to last block of first vol, and first block of
         // second vol.
@@ -1135,7 +1137,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 2, BLOCK_SIZE);
+        let buffer = Buffer::new(2, BLOCK_SIZE);
         volume
             .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1154,7 +1156,7 @@ mod test {
 
         // Read full volume, verify first write_unwritten still valid, but the
         // other blocks of the 2nd write_unwritten are updated.
-        let buffer = Buffer::new(full_volume_size, BLOCK_SIZE);
+        let buffer = Buffer::new(full_volume_blocks, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1231,7 +1233,8 @@ mod test {
         let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
         volume.activate().await?;
-        let full_volume_size = BLOCK_SIZE * 20;
+        let full_volume_blocks = 20;
+        let full_volume_size = BLOCK_SIZE * full_volume_blocks;
 
         // Write data to last block of first vol, and first block of
         // second vol.
@@ -1261,7 +1264,7 @@ mod test {
             .await?;
 
         // Read full volume
-        let buffer = Buffer::new(full_volume_size, BLOCK_SIZE);
+        let buffer = Buffer::new(full_volume_blocks, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1320,7 +1323,7 @@ mod test {
             .await?;
 
         // Read back in_memory, verify 1s
-        let buffer = Buffer::new(BLOCK_SIZE * 5, BLOCK_SIZE);
+        let buffer = Buffer::new(5, BLOCK_SIZE);
         in_memory_data
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1345,7 +1348,7 @@ mod test {
         volume.activate().await?;
 
         // Verify parent contents in one read
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1364,7 +1367,7 @@ mod test {
         }
 
         // Verify volume contents in one read
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1425,7 +1428,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 11 at startup
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1446,7 +1449,7 @@ mod test {
             .await?;
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1508,7 +1511,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents of RO parent are 1s at startup
-        let buffer = Buffer::new(BLOCK_SIZE * 5, BLOCK_SIZE);
+        let buffer = Buffer::new(5, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1516,7 +1519,7 @@ mod test {
         assert_eq!(vec![11; BLOCK_SIZE * 5], *buffer.as_vec().await);
 
         // Verify contents of blocks 5-10 are zero.
-        let buffer = Buffer::new(BLOCK_SIZE * 5, BLOCK_SIZE);
+        let buffer = Buffer::new(5, BLOCK_SIZE);
         volume
             .read(Block::new(5, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1537,7 +1540,7 @@ mod test {
             .await?;
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1633,7 +1636,7 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1707,7 +1710,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 11 at startup
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1726,7 +1729,7 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1823,7 +1826,7 @@ mod test {
             .await?;
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 2, BLOCK_SIZE);
+        let buffer = Buffer::new(2, BLOCK_SIZE);
         volume
             .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1842,7 +1845,7 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read full volume
-        let buffer = Buffer::new(BLOCK_SIZE * 20, BLOCK_SIZE);
+        let buffer = Buffer::new(20, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1950,7 +1953,7 @@ mod test {
             .await?;
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 2, BLOCK_SIZE);
+        let buffer = Buffer::new(2, BLOCK_SIZE);
         volume
             .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -1979,7 +1982,7 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read full volume
-        let buffer = Buffer::new(BLOCK_SIZE * 20, BLOCK_SIZE);
+        let buffer = Buffer::new(20, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -2053,14 +2056,14 @@ mod test {
         volume2.activate().await?;
 
         // Read one block: should be all 0x00
-        let buffer = Buffer::new(BLOCK_SIZE, BLOCK_SIZE);
+        let buffer = Buffer::new(1, BLOCK_SIZE);
         volume1
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
 
         assert_eq!(vec![0x00; BLOCK_SIZE], *buffer.as_vec().await);
 
-        let buffer = Buffer::new(BLOCK_SIZE, BLOCK_SIZE);
+        let buffer = Buffer::new(1, BLOCK_SIZE);
         volume2
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -2106,7 +2109,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 00 at startup
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -2125,7 +2128,7 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -2205,9 +2208,10 @@ mod test {
                 .await?;
 
             volume.activate().await?;
+            let volume_blocks =
+                volume.total_size().await? as usize / BLOCK_SIZE;
 
-            let buffer =
-                Buffer::new(volume.total_size().await? as usize, BLOCK_SIZE);
+            let buffer = Buffer::new(volume_blocks, BLOCK_SIZE);
             volume
                 .read(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
@@ -2264,11 +2268,11 @@ mod test {
 
         let volume = Volume::construct(vcr, None, csl()).await?;
         volume.activate().await?;
+        let volume_blocks = volume.total_size().await? as usize / BLOCK_SIZE;
 
         // Validate that source blocks originally come from the read-only parent
         {
-            let buffer =
-                Buffer::new(volume.total_size().await? as usize, BLOCK_SIZE);
+            let buffer = Buffer::new(volume_blocks, BLOCK_SIZE);
             volume
                 .read(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
@@ -2291,8 +2295,7 @@ mod test {
             .await?;
 
         {
-            let buffer =
-                Buffer::new(volume.total_size().await? as usize, BLOCK_SIZE);
+            let buffer = Buffer::new(volume_blocks, BLOCK_SIZE);
             volume
                 .read(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
@@ -2391,9 +2394,10 @@ mod test {
                 .await?;
 
             volume.activate().await?;
+            let volume_blocks =
+                volume.total_size().await? as usize / BLOCK_SIZE;
 
-            let buffer =
-                Buffer::new(volume.total_size().await? as usize, BLOCK_SIZE);
+            let buffer = Buffer::new(volume_blocks, BLOCK_SIZE);
             volume
                 .read(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
@@ -2457,11 +2461,11 @@ mod test {
 
         let volume = Volume::construct(vcr, None, csl()).await?;
         volume.activate().await?;
+        let volume_blocks = volume.total_size().await? as usize / BLOCK_SIZE;
 
         // Validate that source blocks originally come from the read-only parent
         {
-            let buffer =
-                Buffer::new(volume.total_size().await? as usize, BLOCK_SIZE);
+            let buffer = Buffer::new(volume_blocks, BLOCK_SIZE);
             volume
                 .read(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
@@ -2484,8 +2488,7 @@ mod test {
             .await?;
 
         {
-            let buffer =
-                Buffer::new(volume.total_size().await? as usize, BLOCK_SIZE);
+            let buffer = Buffer::new(volume_blocks, BLOCK_SIZE);
             volume
                 .read(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
@@ -2579,9 +2582,9 @@ mod test {
             .await?;
 
         volume.activate().await?;
+        let volume_blocks = volume.total_size().await? as usize / BLOCK_SIZE;
         // Validate that source blocks are the same
-        let buffer =
-            Buffer::new(volume.total_size().await? as usize, BLOCK_SIZE);
+        let buffer = Buffer::new(volume_blocks, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -2614,6 +2617,7 @@ mod test {
             .await?;
 
         volume.activate().await?;
+        let volume_blocks = volume.total_size().await? as usize / BLOCK_SIZE;
 
         let random_buffer = {
             let mut random_buffer =
@@ -2671,8 +2675,7 @@ mod test {
         }
 
         // Read back what we wrote.
-        let buffer =
-            Buffer::new(volume.total_size().await? as usize, BLOCK_SIZE);
+        let buffer = Buffer::new(volume_blocks, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -2897,6 +2900,7 @@ mod test {
             .await?;
 
         volume.activate().await?;
+        let volume_blocks = volume.total_size().await? as usize / BLOCK_SIZE;
 
         let random_buffer = {
             let mut random_buffer =
@@ -2981,8 +2985,7 @@ mod test {
         }
 
         // Read back what we wrote.
-        let buffer =
-            Buffer::new(new_volume.total_size().await? as usize, BLOCK_SIZE);
+        let buffer = Buffer::new(volume_blocks, BLOCK_SIZE);
         new_volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3020,6 +3023,7 @@ mod test {
         // Write three times, read three times, for a total of 150M
         let total_size = volume.total_size().await? as usize;
         const CHUNK_SIZE: usize = 1048576; // 1M
+        assert_eq!(CHUNK_SIZE % BLOCK_SIZE, 0);
 
         for _ in 0..3 {
             let chunks: Vec<(usize, Vec<u8>)> = (0..total_size)
@@ -3046,7 +3050,7 @@ mod test {
             }
 
             for (i, random_buffer) in chunks {
-                let buffer = Buffer::new(CHUNK_SIZE, BLOCK_SIZE);
+                let buffer = Buffer::new(CHUNK_SIZE / BLOCK_SIZE, BLOCK_SIZE);
                 volume
                     .read(
                         Block::new(i as u64, BLOCK_SIZE.trailing_zeros()),
@@ -3086,7 +3090,7 @@ mod test {
         guest.query_work_queue().await?;
 
         // Verify contents are zero on init
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3102,7 +3106,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3213,7 +3217,7 @@ mod test {
         }
 
         // Read back our block post replacement, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3329,7 +3333,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3345,7 +3349,7 @@ mod test {
             .await?;
 
         // Read back the same blocks.
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3362,7 +3366,7 @@ mod test {
             .await?;
 
         // Read back the same blocks.
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3411,7 +3415,7 @@ mod test {
             .await?;
 
         // Read back the first block.
-        let buffer = Buffer::new(BLOCK_SIZE, BLOCK_SIZE);
+        let buffer = Buffer::new(1, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3420,7 +3424,7 @@ mod test {
         assert_eq!(vec![0x55_u8; BLOCK_SIZE], *buffer.as_vec().await);
 
         // Read back the next two blocks.
-        let buffer = Buffer::new(BLOCK_SIZE * 2, BLOCK_SIZE);
+        let buffer = Buffer::new(2, BLOCK_SIZE);
         guest
             .read(Block::new(1, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3469,7 +3473,7 @@ mod test {
             .await?;
 
         // Read back the all three blocks.
-        let buffer = Buffer::new(BLOCK_SIZE * 3, BLOCK_SIZE);
+        let buffer = Buffer::new(3, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3528,7 +3532,7 @@ mod test {
             .await?;
 
         // Read back the all three blocks.
-        let buffer = Buffer::new(BLOCK_SIZE * 3, BLOCK_SIZE);
+        let buffer = Buffer::new(3, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3585,7 +3589,7 @@ mod test {
             .await?;
 
         // Read back both blocks
-        let buffer = Buffer::new(BLOCK_SIZE * 2, BLOCK_SIZE);
+        let buffer = Buffer::new(2, BLOCK_SIZE);
         guest
             .read(Block::new(4, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3642,7 +3646,7 @@ mod test {
             .await?;
 
         // Read back both blocks
-        let buffer = Buffer::new(BLOCK_SIZE * 2, BLOCK_SIZE);
+        let buffer = Buffer::new(2, BLOCK_SIZE);
         guest
             .read(Block::new(4, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await?;
@@ -3689,7 +3693,7 @@ mod test {
         assert!(res.is_err());
 
         // Read a block past the end of the extent
-        let buffer = Buffer::new(BLOCK_SIZE, BLOCK_SIZE);
+        let buffer = Buffer::new(1, BLOCK_SIZE);
         let res = guest
             .read(Block::new(11, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await;
@@ -3725,7 +3729,7 @@ mod test {
         assert!(res.is_err());
 
         // Read a block with buffer that extends past the end of the region
-        let buffer = Buffer::new(BLOCK_SIZE * 2, BLOCK_SIZE);
+        let buffer = Buffer::new(2, BLOCK_SIZE);
         let res = guest
             .read(Block::new(10, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await;
@@ -3877,7 +3881,8 @@ mod test {
         let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let buffer = Buffer::new(bytes.len(), BLOCK_SIZE);
+        assert_eq!(bytes.len() % BLOCK_SIZE, 0);
+        let buffer = Buffer::new(bytes.len() / BLOCK_SIZE, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await
@@ -3988,7 +3993,7 @@ mod test {
                 .unwrap();
             volume.activate().await.unwrap();
 
-            let buffer = Buffer::new(5120, BLOCK_SIZE);
+            let buffer = Buffer::new(10, BLOCK_SIZE);
             volume
                 .read(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
@@ -4043,7 +4048,7 @@ mod test {
         let volume = Volume::construct(vcr, None, log.clone()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let buffer = Buffer::new(5120, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await
@@ -4121,7 +4126,7 @@ mod test {
         let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let buffer = Buffer::new(5120, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await
@@ -4184,8 +4189,12 @@ mod test {
         let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
+        assert_eq!(
+            crucible_pantry::pantry::PantryEntry::MAX_CHUNK_SIZE % BLOCK_SIZE,
+            0
+        );
         let buffer = Buffer::new(
-            crucible_pantry::pantry::PantryEntry::MAX_CHUNK_SIZE,
+            crucible_pantry::pantry::PantryEntry::MAX_CHUNK_SIZE / BLOCK_SIZE,
             BLOCK_SIZE,
         );
         volume
@@ -4324,7 +4333,8 @@ mod test {
             let volume = Volume::construct(vcr, None, csl()).await.unwrap();
             volume.activate().await.unwrap();
 
-            let buffer = Buffer::new(data.len(), BLOCK_SIZE);
+            assert_eq!(data.len() % BLOCK_SIZE, 0);
+            let buffer = Buffer::new(data.len() / BLOCK_SIZE, BLOCK_SIZE);
             volume
                 .read(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
@@ -4422,7 +4432,8 @@ mod test {
         let volume = Volume::construct(vcr, None, log.clone()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let buffer = Buffer::new(data.len(), BLOCK_SIZE);
+        assert_eq!(data.len() % BLOCK_SIZE, 0);
+        let buffer = Buffer::new(data.len() / BLOCK_SIZE, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await
@@ -4913,7 +4924,7 @@ mod test {
             .unwrap();
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await
@@ -4953,7 +4964,7 @@ mod test {
         info!(log, "Replace VCR now: {:?}", replacement);
         volume.target_replace(original, replacement).await.unwrap();
         info!(log, "send read now");
-        let buffer = Buffer::new(BLOCK_SIZE * 10, BLOCK_SIZE);
+        let buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
             .await

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -135,8 +135,12 @@ async fn main() -> Result<()> {
         1
     };
 
+    if io_size % bsz as usize != 0 {
+        bail!("io size ({io_size}) must be a multiple of block size ({bsz})");
+    }
+
     let read_buffers: Vec<Buffer> = (0..io_depth)
-        .map(|_| Buffer::new(io_size, bsz as usize))
+        .map(|_| Buffer::new(io_size / bsz as usize, bsz as usize))
         .collect();
 
     let mut io_operations_sent = 0;

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -135,8 +135,9 @@ async fn main() -> Result<()> {
         1
     };
 
-    let read_buffers: Vec<Buffer> =
-        (0..io_depth).map(|_| Buffer::new(io_size)).collect();
+    let read_buffers: Vec<Buffer> = (0..io_depth)
+        .map(|_| Buffer::new(io_size, bsz as usize))
+        .collect();
 
     let mut io_operations_sent = 0;
     let mut bw_consumed = 0;

--- a/pantry/src/pantry.rs
+++ b/pantry/src/pantry.rs
@@ -292,7 +292,8 @@ impl PantryEntry {
             );
         }
 
-        let buffer = crucible::Buffer::new(size);
+        let volume_block_size = self.volume.get_block_size().await?;
+        let buffer = crucible::Buffer::new(size, volume_block_size as usize);
 
         self.volume
             .read_from_byte_offset(offset, buffer.clone())
@@ -334,7 +335,10 @@ impl PantryEntry {
                 size_to_validate,
             );
 
-            let data = crucible::Buffer::new((end - start) as usize);
+            let data = crucible::Buffer::new(
+                (end - start) as usize,
+                block_size as usize,
+            );
 
             self.volume
                 .read_from_byte_offset(start, data.clone())

--- a/upstairs/src/block_io.rs
+++ b/upstairs/src/block_io.rs
@@ -74,10 +74,7 @@ impl BlockIO for FileBlockIO {
         let mut file = self.file.lock().await;
         file.seek(SeekFrom::Start(start))?;
         file.read_exact(&mut data_vec[..])?;
-
-        for i in 0..data_vec.len().div_ceil(self.block_size as usize) {
-            owned_vec[i] = true;
-        }
+        owned_vec.fill(true);
 
         Ok(())
     }

--- a/upstairs/src/block_io.rs
+++ b/upstairs/src/block_io.rs
@@ -65,6 +65,7 @@ impl BlockIO for FileBlockIO {
         offset: Block,
         data: Buffer,
     ) -> Result<(), CrucibleError> {
+        self.check_data_size(data.len()).await?;
         let mut data_vec = data.as_vec().await;
         let mut owned_vec = data.owned_vec().await;
 
@@ -86,6 +87,7 @@ impl BlockIO for FileBlockIO {
         offset: Block,
         data: Bytes,
     ) -> Result<(), CrucibleError> {
+        self.check_data_size(data.len()).await?;
         let start = offset.value * self.block_size;
 
         let mut file = self.file.lock().await;
@@ -211,13 +213,7 @@ impl BlockIO for ReqwestBlockIO {
         offset: Block,
         data: Buffer,
     ) -> Result<(), CrucibleError> {
-        if data.len() as u64 % self.block_size != 0 {
-            return Err(CrucibleError::InvalidNumberOfBlocks(format!(
-                "data length {} is not divisible by block size {}",
-                data.len(),
-                self.block_size
-            )));
-        }
+        self.check_data_size(data.len()).await?;
         let cc = self.next_count();
         cdt::reqwest__read__start!(|| (cc, self.uuid));
 

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -655,7 +655,7 @@ pub(crate) mod protocol_test {
             // We must tokio::spawn here because `read` will wait for the
             // response to come back before returning
             tokio::spawn(async move {
-                let buffer = Buffer::new(512);
+                let buffer = Buffer::new(512, 512);
                 harness.guest.read(Block::new_512(0), buffer).await.unwrap();
             });
         }
@@ -705,7 +705,7 @@ pub(crate) mod protocol_test {
             let harness = harness.clone();
 
             tokio::spawn(async move {
-                let buffer = Buffer::new(512);
+                let buffer = Buffer::new(512, 512);
                 harness.guest.read(Block::new_512(0), buffer).await.unwrap();
             });
         }
@@ -859,7 +859,7 @@ pub(crate) mod protocol_test {
             // We must tokio::spawn here because `read` will wait for the
             // response to come back before returning
             tokio::spawn(async move {
-                let buffer = Buffer::new(512);
+                let buffer = Buffer::new(512, 512);
                 harness.guest.read(Block::new_512(0), buffer).await.unwrap();
             });
         }
@@ -939,7 +939,7 @@ pub(crate) mod protocol_test {
                 // We must tokio::spawn here because `read` will wait for the
                 // response to come back before returning
                 tokio::spawn(async move {
-                    let buffer = Buffer::new(512);
+                    let buffer = Buffer::new(512, 512);
                     harness
                         .guest
                         .read(Block::new_512(0), buffer)
@@ -1243,7 +1243,7 @@ pub(crate) mod protocol_test {
                 {
                     let harness = harness.clone();
                     tokio::spawn(async move {
-                        let buffer = Buffer::new(512);
+                        let buffer = Buffer::new(512, 512);
                         harness
                             .guest
                             .read(Block::new_512(io_eid as u64 * 10), buffer)
@@ -1921,7 +1921,7 @@ pub(crate) mod protocol_test {
                 // We must tokio::spawn here because `read` will wait for the
                 // response to come back before returning
                 tokio::spawn(async move {
-                    let buffer = Buffer::new(512);
+                    let buffer = Buffer::new(512, 512);
                     harness
                         .guest
                         .read(Block::new_512(0), buffer)
@@ -1975,7 +1975,7 @@ pub(crate) mod protocol_test {
                 // We must tokio::spawn here because `read` will wait for the
                 // response to come back before returning
                 tokio::spawn(async move {
-                    let buffer = Buffer::new(512);
+                    let buffer = Buffer::new(512, 512);
                     harness
                         .guest
                         .read(Block::new_512(0), buffer)
@@ -2679,7 +2679,7 @@ pub(crate) mod protocol_test {
                 // We must tokio::spawn here because `read` will wait for the
                 // response to come back before returning
                 tokio::spawn(async move {
-                    let buffer = Buffer::new(512);
+                    let buffer = Buffer::new(512, 512);
                     harness
                         .guest
                         .read(Block::new_512(0), buffer)
@@ -2928,7 +2928,7 @@ pub(crate) mod protocol_test {
         // We must tokio::spawn here because `read` will wait for the
         // response to come back before returning
         tokio::spawn(async move {
-            let buffer = Buffer::new(512);
+            let buffer = Buffer::new(512, 512);
             harness.guest.read(Block::new_512(0), buffer).await.unwrap();
         });
 
@@ -2967,7 +2967,7 @@ pub(crate) mod protocol_test {
             // We must tokio::spawn here because `read` will wait for the
             // response to come back before returning
             tokio::spawn(async move {
-                let buffer = Buffer::new(512);
+                let buffer = Buffer::new(512, 512);
                 harness.guest.read(Block::new_512(0), buffer).await.unwrap();
             });
         }

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -655,7 +655,7 @@ pub(crate) mod protocol_test {
             // We must tokio::spawn here because `read` will wait for the
             // response to come back before returning
             tokio::spawn(async move {
-                let buffer = Buffer::new(512, 512);
+                let buffer = Buffer::new(1, 512);
                 harness.guest.read(Block::new_512(0), buffer).await.unwrap();
             });
         }
@@ -705,7 +705,7 @@ pub(crate) mod protocol_test {
             let harness = harness.clone();
 
             tokio::spawn(async move {
-                let buffer = Buffer::new(512, 512);
+                let buffer = Buffer::new(1, 512);
                 harness.guest.read(Block::new_512(0), buffer).await.unwrap();
             });
         }
@@ -859,7 +859,7 @@ pub(crate) mod protocol_test {
             // We must tokio::spawn here because `read` will wait for the
             // response to come back before returning
             tokio::spawn(async move {
-                let buffer = Buffer::new(512, 512);
+                let buffer = Buffer::new(1, 512);
                 harness.guest.read(Block::new_512(0), buffer).await.unwrap();
             });
         }
@@ -939,7 +939,7 @@ pub(crate) mod protocol_test {
                 // We must tokio::spawn here because `read` will wait for the
                 // response to come back before returning
                 tokio::spawn(async move {
-                    let buffer = Buffer::new(512, 512);
+                    let buffer = Buffer::new(1, 512);
                     harness
                         .guest
                         .read(Block::new_512(0), buffer)
@@ -1243,7 +1243,7 @@ pub(crate) mod protocol_test {
                 {
                     let harness = harness.clone();
                     tokio::spawn(async move {
-                        let buffer = Buffer::new(512, 512);
+                        let buffer = Buffer::new(1, 512);
                         harness
                             .guest
                             .read(Block::new_512(io_eid as u64 * 10), buffer)
@@ -1921,7 +1921,7 @@ pub(crate) mod protocol_test {
                 // We must tokio::spawn here because `read` will wait for the
                 // response to come back before returning
                 tokio::spawn(async move {
-                    let buffer = Buffer::new(512, 512);
+                    let buffer = Buffer::new(1, 512);
                     harness
                         .guest
                         .read(Block::new_512(0), buffer)
@@ -1975,7 +1975,7 @@ pub(crate) mod protocol_test {
                 // We must tokio::spawn here because `read` will wait for the
                 // response to come back before returning
                 tokio::spawn(async move {
-                    let buffer = Buffer::new(512, 512);
+                    let buffer = Buffer::new(1, 512);
                     harness
                         .guest
                         .read(Block::new_512(0), buffer)
@@ -2679,7 +2679,7 @@ pub(crate) mod protocol_test {
                 // We must tokio::spawn here because `read` will wait for the
                 // response to come back before returning
                 tokio::spawn(async move {
-                    let buffer = Buffer::new(512, 512);
+                    let buffer = Buffer::new(1, 512);
                     harness
                         .guest
                         .read(Block::new_512(0), buffer)
@@ -2928,7 +2928,7 @@ pub(crate) mod protocol_test {
         // We must tokio::spawn here because `read` will wait for the
         // response to come back before returning
         tokio::spawn(async move {
-            let buffer = Buffer::new(512, 512);
+            let buffer = Buffer::new(1, 512);
             harness.guest.read(Block::new_512(0), buffer).await.unwrap();
         });
 
@@ -2967,7 +2967,7 @@ pub(crate) mod protocol_test {
             // We must tokio::spawn here because `read` will wait for the
             // response to come back before returning
             tokio::spawn(async move {
-                let buffer = Buffer::new(512, 512);
+                let buffer = Buffer::new(1, 512);
                 harness.guest.read(Block::new_512(0), buffer).await.unwrap();
             });
         }

--- a/upstairs/src/in_memory.rs
+++ b/upstairs/src/in_memory.rs
@@ -25,17 +25,6 @@ impl InMemoryBlockIO {
             }),
         }
     }
-
-    fn check_size(&self, size: usize) -> Result<(), CrucibleError> {
-        if size as u64 % self.block_size == 0 {
-            Ok(())
-        } else {
-            Err(CrucibleError::InvalidNumberOfBlocks(format!(
-                "data length {} is not divisible by block size {}",
-                size, self.block_size
-            )))
-        }
-    }
 }
 
 #[async_trait]
@@ -70,7 +59,8 @@ impl BlockIO for InMemoryBlockIO {
         offset: Block,
         data: Buffer,
     ) -> Result<(), CrucibleError> {
-        self.check_size(data.len())?;
+        self.check_data_size(data.len()).await?;
+
         let inner = self.inner.lock().await;
 
         let mut data_vec = data.as_vec().await;
@@ -95,7 +85,7 @@ impl BlockIO for InMemoryBlockIO {
         offset: Block,
         data: Bytes,
     ) -> Result<(), CrucibleError> {
-        self.check_size(data.len())?;
+        self.check_data_size(data.len()).await?;
 
         let mut inner = self.inner.lock().await;
 
@@ -115,7 +105,7 @@ impl BlockIO for InMemoryBlockIO {
         offset: Block,
         data: Bytes,
     ) -> Result<(), CrucibleError> {
-        self.check_size(data.len())?;
+        self.check_data_size(data.len()).await?;
 
         let mut inner = self.inner.lock().await;
 

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -1172,7 +1172,7 @@ pub mod repair_test {
         )
         .await;
 
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
+        up.submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         // WriteUnwritten
@@ -1210,7 +1210,7 @@ pub mod repair_test {
         )
         .await;
 
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
+        up.submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         // WriteUnwritten
@@ -1244,7 +1244,7 @@ pub mod repair_test {
         )
         .await;
 
-        up.submit_dummy_read(Block::new_512(3), Buffer::new(512, 512))
+        up.submit_dummy_read(Block::new_512(3), Buffer::new(1, 512))
             .await;
 
         // WriteUnwritten
@@ -1329,7 +1329,7 @@ pub mod repair_test {
         )
         .await;
 
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(512 * 9, 512))
+        up.submit_dummy_read(Block::new_512(0), Buffer::new(9, 512))
             .await;
 
         // WriteUnwritten
@@ -1392,7 +1392,7 @@ pub mod repair_test {
         finish_live_repair(&mut up, 1000).await;
 
         // Our default extent size is 3, so 9 blocks will span 3 extents
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(512 * 9, 512))
+        up.submit_dummy_read(Block::new_512(0), Buffer::new(9, 512))
             .await;
 
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -1172,7 +1172,7 @@ pub mod repair_test {
         )
         .await;
 
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(512))
+        up.submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
             .await;
 
         // WriteUnwritten
@@ -1210,7 +1210,7 @@ pub mod repair_test {
         )
         .await;
 
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(512))
+        up.submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
             .await;
 
         // WriteUnwritten
@@ -1244,7 +1244,7 @@ pub mod repair_test {
         )
         .await;
 
-        up.submit_dummy_read(Block::new_512(3), Buffer::new(512))
+        up.submit_dummy_read(Block::new_512(3), Buffer::new(512, 512))
             .await;
 
         // WriteUnwritten
@@ -1329,7 +1329,7 @@ pub mod repair_test {
         )
         .await;
 
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(512 * 9))
+        up.submit_dummy_read(Block::new_512(0), Buffer::new(512 * 9, 512))
             .await;
 
         // WriteUnwritten
@@ -1392,7 +1392,7 @@ pub mod repair_test {
         finish_live_repair(&mut up, 1000).await;
 
         // Our default extent size is 3, so 9 blocks will span 3 extents
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(512 * 9))
+        up.submit_dummy_read(Block::new_512(0), Buffer::new(512 * 9, 512))
             .await;
 
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -39,6 +39,7 @@ impl IOSpan {
             phase: offset % block_size,
             buffer: Buffer::new(
                 affected_block_numbers.len() * block_size as usize,
+                block_size as usize,
             ),
             affected_block_numbers,
         }

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -38,7 +38,7 @@ impl IOSpan {
             block_size,
             phase: offset % block_size,
             buffer: Buffer::new(
-                affected_block_numbers.len() * block_size as usize,
+                affected_block_numbers.len(),
                 block_size as usize,
             ),
             affected_block_numbers,

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -130,7 +130,7 @@ pub(crate) mod up_test {
             assert_eq!(span.buffer().as_vec().await[i], 0);
         }
 
-        let data = Buffer::new(64);
+        let data = Buffer::new(64, 512);
         span.read_from_blocks_into_buffer(&mut data.as_vec().await[..])
             .await;
 
@@ -738,19 +738,19 @@ pub(crate) mod up_test {
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(1),
+                data: Buffer::new(1, 512),
             })
             .await;
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(8000),
+                data: Buffer::new(8000, 512),
             })
             .await;
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(16000),
+                data: Buffer::new(16000, 512),
             })
             .await;
 
@@ -779,19 +779,19 @@ pub(crate) mod up_test {
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(1),
+                data: Buffer::new(1, 512),
             })
             .await;
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(8000),
+                data: Buffer::new(8000, 512),
             })
             .await;
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(16000),
+                data: Buffer::new(16000, 512),
             })
             .await;
 
@@ -867,19 +867,19 @@ pub(crate) mod up_test {
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(1024 * 1024 / 2),
+                data: Buffer::new(1024 * 1024 / 2, 512),
             })
             .await;
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(1024 * 1024 / 2),
+                data: Buffer::new(1024 * 1024 / 2, 512),
             })
             .await;
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(1024 * 1024 / 2),
+                data: Buffer::new(1024 * 1024 / 2, 512),
             })
             .await;
 
@@ -960,13 +960,13 @@ pub(crate) mod up_test {
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(7000 * 1024),
+                data: Buffer::new(7000 * 1024, 512),
             })
             .await;
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(7000 * 1024),
+                data: Buffer::new(7000 * 1024, 512),
             })
             .await;
 
@@ -995,7 +995,7 @@ pub(crate) mod up_test {
             let _ = guest
                 .send(BlockOp::Read {
                     offset: Block::new_512(0),
-                    data: Buffer::new(1024),
+                    data: Buffer::new(1024, 512),
                 })
                 .await;
             assert_consumed!(&guest);
@@ -1004,7 +1004,7 @@ pub(crate) mod up_test {
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(1024),
+                data: Buffer::new(1024, 512),
             })
             .await;
         assert_none_consumed!(&guest);
@@ -1047,7 +1047,7 @@ pub(crate) mod up_test {
             let _ = guest
                 .send(BlockOp::Read {
                     offset: Block::new_512(0),
-                    data: Buffer::new(optimal_io_size),
+                    data: Buffer::new(optimal_io_size, 512),
                 })
                 .await;
 
@@ -1074,13 +1074,13 @@ pub(crate) mod up_test {
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(10 * 1024 * 1024),
+                data: Buffer::new(10 * 1024 * 1024, 512),
             })
             .await;
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(0),
+                data: Buffer::new(0, 512),
             })
             .await;
 
@@ -1248,8 +1248,8 @@ pub(crate) mod up_test {
         let second_id = JobId(1011);
 
         let mut data_buffers = HashMap::new();
-        data_buffers.insert(first_id, Buffer::new(512));
-        data_buffers.insert(second_id, Buffer::new(512));
+        data_buffers.insert(first_id, Buffer::new(512, 512));
+        data_buffers.insert(second_id, Buffer::new(512, 512));
 
         let mut sub = HashSet::new();
         sub.insert(first_id);

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -130,7 +130,7 @@ pub(crate) mod up_test {
             assert_eq!(span.buffer().as_vec().await[i], 0);
         }
 
-        let data = Buffer::new(64, 512);
+        let data = Buffer::new(span.affected_block_count(), 512);
         span.read_from_blocks_into_buffer(&mut data.as_vec().await[..])
             .await;
 
@@ -744,13 +744,13 @@ pub(crate) mod up_test {
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(8000, 512),
+                data: Buffer::new(8, 512),
             })
             .await;
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(16000, 512),
+                data: Buffer::new(32, 512),
             })
             .await;
 
@@ -785,13 +785,13 @@ pub(crate) mod up_test {
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(8000, 512),
+                data: Buffer::new(8, 512),
             })
             .await;
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(16000, 512),
+                data: Buffer::new(32, 512),
             })
             .await;
 
@@ -867,19 +867,19 @@ pub(crate) mod up_test {
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(1024 * 1024 / 2, 512),
+                data: Buffer::new(1024 * 1024 / 2 / 512, 512),
             })
             .await;
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(1024 * 1024 / 2, 512),
+                data: Buffer::new(1024 * 1024 / 2 / 512, 512),
             })
             .await;
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(1024 * 1024 / 2, 512),
+                data: Buffer::new(1024 * 1024 / 2 / 512, 512),
             })
             .await;
 
@@ -960,13 +960,13 @@ pub(crate) mod up_test {
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(7000 * 1024, 512),
+                data: Buffer::new(7000 * 1024 / 512, 512),
             })
             .await;
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(7000 * 1024, 512),
+                data: Buffer::new(7000 * 1024 / 512, 512),
             })
             .await;
 
@@ -995,7 +995,7 @@ pub(crate) mod up_test {
             let _ = guest
                 .send(BlockOp::Read {
                     offset: Block::new_512(0),
-                    data: Buffer::new(1024, 512),
+                    data: Buffer::new(1024 / 512, 512),
                 })
                 .await;
             assert_consumed!(&guest);
@@ -1004,7 +1004,7 @@ pub(crate) mod up_test {
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(1024, 512),
+                data: Buffer::new(1024 / 512, 512),
             })
             .await;
         assert_none_consumed!(&guest);
@@ -1043,11 +1043,12 @@ pub(crate) mod up_test {
         for i in 0..500 {
             assert_eq!(*guest.iop_tokens.lock().unwrap(), i);
             assert_eq!(*guest.bw_tokens.lock().unwrap(), i * optimal_io_size);
+            assert_eq!(optimal_io_size % 512, 0);
 
             let _ = guest
                 .send(BlockOp::Read {
                     offset: Block::new_512(0),
-                    data: Buffer::new(optimal_io_size, 512),
+                    data: Buffer::new(optimal_io_size / 512, 512),
                 })
                 .await;
 
@@ -1074,7 +1075,7 @@ pub(crate) mod up_test {
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(10 * 1024 * 1024, 512),
+                data: Buffer::new(10 * 1024 * 1024 / 512, 512),
             })
             .await;
         let _ = guest
@@ -1248,8 +1249,8 @@ pub(crate) mod up_test {
         let second_id = JobId(1011);
 
         let mut data_buffers = HashMap::new();
-        data_buffers.insert(first_id, Buffer::new(512, 512));
-        data_buffers.insert(second_id, Buffer::new(512, 512));
+        data_buffers.insert(first_id, Buffer::new(1, 512));
+        data_buffers.insert(second_id, Buffer::new(1, 512));
 
         let mut sub = HashSet::new();
         sub.insert(first_id);

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -131,7 +131,7 @@ pub(crate) mod up_test {
         }
 
         let data = Buffer::new(span.affected_block_count(), 512);
-        span.read_from_blocks_into_buffer(&mut data.as_vec().await[..])
+        span.read_from_blocks_into_buffer(&mut data.as_vec().await[..64])
             .await;
 
         for i in 0..64 {

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -791,7 +791,7 @@ pub(crate) mod up_test {
         let _ = guest
             .send(BlockOp::Read {
                 offset: Block::new_512(0),
-                data: Buffer::new(32, 512),
+                data: Buffer::new(31, 512),
             })
             .await;
 
@@ -1034,6 +1034,9 @@ pub(crate) mod up_test {
         // equation: throughput / number of IOPS = optimal I/O size.
 
         let optimal_io_size: usize = 6400 * 1024 / 500;
+
+        // Round down to the nearest size in blocks
+        let optimal_io_size = (optimal_io_size / 512) * 512;
 
         // Make sure this is <= an IOP size
         assert!(optimal_io_size <= 16384);

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -2474,7 +2474,7 @@ pub(crate) mod test {
 
         // op 1
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2512,7 +2512,7 @@ pub(crate) mod test {
 
         // op 3
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512 * 2, 512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(2, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2545,12 +2545,12 @@ pub(crate) mod test {
 
         // op 0
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         // op 1
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2585,12 +2585,12 @@ pub(crate) mod test {
 
         // op 1
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         // op 2
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2629,7 +2629,7 @@ pub(crate) mod test {
 
         // op 2
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512 * 2, 512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(2, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2756,7 +2756,7 @@ pub(crate) mod test {
 
         // op 0
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         // op 1
@@ -2791,7 +2791,7 @@ pub(crate) mod test {
 
         // op 0
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         // op 1
@@ -2805,7 +2805,7 @@ pub(crate) mod test {
 
         // op 2
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2835,7 +2835,7 @@ pub(crate) mod test {
 
         // op 0
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         // op 1
@@ -2849,7 +2849,7 @@ pub(crate) mod test {
 
         // op 2
         upstairs
-            .submit_dummy_read(Block::new_512(1), Buffer::new(512 * 2, 512))
+            .submit_dummy_read(Block::new_512(1), Buffer::new(2, 512))
             .await;
 
         // op 3
@@ -2863,7 +2863,7 @@ pub(crate) mod test {
 
         // op 4
         upstairs
-            .submit_dummy_read(Block::new_512(3), Buffer::new(512 * 2, 512))
+            .submit_dummy_read(Block::new_512(3), Buffer::new(2, 512))
             .await;
 
         // op 5
@@ -3124,7 +3124,7 @@ pub(crate) mod test {
 
         // op 4
         upstairs
-            .submit_dummy_read(Block::new_512(99), Buffer::new(512, 512))
+            .submit_dummy_read(Block::new_512(99), Buffer::new(1, 512))
             .await;
 
         let ds = &upstairs.downstairs;
@@ -3221,7 +3221,7 @@ pub(crate) mod test {
 
         // op 0
         upstairs
-            .submit_dummy_read(Block::new_512(95), Buffer::new(512 * 2, 512))
+            .submit_dummy_read(Block::new_512(95), Buffer::new(2, 512))
             .await;
 
         // op 1
@@ -3579,7 +3579,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512, 512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -3634,7 +3634,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512, 512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -3713,7 +3713,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512, 512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -3781,7 +3781,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512, 512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -3834,7 +3834,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512, 512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -3912,7 +3912,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512, 512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -3992,7 +3992,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512, 512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -4069,7 +4069,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512, 512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -4139,7 +4139,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512, 512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -2474,7 +2474,7 @@ pub(crate) mod test {
 
         // op 1
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2512,7 +2512,7 @@ pub(crate) mod test {
 
         // op 3
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512 * 2))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(512 * 2, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2545,12 +2545,12 @@ pub(crate) mod test {
 
         // op 0
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
             .await;
 
         // op 1
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2585,12 +2585,12 @@ pub(crate) mod test {
 
         // op 1
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
             .await;
 
         // op 2
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2629,7 +2629,7 @@ pub(crate) mod test {
 
         // op 2
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512 * 2))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(512 * 2, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2756,7 +2756,7 @@ pub(crate) mod test {
 
         // op 0
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
             .await;
 
         // op 1
@@ -2791,7 +2791,7 @@ pub(crate) mod test {
 
         // op 0
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
             .await;
 
         // op 1
@@ -2805,7 +2805,7 @@ pub(crate) mod test {
 
         // op 2
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2835,7 +2835,7 @@ pub(crate) mod test {
 
         // op 0
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(512, 512))
             .await;
 
         // op 1
@@ -2849,7 +2849,7 @@ pub(crate) mod test {
 
         // op 2
         upstairs
-            .submit_dummy_read(Block::new_512(1), Buffer::new(512 * 2))
+            .submit_dummy_read(Block::new_512(1), Buffer::new(512 * 2, 512))
             .await;
 
         // op 3
@@ -2863,7 +2863,7 @@ pub(crate) mod test {
 
         // op 4
         upstairs
-            .submit_dummy_read(Block::new_512(3), Buffer::new(512 * 2))
+            .submit_dummy_read(Block::new_512(3), Buffer::new(512 * 2, 512))
             .await;
 
         // op 5
@@ -3124,7 +3124,7 @@ pub(crate) mod test {
 
         // op 4
         upstairs
-            .submit_dummy_read(Block::new_512(99), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(99), Buffer::new(512, 512))
             .await;
 
         let ds = &upstairs.downstairs;
@@ -3221,7 +3221,7 @@ pub(crate) mod test {
 
         // op 0
         upstairs
-            .submit_dummy_read(Block::new_512(95), Buffer::new(512 * 2))
+            .submit_dummy_read(Block::new_512(95), Buffer::new(512 * 2, 512))
             .await;
 
         // op 1
@@ -3579,7 +3579,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(512, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -3634,7 +3634,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(512, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -3713,7 +3713,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(512, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -3781,7 +3781,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(512, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -3834,7 +3834,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(512, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -3912,7 +3912,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(512, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -3992,7 +3992,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(512, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -4069,7 +4069,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(512, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -4139,7 +4139,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(512, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -479,11 +479,7 @@ impl Volume {
             return Ok(());
         }
 
-        let bs = self.get_block_size().await?;
-
-        if (data.len() % bs as usize) != 0 {
-            crucible_bail!(DataLenUnaligned);
-        }
+        self.check_data_size(data.len()).await?;
 
         let affected_sub_volumes = self.sub_volumes_for_lba_range(
             offset.value,
@@ -640,11 +636,7 @@ impl BlockIO for Volume {
             }
         }
 
-        let bs = self.get_block_size().await?;
-
-        if (data.len() % bs as usize) != 0 {
-            crucible_bail!(DataLenUnaligned);
-        }
+        self.check_data_size(data.len()).await?;
 
         let affected_sub_volumes = self.sub_volumes_for_lba_range(
             offset.value,


### PR DESCRIPTION
This reduces storage (and operations) in the `struct Buffer` by the block size, so a factor of 512× or 4096×.

The downside is that we need to know the block size at construction time, so there's a bunch of mechanical changes in this PR.

I see significant speedups for all sizes of random reads except 4K, which become slightly slower (50.6 MiB/s → 46.9 MiB/s, not sure why).

<img width="750" alt="Screenshot 2024-01-09 at 3 01 13 PM" src="https://github.com/oxidecomputer/crucible/assets/745333/21191399-3e0b-44c9-8cc4-135d708b23a5">