### PR TITLE
Use the omicron-zone-package methods for topo sorting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,7 +1035,6 @@ dependencies = [
  "crucible-workspace-hack",
  "omicron-zone-package",
  "tokio",
- "topological-sort",
 ]
 
 [[package]]
@@ -2753,9 +2752,9 @@ checksum = "e22821954cca73148cdd1547a540ac79a3f27b6d55b518490437bb9867212828"
 
 [[package]]
 name = "omicron-zone-package"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620c53207d39a385f298444337d575690e0d9e793561d471ba7a614dc213e372"
+checksum = "35e0b92149236c16677cda6e1efb8bde8f7b5f838344c65c621888f8251170ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2774,6 +2773,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml 0.7.8",
+ "topological-sort",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ nix = { version = "0.26", features = [ "feature", "uio" ] }
 num_enum = "0.7"
 num-derive = "0.4"
 num-traits = "0.2"
-omicron-zone-package = "0.9.1"
+omicron-zone-package = "0.10.0"
 openapiv3 = "2.0.0"
 opentelemetry = "0.21.0"
 opentelemetry-jaeger = { version = "0.17.0" }
@@ -97,7 +97,6 @@ tokio-rustls = { version = "0.24.1" }
 tokio-test = "*"
 tokio-util = { version = "0.7", features = ["codec"]}
 toml = "0.8"
-topological-sort = "0.2.2"
 tracing = "0.1"
 tracing-opentelemetry = "0.18.0"
 tracing-subscriber = "0.3.18"

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 anyhow.workspace = true
 omicron-zone-package.workspace = true
 tokio.workspace = true
-topological-sort.workspace = true
 crucible-workspace-hack.workspace = true

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -14,13 +14,13 @@ async fn main() -> Result<()> {
     create_dir_all(output_dir)?;
 
     let packages = cfg.packages_to_deploy(&Target::default());
-    let mut package_iter = packages.build_order();
+    let package_iter = packages.build_order();
 
-    while let Some(batch) = package_iter.next() {
+    for batch in package_iter {
         for (name, package) in &batch {
             println!("Building '{name}'");
             package
-                .create_for_target(&Target::default(), &name, output_dir)
+                .create_for_target(&Target::default(), name, output_dir)
                 .await?;
         }
     }

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -1,13 +1,10 @@
 // Copyright 2022 Oxide Computer Company
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use omicron_zone_package::config;
-use omicron_zone_package::package::{PackageOutput, PackageSource};
 use omicron_zone_package::target::Target;
-use std::collections::BTreeMap;
 use std::fs::create_dir_all;
 use std::path::Path;
-use topological_sort::TopologicalSort;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -16,59 +13,12 @@ async fn main() -> Result<()> {
     let output_dir = Path::new("out");
     create_dir_all(output_dir)?;
 
-    // Reverse lookup of "output" -> "package creating this output".
-    let all_packages = cfg
-        .packages
-        .iter()
-        .map(|(name, package)| (package.get_output_file(name), (name, package)))
-        .collect::<BTreeMap<_, _>>();
+    let packages = cfg.packages_to_deploy(&Target::default());
+    let mut package_iter = packages.build_order();
 
-    // Collect all packages, and sort them in dependency order,
-    // so we know which ones to build first.
-    let mut outputs = TopologicalSort::<String>::new();
-    for (package_output, (_, package)) in &all_packages {
-        match &package.source {
-            PackageSource::Local { .. }
-            | PackageSource::Prebuilt { .. }
-            | PackageSource::Manual => {
-                // Skip intermediate leaf packages; if necessary they'll be
-                // added to the dependency graph by whatever composite package
-                // actually depends on them.
-                if !matches!(
-                    package.output,
-                    PackageOutput::Zone {
-                        intermediate_only: true
-                    }
-                ) {
-                    outputs.insert(package_output);
-                }
-            }
-            PackageSource::Composite { packages: deps } => {
-                for dep in deps {
-                    outputs.add_dependency(dep, package_output);
-                }
-            }
-        }
-    }
-
-    while !outputs.is_empty() {
-        let batch = outputs.pop_all();
-        assert!(
-            !batch.is_empty() || outputs.is_empty(),
-            "cyclic dependency in package manifest!"
-        );
-
-        for output in &batch {
-            println!("Creating '{output}'");
-
-            let Some((name, package)) = all_packages.get(output) else {
-                bail!(
-                    "Cannot find a package to create output: '{output}' \n\
-                     \tThis can happen when building a composite package, where one of \n\
-                     \tthe 'source.packages' has not been found."
-                );
-            };
-
+    while let Some(batch) = package_iter.next() {
+        for (name, package) in &batch {
+            println!("Building '{name}'");
             package
                 .create_for_target(&Target::default(), &name, output_dir)
                 .await?;


### PR DESCRIPTION
I moved this logic (and tested it) in `omicron-zone-package`: https://github.com/oxidecomputer/omicron-package/pull/57

This PR uses that version, to simplify how much logic Crucible needs to know