### PR TITLE
Don't check ROP if the scrub is done

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ hyper = { version = "0.14", features = [ "full" ] }
 hyper-staticfile = "0.9"
 indicatif = { version = "0.17.7", features = ["rayon"] }
 itertools = "0.12.0"
-libc = "0.2.151"
+libc = "0.2"
 mime_guess = "2.0.4"
 nbd = "0.2.3"
 nix = { version = "0.26", features = [ "feature", "uio" ] }

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -881,13 +881,6 @@ impl DownstairsClient {
                     IOState::Skipped
                 }
             }
-            DsState::Offline => {
-                error!(
-                    self.log,
-                    "[{}] enqueues job {:?} when offline", self.client_id, io,
-                );
-                IOState::New
-            }
             _ => {
                 self.new_jobs.insert(io.ds_id);
                 IOState::New

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -884,9 +884,7 @@ impl DownstairsClient {
             DsState::Offline => {
                 error!(
                     self.log,
-                    "[{}] enqueues job {:?} when offline",
-                    self.client_id,
-                    io,
+                    "[{}] enqueues job {:?} when offline", self.client_id, io,
                 );
                 IOState::New
             }

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -881,6 +881,15 @@ impl DownstairsClient {
                     IOState::Skipped
                 }
             }
+            DsState::Offline => {
+                error!(
+                    self.log,
+                    "[{}] enqueues job {:?} when offline",
+                    self.client_id,
+                    io,
+                );
+                IOState::New
+            }
             _ => {
                 self.new_jobs.insert(io.ds_id);
                 IOState::New

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -274,6 +274,7 @@ impl Volume {
         sv_vec
     }
 
+    #[allow(clippy::if_same_then_else)]
     pub fn read_only_parent_for_lba_range(
         &self,
         start: u64,
@@ -283,12 +284,7 @@ impl Volume {
             // Check if the scrubber has passed this offset
             let scrub_point = self.scrub_point.load(Ordering::SeqCst);
             if scrub_point >= read_only_parent.lba_range.end {
-                error!(
-                    self.log,
-                    "ZZZ Scrub is done, end:{}  sp:{}",
-                    read_only_parent.lba_range.end,
-                    scrub_point,
-                );
+                // No need to check ROP, the scrub is done.
                 None
             } else if start + length <= scrub_point {
                 None
@@ -313,7 +309,7 @@ impl Volume {
         start_delay: Option<u64>,
         scrub_pause: Option<u64>,
     ) -> Result<(), CrucibleError> {
-        info!(self.log, "ZZZ Scrub check for {}", self.uuid);
+        info!(self.log, "Scrub check for {}", self.uuid);
         // XXX Can we assert volume is activated?
 
         if let Some(ref read_only_parent) = self.read_only_parent {
@@ -427,7 +423,7 @@ impl Volume {
                 if offset > showat {
                     info!(
                         self.log,
-                        "ZZZ Scrub at offset {}/{} sp:{:?}",
+                        "Scrub at offset {}/{} sp:{:?}",
                         offset,
                         end,
                         self.scrub_point
@@ -442,7 +438,7 @@ impl Volume {
             let total_time = scrub_start.elapsed();
             info!(
                 self.log,
-                "ZZZ Scrub {} done in {} seconds. Retries:{} scrub_size:{} size:{} pause_milli:{}",
+                "Scrub {} done in {} seconds. Retries:{} scrub_size:{} size:{} pause_milli:{}",
                 self.uuid,
                 total_time.as_secs(),
                 retries,


### PR DESCRIPTION
**Don't ask the read only parent for anything once the scrub has completed.**

When asking a Volume with a ROP to see if we need to read from the ROP
or not, also check to see if the scrub is done and don't read from the ROP if so.

There was a problem where a read that started inside the ROP range, but extended
beyond it would still request data from the ROP (which we would have later discarded).

This is not a terrible problem, unless the ROP has gone away.  If the ROP is gone, then the
IO will sit in the upstairs waiting for at least one downstairs to answer.