### PR TITLE
Remove Arc + Mutex from Buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,6 +763,7 @@ dependencies = [
  "expectorate",
  "futures",
  "futures-core",
+ "httptest",
  "itertools 0.12.0",
  "libc",
  "omicron-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,7 +763,6 @@ dependencies = [
  "expectorate",
  "futures",
  "futures-core",
- "httptest",
  "itertools 0.12.0",
  "libc",
  "omicron-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,6 +1182,7 @@ dependencies = [
  "crucible-workspace-hack",
  "futures",
  "futures-core",
+ "itertools 0.12.0",
  "ringbuffer",
  "serde",
  "serde_json",

--- a/crudd/Cargo.toml
+++ b/crudd/Cargo.toml
@@ -23,3 +23,4 @@ tokio-util.workspace = true
 tokio.workspace = true
 toml.workspace = true
 crucible-workspace-hack.workspace = true
+itertools.workspace = true

--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -242,8 +242,8 @@ async fn cmd_read<T: BlockIO>(
     // Drain the outstanding commands
     if !futures.is_empty() {
         // drain the buffer to the output file
-        while !futures.is_empty() {
-            let r_buf = futures.pop_front().unwrap().await?;
+        for f in futures.drain(..) {
+            let r_buf = f.await?;
             output.write_all(&r_buf)?;
         }
     }

--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -154,7 +154,6 @@ async fn cmd_read<T: BlockIO>(
     //
     // TODO this is no longer true after the Upstairs is async, multiple
     // requests can be submitted and await'ed on at the same time.
-    let mut buffers = VecDeque::with_capacity(opt.pipeline_length);
     let mut futures = VecDeque::with_capacity(opt.pipeline_length);
 
     // First, align our offset to the underlying blocks with an initial read
@@ -174,13 +173,13 @@ async fn cmd_read<T: BlockIO>(
         let buffer = Buffer::new(native_block_size as usize);
         let block_idx = opt.byte_offset / native_block_size;
         let offset = Block::new(block_idx, native_block_size.trailing_zeros());
-        crucible.read(offset, buffer.clone()).await?;
+        let buffer = crucible.read(offset, buffer).await?;
 
         // write only (block size - misalignment) bytes
         // So say we have an offset of 5. we're misaligned by 5 bytes, so we
         // read 5 bytes we don't need. we skip those 5 bytes then write
         // the rest to the output
-        let bytes = buffer.into_vec().unwrap();
+        let bytes = buffer.into_vec();
         output.write_all(
             &bytes[offset_misalignment as usize
                 ..(offset_misalignment + alignment_bytes) as usize],
@@ -215,37 +214,37 @@ async fn cmd_read<T: BlockIO>(
 
         // Send the read command with whichever buffer is at the back of the
         // queue. We re-use the buffers to avoid lots of allocations
-        let w_buf =
+        let buf =
             Buffer::new((opt.iocmd_block_count * native_block_size) as usize);
-        let w_future = crucible.read(offset, w_buf.clone());
-        buffers.push_back(w_buf);
-        futures.push_back(w_future);
+        let r_future = crucible.read(offset, buf);
+        futures.push_back(r_future);
         total_bytes_read +=
             (opt.iocmd_block_count * native_block_size) as usize;
 
         // If we have a queue of futures, drain the oldest one to output.
         if futures.len() == opt.pipeline_length {
-            futures.pop_front().unwrap().await?;
-            let r_buf = buffers.pop_front().unwrap();
-            output.write_all(&r_buf.as_vec().await)?;
+            let r_buf = futures.pop_front().unwrap().await?;
+            output.write_all(&r_buf)?;
         }
 
         if early_shutdown.try_recv().is_ok() {
             eprintln!("shutting down early in response to SIGUSR1");
-            join_all(futures).await?;
+
+            // Drain all read buffers
+            for future in futures {
+                let _r_buf = future.await?;
+            }
+
             return Ok(total_bytes_read);
         }
     }
 
     // Drain the outstanding commands
     if !futures.is_empty() {
-        crucible::join_all(futures).await?;
-
         // drain the buffer to the output file
-        while !buffers.is_empty() {
-            // unwrapping is safe because of the length check
-            let r_buf = buffers.pop_front().unwrap();
-            output.write_all(&r_buf.as_vec().await)?;
+        while !futures.is_empty() {
+            let r_buf = futures.pop_front().unwrap().await?;
+            output.write_all(&r_buf)?;
         }
     }
 
@@ -259,9 +258,9 @@ async fn cmd_read<T: BlockIO>(
         let buffer = Buffer::new((blocks * native_block_size) as usize);
         let block_idx = (cmd_count * opt.iocmd_block_count) + block_offset;
         let offset = Block::new(block_idx, native_block_size.trailing_zeros());
-        crucible.read(offset, buffer.clone()).await?;
+        let buffer = crucible.read(offset, buffer).await?;
         total_bytes_read += remainder as usize;
-        output.write_all(&buffer.as_vec().await[0..remainder as usize])?;
+        output.write_all(&buffer[0..remainder as usize])?;
     }
 
     Ok(total_bytes_read)
@@ -280,7 +279,7 @@ async fn write_remainder_and_finalize<'a, T: BlockIO>(
     offset: Block,
     n_read: usize,
     native_block_size: u64,
-    mut futures: VecDeque<crucible::CrucibleBlockIOFuture<'a>>,
+    mut futures: VecDeque<CrucibleBlockIOFuture<'a>>,
 ) -> Result<()> {
     // the input stream ended,
     // - read/mod/write for alignment
@@ -311,10 +310,10 @@ async fn write_remainder_and_finalize<'a, T: BlockIO>(
             native_block_size.trailing_zeros(),
         );
         let uflow_r_buf = Buffer::new(native_block_size as usize);
-        crucible.read(uflow_offset, uflow_r_buf.clone()).await?;
+        let uflow_r_buf = crucible.read(uflow_offset, uflow_r_buf).await?;
 
         // Copy it into w_buf
-        let r_bytes = uflow_r_buf.into_vec().unwrap();
+        let r_bytes = uflow_r_buf.into_vec();
         w_buf[n_read..n_read + uflow_backfill]
             .copy_from_slice(&r_bytes[uflow_remainder as usize..]);
 
@@ -323,12 +322,12 @@ async fn write_remainder_and_finalize<'a, T: BlockIO>(
         futures.push_back(w_future);
     }
 
-    // Flush
-    let flush_future = crucible.flush(None);
-    futures.push_back(flush_future);
+    // Wait for all the writes first, then flush
+    for future in futures {
+        future.await?;
+    }
 
-    // Wait for all the writes
-    join_all(futures).await?;
+    crucible.flush(None).await?;
 
     Ok(())
 }
@@ -398,9 +397,9 @@ async fn cmd_write<T: BlockIO>(
         let buffer = Buffer::new(native_block_size as usize);
         let block_idx = opt.byte_offset / native_block_size;
         let offset = Block::new(block_idx, native_block_size.trailing_zeros());
-        crucible.read(offset, buffer.clone()).await?;
+        let buffer = crucible.read(offset, buffer).await?;
 
-        let mut w_vec = buffer.into_vec().unwrap();
+        let mut w_vec = buffer.into_vec();
         // Write our data into the buffer
         let bytes_read = input.read(
             &mut w_vec[offset_misalignment as usize
@@ -485,7 +484,9 @@ async fn cmd_write<T: BlockIO>(
 
         if early_shutdown.try_recv().is_ok() {
             eprintln!("shutting down early in response to SIGUSR1");
-            join_all(futures).await?;
+            for future in futures {
+                future.await?;
+            }
             crucible.flush(None).await?;
             return Ok(total_bytes_written);
         }
@@ -523,7 +524,9 @@ async fn cmd_write<T: BlockIO>(
         )
         .await?;
     } else {
-        join_all(futures).await?;
+        for future in futures {
+            future.await?;
+        }
         crucible.flush(None).await?;
     }
 

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -230,9 +230,9 @@ async fn cli_read(
     let data = crucible::Buffer::from_vec(vec![255; length]);
 
     println!("Read  at block {:5}, len:{:7}", offset.value, data.len());
-    guest.read(offset, data.clone()).await?;
+    let data = guest.read(offset, data).await?;
 
-    let mut dl = data.into_vec().unwrap();
+    let mut dl = data.into_vec();
     match validate_vec(
         dl.clone(),
         block_index,

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -227,10 +227,10 @@ async fn cli_read(
     let offset = Block::new(block_index as u64, ri.block_size.trailing_zeros());
     let length: usize = size * ri.block_size as usize;
 
-    let data = crucible::Buffer::from_vec(vec![255; length]);
+    let mut data = crucible::Buffer::from_vec(vec![255; length]);
 
     println!("Read  at block {:5}, len:{:7}", offset.value, data.len());
-    let data = guest.read(offset, data).await?;
+    guest.read(offset, &mut data).await?;
 
     let mut dl = data.into_vec();
     match validate_vec(

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -2544,7 +2544,7 @@ async fn repair_workload(
                     bw = block_width,
                     sw = size_width,
                 );
-                guest.read(offset, data).await?;
+                let _data = guest.read(offset, data).await?;
             }
         }
     }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -398,11 +398,11 @@ mod test {
 
         // Verify contents are zero on init
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x00_u8; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0x00_u8; BLOCK_SIZE * 10], buffer.into_vec());
 
         // Write data in
         volume
@@ -414,11 +414,11 @@ mod test {
 
         // Read parent, verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], buffer.into_vec());
 
         Ok(())
     }
@@ -450,8 +450,8 @@ mod test {
 
         // A read of zero length does not error.
         let buffer = Buffer::new(0);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let _buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
         // A write of zero length does not return error.
@@ -500,11 +500,11 @@ mod test {
             .await?;
 
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        in_memory_data
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = in_memory_data
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![11; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
         let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
         volume
@@ -525,11 +525,11 @@ mod test {
 
         // Verify contents are 11 on init
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![11; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
         // Write data in
         if is_write_unwritten {
@@ -550,19 +550,19 @@ mod test {
 
         // Verify parent wasn't written to
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        in_memory_data
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = in_memory_data
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![11; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
         // Read and verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![55; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![55; BLOCK_SIZE * 10], &buffer[..]);
 
         Ok(())
     }
@@ -589,11 +589,11 @@ mod test {
             .await?;
 
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        in_memory_data
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = in_memory_data
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![11; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
         // Create volume with read only parent
         let vcr: VolumeConstructionRequest =
@@ -625,11 +625,11 @@ mod test {
 
         // Verify contents are 11 on init
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![11; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
         // Write data in
         volume
@@ -641,19 +641,19 @@ mod test {
 
         // Verify parent wasn't written to
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        in_memory_data
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = in_memory_data
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![11; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
         // Read and verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![55; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![55; BLOCK_SIZE * 10], &buffer[..]);
 
         Ok(())
     }
@@ -710,11 +710,11 @@ mod test {
 
         // Read one block: should be all 0xff
         let buffer = Buffer::new(BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0xff; BLOCK_SIZE], *buffer.as_vec().await);
+        assert_eq!(vec![0xff; BLOCK_SIZE], &buffer[..]);
 
         // Write one block full of 0x01
         volume
@@ -726,11 +726,11 @@ mod test {
 
         // Read one block: should be all 0x01
         let buffer = Buffer::new(BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x01; BLOCK_SIZE], *buffer.as_vec().await);
+        assert_eq!(vec![0x01; BLOCK_SIZE], &buffer[..]);
         Ok(())
     }
 
@@ -763,11 +763,11 @@ mod test {
 
         // Read one block: should be all 0x00
         let buffer = Buffer::new(BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x00; BLOCK_SIZE], *buffer.as_vec().await);
+        assert_eq!(vec![0x00; BLOCK_SIZE], &buffer[..]);
 
         Ok(())
     }
@@ -819,11 +819,11 @@ mod test {
 
         // Read volume, verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         // Write_unwritten data in, should not change anything
         volume
@@ -835,11 +835,11 @@ mod test {
 
         // Read volume, verify original contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         Ok(())
     }
@@ -890,11 +890,11 @@ mod test {
 
         // Read parent, verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         // A second Write_unwritten data, should not change anything
         volume
@@ -906,11 +906,11 @@ mod test {
 
         // Read volume, verify original contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         Ok(())
     }
@@ -971,20 +971,17 @@ mod test {
 
         // Read and verify
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        // Get the data into a vec we can take slices of.
-        let dl = buffer.as_vec().await.to_vec();
-
         // Verify data in the first block is from the first write
-        assert_eq!(vec![0x33_u8; BLOCK_SIZE], dl[0..BLOCK_SIZE]);
+        assert_eq!(vec![0x33_u8; BLOCK_SIZE], &buffer[0..BLOCK_SIZE]);
 
         // Verify the remaining blocks have the write_unwritten data
         assert_eq!(
             vec![0x55_u8; BLOCK_SIZE * 9],
-            dl[BLOCK_SIZE..BLOCK_SIZE * 10]
+            &buffer[BLOCK_SIZE..BLOCK_SIZE * 10]
         );
 
         Ok(())
@@ -1049,11 +1046,11 @@ mod test {
 
         // Read parent, verify contents
         let buffer = Buffer::new(full_volume_size);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x55_u8; full_volume_size], *buffer.as_vec().await);
+        assert_eq!(vec![0x55_u8; full_volume_size], &buffer[..]);
 
         // A second Write_unwritten data, should not change anything
         volume
@@ -1065,11 +1062,11 @@ mod test {
 
         // Read volume, verify original contents
         let buffer = Buffer::new(full_volume_size);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x55_u8; full_volume_size], *buffer.as_vec().await);
+        assert_eq!(vec![0x55_u8; full_volume_size], &buffer[..]);
 
         Ok(())
     }
@@ -1136,11 +1133,11 @@ mod test {
 
         // Read parent, verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 2);
-        volume
-            .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 2], *buffer.as_vec().await);
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 2], &buffer[..]);
 
         // A second Write_unwritten data, should not change the previous
         // write_unwritten, but should change the remaining blocks that
@@ -1155,26 +1152,23 @@ mod test {
         // Read full volume, verify first write_unwritten still valid, but the
         // other blocks of the 2nd write_unwritten are updated.
         let buffer = Buffer::new(full_volume_size);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        // Get the data into a vec we can take slices of.
-        let dl = buffer.as_vec().await.to_vec();
-
         // Verify data in blocks 0-9 is the second write_unwritten
-        assert_eq!(vec![0x22_u8; BLOCK_SIZE * 9], dl[0..(BLOCK_SIZE * 9)]);
+        assert_eq!(vec![0x22_u8; BLOCK_SIZE * 9], &buffer[0..(BLOCK_SIZE * 9)]);
 
         // Verify data in blocks 10-11 is the first write_unwritten
         assert_eq!(
             vec![0x55_u8; BLOCK_SIZE * 2],
-            dl[(BLOCK_SIZE * 9)..(BLOCK_SIZE * 11)]
+            &buffer[(BLOCK_SIZE * 9)..(BLOCK_SIZE * 11)]
         );
 
         // Verify the remaining blocks have the second write_unwritten data
         assert_eq!(
             vec![0x22_u8; BLOCK_SIZE * 9],
-            dl[(BLOCK_SIZE * 11)..full_volume_size]
+            &buffer[(BLOCK_SIZE * 11)..full_volume_size]
         );
 
         Ok(())
@@ -1262,20 +1256,17 @@ mod test {
 
         // Read full volume
         let buffer = Buffer::new(full_volume_size);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        // Get the data into a vec we can take slices of.
-        let dl = buffer.as_vec().await.to_vec();
-
         // Verify data in blocks 0-7 is the second write_unwritten
-        assert_eq!(vec![0x22_u8; BLOCK_SIZE * 7], dl[0..(BLOCK_SIZE * 7)]);
+        assert_eq!(vec![0x22_u8; BLOCK_SIZE * 7], &buffer[0..(BLOCK_SIZE * 7)]);
 
         // Verify data in blocks 8-19 is the third write
         assert_eq!(
             vec![0x11_u8; BLOCK_SIZE * 13],
-            dl[(BLOCK_SIZE * 7)..full_volume_size]
+            &buffer[(BLOCK_SIZE * 7)..full_volume_size]
         );
 
         Ok(())
@@ -1321,11 +1312,11 @@ mod test {
 
         // Read back in_memory, verify 1s
         let buffer = Buffer::new(BLOCK_SIZE * 5);
-        in_memory_data
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = in_memory_data
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![11; BLOCK_SIZE * 5], *buffer.as_vec().await);
+        assert_eq!(vec![11; BLOCK_SIZE * 5], &buffer[..]);
 
         let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
         volume
@@ -1346,13 +1337,13 @@ mod test {
 
         // Verify parent contents in one read
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
         let mut expected = vec![11; BLOCK_SIZE * 5];
         expected.extend(vec![0x00; BLOCK_SIZE * 5]);
-        assert_eq!(expected, *buffer.as_vec().await);
+        assert_eq!(expected, &buffer[..]);
 
         // One big write!
         let write_offset = Block::new(0, BLOCK_SIZE.trailing_zeros());
@@ -1365,11 +1356,11 @@ mod test {
 
         // Verify volume contents in one read
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![55; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![55; BLOCK_SIZE * 10], &buffer[..]);
 
         Ok(())
     }
@@ -1426,11 +1417,11 @@ mod test {
 
         // Verify contents are 11 at startup
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![11; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
         // Call the scrubber.  This should replace all data from the
         // RO parent into the main volume.
@@ -1447,11 +1438,11 @@ mod test {
 
         // Read and verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![11; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
         Ok(())
     }
@@ -1509,19 +1500,19 @@ mod test {
 
         // Verify contents of RO parent are 1s at startup
         let buffer = Buffer::new(BLOCK_SIZE * 5);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![11; BLOCK_SIZE * 5], *buffer.as_vec().await);
+        assert_eq!(vec![11; BLOCK_SIZE * 5], &buffer[..]);
 
         // Verify contents of blocks 5-10 are zero.
         let buffer = Buffer::new(BLOCK_SIZE * 5);
-        volume
-            .read(Block::new(5, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(5, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![00; BLOCK_SIZE * 5], *buffer.as_vec().await);
+        assert_eq!(vec![00; BLOCK_SIZE * 5], &buffer[..]);
 
         // Call the scrubber.  This should replace all data from the
         // RO parent into the main volume.
@@ -1538,19 +1529,16 @@ mod test {
 
         // Read and verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        // Get the data into a vec we can take slices of.
-        let dl = buffer.as_vec().await.to_vec();
-
         // Verify data in the first half is from the RO parent
-        assert_eq!(vec![11; BLOCK_SIZE * 5], dl[0..BLOCK_SIZE * 5]);
+        assert_eq!(vec![11; BLOCK_SIZE * 5], &buffer[0..BLOCK_SIZE * 5]);
         // Verify data in the second half is from the write unwritten
         assert_eq!(
             vec![55; BLOCK_SIZE * 5],
-            dl[BLOCK_SIZE * 5..BLOCK_SIZE * 10]
+            &buffer[BLOCK_SIZE * 5..BLOCK_SIZE * 10]
         );
 
         Ok(())
@@ -1634,8 +1622,8 @@ mod test {
 
         // Read and verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
         // First blocks are 1s   |11--------|
@@ -1650,7 +1638,7 @@ mod test {
         expected.extend(vec![33; BLOCK_SIZE]);
         // Two final blocks of 0 |1121100300|
         expected.extend(vec![0; BLOCK_SIZE * 2]);
-        assert_eq!(expected, *buffer.as_vec().await);
+        assert_eq!(expected, &buffer[..]);
 
         Ok(())
     }
@@ -1708,11 +1696,11 @@ mod test {
 
         // Verify contents are 11 at startup
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![11; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
         // Write to the whole volume
         volume
@@ -1727,11 +1715,11 @@ mod test {
 
         // Read and verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![55; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![55; BLOCK_SIZE * 10], &buffer[..]);
 
         Ok(())
     }
@@ -1824,11 +1812,11 @@ mod test {
 
         // Read and verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 2);
-        volume
-            .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![22; BLOCK_SIZE * 2], *buffer.as_vec().await);
+        assert_eq!(vec![22; BLOCK_SIZE * 2], &buffer[..]);
 
         // A second write
         volume
@@ -1843,8 +1831,8 @@ mod test {
 
         // Read full volume
         let buffer = Buffer::new(BLOCK_SIZE * 20);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
         // Build the expected vec to compare our read with.
@@ -1856,7 +1844,7 @@ mod test {
         expected.extend(vec![22; BLOCK_SIZE * 2]);
         // remaining final blocks of 0 |3311111112||2000000000|
         expected.extend(vec![0; BLOCK_SIZE * 9]);
-        assert_eq!(expected, *buffer.as_vec().await);
+        assert_eq!(expected, &buffer[..]);
 
         Ok(())
     }
@@ -1951,11 +1939,11 @@ mod test {
 
         // Read and verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 2);
-        volume
-            .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![22; BLOCK_SIZE * 2], *buffer.as_vec().await);
+        assert_eq!(vec![22; BLOCK_SIZE * 2], &buffer[..]);
 
         // Write B
         //     |33--------||----------|
@@ -1980,8 +1968,8 @@ mod test {
 
         // Read full volume
         let buffer = Buffer::new(BLOCK_SIZE * 20);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
         // Build the expected vec to compare our read with.
@@ -1997,7 +1985,7 @@ mod test {
         expected.extend(vec![44; BLOCK_SIZE * 2]);
         // remaining final blocks of 0 |3311111112||2111440000|
         expected.extend(vec![0; BLOCK_SIZE * 4]);
-        assert_eq!(expected, *buffer.as_vec().await);
+        assert_eq!(expected, &buffer[..]);
 
         Ok(())
     }
@@ -2054,18 +2042,18 @@ mod test {
 
         // Read one block: should be all 0x00
         let buffer = Buffer::new(BLOCK_SIZE);
-        volume1
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume1
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x00; BLOCK_SIZE], *buffer.as_vec().await);
+        assert_eq!(vec![0x00; BLOCK_SIZE], &buffer[..]);
 
         let buffer = Buffer::new(BLOCK_SIZE);
-        volume2
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume2
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x00; BLOCK_SIZE], *buffer.as_vec().await);
+        assert_eq!(vec![0x00; BLOCK_SIZE], &buffer[..]);
 
         Ok(())
     }
@@ -2107,11 +2095,11 @@ mod test {
 
         // Verify contents are 00 at startup
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0; BLOCK_SIZE * 10], &buffer[..]);
 
         // Write to half volume
         volume
@@ -2126,8 +2114,8 @@ mod test {
 
         // Read and verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
         // Build the expected vec to compare our read with.
@@ -2135,7 +2123,7 @@ mod test {
         let mut expected = vec![55; BLOCK_SIZE * 5];
         // Original 0s from unwritten blocks  |5555500000|
         expected.extend(vec![0; BLOCK_SIZE * 5]);
-        assert_eq!(expected, *buffer.as_vec().await);
+        assert_eq!(expected, &buffer[..]);
 
         Ok(())
     }
@@ -2207,14 +2195,11 @@ mod test {
             volume.activate().await?;
 
             let buffer = Buffer::new(volume.total_size().await? as usize);
-            volume
-                .read(
-                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                    buffer.clone(),
-                )
+            let buffer = volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
                 .await?;
 
-            assert_eq!(*buffer.as_vec().await, random_buffer);
+            assert_eq!(&buffer[..], random_buffer);
 
             assert!(volume
                 .write(
@@ -2267,14 +2252,11 @@ mod test {
         // Validate that source blocks originally come from the read-only parent
         {
             let buffer = Buffer::new(volume.total_size().await? as usize);
-            volume
-                .read(
-                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                    buffer.clone(),
-                )
+            let buffer = volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
                 .await?;
 
-            assert_eq!(*buffer.as_vec().await, random_buffer);
+            assert_eq!(&buffer[..], random_buffer);
         }
 
         // Validate a flush works
@@ -2290,17 +2272,12 @@ mod test {
 
         {
             let buffer = Buffer::new(volume.total_size().await? as usize);
-            volume
-                .read(
-                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                    buffer.clone(),
-                )
+            let buffer = volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
                 .await?;
 
-            let buffer_vec = buffer.as_vec().await;
-
-            assert_eq!(buffer_vec[..BLOCK_SIZE], vec![0u8; BLOCK_SIZE]);
-            assert_eq!(buffer_vec[BLOCK_SIZE..], random_buffer[BLOCK_SIZE..]);
+            assert_eq!(&buffer[..BLOCK_SIZE], vec![0u8; BLOCK_SIZE]);
+            assert_eq!(&buffer[BLOCK_SIZE..], &random_buffer[BLOCK_SIZE..]);
         }
 
         // Validate a flush still works
@@ -2319,6 +2296,7 @@ mod test {
         // read-only.
         let mut test_downstairs_set =
             TestDownstairsSet::small_sqlite(false).await?;
+
         // This must be a SQLite extent!
         assert!(test_downstairs_set
             .downstairs1
@@ -2362,6 +2340,7 @@ mod test {
         drop(volume);
 
         test_downstairs_set.reboot_read_only().await?;
+
         // This must still be a SQLite backend!
         assert!(test_downstairs_set
             .downstairs1
@@ -2390,14 +2369,11 @@ mod test {
             volume.activate().await?;
 
             let buffer = Buffer::new(volume.total_size().await? as usize);
-            volume
-                .read(
-                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                    buffer.clone(),
-                )
+            let buffer = volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
                 .await?;
 
-            assert_eq!(*buffer.as_vec().await, random_buffer);
+            assert_eq!(&buffer[..], random_buffer);
 
             assert!(volume
                 .write(
@@ -2415,6 +2391,7 @@ mod test {
         let top_layer_tds = TestDownstairsSet::small(false).await?;
         let top_layer_opts = top_layer_tds.opts();
         let bottom_layer_opts = test_downstairs_set.opts();
+
         // The new volume is **not** using the SQLite backend!
         assert!(!top_layer_tds
             .downstairs1
@@ -2457,14 +2434,11 @@ mod test {
         // Validate that source blocks originally come from the read-only parent
         {
             let buffer = Buffer::new(volume.total_size().await? as usize);
-            volume
-                .read(
-                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                    buffer.clone(),
-                )
+            let buffer = volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
                 .await?;
 
-            assert_eq!(*buffer.as_vec().await, random_buffer);
+            assert_eq!(&buffer[..], random_buffer);
         }
 
         // Validate a flush works
@@ -2480,17 +2454,12 @@ mod test {
 
         {
             let buffer = Buffer::new(volume.total_size().await? as usize);
-            volume
-                .read(
-                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                    buffer.clone(),
-                )
+            let buffer = volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
                 .await?;
 
-            let buffer_vec = buffer.as_vec().await;
-
-            assert_eq!(buffer_vec[..BLOCK_SIZE], vec![0u8; BLOCK_SIZE]);
-            assert_eq!(buffer_vec[BLOCK_SIZE..], random_buffer[BLOCK_SIZE..]);
+            assert_eq!(&buffer[..BLOCK_SIZE], vec![0u8; BLOCK_SIZE]);
+            assert_eq!(&buffer[BLOCK_SIZE..], &random_buffer[BLOCK_SIZE..]);
         }
 
         // Validate a flush still works
@@ -2575,11 +2544,11 @@ mod test {
         volume.activate().await?;
         // Validate that source blocks are the same
         let buffer = Buffer::new(volume.total_size().await? as usize);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(*buffer.as_vec().await, random_buffer);
+        assert_eq!(&buffer[..], random_buffer);
 
         Ok(())
     }
@@ -2665,12 +2634,11 @@ mod test {
 
         // Read back what we wrote.
         let buffer = Buffer::new(volume.total_size().await? as usize);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        let buffer_vec = buffer.as_vec().await;
-        assert_eq!(buffer_vec[BLOCK_SIZE..], random_buffer[BLOCK_SIZE..]);
+        assert_eq!(&buffer[BLOCK_SIZE..], &random_buffer[BLOCK_SIZE..]);
 
         Ok(())
     }
@@ -2974,12 +2942,11 @@ mod test {
 
         // Read back what we wrote.
         let buffer = Buffer::new(new_volume.total_size().await? as usize);
-        new_volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = new_volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        let buffer_vec = buffer.as_vec().await;
-        assert_eq!(buffer_vec[BLOCK_SIZE..], random_buffer[BLOCK_SIZE..]);
+        assert_eq!(&buffer[BLOCK_SIZE..], &random_buffer[BLOCK_SIZE..]);
 
         Ok(())
     }
@@ -3038,14 +3005,14 @@ mod test {
 
             for (i, random_buffer) in chunks {
                 let buffer = Buffer::new(CHUNK_SIZE);
-                volume
+                let buffer = volume
                     .read(
                         Block::new(i as u64, BLOCK_SIZE.trailing_zeros()),
-                        buffer.clone(),
+                        buffer,
                     )
                     .await?;
 
-                assert_eq!(random_buffer, *buffer.as_vec().await);
+                assert_eq!(random_buffer, &buffer[..]);
             }
         }
 
@@ -3078,11 +3045,11 @@ mod test {
 
         // Verify contents are zero on init
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x00_u8; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0x00_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         // Write data in
         guest
@@ -3094,11 +3061,11 @@ mod test {
 
         // Read parent, verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         Ok(())
     }
@@ -3122,8 +3089,8 @@ mod test {
 
         // Read of length 0
         let buffer = Buffer::new(0);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let _buffer = guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
         // Write of length 0
@@ -3205,11 +3172,11 @@ mod test {
 
         // Read back our block post replacement, verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         Ok(())
     }
@@ -3321,11 +3288,11 @@ mod test {
 
         // Read parent, verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         // Write_unwritten again with different data
         guest
@@ -3337,12 +3304,12 @@ mod test {
 
         // Read back the same blocks.
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
         // Verify data is still the original contents.
-        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         // Now, just write.  This should update our data.
         guest
@@ -3354,12 +3321,12 @@ mod test {
 
         // Read back the same blocks.
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
         // Verify data is now from the new write.
-        assert_eq!(vec![0x89_u8; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0x89_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         Ok(())
     }
@@ -3403,21 +3370,21 @@ mod test {
 
         // Read back the first block.
         let buffer = Buffer::new(BLOCK_SIZE);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
         // Verify data is still the original contents.
-        assert_eq!(vec![0x55_u8; BLOCK_SIZE], *buffer.as_vec().await);
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE], &buffer[..]);
 
         // Read back the next two blocks.
         let buffer = Buffer::new(BLOCK_SIZE * 2);
-        guest
-            .read(Block::new(1, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = guest
+            .read(Block::new(1, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
         // Verify data is still the original contents.
-        assert_eq!(vec![0x99_u8; BLOCK_SIZE * 2], *buffer.as_vec().await);
+        assert_eq!(vec![0x99_u8; BLOCK_SIZE * 2], &buffer[..]);
 
         Ok(())
     }
@@ -3461,23 +3428,23 @@ mod test {
 
         // Read back the all three blocks.
         let buffer = Buffer::new(BLOCK_SIZE * 3);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        // Get the data into a vec we can take slices of.
-        let dl = buffer.as_vec().await.to_vec();
-
         // Verify data in the first block is from the second write_unwritten
-        assert_eq!(vec![0x99_u8; BLOCK_SIZE], dl[0..BLOCK_SIZE]);
+        assert_eq!(vec![0x99_u8; BLOCK_SIZE], &buffer[0..BLOCK_SIZE]);
 
         // Verify data in the second block is from the first write_unwritten
-        assert_eq!(vec![0x55_u8; BLOCK_SIZE], dl[BLOCK_SIZE..(BLOCK_SIZE * 2)]);
+        assert_eq!(
+            vec![0x55_u8; BLOCK_SIZE],
+            &buffer[BLOCK_SIZE..(BLOCK_SIZE * 2)]
+        );
 
         // Verify data in the third block is from the second write_unwritten
         assert_eq!(
             vec![0x99_u8; BLOCK_SIZE],
-            dl[(BLOCK_SIZE * 2)..(BLOCK_SIZE * 2 + BLOCK_SIZE)]
+            &buffer[(BLOCK_SIZE * 2)..(BLOCK_SIZE * 2 + BLOCK_SIZE)]
         );
         Ok(())
     }
@@ -3520,21 +3487,18 @@ mod test {
 
         // Read back the all three blocks.
         let buffer = Buffer::new(BLOCK_SIZE * 3);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
-
-        // Get the data into a vec we can take slices of.
-        let dl = buffer.as_vec().await.to_vec();
 
         // Verify data in the first two blocks is the data from the
         // second write_unwritten
-        assert_eq!(vec![0x99_u8; BLOCK_SIZE * 2], dl[0..BLOCK_SIZE * 2]);
+        assert_eq!(vec![0x99_u8; BLOCK_SIZE * 2], &buffer[0..BLOCK_SIZE * 2]);
 
         // Verify data in the third block is from the first write_unwritten
         assert_eq!(
             vec![0x55_u8; BLOCK_SIZE],
-            dl[(BLOCK_SIZE * 2)..(BLOCK_SIZE * 2 + BLOCK_SIZE)]
+            &buffer[(BLOCK_SIZE * 2)..(BLOCK_SIZE * 2 + BLOCK_SIZE)]
         );
 
         Ok(())
@@ -3577,20 +3541,17 @@ mod test {
 
         // Read back both blocks
         let buffer = Buffer::new(BLOCK_SIZE * 2);
-        guest
-            .read(Block::new(4, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = guest
+            .read(Block::new(4, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        // Get the data into a vec we can take slices of.
-        let dl = buffer.as_vec().await.to_vec();
-
         // Verify data in the first block is the data from the first write.
-        assert_eq!(vec![0x55_u8; BLOCK_SIZE], dl[0..BLOCK_SIZE]);
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE], &buffer[0..BLOCK_SIZE]);
 
         // Verify data in the second block is from the 2nd write
         assert_eq!(
             vec![0x99_u8; BLOCK_SIZE],
-            dl[(BLOCK_SIZE)..(BLOCK_SIZE * 2)]
+            &buffer[(BLOCK_SIZE)..(BLOCK_SIZE * 2)]
         );
 
         Ok(())
@@ -3634,20 +3595,17 @@ mod test {
 
         // Read back both blocks
         let buffer = Buffer::new(BLOCK_SIZE * 2);
-        guest
-            .read(Block::new(4, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = guest
+            .read(Block::new(4, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        // Get the data into a vec we can take slices of.
-        let dl = buffer.as_vec().await.to_vec();
-
         // Verify data in the first block is the data from the first write.
-        assert_eq!(vec![0x55_u8; BLOCK_SIZE], dl[0..BLOCK_SIZE]);
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE], &buffer[0..BLOCK_SIZE]);
 
         // Verify data in the second block is from the 2nd write
         assert_eq!(
             vec![0x99_u8; BLOCK_SIZE],
-            dl[(BLOCK_SIZE)..(BLOCK_SIZE * 2)]
+            &buffer[(BLOCK_SIZE)..(BLOCK_SIZE * 2)]
         );
 
         Ok(())
@@ -3682,7 +3640,7 @@ mod test {
         // Read a block past the end of the extent
         let buffer = Buffer::new(BLOCK_SIZE);
         let res = guest
-            .read(Block::new(11, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+            .read(Block::new(11, BLOCK_SIZE.trailing_zeros()), buffer)
             .await;
 
         assert!(res.is_err());
@@ -3718,7 +3676,7 @@ mod test {
         // Read a block with buffer that extends past the end of the region
         let buffer = Buffer::new(BLOCK_SIZE * 2);
         let res = guest
-            .read(Block::new(10, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+            .read(Block::new(10, BLOCK_SIZE.trailing_zeros()), buffer)
             .await;
 
         assert!(res.is_err());
@@ -3869,8 +3827,8 @@ mod test {
         volume.activate().await.unwrap();
 
         let buffer = Buffer::new(bytes.len());
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await
             .unwrap();
 
@@ -3879,10 +3837,7 @@ mod test {
         for i in (0..bytes.len()).step_by(BLOCK_SIZE) {
             let start = i;
             let end = i + BLOCK_SIZE;
-            assert_eq!(
-                bytes[..][start..end],
-                buffer.as_vec().await[start..end]
-            );
+            assert_eq!(&bytes[..][start..end], &buffer[start..end]);
             eprintln!("{} {} ok", start, end);
         }
     }
@@ -3980,15 +3935,12 @@ mod test {
             volume.activate().await.unwrap();
 
             let buffer = Buffer::new(5120);
-            volume
-                .read(
-                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                    buffer.clone(),
-                )
+            let buffer = volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
                 .await
                 .unwrap();
 
-            assert_eq!(vec![0x00; 5120], *buffer.as_vec().await);
+            assert_eq!(vec![0x00; 5120], &buffer[..]);
 
             volume.deactivate().await.unwrap();
 
@@ -4035,12 +3987,12 @@ mod test {
         volume.activate().await.unwrap();
 
         let buffer = Buffer::new(5120);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await
             .unwrap();
 
-        assert_eq!(vec![0x55; 5120], *buffer.as_vec().await);
+        assert_eq!(vec![0x55; 5120], &buffer[..]);
     }
 
     #[tokio::test]
@@ -4113,12 +4065,12 @@ mod test {
         volume.activate().await.unwrap();
 
         let buffer = Buffer::new(5120);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await
             .unwrap();
 
-        let buffer_data = &*buffer.as_vec().await;
+        let buffer_data = &&buffer[..];
 
         for i in 0..10 {
             let start = i * 512;
@@ -4177,14 +4129,14 @@ mod test {
 
         let buffer =
             Buffer::new(crucible_pantry::pantry::PantryEntry::MAX_CHUNK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await
             .unwrap();
 
         assert_eq!(
             vec![0x99; crucible_pantry::pantry::PantryEntry::MAX_CHUNK_SIZE],
-            *buffer.as_vec().await
+            &buffer[..]
         );
     }
 
@@ -4314,15 +4266,12 @@ mod test {
             volume.activate().await.unwrap();
 
             let buffer = Buffer::new(data.len());
-            volume
-                .read(
-                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                    buffer.clone(),
-                )
+            let buffer = volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
                 .await
                 .unwrap();
 
-            assert_eq!(data, *buffer.as_vec().await);
+            assert_eq!(data, &buffer[..]);
 
             volume.deactivate().await.unwrap();
 
@@ -4412,12 +4361,12 @@ mod test {
         volume.activate().await.unwrap();
 
         let buffer = Buffer::new(data.len());
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await
             .unwrap();
 
-        assert_eq!(data, *buffer.as_vec().await);
+        assert_eq!(data, &buffer[..]);
     }
 
     #[tokio::test]
@@ -4903,12 +4852,12 @@ mod test {
 
         // Read parent, verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await
             .unwrap();
 
-        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         // Make one new downstairs
         let new_downstairs = tds.new_downstairs().await.unwrap();
@@ -4943,11 +4892,11 @@ mod test {
         volume.target_replace(original, replacement).await.unwrap();
         info!(log, "send read now");
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await
             .unwrap();
 
-        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], *buffer.as_vec().await);
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
     }
 }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -402,7 +402,7 @@ mod test {
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x00_u8; BLOCK_SIZE * 10], buffer.into_vec());
+        assert_eq!(vec![0x00_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         // Write data in
         volume
@@ -418,7 +418,7 @@ mod test {
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], buffer.into_vec());
+        assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         Ok(())
     }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -397,9 +397,9 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are zero on init
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x00_u8; BLOCK_SIZE * 10], &buffer[..]);
@@ -413,9 +413,9 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
@@ -449,9 +449,9 @@ mod test {
         volume.activate().await?;
 
         // A read of zero length does not error.
-        let buffer = Buffer::new(0);
-        let _buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(0);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // A write of zero length does not return error.
@@ -499,9 +499,9 @@ mod test {
             )
             .await?;
 
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = in_memory_data
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        in_memory_data
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
@@ -524,9 +524,9 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 11 on init
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
@@ -549,17 +549,17 @@ mod test {
         }
 
         // Verify parent wasn't written to
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = in_memory_data
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        in_memory_data
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![55; BLOCK_SIZE * 10], &buffer[..]);
@@ -588,9 +588,9 @@ mod test {
             )
             .await?;
 
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = in_memory_data
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        in_memory_data
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
@@ -624,9 +624,9 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 11 on init
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
@@ -640,17 +640,17 @@ mod test {
             .await?;
 
         // Verify parent wasn't written to
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = in_memory_data
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        in_memory_data
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![55; BLOCK_SIZE * 10], &buffer[..]);
@@ -709,9 +709,9 @@ mod test {
         volume.activate().await?;
 
         // Read one block: should be all 0xff
-        let buffer = Buffer::new(BLOCK_SIZE);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0xff; BLOCK_SIZE], &buffer[..]);
@@ -725,9 +725,9 @@ mod test {
             .await?;
 
         // Read one block: should be all 0x01
-        let buffer = Buffer::new(BLOCK_SIZE);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x01; BLOCK_SIZE], &buffer[..]);
@@ -762,9 +762,9 @@ mod test {
         volume.activate().await?;
 
         // Read one block: should be all 0x00
-        let buffer = Buffer::new(BLOCK_SIZE);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x00; BLOCK_SIZE], &buffer[..]);
@@ -818,9 +818,9 @@ mod test {
             .await?;
 
         // Read volume, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
@@ -834,9 +834,9 @@ mod test {
             .await?;
 
         // Read volume, verify original contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
@@ -889,9 +889,9 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
@@ -905,9 +905,9 @@ mod test {
             .await?;
 
         // Read volume, verify original contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
@@ -970,9 +970,9 @@ mod test {
             .await?;
 
         // Read and verify
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // Verify data in the first block is from the first write
@@ -1045,9 +1045,9 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(full_volume_size);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(full_volume_size);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x55_u8; full_volume_size], &buffer[..]);
@@ -1061,9 +1061,9 @@ mod test {
             .await?;
 
         // Read volume, verify original contents
-        let buffer = Buffer::new(full_volume_size);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(full_volume_size);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x55_u8; full_volume_size], &buffer[..]);
@@ -1132,9 +1132,9 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 2);
-        let buffer = volume
-            .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 2);
+        volume
+            .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 2], &buffer[..]);
@@ -1151,9 +1151,9 @@ mod test {
 
         // Read full volume, verify first write_unwritten still valid, but the
         // other blocks of the 2nd write_unwritten are updated.
-        let buffer = Buffer::new(full_volume_size);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(full_volume_size);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // Verify data in blocks 0-9 is the second write_unwritten
@@ -1255,9 +1255,9 @@ mod test {
             .await?;
 
         // Read full volume
-        let buffer = Buffer::new(full_volume_size);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(full_volume_size);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // Verify data in blocks 0-7 is the second write_unwritten
@@ -1311,9 +1311,9 @@ mod test {
             .await?;
 
         // Read back in_memory, verify 1s
-        let buffer = Buffer::new(BLOCK_SIZE * 5);
-        let buffer = in_memory_data
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 5);
+        in_memory_data
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 5], &buffer[..]);
@@ -1336,9 +1336,9 @@ mod test {
         volume.activate().await?;
 
         // Verify parent contents in one read
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         let mut expected = vec![11; BLOCK_SIZE * 5];
@@ -1355,9 +1355,9 @@ mod test {
         }
 
         // Verify volume contents in one read
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![55; BLOCK_SIZE * 10], &buffer[..]);
@@ -1416,9 +1416,9 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 11 at startup
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
@@ -1437,9 +1437,9 @@ mod test {
             .await?;
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
@@ -1499,17 +1499,17 @@ mod test {
         volume.activate().await?;
 
         // Verify contents of RO parent are 1s at startup
-        let buffer = Buffer::new(BLOCK_SIZE * 5);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 5);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 5], &buffer[..]);
 
         // Verify contents of blocks 5-10 are zero.
-        let buffer = Buffer::new(BLOCK_SIZE * 5);
-        let buffer = volume
-            .read(Block::new(5, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 5);
+        volume
+            .read(Block::new(5, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![00; BLOCK_SIZE * 5], &buffer[..]);
@@ -1528,9 +1528,9 @@ mod test {
             .await?;
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // Verify data in the first half is from the RO parent
@@ -1621,9 +1621,9 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // First blocks are 1s   |11--------|
@@ -1695,9 +1695,9 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 11 at startup
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
@@ -1714,9 +1714,9 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![55; BLOCK_SIZE * 10], &buffer[..]);
@@ -1811,9 +1811,9 @@ mod test {
             .await?;
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 2);
-        let buffer = volume
-            .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 2);
+        volume
+            .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![22; BLOCK_SIZE * 2], &buffer[..]);
@@ -1830,9 +1830,9 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read full volume
-        let buffer = Buffer::new(BLOCK_SIZE * 20);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 20);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // Build the expected vec to compare our read with.
@@ -1938,9 +1938,9 @@ mod test {
             .await?;
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 2);
-        let buffer = volume
-            .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 2);
+        volume
+            .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![22; BLOCK_SIZE * 2], &buffer[..]);
@@ -1967,9 +1967,9 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read full volume
-        let buffer = Buffer::new(BLOCK_SIZE * 20);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 20);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // Build the expected vec to compare our read with.
@@ -2041,16 +2041,16 @@ mod test {
         volume2.activate().await?;
 
         // Read one block: should be all 0x00
-        let buffer = Buffer::new(BLOCK_SIZE);
-        let buffer = volume1
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE);
+        volume1
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x00; BLOCK_SIZE], &buffer[..]);
 
-        let buffer = Buffer::new(BLOCK_SIZE);
-        let buffer = volume2
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE);
+        volume2
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x00; BLOCK_SIZE], &buffer[..]);
@@ -2094,9 +2094,9 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 00 at startup
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0; BLOCK_SIZE * 10], &buffer[..]);
@@ -2113,9 +2113,9 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read and verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // Build the expected vec to compare our read with.
@@ -2194,9 +2194,9 @@ mod test {
 
             volume.activate().await?;
 
-            let buffer = Buffer::new(volume.total_size().await? as usize);
-            let buffer = volume
-                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+            let mut buffer = Buffer::new(volume.total_size().await? as usize);
+            volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
                 .await?;
 
             assert_eq!(&buffer[..], random_buffer);
@@ -2251,9 +2251,9 @@ mod test {
 
         // Validate that source blocks originally come from the read-only parent
         {
-            let buffer = Buffer::new(volume.total_size().await? as usize);
-            let buffer = volume
-                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+            let mut buffer = Buffer::new(volume.total_size().await? as usize);
+            volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
                 .await?;
 
             assert_eq!(&buffer[..], random_buffer);
@@ -2271,9 +2271,9 @@ mod test {
             .await?;
 
         {
-            let buffer = Buffer::new(volume.total_size().await? as usize);
-            let buffer = volume
-                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+            let mut buffer = Buffer::new(volume.total_size().await? as usize);
+            volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
                 .await?;
 
             assert_eq!(&buffer[..BLOCK_SIZE], vec![0u8; BLOCK_SIZE]);
@@ -2368,9 +2368,9 @@ mod test {
 
             volume.activate().await?;
 
-            let buffer = Buffer::new(volume.total_size().await? as usize);
-            let buffer = volume
-                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+            let mut buffer = Buffer::new(volume.total_size().await? as usize);
+            volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
                 .await?;
 
             assert_eq!(&buffer[..], random_buffer);
@@ -2433,9 +2433,9 @@ mod test {
 
         // Validate that source blocks originally come from the read-only parent
         {
-            let buffer = Buffer::new(volume.total_size().await? as usize);
-            let buffer = volume
-                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+            let mut buffer = Buffer::new(volume.total_size().await? as usize);
+            volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
                 .await?;
 
             assert_eq!(&buffer[..], random_buffer);
@@ -2453,9 +2453,9 @@ mod test {
             .await?;
 
         {
-            let buffer = Buffer::new(volume.total_size().await? as usize);
-            let buffer = volume
-                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+            let mut buffer = Buffer::new(volume.total_size().await? as usize);
+            volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
                 .await?;
 
             assert_eq!(&buffer[..BLOCK_SIZE], vec![0u8; BLOCK_SIZE]);
@@ -2543,9 +2543,9 @@ mod test {
 
         volume.activate().await?;
         // Validate that source blocks are the same
-        let buffer = Buffer::new(volume.total_size().await? as usize);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(volume.total_size().await? as usize);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(&buffer[..], random_buffer);
@@ -2633,9 +2633,9 @@ mod test {
         }
 
         // Read back what we wrote.
-        let buffer = Buffer::new(volume.total_size().await? as usize);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(volume.total_size().await? as usize);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(&buffer[BLOCK_SIZE..], &random_buffer[BLOCK_SIZE..]);
@@ -2941,9 +2941,9 @@ mod test {
         }
 
         // Read back what we wrote.
-        let buffer = Buffer::new(new_volume.total_size().await? as usize);
-        let buffer = new_volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(new_volume.total_size().await? as usize);
+        new_volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(&buffer[BLOCK_SIZE..], &random_buffer[BLOCK_SIZE..]);
@@ -3004,11 +3004,11 @@ mod test {
             }
 
             for (i, random_buffer) in chunks {
-                let buffer = Buffer::new(CHUNK_SIZE);
-                let buffer = volume
+                let mut buffer = Buffer::new(CHUNK_SIZE);
+                volume
                     .read(
                         Block::new(i as u64, BLOCK_SIZE.trailing_zeros()),
-                        buffer,
+                        &mut buffer,
                     )
                     .await?;
 
@@ -3044,9 +3044,9 @@ mod test {
         guest.query_work_queue().await?;
 
         // Verify contents are zero on init
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x00_u8; BLOCK_SIZE * 10], &buffer[..]);
@@ -3060,9 +3060,9 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
@@ -3088,9 +3088,9 @@ mod test {
         guest.query_work_queue().await?;
 
         // Read of length 0
-        let buffer = Buffer::new(0);
-        let _buffer = guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(0);
+        guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // Write of length 0
@@ -3171,9 +3171,9 @@ mod test {
         }
 
         // Read back our block post replacement, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
@@ -3287,9 +3287,9 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
@@ -3303,9 +3303,9 @@ mod test {
             .await?;
 
         // Read back the same blocks.
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // Verify data is still the original contents.
@@ -3320,9 +3320,9 @@ mod test {
             .await?;
 
         // Read back the same blocks.
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // Verify data is now from the new write.
@@ -3369,18 +3369,18 @@ mod test {
             .await?;
 
         // Read back the first block.
-        let buffer = Buffer::new(BLOCK_SIZE);
-        let buffer = guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE);
+        guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // Verify data is still the original contents.
         assert_eq!(vec![0x55_u8; BLOCK_SIZE], &buffer[..]);
 
         // Read back the next two blocks.
-        let buffer = Buffer::new(BLOCK_SIZE * 2);
-        let buffer = guest
-            .read(Block::new(1, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 2);
+        guest
+            .read(Block::new(1, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // Verify data is still the original contents.
@@ -3427,9 +3427,9 @@ mod test {
             .await?;
 
         // Read back the all three blocks.
-        let buffer = Buffer::new(BLOCK_SIZE * 3);
-        let buffer = guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 3);
+        guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // Verify data in the first block is from the second write_unwritten
@@ -3486,9 +3486,9 @@ mod test {
             .await?;
 
         // Read back the all three blocks.
-        let buffer = Buffer::new(BLOCK_SIZE * 3);
-        let buffer = guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 3);
+        guest
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // Verify data in the first two blocks is the data from the
@@ -3540,9 +3540,9 @@ mod test {
             .await?;
 
         // Read back both blocks
-        let buffer = Buffer::new(BLOCK_SIZE * 2);
-        let buffer = guest
-            .read(Block::new(4, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 2);
+        guest
+            .read(Block::new(4, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // Verify data in the first block is the data from the first write.
@@ -3594,9 +3594,9 @@ mod test {
             .await?;
 
         // Read back both blocks
-        let buffer = Buffer::new(BLOCK_SIZE * 2);
-        let buffer = guest
-            .read(Block::new(4, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 2);
+        guest
+            .read(Block::new(4, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         // Verify data in the first block is the data from the first write.
@@ -3638,9 +3638,9 @@ mod test {
         assert!(res.is_err());
 
         // Read a block past the end of the extent
-        let buffer = Buffer::new(BLOCK_SIZE);
+        let mut buffer = Buffer::new(BLOCK_SIZE);
         let res = guest
-            .read(Block::new(11, BLOCK_SIZE.trailing_zeros()), buffer)
+            .read(Block::new(11, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await;
 
         assert!(res.is_err());
@@ -3674,9 +3674,9 @@ mod test {
         assert!(res.is_err());
 
         // Read a block with buffer that extends past the end of the region
-        let buffer = Buffer::new(BLOCK_SIZE * 2);
+        let mut buffer = Buffer::new(BLOCK_SIZE * 2);
         let res = guest
-            .read(Block::new(10, BLOCK_SIZE.trailing_zeros()), buffer)
+            .read(Block::new(10, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await;
 
         assert!(res.is_err());
@@ -3826,9 +3826,9 @@ mod test {
         let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let buffer = Buffer::new(bytes.len());
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(bytes.len());
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await
             .unwrap();
 
@@ -3934,9 +3934,9 @@ mod test {
                 .unwrap();
             volume.activate().await.unwrap();
 
-            let buffer = Buffer::new(5120);
-            let buffer = volume
-                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+            let mut buffer = Buffer::new(5120);
+            volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
                 .await
                 .unwrap();
 
@@ -3986,9 +3986,9 @@ mod test {
         let volume = Volume::construct(vcr, None, log.clone()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let buffer = Buffer::new(5120);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(5120);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await
             .unwrap();
 
@@ -4064,9 +4064,9 @@ mod test {
         let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let buffer = Buffer::new(5120);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(5120);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await
             .unwrap();
 
@@ -4127,10 +4127,10 @@ mod test {
         let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let buffer =
+        let mut buffer =
             Buffer::new(crucible_pantry::pantry::PantryEntry::MAX_CHUNK_SIZE);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await
             .unwrap();
 
@@ -4265,9 +4265,9 @@ mod test {
             let volume = Volume::construct(vcr, None, csl()).await.unwrap();
             volume.activate().await.unwrap();
 
-            let buffer = Buffer::new(data.len());
-            let buffer = volume
-                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+            let mut buffer = Buffer::new(data.len());
+            volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
                 .await
                 .unwrap();
 
@@ -4360,9 +4360,9 @@ mod test {
         let volume = Volume::construct(vcr, None, log.clone()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let buffer = Buffer::new(data.len());
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(data.len());
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await
             .unwrap();
 
@@ -4851,9 +4851,9 @@ mod test {
             .unwrap();
 
         // Read parent, verify contents
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await
             .unwrap();
 
@@ -4891,9 +4891,9 @@ mod test {
         info!(log, "Replace VCR now: {:?}", replacement);
         volume.target_replace(original, replacement).await.unwrap();
         info!(log, "send read now");
-        let buffer = Buffer::new(BLOCK_SIZE * 10);
-        let buffer = volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await
             .unwrap();
 

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -135,9 +135,6 @@ async fn main() -> Result<()> {
         1
     };
 
-    let read_buffers: Vec<Buffer> =
-        (0..io_depth).map(|_| Buffer::new(io_size)).collect();
-
     let mut io_operations_sent = 0;
     let mut bw_consumed = 0;
     let mut measurement_time = Instant::now();
@@ -146,44 +143,58 @@ async fn main() -> Result<()> {
     let mut bws: Vec<f32> = vec![];
 
     'outer: loop {
-        let mut futures = Vec::with_capacity(io_depth);
+        enum RandomOp {
+            Read(u64, Buffer),
+            Write(u64, Bytes),
+        }
 
-        let write_buffers: Vec<Bytes> = (0..io_depth)
-            .map(|_| {
-                Bytes::from(if opt.all_zeroes {
+        let mut ops = Vec::with_capacity(io_depth);
+        for _ in 0..io_depth {
+            let offset: u64 =
+                rng.gen::<u64>() % (total_blocks - io_size as u64 / bsz);
+
+            if rng.gen::<bool>() {
+                ops.push(RandomOp::Read(offset, Buffer::new(io_size)));
+            } else {
+                let bytes = Bytes::from(if opt.all_zeroes {
                     vec![0u8; io_size]
                 } else {
                     (0..io_size)
                         .map(|_| rng.sample(rand::distributions::Standard))
                         .collect::<Vec<u8>>()
-                })
-            })
-            .collect();
-
-        let io_operation_time = Instant::now();
-
-        for i in 0..io_depth {
-            let offset: u64 =
-                rng.gen::<u64>() % (total_blocks - io_size as u64 / bsz);
-
-            if rng.gen::<bool>() {
-                let future = guest.write_to_byte_offset(
-                    offset * bsz,
-                    write_buffers[i].clone(),
-                );
-
-                futures.push(future);
-            } else {
-                let future = guest.read_from_byte_offset(
-                    offset * bsz,
-                    read_buffers[i].clone(),
-                );
-
-                futures.push(future);
+                });
+                ops.push(RandomOp::Write(offset, bytes));
             }
         }
 
-        crucible::join_all(futures).await?;
+        let mut read_futures = Vec::with_capacity(io_depth);
+        let mut write_futures = Vec::with_capacity(io_depth);
+
+        let io_operation_time = Instant::now();
+
+        for op in ops {
+            let guest = guest.clone();
+            match op {
+                RandomOp::Read(offset, buffer) => {
+                    read_futures.push(tokio::spawn(async move {
+                        guest.read_from_byte_offset(offset * bsz, buffer).await
+                    }));
+                }
+
+                RandomOp::Write(offset, bytes) => {
+                    write_futures.push(tokio::spawn(async move {
+                        guest.write_to_byte_offset(offset * bsz, bytes).await
+                    }));
+                }
+            }
+        }
+
+        for future in read_futures {
+            future.await??;
+        }
+        for future in write_futures {
+            future.await??;
+        }
 
         total_io_time += io_operation_time.elapsed();
         io_operations_sent +=

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -190,7 +190,7 @@ async fn main() -> Result<()> {
         }
 
         for future in read_futures {
-            future.await??;
+            let _buffer = future.await??;
         }
         for future in write_futures {
             future.await??;

--- a/pantry/src/pantry.rs
+++ b/pantry/src/pantry.rs
@@ -294,11 +294,9 @@ impl PantryEntry {
 
         let buffer = crucible::Buffer::new(size);
 
-        self.volume
-            .read_from_byte_offset(offset, buffer.clone())
-            .await?;
+        let buffer = self.volume.read_from_byte_offset(offset, buffer).await?;
 
-        Ok(buffer.into_vec().unwrap())
+        Ok(buffer.into_vec())
     }
 
     pub async fn scrub(&self) -> Result<(), CrucibleError> {
@@ -336,11 +334,9 @@ impl PantryEntry {
 
             let data = crucible::Buffer::new((end - start) as usize);
 
-            self.volume
-                .read_from_byte_offset(start, data.clone())
-                .await?;
+            let data = self.volume.read_from_byte_offset(start, data).await?;
 
-            hasher.update(&data.into_vec().unwrap())
+            hasher.update(&data.into_vec())
         }
 
         let digest = hex::encode(hasher.finalize());

--- a/upstairs/Cargo.toml
+++ b/upstairs/Cargo.toml
@@ -60,6 +60,7 @@ tokio-test.workspace = true
 tempfile.workspace = true
 test-strategy.workspace = true
 proptest.workspace = true
+httptest.workspace = true
 
 [build-dependencies]
 version_check = "0.9.4"

--- a/upstairs/Cargo.toml
+++ b/upstairs/Cargo.toml
@@ -60,7 +60,6 @@ tokio-test.workspace = true
 tempfile.workspace = true
 test-strategy.workspace = true
 proptest.workspace = true
-httptest.workspace = true
 
 [build-dependencies]
 version_check = "0.9.4"

--- a/upstairs/src/block_io.rs
+++ b/upstairs/src/block_io.rs
@@ -63,8 +63,8 @@ impl BlockIO for FileBlockIO {
     async fn read(
         &self,
         offset: Block,
-        mut data: Buffer,
-    ) -> Result<Buffer, CrucibleError> {
+        data: &mut Buffer,
+    ) -> Result<(), CrucibleError> {
         let start: usize = (offset.value * self.block_size) as usize;
 
         let mut file = self.file.lock().await;
@@ -74,7 +74,7 @@ impl BlockIO for FileBlockIO {
         file.read_exact(&mut buf)?;
         data.write(0, &buf);
 
-        Ok(data)
+        Ok(())
     }
 
     async fn write(
@@ -205,8 +205,8 @@ impl BlockIO for ReqwestBlockIO {
     async fn read(
         &self,
         offset: Block,
-        mut data: Buffer,
-    ) -> Result<Buffer, CrucibleError> {
+        data: &mut Buffer,
+    ) -> Result<(), CrucibleError> {
         let cc = self.next_count();
         cdt::reqwest__read__start!(|| (cc, self.uuid));
 
@@ -253,7 +253,7 @@ impl BlockIO for ReqwestBlockIO {
         data.write(0, &bytes);
 
         cdt::reqwest__read__done!(|| (cc, self.uuid));
-        Ok(data)
+        Ok(())
     }
 
     async fn write(

--- a/upstairs/src/block_io.rs
+++ b/upstairs/src/block_io.rs
@@ -12,6 +12,7 @@ pub struct FileBlockIO {
     block_size: u64,
     total_size: u64,
     file: Mutex<File>,
+    owned: Mutex<Vec<bool>>,
 }
 
 impl FileBlockIO {
@@ -22,12 +23,14 @@ impl FileBlockIO {
             }
             Ok(f) => {
                 let total_size = f.metadata()?.len();
+                let owned = vec![false; total_size as usize];
 
                 Ok(Self {
                     uuid: id,
                     block_size,
                     total_size,
                     file: Mutex::new(f),
+                    owned: Mutex::new(owned),
                 })
             }
         }
@@ -72,7 +75,9 @@ impl BlockIO for FileBlockIO {
 
         let mut buf = vec![0u8; data.len()];
         file.read_exact(&mut buf)?;
-        data.write(0, &buf);
+
+        let owned = self.owned.lock().await;
+        data.write_with_ownership(0, &buf, &owned[start..][..data.len()]);
 
         Ok(data)
     }
@@ -87,6 +92,9 @@ impl BlockIO for FileBlockIO {
         let mut file = self.file.lock().await;
         file.seek(SeekFrom::Start(start))?;
         file.write_all(&data[..])?;
+
+        let mut owned = self.owned.lock().await;
+        owned[(start as usize)..][..data.len()].fill(true);
 
         Ok(())
     }
@@ -280,5 +288,135 @@ impl BlockIO for ReqwestBlockIO {
             ds_count: 0,
             active_count: 0,
         })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use httptest::{matchers::*, responders::*, Expectation, ServerBuilder};
+    use tempfile::tempdir;
+
+    const BLOCK_SIZE: usize = 512;
+
+    /// Test that `block_io`, which is at least of size 1024, has the proper
+    /// ownership behaviour.
+    async fn test_ownership(block_io: impl BlockIO) -> Result<()> {
+        // Ownership starts off false
+
+        let buffer = Buffer::new(1024);
+        let buffer = block_io
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+            .await?;
+
+        assert_eq!(buffer.owned_ref(), &[false; 1024]);
+
+        // Ownership is set by writing to blocks
+
+        block_io
+            .write(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(vec![9; 512]),
+            )
+            .await?;
+
+        // Ownership is returned properly
+
+        let buffer = Buffer::new(1024);
+        let buffer = block_io
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+            .await?;
+
+        let mut expected = vec![9u8; 512];
+        expected.extend(vec![0u8; 512]);
+
+        assert_eq!(&*buffer, &expected);
+
+        let mut expected_ownership = vec![true; 512];
+        expected_ownership.extend(vec![false; 512]);
+
+        assert_eq!(buffer.owned_ref(), &expected_ownership);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ownership_file() -> Result<()> {
+        let dir = tempdir()?;
+        let mut path = dir.path().to_path_buf();
+        path.push("downstairs");
+
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)?;
+        file.set_len(2048)?;
+        drop(file);
+
+        let block_io = FileBlockIO::new(
+            Uuid::new_v4(),
+            BLOCK_SIZE as u64,
+            path.into_os_string().into_string().unwrap(),
+        )?;
+
+        test_ownership(block_io).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ownership_in_memory() -> Result<()> {
+        let block_io =
+            InMemoryBlockIO::new(Uuid::new_v4(), BLOCK_SIZE as u64, 2048);
+
+        test_ownership(block_io).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ownership_http() -> Result<()> {
+        // ReqwestBlockIO does not support write so we can't use the
+        // `test_ownership` helper. Also, httptest's server does not support
+        // Range requests, so we have to limit it to one block.
+
+        let server = ServerBuilder::new().run()?;
+
+        server.expect(
+            Expectation::matching(request::method_path("HEAD", "/image.raw"))
+                .times(1..)
+                .respond_with(
+                    status_code(200)
+                        .append_header("Content-Length", format!("{}", 512)),
+                ),
+        );
+
+        server.expect(
+            Expectation::matching(request::method_path("GET", "/image.raw"))
+                .times(1..)
+                .respond_with(status_code(200).body(vec![9; 512])),
+        );
+
+        let block_io = ReqwestBlockIO::new(
+            Uuid::new_v4(),
+            BLOCK_SIZE as u64,
+            server.url("/image.raw").to_string(),
+        )
+        .await?;
+
+        // Ownership from this will be true always, `ReqwestBlockIO` does not
+        // support writes.
+
+        let buffer = Buffer::new(512);
+        let buffer = block_io
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
+            .await?;
+
+        assert_eq!(&*buffer, &[9; 512]);
+        assert_eq!(buffer.owned_ref(), &[true; 512]);
+
+        Ok(())
     }
 }

--- a/upstairs/src/block_io.rs
+++ b/upstairs/src/block_io.rs
@@ -63,22 +63,18 @@ impl BlockIO for FileBlockIO {
     async fn read(
         &self,
         offset: Block,
-        data: Buffer,
-    ) -> Result<(), CrucibleError> {
-        let mut data_vec = data.as_vec().await;
-        let mut owned_vec = data.owned_vec().await;
-
-        let start = offset.value * self.block_size;
+        mut data: Buffer,
+    ) -> Result<Buffer, CrucibleError> {
+        let start: usize = (offset.value * self.block_size) as usize;
 
         let mut file = self.file.lock().await;
-        file.seek(SeekFrom::Start(start))?;
-        file.read_exact(&mut data_vec[..])?;
+        file.seek(SeekFrom::Start(start as u64))?;
 
-        for i in 0..data_vec.len() {
-            owned_vec[i] = true;
-        }
+        let mut buf = vec![0u8; data.len()];
+        file.read_exact(&mut buf)?;
+        data.write(0, &buf);
 
-        Ok(())
+        Ok(data)
     }
 
     async fn write(
@@ -209,13 +205,10 @@ impl BlockIO for ReqwestBlockIO {
     async fn read(
         &self,
         offset: Block,
-        data: Buffer,
-    ) -> Result<(), CrucibleError> {
+        mut data: Buffer,
+    ) -> Result<Buffer, CrucibleError> {
         let cc = self.next_count();
         cdt::reqwest__read__start!(|| (cc, self.uuid));
-
-        let mut data_vec = data.as_vec().await;
-        let mut owned_vec = data.owned_vec().await;
 
         let start = offset.value * self.block_size;
 
@@ -224,11 +217,7 @@ impl BlockIO for ReqwestBlockIO {
             .get(&self.url)
             .header(
                 RANGE,
-                format!(
-                    "bytes={}-{}",
-                    start,
-                    start + data_vec.len() as u64 - 1
-                ),
+                format!("bytes={}-{}", start, start + data.len() as u64 - 1),
             )
             .send()
             .await
@@ -246,20 +235,17 @@ impl BlockIO for ReqwestBlockIO {
         )
         .map_err(|e| CrucibleError::GenericError(e.to_string()))?;
 
-        assert_eq!(total_size, data_vec.len() as u64);
+        assert_eq!(total_size, data.len() as u64);
 
         let bytes = response
             .bytes()
             .await
             .map_err(|e| CrucibleError::GenericError(e.to_string()))?;
 
-        for i in 0..data_vec.len() {
-            data_vec[i] = bytes[i];
-            owned_vec[i] = true;
-        }
+        data.write(0, &bytes);
 
         cdt::reqwest__read__done!(|| (cc, self.uuid));
-        Ok(())
+        Ok(data)
     }
 
     async fn write(

--- a/upstairs/src/block_io.rs
+++ b/upstairs/src/block_io.rs
@@ -243,7 +243,15 @@ impl BlockIO for ReqwestBlockIO {
         )
         .map_err(|e| CrucibleError::GenericError(e.to_string()))?;
 
-        assert_eq!(total_size, data.len() as u64);
+        // Did the HTTP server _not_ honour the Range request?
+        if total_size != data.len() as u64 {
+            crucible_bail!(
+                IoError,
+                "Requested {} bytes but HTTP server returned {}!",
+                data.len(),
+                total_size
+            );
+        }
 
         let bytes = response
             .bytes()

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -655,10 +655,10 @@ pub(crate) mod protocol_test {
             // We must tokio::spawn here because `read` will wait for the
             // response to come back before returning
             tokio::spawn(async move {
-                let buffer = Buffer::new(512);
-                let _buffer = harness
+                let mut buffer = Buffer::new(512);
+                harness
                     .guest
-                    .read(Block::new_512(0), buffer)
+                    .read(Block::new_512(0), &mut buffer)
                     .await
                     .unwrap();
             });
@@ -709,10 +709,10 @@ pub(crate) mod protocol_test {
             let harness = harness.clone();
 
             tokio::spawn(async move {
-                let buffer = Buffer::new(512);
-                let _buffer = harness
+                let mut buffer = Buffer::new(512);
+                harness
                     .guest
-                    .read(Block::new_512(0), buffer)
+                    .read(Block::new_512(0), &mut buffer)
                     .await
                     .unwrap();
             });
@@ -867,10 +867,10 @@ pub(crate) mod protocol_test {
             // We must tokio::spawn here because `read` will wait for the
             // response to come back before returning
             tokio::spawn(async move {
-                let buffer = Buffer::new(512);
-                let _buffer = harness
+                let mut buffer = Buffer::new(512);
+                harness
                     .guest
-                    .read(Block::new_512(0), buffer)
+                    .read(Block::new_512(0), &mut buffer)
                     .await
                     .unwrap();
             });
@@ -951,10 +951,10 @@ pub(crate) mod protocol_test {
                 // We must tokio::spawn here because `read` will wait for the
                 // response to come back before returning
                 tokio::spawn(async move {
-                    let buffer = Buffer::new(512);
-                    let _buffer = harness
+                    let mut buffer = Buffer::new(512);
+                    harness
                         .guest
-                        .read(Block::new_512(0), buffer)
+                        .read(Block::new_512(0), &mut buffer)
                         .await
                         .unwrap();
                 });
@@ -1255,10 +1255,13 @@ pub(crate) mod protocol_test {
                 {
                     let harness = harness.clone();
                     tokio::spawn(async move {
-                        let buffer = Buffer::new(512);
-                        let _buffer = harness
+                        let mut buffer = Buffer::new(512);
+                        harness
                             .guest
-                            .read(Block::new_512(io_eid as u64 * 10), buffer)
+                            .read(
+                                Block::new_512(io_eid as u64 * 10),
+                                &mut buffer,
+                            )
                             .await
                             .unwrap();
                     })
@@ -1933,10 +1936,10 @@ pub(crate) mod protocol_test {
                 // We must tokio::spawn here because `read` will wait for the
                 // response to come back before returning
                 tokio::spawn(async move {
-                    let buffer = Buffer::new(512);
-                    let _buffer = harness
+                    let mut buffer = Buffer::new(512);
+                    harness
                         .guest
-                        .read(Block::new_512(0), buffer)
+                        .read(Block::new_512(0), &mut buffer)
                         .await
                         .unwrap();
                 });
@@ -1987,10 +1990,10 @@ pub(crate) mod protocol_test {
                 // We must tokio::spawn here because `read` will wait for the
                 // response to come back before returning
                 tokio::spawn(async move {
-                    let buffer = Buffer::new(512);
-                    let _buffer = harness
+                    let mut buffer = Buffer::new(512);
+                    harness
                         .guest
-                        .read(Block::new_512(0), buffer)
+                        .read(Block::new_512(0), &mut buffer)
                         .await
                         .unwrap();
                 });
@@ -2691,10 +2694,10 @@ pub(crate) mod protocol_test {
                 // We must tokio::spawn here because `read` will wait for the
                 // response to come back before returning
                 tokio::spawn(async move {
-                    let buffer = Buffer::new(512);
-                    let _buffer = harness
+                    let mut buffer = Buffer::new(512);
+                    harness
                         .guest
-                        .read(Block::new_512(0), buffer)
+                        .read(Block::new_512(0), &mut buffer)
                         .await
                         .unwrap();
                 });
@@ -2940,9 +2943,12 @@ pub(crate) mod protocol_test {
         // We must tokio::spawn here because `read` will wait for the
         // response to come back before returning
         tokio::spawn(async move {
-            let buffer = Buffer::new(512);
-            let _buffer =
-                harness.guest.read(Block::new_512(0), buffer).await.unwrap();
+            let mut buffer = Buffer::new(512);
+            harness
+                .guest
+                .read(Block::new_512(0), &mut buffer)
+                .await
+                .unwrap();
         });
 
         // All downstairs should see it
@@ -2980,10 +2986,10 @@ pub(crate) mod protocol_test {
             // We must tokio::spawn here because `read` will wait for the
             // response to come back before returning
             tokio::spawn(async move {
-                let buffer = Buffer::new(512);
-                let _buffer = harness
+                let mut buffer = Buffer::new(512);
+                harness
                     .guest
-                    .read(Block::new_512(0), buffer)
+                    .read(Block::new_512(0), &mut buffer)
                     .await
                     .unwrap();
             });

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -656,7 +656,11 @@ pub(crate) mod protocol_test {
             // response to come back before returning
             tokio::spawn(async move {
                 let buffer = Buffer::new(512);
-                harness.guest.read(Block::new_512(0), buffer).await.unwrap();
+                let _buffer = harness
+                    .guest
+                    .read(Block::new_512(0), buffer)
+                    .await
+                    .unwrap();
             });
         }
 
@@ -706,7 +710,11 @@ pub(crate) mod protocol_test {
 
             tokio::spawn(async move {
                 let buffer = Buffer::new(512);
-                harness.guest.read(Block::new_512(0), buffer).await.unwrap();
+                let _buffer = harness
+                    .guest
+                    .read(Block::new_512(0), buffer)
+                    .await
+                    .unwrap();
             });
         }
 
@@ -860,7 +868,11 @@ pub(crate) mod protocol_test {
             // response to come back before returning
             tokio::spawn(async move {
                 let buffer = Buffer::new(512);
-                harness.guest.read(Block::new_512(0), buffer).await.unwrap();
+                let _buffer = harness
+                    .guest
+                    .read(Block::new_512(0), buffer)
+                    .await
+                    .unwrap();
             });
         }
 
@@ -940,7 +952,7 @@ pub(crate) mod protocol_test {
                 // response to come back before returning
                 tokio::spawn(async move {
                     let buffer = Buffer::new(512);
-                    harness
+                    let _buffer = harness
                         .guest
                         .read(Block::new_512(0), buffer)
                         .await
@@ -1244,7 +1256,7 @@ pub(crate) mod protocol_test {
                     let harness = harness.clone();
                     tokio::spawn(async move {
                         let buffer = Buffer::new(512);
-                        harness
+                        let _buffer = harness
                             .guest
                             .read(Block::new_512(io_eid as u64 * 10), buffer)
                             .await
@@ -1922,7 +1934,7 @@ pub(crate) mod protocol_test {
                 // response to come back before returning
                 tokio::spawn(async move {
                     let buffer = Buffer::new(512);
-                    harness
+                    let _buffer = harness
                         .guest
                         .read(Block::new_512(0), buffer)
                         .await
@@ -1976,7 +1988,7 @@ pub(crate) mod protocol_test {
                 // response to come back before returning
                 tokio::spawn(async move {
                     let buffer = Buffer::new(512);
-                    harness
+                    let _buffer = harness
                         .guest
                         .read(Block::new_512(0), buffer)
                         .await
@@ -2680,7 +2692,7 @@ pub(crate) mod protocol_test {
                 // response to come back before returning
                 tokio::spawn(async move {
                     let buffer = Buffer::new(512);
-                    harness
+                    let _buffer = harness
                         .guest
                         .read(Block::new_512(0), buffer)
                         .await
@@ -2929,7 +2941,8 @@ pub(crate) mod protocol_test {
         // response to come back before returning
         tokio::spawn(async move {
             let buffer = Buffer::new(512);
-            harness.guest.read(Block::new_512(0), buffer).await.unwrap();
+            let _buffer =
+                harness.guest.read(Block::new_512(0), buffer).await.unwrap();
         });
 
         // All downstairs should see it
@@ -2968,7 +2981,11 @@ pub(crate) mod protocol_test {
             // response to come back before returning
             tokio::spawn(async move {
                 let buffer = Buffer::new(512);
-                harness.guest.read(Block::new_512(0), buffer).await.unwrap();
+                let _buffer = harness
+                    .guest
+                    .read(Block::new_512(0), buffer)
+                    .await
+                    .unwrap();
             });
         }
 

--- a/upstairs/src/in_memory.rs
+++ b/upstairs/src/in_memory.rs
@@ -54,32 +54,31 @@ impl BlockIO for InMemoryBlockIO {
         Ok(self.uuid)
     }
 
+    /// Read from `self` into `data`, setting ownership accordingly
     async fn read(
         &self,
         offset: Block,
         mut data: Buffer,
     ) -> Result<Buffer, CrucibleError> {
-        // Read from self into Buffer
         let inner = self.inner.lock().await;
 
         let start = offset.value as usize * self.block_size as usize;
 
         data.write_with_ownership(
             0,
-            &inner.bytes[start..(start + data.len())],
-            &inner.owned[start..(start + data.len())],
+            &inner.bytes[start..][..data.len()],
+            &inner.owned[start..][..data.len()],
         );
 
         Ok(data)
     }
 
+    /// Write from `data` into `self`, setting all owned bits to `true`
     async fn write(
         &self,
         offset: Block,
         data: Bytes,
     ) -> Result<(), CrucibleError> {
-        // Write from Buffer into self
-
         let mut inner = self.inner.lock().await;
 
         let start = offset.value as usize * self.block_size as usize;

--- a/upstairs/src/in_memory.rs
+++ b/upstairs/src/in_memory.rs
@@ -58,8 +58,8 @@ impl BlockIO for InMemoryBlockIO {
     async fn read(
         &self,
         offset: Block,
-        mut data: Buffer,
-    ) -> Result<Buffer, CrucibleError> {
+        data: &mut Buffer,
+    ) -> Result<(), CrucibleError> {
         let inner = self.inner.lock().await;
 
         let start = offset.value as usize * self.block_size as usize;
@@ -70,7 +70,7 @@ impl BlockIO for InMemoryBlockIO {
             &inner.owned[start..][..data.len()],
         );
 
-        Ok(data)
+        Ok(())
     }
 
     /// Write from `data` into `self`, setting all owned bits to `true`

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1568,10 +1568,6 @@ impl Buffer {
             }
         }
     }
-
-    pub fn owned_ref(&self) -> &[bool] {
-        &self.owned
-    }
 }
 
 impl std::ops::Deref for Buffer {

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1496,6 +1496,7 @@ impl Buffer {
     }
 
     /// Extract the underlying `Vec<u8>` bearing buffered data.
+    #[must_use]
     pub fn into_vec(self) -> Vec<u8> {
         self.data
     }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1553,8 +1553,8 @@ impl Buffer {
         }
     }
 
-    pub fn as_bytes(&self) -> Bytes {
-        Bytes::from(self.data.clone())
+    pub fn into_bytes(self) -> Bytes {
+        Bytes::from(self.data)
     }
 
     /// Consume and layer buffer contents on top of this one

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1511,10 +1511,9 @@ impl Buffer {
 
     pub fn write(&mut self, offset: usize, data: &[u8]) {
         assert!(offset + data.len() <= self.data.len());
-        for i in 0..data.len() {
-            self.data[offset + i] = data[i];
-            self.owned[offset + i] = true;
-        }
+
+        self.data[offset..][..data.len()].copy_from_slice(data);
+        self.owned[offset..][..data.len()].fill(true);
     }
 
     pub fn write_with_ownership(
@@ -1578,6 +1577,20 @@ impl std::ops::Deref for Buffer {
     fn deref(&self) -> &Self::Target {
         &self.data
     }
+}
+
+#[test]
+fn test_buffer_sane() {
+    const BLOCK_SIZE: usize = 512;
+    let mut data = Buffer::new(1024);
+
+    data.write(0, &[99u8; BLOCK_SIZE]);
+
+    let mut read_data = vec![0u8; BLOCK_SIZE];
+    data.read(0, &mut read_data);
+
+    assert_eq!(&read_data[..], &data[..BLOCK_SIZE]);
+    assert_eq!(&data[..BLOCK_SIZE], &[99u8; BLOCK_SIZE]);
 }
 
 #[test]

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1460,6 +1460,7 @@ impl fmt::Display for AckStatus {
  * was shared between cloned BytesMut objects. Additionally, we added the
  * idea of ownership and that necessitated another field.
  */
+#[must_use]
 #[derive(Debug, PartialEq)]
 pub struct Buffer {
     len: usize,

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1538,10 +1538,9 @@ impl Buffer {
     ) {
         assert!(offset + response.data.len() <= self.data.len());
         if !response.block_contexts.is_empty() {
-            for i in 0..response.data.len() {
-                self.data[offset + i] = response.data[i];
-                self.owned[offset + i] = true;
-            }
+            self.data[offset..][..response.data.len()]
+                .copy_from_slice(&response.data);
+            self.owned[offset..][..response.data.len()].fill(true);
         }
     }
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1568,6 +1568,10 @@ impl Buffer {
             }
         }
     }
+
+    pub fn owned_ref(&self) -> &[bool] {
+        &self.owned
+    }
 }
 
 impl std::ops::Deref for Buffer {

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1477,7 +1477,7 @@ impl fmt::Display for AckStatus {
  * information) and be propagated "up".
  */
 #[must_use]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Default)]
 pub struct Buffer {
     len: usize,
     data: Vec<u8>,

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -71,17 +71,17 @@ impl IOSpan {
         &mut self,
         block_io: &Arc<T>,
     ) -> Result<(), CrucibleError> {
-        let buffer = block_io
+        let b = std::mem::take(&mut self.buffer);
+
+        self.buffer = block_io
             .read(
                 Block::new(
                     self.affected_block_numbers[0],
                     self.block_size.trailing_zeros(),
                 ),
-                Buffer::new(self.buffer.len()),
+                b,
             )
             .await?;
-
-        self.buffer.eat(0, buffer);
 
         Ok(())
     }
@@ -329,6 +329,91 @@ impl<T: BlockIO> CruciblePseudoFile<T> {
         let _guard = self.rmw_lock.write().await;
 
         self.block_io.flush(None).await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rand::Rng;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_pseudo_file_sane() -> Result<()> {
+        const BLOCK_SIZE: usize = 512;
+
+        let in_memory = Arc::new(InMemoryBlockIO::new(
+            Uuid::new_v4(),
+            BLOCK_SIZE as u64,
+            1024 * 1024,
+        ));
+        let mut cpf = CruciblePseudoFile::from(in_memory)?;
+        cpf.activate().await?;
+
+        // Should start as zeros (this will not read in anything due to
+        // `in_memory` having all ownership set as false
+        let mut buf = vec![0u8; 3000];
+        cpf.read_exact(&mut buf)?;
+
+        assert_eq!(&buf, &[0u8; 3000]);
+
+        // Writing and reading works
+        cpf.seek(SeekFrom::Start(777))?;
+
+        cpf.write_all(&[7u8; 100])?;
+        cpf.write_all(&[8u8; 100])?;
+        cpf.write_all(&[9u8; 100])?;
+
+        cpf.seek(SeekFrom::Start(877))?;
+
+        let mut buf = vec![99u8; 200];
+        cpf.read_exact(&mut buf)?;
+
+        assert_eq!(&buf[0..100], &[8u8; 100]);
+        assert_eq!(&buf[100..200], &[9u8; 100]);
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_pseudo_file_hammer() -> Result<()> {
+        const BLOCK_SIZE: usize = 512;
+
+        let in_memory = Arc::new(InMemoryBlockIO::new(
+            Uuid::new_v4(),
+            BLOCK_SIZE as u64,
+            1024 * 1024,
+        ));
+        let mut cpf = CruciblePseudoFile::from(in_memory)?;
+        cpf.activate().await?;
+
+        let mut rng = rand::thread_rng();
+        let sz = cpf.sz();
+
+        for _ in 0..1000 {
+            let mut offset: u64 = rng.gen::<u64>() % sz;
+            let mut bsz: usize = rng.gen::<usize>() % 4096;
+
+            while ((offset + bsz as u64) > sz) || (bsz == 0) {
+                offset = rng.gen::<u64>() % sz;
+                bsz = rng.gen::<usize>() % 4096;
+            }
+
+            let vec: Vec<u8> = (0..bsz)
+                .map(|_| rng.sample(rand::distributions::Standard))
+                .collect();
+
+            let mut vec2 = vec![0; bsz];
+
+            cpf.seek(SeekFrom::Start(offset))?;
+            cpf.write_all(&vec[..])?;
+
+            cpf.seek(SeekFrom::Start(offset))?;
+            cpf.read_exact(&mut vec2[..])?;
+
+            assert_eq!(&vec, &vec2);
+        }
 
         Ok(())
     }

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -103,13 +103,13 @@ impl IOSpan {
     }
 
     #[instrument]
-    pub async fn read_from_blocks_into_buffer(&self, data: &mut [u8]) {
+    pub fn read_from_blocks_into_buffer(&self, data: &mut [u8]) {
         assert_eq!(data.len(), self.sz as usize);
         self.buffer.read(self.phase as usize, data);
     }
 
     #[instrument]
-    pub async fn write_from_buffer_into_blocks(&mut self, data: &[u8]) {
+    pub fn write_from_buffer_into_blocks(&mut self, data: &[u8]) {
         assert_eq!(data.len(), self.sz as usize);
         self.buffer.write(self.phase as usize, data);
     }
@@ -275,7 +275,7 @@ impl<T: BlockIO> CruciblePseudoFile<T> {
         span.read_affected_blocks_from_volume(&self.block_io)
             .await?;
 
-        span.read_from_blocks_into_buffer(buf).await;
+        span.read_from_blocks_into_buffer(buf);
 
         // TODO: for block devices, we can't increment offset past the
         // device size but we're supposed to be pretending to be a proper
@@ -305,7 +305,7 @@ impl<T: BlockIO> CruciblePseudoFile<T> {
             span.read_affected_blocks_from_volume(&self.block_io)
                 .await?;
 
-            span.write_from_buffer_into_blocks(buf).await;
+            span.write_from_buffer_into_blocks(buf);
 
             span.write_affected_blocks_to_volume(&self.block_io).await?;
         } else {

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -88,7 +88,7 @@ impl IOSpan {
 
     #[instrument(skip(block_io))]
     pub async fn write_affected_blocks_to_volume<T: BlockIO>(
-        &self,
+        self,
         block_io: &Arc<T>,
     ) -> Result<(), CrucibleError> {
         block_io
@@ -97,7 +97,7 @@ impl IOSpan {
                     self.affected_block_numbers[0],
                     self.block_size.trailing_zeros(),
                 ),
-                self.buffer.as_bytes(),
+                self.buffer.into_bytes(),
             )
             .await
     }

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -71,15 +71,13 @@ impl IOSpan {
         &mut self,
         block_io: &Arc<T>,
     ) -> Result<(), CrucibleError> {
-        let b = std::mem::take(&mut self.buffer);
-
-        self.buffer = block_io
+        block_io
             .read(
                 Block::new(
                     self.affected_block_numbers[0],
                     self.block_size.trailing_zeros(),
                 ),
-                b,
+                &mut self.buffer,
             )
             .await?;
 

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -112,8 +112,7 @@ pub(crate) mod up_test {
         assert_eq!(span.affected_block_count(), 2);
         assert_eq!(span.affected_block_numbers(), &vec![0, 1]);
 
-        span.write_from_buffer_into_blocks(&Bytes::from(vec![1; 64]))
-            .await;
+        span.write_from_buffer_into_blocks(&Bytes::from(vec![1; 64]));
 
         for i in 0..500 {
             assert_eq!(span.buffer()[i], 0);
@@ -129,7 +128,7 @@ pub(crate) mod up_test {
         }
 
         let mut data = vec![0u8; 64];
-        span.read_from_blocks_into_buffer(&mut data[..]).await;
+        span.read_from_blocks_into_buffer(&mut data[..]);
 
         for i in 0..64 {
             assert_eq!(data[i], 1);

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -3562,7 +3562,8 @@ pub(crate) mod test {
             }))
             .await;
         }
-        assert_eq!(deactivate_done_brw.try_wait(), Some(Ok(())));
+
+        deactivate_done_brw.try_wait().unwrap().unwrap();
 
         // Verify we have disconnected and can go back to init.
         assert!(matches!(up.state, UpstairsState::Initializing));

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1993,9 +1993,9 @@ pub(crate) mod test {
         }))
         .await;
 
-        let (maybe_buffer, result) = ds_done_brw.wait(&up.log).await;
-        assert!(maybe_buffer.is_none());
-        assert!(result.is_err());
+        let reply = ds_done_brw.wait(&up.log).await;
+        assert!(reply.buffer.is_none());
+        assert!(reply.result.is_err());
 
         up.force_active().unwrap();
 
@@ -2006,9 +2006,9 @@ pub(crate) mod test {
         }))
         .await;
 
-        let (maybe_buffer, result) = ds_done_brw.wait(&up.log).await;
-        assert!(maybe_buffer.is_none());
-        assert!(result.is_ok());
+        let reply = ds_done_brw.wait(&up.log).await;
+        assert!(reply.buffer.is_none());
+        assert!(reply.result.is_ok());
 
         let (ds_done_brw, ds_done_res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -2017,9 +2017,9 @@ pub(crate) mod test {
         }))
         .await;
 
-        let (maybe_buffer, result) = ds_done_brw.wait(&up.log).await;
-        assert!(maybe_buffer.is_none());
-        assert!(result.is_err());
+        let reply = ds_done_brw.wait(&up.log).await;
+        assert!(reply.buffer.is_none());
+        assert!(reply.result.is_err());
     }
 
     #[tokio::test]
@@ -2069,9 +2069,9 @@ pub(crate) mod test {
             }
         }
 
-        let (maybe_buffer, result) = ds_done_brw.wait(&up.log).await;
-        assert!(maybe_buffer.is_none());
-        assert!(result.is_ok());
+        let reply = ds_done_brw.wait(&up.log).await;
+        assert!(reply.buffer.is_none());
+        assert!(reply.result.is_ok());
     }
 
     // Job dependency tests
@@ -3575,10 +3575,9 @@ pub(crate) mod test {
             .await;
         }
 
-        let tuple = deactivate_done_brw.try_wait();
-        let (maybe_buffer, result) = tuple.unwrap();
-        assert!(maybe_buffer.is_none());
-        result.unwrap();
+        let reply = deactivate_done_brw.try_wait().unwrap();
+        assert!(reply.buffer.is_none());
+        reply.result.unwrap();
 
         // Verify we have disconnected and can go back to init.
         assert!(matches!(up.state, UpstairsState::Initializing));

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -2616,16 +2616,14 @@ mod test {
         assert_eq!(volume.total_size().await?, block_size as u64 * 10);
 
         // Verify volume contents in one read
-        let buffer = Buffer::new(block_size * 1);
+        let buffer = Buffer::new(block_size * 10);
         let buffer = volume
             .read(Block::new(0, block_size.trailing_zeros()), buffer)
             .await?;
 
-        //let mut expected = vec![11; block_size * 5];
-        //expected.extend(vec![0x00; block_size * 5]);
-        //assert_eq!(expected, buffer.into_vec());
-
-        assert_eq!(vec![11; block_size], buffer.into_vec());
+        let mut expected = vec![11; block_size * 5];
+        expected.extend(vec![0x00; block_size * 5]);
+        assert_eq!(expected, buffer.into_vec());
 
         // One big write!
         volume

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -372,28 +372,32 @@ impl Volume {
                 }
                 assert!(offset + block_count as u64 <= end);
                 let block = Block::new(offset, bs.trailing_zeros());
-                let buffer = Buffer::new(block_count * bs);
 
                 // The read will first try to establish a connection to
                 // the remote side before returning something we can await
                 // on. If that initial connection fails, we can retry.
-                let mut retry_needed = true;
                 let mut retry_count = 0;
-                while retry_needed {
-                    match read_only_parent.read(block, buffer.clone()).await {
-                        Ok(_) => {
-                            retry_needed = false;
+
+                let buffer = loop {
+                    let buffer = Buffer::new(block_count * bs);
+
+                    match read_only_parent.read(block, buffer).await {
+                        Ok(returned_buffer) => {
                             if retry_count > 0 {
                                 // This counter indicates a retry was
                                 // eventually successful.
                                 retries += 1;
                             }
+
+                            break returned_buffer;
                         }
+
                         Err(e) => {
                             warn!(self.log, "scrub {}, offset {}", e, offset);
                             retry_count += 1;
                         }
                     }
+
                     if retry_count > 5 {
                         // TODO: Nexus needs to know the scrub had problems.
                         crucible_bail!(
@@ -402,12 +406,12 @@ impl Volume {
                             offset
                         );
                     }
-                }
+                };
 
                 // TODO: Nexus needs to know about this failure.
                 self.write_unwritten(
                     Block::new(offset, bs.trailing_zeros()),
-                    Bytes::from(buffer.into_vec().unwrap()),
+                    buffer.as_bytes(),
                 )
                 .await?;
 
@@ -615,8 +619,8 @@ impl BlockIO for Volume {
     async fn read(
         &self,
         offset: Block,
-        data: Buffer,
-    ) -> Result<(), CrucibleError> {
+        mut data: Buffer,
+    ) -> Result<Buffer, CrucibleError> {
         // In the case that this volume only has a read only parent, serve
         // reads directly from that
         let cc = self.next_count();
@@ -624,7 +628,7 @@ impl BlockIO for Volume {
 
         if data.is_empty() {
             cdt::volume__read__done!(|| (cc, self.uuid));
-            return Ok(());
+            return Ok(data);
         }
 
         if self.sub_volumes.is_empty() {
@@ -657,18 +661,8 @@ impl BlockIO for Volume {
 
         // TODO parallel dispatch!
         let mut data_index = 0;
+
         for (coverage, sub_volume) in affected_sub_volumes {
-            let sub_offset = Block::new(
-                sub_volume.compute_sub_volume_lba(coverage.start),
-                offset.shift,
-            );
-            // 0..10 would be size 10
-            let sz = (coverage.end - coverage.start) as usize
-                * self.block_size as usize;
-            let sub_buffer = Buffer::new(sz);
-
-            sub_volume.read(sub_offset, sub_buffer.clone()).await?;
-
             // When performing a read, check the parent coverage: if it's
             // Some(range), then we have to perform multiple reads:
             //
@@ -684,92 +678,27 @@ impl BlockIO for Volume {
                 let sub_sz = self.block_size as usize
                     * (parent_coverage.end - parent_coverage.start) as usize;
 
-                let parent_buffer = Buffer::new(sub_sz);
-                self.read_only_parent
+                let parent_buffer = self
+                    .read_only_parent
                     .as_ref()
                     .unwrap()
-                    .read(parent_offset, parent_buffer.clone())
+                    .read(parent_offset, Buffer::new(sub_sz))
                     .await?;
 
-                let mut data_vec = data.as_vec().await;
-                let mut owned_vec = data.owned_vec().await;
-
-                let sub_data_vec = sub_buffer.as_vec().await;
-                let sub_owned_vec = sub_buffer.owned_vec().await;
-                let parent_data_vec = parent_buffer.as_vec().await;
-
-                // "ownership" comes back from the downstairs per byte but all
-                // writes occur per block. Iterate over the blocks that both the
-                // read-only parent and subvolume cover here.
-                //
-                // This layer of the volume "owns" a block if the subvolume
-                // "owns" the block, *not* if the read only parent does.
-                for i in 0..(sub_sz as u64 / self.block_size) {
-                    let start_of_block = (i * self.block_size) as usize;
-
-                    if sub_owned_vec[start_of_block] {
-                        // sub volume has written to this block, use it
-                        for block_offset in 0..self.block_size {
-                            let inside_block =
-                                start_of_block + block_offset as usize;
-
-                            data_vec[data_index + inside_block] =
-                                sub_data_vec[inside_block];
-
-                            // this layer of the volume does own this
-                            // block, it was written to the subvolume
-                            owned_vec[data_index + inside_block] = true;
-                        }
-                    } else {
-                        // sub volume hasn't written to this block, use the
-                        // parent
-                        for block_offset in 0..self.block_size {
-                            let inside_block =
-                                start_of_block + block_offset as usize;
-
-                            data_vec[data_index + inside_block] =
-                                parent_data_vec[inside_block];
-
-                            // this layer of the volume doesn't own this
-                            // block, it came from the read only parent. Note
-                            // this doesn't depend if the block was owned by
-                            // the read only parent, just that the subvolume
-                            // doesn't own it.
-                            owned_vec[data_index + inside_block] = false;
-                        }
-                    }
-                }
-
-                // Iterate over all the blocks that only come from the subvolume
-                // here.
-                for i in (sub_sz as u64 / self.block_size)
-                    ..(sz as u64 / self.block_size)
-                {
-                    let start_of_block = (i * self.block_size) as usize;
-                    for block_offset in 0..self.block_size {
-                        let inside_block =
-                            start_of_block + block_offset as usize;
-
-                        data_vec[data_index + inside_block] =
-                            sub_data_vec[inside_block];
-
-                        // this layer of the volume does own this block, it came
-                        // from the subvolume's LBA - the read-only parent
-                        // cannot own this block because it's outside their LBA.
-                        owned_vec[data_index + inside_block] = true;
-                    }
-                }
-            } else {
-                let mut data_vec = data.as_vec().await;
-                let mut owned_vec = data.owned_vec().await;
-
-                // In the case where this volume has no read only parent,
-                // propagate the sub volume information up.
-                data_vec[data_index..(data_index + sz)]
-                    .copy_from_slice(&sub_buffer.as_vec().await);
-                owned_vec[data_index..(data_index + sz)]
-                    .copy_from_slice(&sub_buffer.owned_vec().await);
+                data.eat(data_index, parent_buffer);
             }
+
+            let sub_offset = Block::new(
+                sub_volume.compute_sub_volume_lba(coverage.start),
+                offset.shift,
+            );
+            let sz = (coverage.end - coverage.start) as usize
+                * self.block_size as usize;
+
+            let sub_buffer =
+                sub_volume.read(sub_offset, Buffer::new(sz)).await?;
+
+            data.eat(data_index, sub_buffer);
 
             data_index += sz;
         }
@@ -777,7 +706,7 @@ impl BlockIO for Volume {
         assert_eq!(data.len(), data_index);
 
         cdt::volume__read__done!(|| (cc, self.uuid));
-        Ok(())
+        Ok(data)
     }
 
     async fn write(
@@ -989,7 +918,7 @@ impl BlockIO for SubVolume {
         &self,
         offset: Block,
         data: Buffer,
-    ) -> Result<(), CrucibleError> {
+    ) -> Result<Buffer, CrucibleError> {
         self.block_io.read(offset, data).await
     }
 
@@ -1828,9 +1757,10 @@ mod test {
 
         // Initial read should come back all zeroes
         let buffer = Buffer::new(4096);
-        disk.read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = disk
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
-        assert_eq!(buffer.into_vec().unwrap(), vec![0; 4096]);
+        assert_eq!(buffer.into_vec(), vec![0; 4096]);
 
         // Write ones to second block
         disk.write(
@@ -1849,13 +1779,14 @@ mod test {
 
         // Read and verify the data is from the first write
         let buffer = Buffer::new(4096);
-        disk.read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = disk
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
         let mut expected = vec![0; 512];
         expected.extend(vec![1; 512]);
         expected.extend(vec![0; 4096 - 1024]);
-        assert_eq!(buffer.into_vec().unwrap(), expected);
+        assert_eq!(buffer.into_vec(), expected);
 
         // Write twos to first block
         disk.write(
@@ -1866,13 +1797,14 @@ mod test {
 
         // Read and verify
         let buffer = Buffer::new(4096);
-        disk.read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = disk
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
         let mut expected = vec![2; 512];
         expected.extend(vec![1; 512]);
         expected.extend(vec![0; 4096 - 1024]);
-        assert_eq!(buffer.into_vec().unwrap(), expected);
+        assert_eq!(buffer.into_vec(), expected);
 
         // Write sevens to third and fourth blocks
         disk.write(
@@ -1890,7 +1822,8 @@ mod test {
 
         // Read and verify
         let buffer = Buffer::new(4096);
-        disk.read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = disk
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
         let mut expected = vec![2; 512];
@@ -1898,7 +1831,7 @@ mod test {
         expected.extend(vec![7; 1024]);
         expected.extend(vec![8; 1024]);
         expected.extend(vec![0; 1024]);
-        assert_eq!(buffer.into_vec().unwrap(), expected);
+        assert_eq!(buffer.into_vec(), expected);
 
         Ok(())
     }
@@ -1931,14 +1864,14 @@ mod test {
         // (aka read_only_parent_init_value), and the second 2048b should come
         // from the subvolume(s) (aka be uninitialized).
         let buffer = Buffer::new(4096);
-        volume
-            .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, block_size.trailing_zeros()), buffer)
             .await?;
 
         let mut expected = vec![read_only_parent_init_value; 512 * 4];
         expected.extend(vec![0x00; 512 * 4]);
 
-        assert_eq!(buffer.into_vec().unwrap(), expected);
+        assert_eq!(buffer.into_vec(), expected);
 
         // If the parent volume has data, it should be returned. Write ones to
         // the first block of the parent:
@@ -1955,15 +1888,15 @@ mod test {
 
         // Read whole volume and verify
         let buffer = Buffer::new(4096);
-        volume
-            .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, block_size.trailing_zeros()), buffer)
             .await?;
 
         let mut expected = vec![1; 512];
         expected.extend(vec![read_only_parent_init_value; 512 * 3]);
         expected.extend(vec![0x00; 512 * 4]); // <- from subvolume, still "-"
 
-        assert_eq!(buffer.into_vec().unwrap(), expected);
+        assert_eq!(buffer.into_vec(), expected);
 
         // If the volume is written to and it doesn't overlap, still return the
         // parent data. Write twos to the volume:
@@ -1980,23 +1913,20 @@ mod test {
         // Make sure the parent data hasn't changed!
         {
             let buffer = Buffer::new(2048);
-            parent
-                .read(
-                    Block::new(0, block_size.trailing_zeros()),
-                    buffer.clone(),
-                )
+            let buffer = parent
+                .read(Block::new(0, block_size.trailing_zeros()), buffer)
                 .await?;
 
             let mut expected = vec![1; 512];
             expected.extend(vec![read_only_parent_init_value; 2048 - 512]);
 
-            assert_eq!(buffer.into_vec().unwrap(), expected);
+            assert_eq!(buffer.into_vec(), expected);
         }
 
         // Read whole volume and verify
         let buffer = Buffer::new(4096);
-        volume
-            .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, block_size.trailing_zeros()), buffer)
             .await?;
 
         let mut expected = vec![1; 512];
@@ -2004,7 +1934,7 @@ mod test {
         expected.extend(vec![read_only_parent_init_value; 512]);
         expected.extend(vec![0x00; 512 * 4]); // <- from subvolume, still "-"
 
-        assert_eq!(buffer.into_vec().unwrap(), expected);
+        assert_eq!(buffer.into_vec(), expected);
 
         // If the volume is written to and it does overlap, return the volume
         // data. Write threes to the volume:
@@ -2021,23 +1951,20 @@ mod test {
         // Make sure the parent data hasn't changed!
         {
             let buffer = Buffer::new(2048);
-            parent
-                .read(
-                    Block::new(0, block_size.trailing_zeros()),
-                    buffer.clone(),
-                )
+            let buffer = parent
+                .read(Block::new(0, block_size.trailing_zeros()), buffer)
                 .await?;
 
             let mut expected = vec![1; 512];
             expected.extend(vec![read_only_parent_init_value; 2048 - 512]);
 
-            assert_eq!(buffer.into_vec().unwrap(), expected);
+            assert_eq!(buffer.into_vec(), expected);
         }
 
         // Read whole volume and verify
         let buffer = Buffer::new(4096);
-        volume
-            .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, block_size.trailing_zeros()), buffer)
             .await?;
 
         let mut expected = vec![3; 512 * 2];
@@ -2045,7 +1972,7 @@ mod test {
         expected.extend(vec![read_only_parent_init_value; 512]);
         expected.extend(vec![0x00; 512 * 4]); // <- from subvolume, still "-"
 
-        assert_eq!(buffer.into_vec().unwrap(), expected);
+        assert_eq!(buffer.into_vec(), expected);
 
         // If the whole parent is now written to, only the last block should be
         // returned. Write fours to the parent
@@ -2061,8 +1988,8 @@ mod test {
 
         // Read whole volume and verify
         let buffer = Buffer::new(4096);
-        volume
-            .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, block_size.trailing_zeros()), buffer)
             .await?;
 
         let mut expected = vec![3; 512 * 2];
@@ -2070,7 +1997,7 @@ mod test {
         expected.extend(vec![4; 512]);
         expected.extend(vec![0x00; 512 * 4]); // <- from subvolume, still "-"
 
-        assert_eq!(buffer.into_vec().unwrap(), expected);
+        assert_eq!(buffer.into_vec(), expected);
 
         // If the parent goes away, then the sub volume data should still be
         // readable.
@@ -2078,8 +2005,8 @@ mod test {
 
         // Read whole volume and verify
         let buffer = Buffer::new(4096);
-        volume
-            .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, block_size.trailing_zeros()), buffer)
             .await?;
 
         let mut expected = vec![3; 512 * 2];
@@ -2087,7 +2014,7 @@ mod test {
         expected.extend(vec![0; 512]); // <- was previously from parent, now "-"
         expected.extend(vec![0x00; 512 * 4]); // <- from subvolume, still "-"
 
-        assert_eq!(buffer.into_vec().unwrap(), expected);
+        assert_eq!(buffer.into_vec(), expected);
 
         // Write to the whole volume. There's no more read-only parent (it was
         // dropped above)
@@ -2099,11 +2026,11 @@ mod test {
             .await?;
 
         let buffer = Buffer::new(4096);
-        volume
-            .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, block_size.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(buffer.into_vec().unwrap(), vec![9; 4096]);
+        assert_eq!(buffer.into_vec(), vec![9; 4096]);
 
         Ok(())
     }
@@ -2378,13 +2305,13 @@ mod test {
 
         // Read volume and verify contents
         let buffer = Buffer::new(2048);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
         let expected = vec![128; 2048];
 
-        assert_eq!(buffer.into_vec().unwrap(), expected);
+        assert_eq!(buffer.into_vec(), expected);
 
         Ok(())
     }
@@ -2491,14 +2418,11 @@ mod test {
             volume.add_read_only_parent(parent.clone()).await?;
 
             let buffer = Buffer::new(BLOCK_SIZE * 10);
-            volume
-                .read(
-                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                    buffer.clone(),
-                )
+            let buffer = volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
                 .await?;
 
-            assert_eq!(vec![0x55; BLOCK_SIZE * 10], buffer.into_vec().unwrap());
+            assert_eq!(vec![0x55; BLOCK_SIZE * 10], buffer.into_vec());
 
             volume
                 .write(
@@ -2508,14 +2432,11 @@ mod test {
                 .await?;
 
             let buffer = Buffer::new(BLOCK_SIZE * 10);
-            volume
-                .read(
-                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                    buffer.clone(),
-                )
+            let buffer = volume
+                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
                 .await?;
 
-            assert_eq!(vec![0xFF; BLOCK_SIZE * 10], buffer.into_vec().unwrap());
+            assert_eq!(vec![0xFF; BLOCK_SIZE * 10], buffer.into_vec());
         }
 
         // Create the same volume, verify data was written
@@ -2525,11 +2446,11 @@ mod test {
         volume.add_subvolume(overlay).await?;
 
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0xFF; BLOCK_SIZE * 10], buffer.into_vec().unwrap());
+        assert_eq!(vec![0xFF; BLOCK_SIZE * 10], buffer.into_vec());
 
         Ok(())
     }
@@ -2553,11 +2474,11 @@ mod test {
 
         // Read parent, verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        parent
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = parent
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x55; BLOCK_SIZE * 10], buffer.into_vec().unwrap());
+        assert_eq!(vec![0x55; BLOCK_SIZE * 10], buffer.into_vec());
 
         let mut parent_volume = Volume::new(BLOCK_SIZE as u64, csl());
         parent_volume.add_subvolume(parent).await?;
@@ -2587,11 +2508,11 @@ mod test {
 
         // Read whole volume, verify contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0x55; BLOCK_SIZE * 10], buffer.into_vec().unwrap());
+        assert_eq!(vec![0x55; BLOCK_SIZE * 10], buffer.into_vec());
 
         // Write over whole volume
         volume
@@ -2603,11 +2524,11 @@ mod test {
 
         // Read whole volume, verify new contents
         let buffer = Buffer::new(BLOCK_SIZE * 10);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![0xFF; BLOCK_SIZE * 10], buffer.into_vec().unwrap());
+        assert_eq!(vec![0xFF; BLOCK_SIZE * 10], buffer.into_vec());
 
         Ok(())
     }
@@ -2636,20 +2557,20 @@ mod test {
         let volume = Volume::construct(request, None, csl()).await.unwrap();
 
         let buffer = Buffer::new(BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), buffer)
             .await
             .unwrap();
 
-        assert_eq!(vec![0x0; BLOCK_SIZE], buffer.into_vec().unwrap());
+        assert_eq!(vec![0x0; BLOCK_SIZE], buffer.into_vec());
 
         let buffer = Buffer::new(BLOCK_SIZE);
-        volume
-            .read(Block::new(1, BLOCK_SIZE.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(1, BLOCK_SIZE.trailing_zeros()), buffer)
             .await
             .unwrap();
 
-        assert_eq!(vec![0x5; BLOCK_SIZE], buffer.into_vec().unwrap());
+        assert_eq!(vec![0x5; BLOCK_SIZE], buffer.into_vec());
     }
 
     // Test that blocks are correctly returned during read-only parent +
@@ -2675,11 +2596,11 @@ mod test {
 
         // Read back parent, verify 1s
         let buffer = Buffer::new(block_size * 5);
-        parent
-            .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())
+        let buffer = parent
+            .read(Block::new(0, block_size.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![11; block_size * 5], buffer.into_vec().unwrap());
+        assert_eq!(vec![11; block_size * 5], buffer.into_vec());
 
         // Create a volume out of this parent and the argument subvolume parts
         let mut volume = Volume::new(block_size as u64, csl());
@@ -2694,15 +2615,17 @@ mod test {
 
         assert_eq!(volume.total_size().await?, block_size as u64 * 10);
 
-        // Verify parent contents in one read
-        let buffer = Buffer::new(block_size * 10);
-        volume
-            .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())
+        // Verify volume contents in one read
+        let buffer = Buffer::new(block_size * 1);
+        let buffer = volume
+            .read(Block::new(0, block_size.trailing_zeros()), buffer)
             .await?;
 
-        let mut expected = vec![11; block_size * 5];
-        expected.extend(vec![0x00; block_size * 5]);
-        assert_eq!(expected, buffer.into_vec().unwrap());
+        //let mut expected = vec![11; block_size * 5];
+        //expected.extend(vec![0x00; block_size * 5]);
+        //assert_eq!(expected, buffer.into_vec());
+
+        assert_eq!(vec![11; block_size], buffer.into_vec());
 
         // One big write!
         volume
@@ -2714,11 +2637,11 @@ mod test {
 
         // Verify volume contents in one read
         let buffer = Buffer::new(block_size * 10);
-        volume
-            .read(Block::new(0, block_size.trailing_zeros()), buffer.clone())
+        let buffer = volume
+            .read(Block::new(0, block_size.trailing_zeros()), buffer)
             .await?;
 
-        assert_eq!(vec![55; block_size * 10], buffer.into_vec().unwrap());
+        assert_eq!(vec![55; block_size * 10], buffer.into_vec());
 
         Ok(())
     }

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -411,7 +411,7 @@ impl Volume {
                 // TODO: Nexus needs to know about this failure.
                 self.write_unwritten(
                     Block::new(offset, bs.trailing_zeros()),
-                    buffer.as_bytes(),
+                    buffer.into_bytes(),
                 )
                 .await?;
 


### PR DESCRIPTION
By transfering Buffer's ownership to the BlockIO implementation instead of passing by reference, the Arc + Mutex that guards Buffer's internals can be removed. Return the Buffer when done so that ownership is transferred back to the caller. Callers will have to change like so:

    -        crucible.read(offset, buffer.clone()).await?;
    +        let buffer = crucible.read(offset, buffer).await?;

Non-read operations are not affected.

Additionally, this commit removes the ability for one Guest operation to be composed of multiple Downstairs operations: this support could be added back, but enough was changing in this commit as is :) We don't currently use this "bulk" functionality except in tests.