### PR TITLE
Order packages topologically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,6 +1035,7 @@ dependencies = [
  "crucible-workspace-hack",
  "omicron-zone-package",
  "tokio",
+ "topological-sort",
 ]
 
 [[package]]
@@ -4921,6 +4922,12 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "topological-sort"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "tower-service"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ tokio-rustls = { version = "0.24.1" }
 tokio-test = "*"
 tokio-util = { version = "0.7", features = ["codec"]}
 toml = "0.8"
+topological-sort = "0.2.2"
 tracing = "0.1"
 tracing-opentelemetry = "0.18.0"
 tracing-subscriber = "0.3.18"

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 anyhow.workspace = true
 omicron-zone-package.workspace = true
 tokio.workspace = true
+topological-sort.workspace = true
 crucible-workspace-hack.workspace = true

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -1,10 +1,13 @@
 // Copyright 2022 Oxide Computer Company
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use omicron_zone_package::config;
+use omicron_zone_package::package::{PackageOutput, PackageSource};
 use omicron_zone_package::target::Target;
+use std::collections::BTreeMap;
 use std::fs::create_dir_all;
 use std::path::Path;
+use topological_sort::TopologicalSort;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -13,10 +16,63 @@ async fn main() -> Result<()> {
     let output_dir = Path::new("out");
     create_dir_all(output_dir)?;
 
-    for (name, package) in cfg.packages {
-        package
-            .create_for_target(&Target::default(), &name, output_dir)
-            .await?;
+    // Reverse lookup of "output" -> "package creating this output".
+    let all_packages = cfg
+        .packages
+        .iter()
+        .map(|(name, package)| (package.get_output_file(name), (name, package)))
+        .collect::<BTreeMap<_, _>>();
+
+    // Collect all packages, and sort them in dependency order,
+    // so we know which ones to build first.
+    let mut outputs = TopologicalSort::<String>::new();
+    for (package_output, (_, package)) in &all_packages {
+        match &package.source {
+            PackageSource::Local { .. }
+            | PackageSource::Prebuilt { .. }
+            | PackageSource::Manual => {
+                // Skip intermediate leaf packages; if necessary they'll be
+                // added to the dependency graph by whatever composite package
+                // actually depends on them.
+                if !matches!(
+                    package.output,
+                    PackageOutput::Zone {
+                        intermediate_only: true
+                    }
+                ) {
+                    outputs.insert(package_output);
+                }
+            }
+            PackageSource::Composite { packages: deps } => {
+                for dep in deps {
+                    outputs.add_dependency(dep, package_output);
+                }
+            }
+        }
+    }
+
+    while !outputs.is_empty() {
+        let batch = outputs.pop_all();
+        assert!(
+            !batch.is_empty() || outputs.is_empty(),
+            "cyclic dependency in package manifest!"
+        );
+
+        for output in &batch {
+            println!("Creating '{output}'");
+
+            let Some((name, package)) = all_packages.get(output) else {
+                bail!(
+                    "Cannot find a package to create output: '{output}' \n\
+                     \tThis can happen when building a composite package, where one of \n\
+                     \tthe 'source.packages' has not been found."
+                );
+            };
+
+            package
+                .create_for_target(&Target::default(), &name, output_dir)
+                .await?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
This doesn't make much of a difference for `main`, but it matters for an upcoming PR which adds more complexity to the Crucible build process: https://github.com/oxidecomputer/crucible/pull/1096 (reasonably so! the network service will be great to have)

Previously, Crucible packages were ordered according to the parsed order of the TOML file (which appears to have been alphabetical). With this PR, packages are now sorted topologically, so that "dependencies are built first".

Also, improved logging for error cases where dependencies cannot be found.