### PR TITLE
Block size buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,6 +1064,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "slog",
+ "static_assertions",
  "subprocess",
  "tokio",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ slog-async = { version = "2.8" }
 slog-bunyan = "2.4.0"
 slog-dtrace = "0.2"
 slog-term = { version = "2.9" }
+static_assertions = "1.1.0"
 statistical = "1.0.0"
 subprocess = "0.2.9"
 tempfile = "3"

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -224,9 +224,7 @@ async fn cli_read(
      * Convert offset to its byte value.
      */
     let offset = Block::new(block_index as u64, ri.block_size.trailing_zeros());
-    let length: usize = size * ri.block_size as usize;
-
-    let mut data = crucible::Buffer::from_vec(vec![255; length]);
+    let mut data = crucible::Buffer::repeat(255, size, ri.block_size as usize);
 
     println!("Read  at block {:5}, len:{:7}", offset.value, data.len());
     guest.read(offset, &mut data).await?;

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -397,7 +397,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are zero on init
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -413,7 +413,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -449,7 +449,7 @@ mod test {
         volume.activate().await?;
 
         // A read of zero length does not error.
-        let mut buffer = Buffer::new(0);
+        let mut buffer = Buffer::new(0, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -499,7 +499,7 @@ mod test {
             )
             .await?;
 
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         in_memory_data
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -524,7 +524,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 11 on init
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -549,7 +549,7 @@ mod test {
         }
 
         // Verify parent wasn't written to
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         in_memory_data
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -557,7 +557,7 @@ mod test {
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
         // Read and verify contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -588,7 +588,7 @@ mod test {
             )
             .await?;
 
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         in_memory_data
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -624,7 +624,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 11 on init
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -640,7 +640,7 @@ mod test {
             .await?;
 
         // Verify parent wasn't written to
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         in_memory_data
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -648,7 +648,7 @@ mod test {
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
         // Read and verify contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -709,7 +709,7 @@ mod test {
         volume.activate().await?;
 
         // Read one block: should be all 0xff
-        let mut buffer = Buffer::new(BLOCK_SIZE);
+        let mut buffer = Buffer::new(1, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -725,7 +725,7 @@ mod test {
             .await?;
 
         // Read one block: should be all 0x01
-        let mut buffer = Buffer::new(BLOCK_SIZE);
+        let mut buffer = Buffer::new(1, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -762,7 +762,7 @@ mod test {
         volume.activate().await?;
 
         // Read one block: should be all 0x00
-        let mut buffer = Buffer::new(BLOCK_SIZE);
+        let mut buffer = Buffer::new(1, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -818,7 +818,7 @@ mod test {
             .await?;
 
         // Read volume, verify contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -834,7 +834,7 @@ mod test {
             .await?;
 
         // Read volume, verify original contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -889,7 +889,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -905,7 +905,7 @@ mod test {
             .await?;
 
         // Read volume, verify original contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -970,7 +970,7 @@ mod test {
             .await?;
 
         // Read and verify
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1035,7 +1035,8 @@ mod test {
 
         volume.activate().await?;
 
-        let full_volume_size = BLOCK_SIZE * 20;
+        let full_volume_blocks = 20;
+        let full_volume_size = BLOCK_SIZE * full_volume_blocks;
         // Write data in
         volume
             .write_unwritten(
@@ -1045,7 +1046,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let mut buffer = Buffer::new(full_volume_size);
+        let mut buffer = Buffer::new(full_volume_blocks, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1061,7 +1062,7 @@ mod test {
             .await?;
 
         // Read volume, verify original contents
-        let mut buffer = Buffer::new(full_volume_size);
+        let mut buffer = Buffer::new(full_volume_blocks, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1120,7 +1121,8 @@ mod test {
         let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
         volume.activate().await?;
-        let full_volume_size = BLOCK_SIZE * 20;
+        let full_volume_blocks = 20;
+        let full_volume_size = BLOCK_SIZE * full_volume_blocks;
 
         // Write data to last block of first vol, and first block of
         // second vol.
@@ -1132,7 +1134,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 2);
+        let mut buffer = Buffer::new(2, BLOCK_SIZE);
         volume
             .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1151,7 +1153,7 @@ mod test {
 
         // Read full volume, verify first write_unwritten still valid, but the
         // other blocks of the 2nd write_unwritten are updated.
-        let mut buffer = Buffer::new(full_volume_size);
+        let mut buffer = Buffer::new(full_volume_blocks, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1225,7 +1227,8 @@ mod test {
         let volume = Arc::new(Volume::construct(vcr, None, csl()).await?);
 
         volume.activate().await?;
-        let full_volume_size = BLOCK_SIZE * 20;
+        let full_volume_blocks = 20;
+        let full_volume_size = BLOCK_SIZE * full_volume_blocks;
 
         // Write data to last block of first vol, and first block of
         // second vol.
@@ -1255,7 +1258,7 @@ mod test {
             .await?;
 
         // Read full volume
-        let mut buffer = Buffer::new(full_volume_size);
+        let mut buffer = Buffer::new(full_volume_blocks, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1311,7 +1314,7 @@ mod test {
             .await?;
 
         // Read back in_memory, verify 1s
-        let mut buffer = Buffer::new(BLOCK_SIZE * 5);
+        let mut buffer = Buffer::new(5, BLOCK_SIZE);
         in_memory_data
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1336,7 +1339,7 @@ mod test {
         volume.activate().await?;
 
         // Verify parent contents in one read
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1355,7 +1358,7 @@ mod test {
         }
 
         // Verify volume contents in one read
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1416,7 +1419,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 11 at startup
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1437,7 +1440,7 @@ mod test {
             .await?;
 
         // Read and verify contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1499,7 +1502,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents of RO parent are 1s at startup
-        let mut buffer = Buffer::new(BLOCK_SIZE * 5);
+        let mut buffer = Buffer::new(5, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1507,7 +1510,7 @@ mod test {
         assert_eq!(vec![11; BLOCK_SIZE * 5], &buffer[..]);
 
         // Verify contents of blocks 5-10 are zero.
-        let mut buffer = Buffer::new(BLOCK_SIZE * 5);
+        let mut buffer = Buffer::new(5, BLOCK_SIZE);
         volume
             .read(Block::new(5, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1528,7 +1531,7 @@ mod test {
             .await?;
 
         // Read and verify contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1621,7 +1624,7 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read and verify contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1695,7 +1698,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 11 at startup
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1714,7 +1717,7 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read and verify contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1811,7 +1814,7 @@ mod test {
             .await?;
 
         // Read and verify contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 2);
+        let mut buffer = Buffer::new(2, BLOCK_SIZE);
         volume
             .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1830,7 +1833,7 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read full volume
-        let mut buffer = Buffer::new(BLOCK_SIZE * 20);
+        let mut buffer = Buffer::new(20, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1938,7 +1941,7 @@ mod test {
             .await?;
 
         // Read and verify contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 2);
+        let mut buffer = Buffer::new(2, BLOCK_SIZE);
         volume
             .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -1967,7 +1970,7 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read full volume
-        let mut buffer = Buffer::new(BLOCK_SIZE * 20);
+        let mut buffer = Buffer::new(20, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -2041,14 +2044,14 @@ mod test {
         volume2.activate().await?;
 
         // Read one block: should be all 0x00
-        let mut buffer = Buffer::new(BLOCK_SIZE);
+        let mut buffer = Buffer::new(1, BLOCK_SIZE);
         volume1
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
         assert_eq!(vec![0x00; BLOCK_SIZE], &buffer[..]);
 
-        let mut buffer = Buffer::new(BLOCK_SIZE);
+        let mut buffer = Buffer::new(1, BLOCK_SIZE);
         volume2
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -2094,7 +2097,7 @@ mod test {
         volume.activate().await?;
 
         // Verify contents are 00 at startup
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -2113,7 +2116,7 @@ mod test {
         volume.scrub(None, None).await.unwrap();
 
         // Read and verify contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -2194,7 +2197,9 @@ mod test {
 
             volume.activate().await?;
 
-            let mut buffer = Buffer::new(volume.total_size().await? as usize);
+            let volume_size = volume.total_size().await? as usize;
+            assert_eq!(volume_size % BLOCK_SIZE, 0);
+            let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
             volume
                 .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
                 .await?;
@@ -2251,7 +2256,9 @@ mod test {
 
         // Validate that source blocks originally come from the read-only parent
         {
-            let mut buffer = Buffer::new(volume.total_size().await? as usize);
+            let volume_size = volume.total_size().await? as usize;
+            assert_eq!(volume_size % BLOCK_SIZE, 0);
+            let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
             volume
                 .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
                 .await?;
@@ -2271,7 +2278,9 @@ mod test {
             .await?;
 
         {
-            let mut buffer = Buffer::new(volume.total_size().await? as usize);
+            let volume_size = volume.total_size().await? as usize;
+            assert_eq!(volume_size % BLOCK_SIZE, 0);
+            let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
             volume
                 .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
                 .await?;
@@ -2368,7 +2377,9 @@ mod test {
 
             volume.activate().await?;
 
-            let mut buffer = Buffer::new(volume.total_size().await? as usize);
+            let volume_size = volume.total_size().await? as usize;
+            assert_eq!(volume_size % BLOCK_SIZE, 0);
+            let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
             volume
                 .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
                 .await?;
@@ -2433,7 +2444,9 @@ mod test {
 
         // Validate that source blocks originally come from the read-only parent
         {
-            let mut buffer = Buffer::new(volume.total_size().await? as usize);
+            let volume_size = volume.total_size().await? as usize;
+            assert_eq!(volume_size % BLOCK_SIZE, 0);
+            let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
             volume
                 .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
                 .await?;
@@ -2453,7 +2466,9 @@ mod test {
             .await?;
 
         {
-            let mut buffer = Buffer::new(volume.total_size().await? as usize);
+            let volume_size = volume.total_size().await? as usize;
+            assert_eq!(volume_size % BLOCK_SIZE, 0);
+            let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
             volume
                 .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
                 .await?;
@@ -2543,7 +2558,9 @@ mod test {
 
         volume.activate().await?;
         // Validate that source blocks are the same
-        let mut buffer = Buffer::new(volume.total_size().await? as usize);
+        let volume_size = volume.total_size().await? as usize;
+        assert_eq!(volume_size % BLOCK_SIZE, 0);
+        let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -2633,7 +2650,9 @@ mod test {
         }
 
         // Read back what we wrote.
-        let mut buffer = Buffer::new(volume.total_size().await? as usize);
+        let volume_size = volume.total_size().await? as usize;
+        assert_eq!(volume_size % BLOCK_SIZE, 0);
+        let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -2941,7 +2960,9 @@ mod test {
         }
 
         // Read back what we wrote.
-        let mut buffer = Buffer::new(new_volume.total_size().await? as usize);
+        let volume_size = volume.total_size().await? as usize;
+        assert_eq!(volume_size % BLOCK_SIZE, 0);
+        let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
         new_volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -3004,7 +3025,9 @@ mod test {
             }
 
             for (i, random_buffer) in chunks {
-                let mut buffer = Buffer::new(CHUNK_SIZE);
+                assert_eq!(CHUNK_SIZE % BLOCK_SIZE, 0);
+                let mut buffer =
+                    Buffer::new(CHUNK_SIZE / BLOCK_SIZE, BLOCK_SIZE);
                 volume
                     .read(
                         Block::new(i as u64, BLOCK_SIZE.trailing_zeros()),
@@ -3044,7 +3067,7 @@ mod test {
         guest.query_work_queue().await?;
 
         // Verify contents are zero on init
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -3060,7 +3083,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -3088,7 +3111,7 @@ mod test {
         guest.query_work_queue().await?;
 
         // Read of length 0
-        let mut buffer = Buffer::new(0);
+        let mut buffer = Buffer::new(0, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -3171,7 +3194,7 @@ mod test {
         }
 
         // Read back our block post replacement, verify contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -3287,7 +3310,7 @@ mod test {
             .await?;
 
         // Read parent, verify contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -3303,7 +3326,7 @@ mod test {
             .await?;
 
         // Read back the same blocks.
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -3320,7 +3343,7 @@ mod test {
             .await?;
 
         // Read back the same blocks.
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -3369,7 +3392,7 @@ mod test {
             .await?;
 
         // Read back the first block.
-        let mut buffer = Buffer::new(BLOCK_SIZE);
+        let mut buffer = Buffer::new(1, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -3378,7 +3401,7 @@ mod test {
         assert_eq!(vec![0x55_u8; BLOCK_SIZE], &buffer[..]);
 
         // Read back the next two blocks.
-        let mut buffer = Buffer::new(BLOCK_SIZE * 2);
+        let mut buffer = Buffer::new(2, BLOCK_SIZE);
         guest
             .read(Block::new(1, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -3427,7 +3450,7 @@ mod test {
             .await?;
 
         // Read back the all three blocks.
-        let mut buffer = Buffer::new(BLOCK_SIZE * 3);
+        let mut buffer = Buffer::new(3, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -3486,7 +3509,7 @@ mod test {
             .await?;
 
         // Read back the all three blocks.
-        let mut buffer = Buffer::new(BLOCK_SIZE * 3);
+        let mut buffer = Buffer::new(3, BLOCK_SIZE);
         guest
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -3540,7 +3563,7 @@ mod test {
             .await?;
 
         // Read back both blocks
-        let mut buffer = Buffer::new(BLOCK_SIZE * 2);
+        let mut buffer = Buffer::new(2, BLOCK_SIZE);
         guest
             .read(Block::new(4, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -3594,7 +3617,7 @@ mod test {
             .await?;
 
         // Read back both blocks
-        let mut buffer = Buffer::new(BLOCK_SIZE * 2);
+        let mut buffer = Buffer::new(2, BLOCK_SIZE);
         guest
             .read(Block::new(4, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
@@ -3638,7 +3661,7 @@ mod test {
         assert!(res.is_err());
 
         // Read a block past the end of the extent
-        let mut buffer = Buffer::new(BLOCK_SIZE);
+        let mut buffer = Buffer::new(1, BLOCK_SIZE);
         let res = guest
             .read(Block::new(11, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await;
@@ -3674,7 +3697,7 @@ mod test {
         assert!(res.is_err());
 
         // Read a block with buffer that extends past the end of the region
-        let mut buffer = Buffer::new(BLOCK_SIZE * 2);
+        let mut buffer = Buffer::new(2, BLOCK_SIZE);
         let res = guest
             .read(Block::new(10, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await;
@@ -3826,7 +3849,8 @@ mod test {
         let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let mut buffer = Buffer::new(bytes.len());
+        assert_eq!(bytes.len() % BLOCK_SIZE, 0);
+        let mut buffer = Buffer::new(bytes.len() / BLOCK_SIZE, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await
@@ -3934,7 +3958,7 @@ mod test {
                 .unwrap();
             volume.activate().await.unwrap();
 
-            let mut buffer = Buffer::new(5120);
+            let mut buffer = Buffer::new(10, BLOCK_SIZE);
             volume
                 .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
                 .await
@@ -3986,7 +4010,7 @@ mod test {
         let volume = Volume::construct(vcr, None, log.clone()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let mut buffer = Buffer::new(5120);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await
@@ -4064,7 +4088,7 @@ mod test {
         let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let mut buffer = Buffer::new(5120);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await
@@ -4127,17 +4151,16 @@ mod test {
         let volume = Volume::construct(vcr, None, csl()).await.unwrap();
         volume.activate().await.unwrap();
 
+        use crucible_pantry::pantry::PantryEntry;
+        assert_eq!(PantryEntry::MAX_CHUNK_SIZE % BLOCK_SIZE, 0);
         let mut buffer =
-            Buffer::new(crucible_pantry::pantry::PantryEntry::MAX_CHUNK_SIZE);
+            Buffer::new(PantryEntry::MAX_CHUNK_SIZE / BLOCK_SIZE, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await
             .unwrap();
 
-        assert_eq!(
-            vec![0x99; crucible_pantry::pantry::PantryEntry::MAX_CHUNK_SIZE],
-            &buffer[..]
-        );
+        assert_eq!(vec![0x99; PantryEntry::MAX_CHUNK_SIZE], &buffer[..]);
     }
 
     /// Assert that the Pantry will fail for non-block sized writes
@@ -4265,7 +4288,8 @@ mod test {
             let volume = Volume::construct(vcr, None, csl()).await.unwrap();
             volume.activate().await.unwrap();
 
-            let mut buffer = Buffer::new(data.len());
+            assert_eq!(data.len() % BLOCK_SIZE, 0);
+            let mut buffer = Buffer::new(data.len() / BLOCK_SIZE, BLOCK_SIZE);
             volume
                 .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
                 .await
@@ -4360,7 +4384,8 @@ mod test {
         let volume = Volume::construct(vcr, None, log.clone()).await.unwrap();
         volume.activate().await.unwrap();
 
-        let mut buffer = Buffer::new(data.len());
+        assert_eq!(data.len() % BLOCK_SIZE, 0);
+        let mut buffer = Buffer::new(data.len() / BLOCK_SIZE, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await
@@ -4851,7 +4876,7 @@ mod test {
             .unwrap();
 
         // Read parent, verify contents
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await
@@ -4891,7 +4916,7 @@ mod test {
         info!(log, "Replace VCR now: {:?}", replacement);
         volume.target_replace(original, replacement).await.unwrap();
         info!(log, "send read now");
-        let mut buffer = Buffer::new(BLOCK_SIZE * 10);
+        let mut buffer = Buffer::new(10, BLOCK_SIZE);
         volume
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await

--- a/pantry/Cargo.toml
+++ b/pantry/Cargo.toml
@@ -17,6 +17,7 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 slog.workspace = true
+static_assertions.workspace = true
 crucible.workspace = true
 crucible-common.workspace = true
 crucible-smf.workspace = true

--- a/pantry/src/pantry.rs
+++ b/pantry/src/pantry.rs
@@ -87,6 +87,18 @@ where
     }
 }
 
+// Static assertions to ensure that MAX_CHUNK_SIZE is divisible into blocks.
+//
+// Block size is always a power of two, so if we're divisible by the largest
+// possible block, then we're also divisible by all others.
+static_assertions::const_assert_eq!(
+    PantryEntry::MAX_CHUNK_SIZE % crucible::MAX_BLOCK_SIZE,
+    0
+);
+static_assertions::const_assert!(
+    PantryEntry::MAX_CHUNK_SIZE >= crucible::MAX_BLOCK_SIZE,
+);
+
 impl PantryEntry {
     pub const MAX_CHUNK_SIZE: usize = 512 * 1024;
 
@@ -332,14 +344,8 @@ impl PantryEntry {
                 block_size,
             );
         }
-        if Self::MAX_CHUNK_SIZE % block_size as usize != 0 {
-            crucible_bail!(
-                InvalidNumberOfBlocks,
-                "max chunk size {} not divisible by block size {}!",
-                Self::MAX_CHUNK_SIZE,
-                block_size,
-            );
-        }
+        // This is checked by static assertions above
+        assert_eq!(Self::MAX_CHUNK_SIZE % block_size as usize, 0);
 
         let mut data = crucible::Buffer::with_capacity(
             Self::MAX_CHUNK_SIZE / block_size as usize,

--- a/upstairs/src/block_io.rs
+++ b/upstairs/src/block_io.rs
@@ -65,6 +65,7 @@ impl BlockIO for FileBlockIO {
         offset: Block,
         data: &mut Buffer,
     ) -> Result<(), CrucibleError> {
+        self.check_data_size(data.len()).await?;
         let start: usize = (offset.value * self.block_size) as usize;
 
         let mut file = self.file.lock().await;
@@ -82,6 +83,7 @@ impl BlockIO for FileBlockIO {
         offset: Block,
         data: Bytes,
     ) -> Result<(), CrucibleError> {
+        self.check_data_size(data.len()).await?;
         let start = offset.value * self.block_size;
 
         let mut file = self.file.lock().await;
@@ -207,6 +209,7 @@ impl BlockIO for ReqwestBlockIO {
         offset: Block,
         data: &mut Buffer,
     ) -> Result<(), CrucibleError> {
+        self.check_data_size(data.len()).await?;
         let cc = self.next_count();
         cdt::reqwest__read__start!(|| (cc, self.uuid));
 

--- a/upstairs/src/block_req.rs
+++ b/upstairs/src/block_req.rs
@@ -149,7 +149,7 @@ mod test {
     async fn test_blockreq_and_blockreqwaiter_with_buffer() {
         let (brw, res) = BlockReqWaiter::pair();
 
-        res.send_ok_with_buffer(Buffer::with_capacity(0));
+        res.send_ok_with_buffer(Buffer::with_capacity(0, 512));
 
         let reply = brw.wait(&crucible_common::build_logger()).await;
         assert!(reply.buffer.is_some());
@@ -172,7 +172,7 @@ mod test {
         let (brw, res) = BlockReqWaiter::pair();
 
         res.send_err_with_buffer(
-            Buffer::with_capacity(0),
+            Buffer::with_capacity(0, 512),
             CrucibleError::UpstairsInactive,
         );
 

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -655,7 +655,7 @@ pub(crate) mod protocol_test {
             // We must tokio::spawn here because `read` will wait for the
             // response to come back before returning
             tokio::spawn(async move {
-                let mut buffer = Buffer::new(512);
+                let mut buffer = Buffer::new(1, 512);
                 harness
                     .guest
                     .read(Block::new_512(0), &mut buffer)
@@ -709,7 +709,7 @@ pub(crate) mod protocol_test {
             let harness = harness.clone();
 
             tokio::spawn(async move {
-                let mut buffer = Buffer::new(512);
+                let mut buffer = Buffer::new(1, 512);
                 harness
                     .guest
                     .read(Block::new_512(0), &mut buffer)
@@ -867,7 +867,7 @@ pub(crate) mod protocol_test {
             // We must tokio::spawn here because `read` will wait for the
             // response to come back before returning
             tokio::spawn(async move {
-                let mut buffer = Buffer::new(512);
+                let mut buffer = Buffer::new(1, 512);
                 harness
                     .guest
                     .read(Block::new_512(0), &mut buffer)
@@ -951,7 +951,7 @@ pub(crate) mod protocol_test {
                 // We must tokio::spawn here because `read` will wait for the
                 // response to come back before returning
                 tokio::spawn(async move {
-                    let mut buffer = Buffer::new(512);
+                    let mut buffer = Buffer::new(1, 512);
                     harness
                         .guest
                         .read(Block::new_512(0), &mut buffer)
@@ -1255,7 +1255,7 @@ pub(crate) mod protocol_test {
                 {
                     let harness = harness.clone();
                     tokio::spawn(async move {
-                        let mut buffer = Buffer::new(512);
+                        let mut buffer = Buffer::new(1, 512);
                         harness
                             .guest
                             .read(
@@ -1936,7 +1936,7 @@ pub(crate) mod protocol_test {
                 // We must tokio::spawn here because `read` will wait for the
                 // response to come back before returning
                 tokio::spawn(async move {
-                    let mut buffer = Buffer::new(512);
+                    let mut buffer = Buffer::new(1, 512);
                     harness
                         .guest
                         .read(Block::new_512(0), &mut buffer)
@@ -1990,7 +1990,7 @@ pub(crate) mod protocol_test {
                 // We must tokio::spawn here because `read` will wait for the
                 // response to come back before returning
                 tokio::spawn(async move {
-                    let mut buffer = Buffer::new(512);
+                    let mut buffer = Buffer::new(1, 512);
                     harness
                         .guest
                         .read(Block::new_512(0), &mut buffer)
@@ -2694,7 +2694,7 @@ pub(crate) mod protocol_test {
                 // We must tokio::spawn here because `read` will wait for the
                 // response to come back before returning
                 tokio::spawn(async move {
-                    let mut buffer = Buffer::new(512);
+                    let mut buffer = Buffer::new(1, 512);
                     harness
                         .guest
                         .read(Block::new_512(0), &mut buffer)
@@ -2943,7 +2943,7 @@ pub(crate) mod protocol_test {
         // We must tokio::spawn here because `read` will wait for the
         // response to come back before returning
         tokio::spawn(async move {
-            let mut buffer = Buffer::new(512);
+            let mut buffer = Buffer::new(1, 512);
             harness
                 .guest
                 .read(Block::new_512(0), &mut buffer)
@@ -2986,7 +2986,7 @@ pub(crate) mod protocol_test {
             // We must tokio::spawn here because `read` will wait for the
             // response to come back before returning
             tokio::spawn(async move {
-                let mut buffer = Buffer::new(512);
+                let mut buffer = Buffer::new(1, 512);
                 harness
                     .guest
                     .read(Block::new_512(0), &mut buffer)

--- a/upstairs/src/in_memory.rs
+++ b/upstairs/src/in_memory.rs
@@ -60,6 +60,7 @@ impl BlockIO for InMemoryBlockIO {
         offset: Block,
         data: &mut Buffer,
     ) -> Result<(), CrucibleError> {
+        self.check_data_size(data.len()).await?;
         let inner = self.inner.lock().await;
 
         let start = offset.value as usize * self.block_size as usize;
@@ -79,6 +80,7 @@ impl BlockIO for InMemoryBlockIO {
         offset: Block,
         data: Bytes,
     ) -> Result<(), CrucibleError> {
+        self.check_data_size(data.len()).await?;
         let mut inner = self.inner.lock().await;
 
         let start = offset.value as usize * self.block_size as usize;
@@ -96,6 +98,7 @@ impl BlockIO for InMemoryBlockIO {
         offset: Block,
         data: Bytes,
     ) -> Result<(), CrucibleError> {
+        self.check_data_size(data.len()).await?;
         let mut inner = self.inner.lock().await;
 
         let start = offset.value as usize * self.block_size as usize;

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1471,7 +1471,6 @@ impl fmt::Display for AckStatus {
 #[must_use]
 #[derive(Debug, PartialEq, Default)]
 pub struct Buffer {
-    len: usize,
     data: Vec<u8>,
     owned: Vec<bool>,
 }
@@ -1480,7 +1479,6 @@ impl Buffer {
     pub fn from_vec(data: Vec<u8>) -> Buffer {
         let len = data.len();
         Buffer {
-            len,
             data,
             owned: vec![false; len],
         }
@@ -1488,7 +1486,6 @@ impl Buffer {
 
     pub fn new(len: usize) -> Buffer {
         Buffer {
-            len,
             data: vec![0; len],
             owned: vec![false; len],
         }
@@ -1498,11 +1495,7 @@ impl Buffer {
         let data = Vec::with_capacity(capacity);
         let owned = Vec::with_capacity(capacity);
 
-        Buffer {
-            len: 0,
-            data,
-            owned,
-        }
+        Buffer { data, owned }
     }
 
     pub fn from_slice(buf: &[u8]) -> Buffer {
@@ -1521,11 +1514,11 @@ impl Buffer {
     }
 
     pub fn len(&self) -> usize {
-        self.len
+        self.data.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.len == 0
+        self.data.is_empty()
     }
 
     pub fn write(&mut self, offset: usize, data: &[u8]) {
@@ -1565,9 +1558,9 @@ impl Buffer {
 
     pub fn read(&self, offset: usize, data: &mut [u8]) {
         assert!(offset + data.len() <= self.data.len());
-        for i in 0..data.len() {
+        for (i, d) in data.iter_mut().enumerate() {
             if self.owned[offset + i] {
-                data[i] = self.data[offset + i];
+                *d = self.data[offset + i];
             }
         }
     }
@@ -1598,10 +1591,8 @@ impl Buffer {
         self.data.clear();
         self.owned.clear();
 
-        self.len = len;
-
-        self.data.resize(self.len, 0u8);
-        self.owned.resize(self.len, false);
+        self.data.resize(len, 0u8);
+        self.owned.resize(len, false);
     }
 }
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -196,6 +196,18 @@ pub trait BlockIO: Sync {
 
         self.activate().await
     }
+
+    /// Checks that the data length is a multiple of block size
+    ///
+    /// Returns block size on success, since we have to look it up anyways.
+    async fn check_data_size(&self, len: usize) -> Result<u64, CrucibleError> {
+        let block_size = self.get_block_size().await?;
+        if len as u64 % block_size == 0 {
+            Ok(block_size)
+        } else {
+            Err(CrucibleError::DataLenUnaligned)
+        }
+    }
 }
 
 pub type CrucibleBlockIOFuture<'a> = Pin<
@@ -1471,40 +1483,41 @@ impl fmt::Display for AckStatus {
 #[must_use]
 #[derive(Debug, PartialEq, Default)]
 pub struct Buffer {
+    block_size: usize,
     data: Vec<u8>,
     owned: Vec<bool>,
 }
 
 impl Buffer {
-    pub fn from_vec(data: Vec<u8>) -> Buffer {
-        let len = data.len();
+    pub fn new(block_count: usize, block_size: usize) -> Buffer {
+        let len = block_count * block_size;
         Buffer {
-            data,
-            owned: vec![false; len],
-        }
-    }
-
-    pub fn new(len: usize) -> Buffer {
-        Buffer {
+            block_size,
             data: vec![0; len],
             owned: vec![false; len],
         }
     }
 
-    pub fn with_capacity(capacity: usize) -> Buffer {
-        let data = Vec::with_capacity(capacity);
-        let owned = Vec::with_capacity(capacity);
-
-        Buffer { data, owned }
+    /// Builds a new buffer that repeats the given value
+    pub fn repeat(v: u8, block_count: usize, block_size: usize) -> Self {
+        let len = block_count * block_size;
+        Buffer {
+            block_size,
+            data: vec![v; len],
+            owned: vec![false; len],
+        }
     }
 
-    pub fn from_slice(buf: &[u8]) -> Buffer {
-        let mut vec = Vec::<u8>::with_capacity(buf.len());
-        for item in buf {
-            vec.push(*item);
-        }
+    pub fn with_capacity(block_count: usize, block_size: usize) -> Buffer {
+        let len = block_count * block_size;
+        let data = Vec::with_capacity(len);
+        let owned = Vec::with_capacity(len);
 
-        Buffer::from_vec(vec)
+        Buffer {
+            block_size,
+            data,
+            owned,
+        }
     }
 
     /// Extract the underlying `Vec<u8>` bearing buffered data.
@@ -1580,19 +1593,21 @@ impl Buffer {
             }
         }
 
-        buffer.reset(0);
+        buffer.reset(0, self.block_size);
     }
 
     pub fn owned_ref(&self) -> &[bool] {
         &self.owned
     }
 
-    pub fn reset(&mut self, len: usize) {
+    pub fn reset(&mut self, block_count: usize, block_size: usize) {
         self.data.clear();
         self.owned.clear();
 
+        let len = block_count * block_size;
         self.data.resize(len, 0u8);
         self.owned.resize(len, false);
+        self.block_size = block_size;
     }
 }
 
@@ -1607,7 +1622,7 @@ impl std::ops::Deref for Buffer {
 #[test]
 fn test_buffer_sane() {
     const BLOCK_SIZE: usize = 512;
-    let mut data = Buffer::new(1024);
+    let mut data = Buffer::new(2, BLOCK_SIZE);
 
     data.write(0, &[99u8; BLOCK_SIZE]);
 
@@ -1621,21 +1636,21 @@ fn test_buffer_sane() {
 #[test]
 fn test_buffer_len() {
     const READ_SIZE: usize = 512;
-    let data = Buffer::from_slice(&[0x99; READ_SIZE]);
+    let data = Buffer::repeat(0x99, 1, READ_SIZE);
     assert_eq!(data.len(), READ_SIZE);
 }
 
 #[test]
 fn test_buffer_len_over_block_size() {
-    const READ_SIZE: usize = 600;
-    let data = Buffer::from_slice(&[0x99; READ_SIZE]);
+    const READ_SIZE: usize = 1024;
+    let data = Buffer::repeat(0x99, 2, 512);
     assert_eq!(data.len(), READ_SIZE);
 }
 
 #[test]
 fn test_buffer_writes() {
     const READ_SIZE: usize = 512;
-    let mut data = Buffer::new(READ_SIZE);
+    let mut data = Buffer::new(1, READ_SIZE);
 
     assert_eq!(&data[..], &vec![0u8; 512]);
 
@@ -1656,16 +1671,16 @@ fn test_buffer_writes() {
 #[test]
 fn test_buffer_eats() {
     const READ_SIZE: usize = 512;
-    let mut data = Buffer::new(READ_SIZE);
+    let mut data = Buffer::new(1, READ_SIZE);
 
     assert_eq!(&data[..], &vec![0u8; 512]);
 
-    let mut buffer = Buffer::new(READ_SIZE);
+    let mut buffer = Buffer::new(1, READ_SIZE);
     buffer.eat(0, &mut data);
 
     assert_eq!(&buffer[..], &vec![0u8; 512]);
 
-    let mut data = Buffer::new(READ_SIZE);
+    let mut data = Buffer::new(1, READ_SIZE);
     data.write(64, &[1u8; 64]);
     buffer.eat(0, &mut data);
 
@@ -1673,7 +1688,7 @@ fn test_buffer_eats() {
     assert_eq!(&buffer[64..128], &vec![1u8; 64]);
     assert_eq!(&buffer[128..], &vec![0u8; 512 - 64 - 64]);
 
-    let mut data = Buffer::new(READ_SIZE);
+    let mut data = Buffer::new(1, READ_SIZE);
     data.write(128, &[7u8; 128]);
     buffer.eat(0, &mut data);
 
@@ -1802,25 +1817,25 @@ async fn test_return_iops() {
 
     let op = BlockOp::Read {
         offset: Block::new_512(1),
-        data: Buffer::new(1),
+        data: Buffer::new(1, 512),
     };
     assert_eq!(op.iops(IOP_SZ).unwrap(), 1);
 
     let op = BlockOp::Read {
         offset: Block::new_512(1),
-        data: Buffer::new(8000),
+        data: Buffer::new(8, 512), // 4096 bytes
     };
     assert_eq!(op.iops(IOP_SZ).unwrap(), 1);
 
     let op = BlockOp::Read {
         offset: Block::new_512(1),
-        data: Buffer::new(16000),
+        data: Buffer::new(31, 512), // 15872 bytes < 16000
     };
     assert_eq!(op.iops(IOP_SZ).unwrap(), 1);
 
     let op = BlockOp::Read {
         offset: Block::new_512(1),
-        data: Buffer::new(16001),
+        data: Buffer::new(32, 512), // 16384 bytes > 16000
     };
     assert_eq!(op.iops(IOP_SZ).unwrap(), 2);
 }
@@ -2549,11 +2564,7 @@ impl BlockIO for Guest {
         offset: Block,
         data: &mut Buffer,
     ) -> Result<(), CrucibleError> {
-        let bs = self.get_block_size().await?;
-
-        if (data.len() % bs as usize) != 0 {
-            crucible_bail!(DataLenUnaligned);
-        }
+        let bs = self.check_data_size(data.len()).await?;
 
         if offset.block_size_in_bytes() as u64 != bs {
             crucible_bail!(BlockSizeMismatch);
@@ -2583,11 +2594,7 @@ impl BlockIO for Guest {
         offset: Block,
         data: Bytes,
     ) -> Result<(), CrucibleError> {
-        let bs = self.get_block_size().await?;
-
-        if (data.len() % bs as usize) != 0 {
-            crucible_bail!(DataLenUnaligned);
-        }
+        let bs = self.check_data_size(data.len()).await?;
 
         if offset.block_size_in_bytes() as u64 != bs {
             crucible_bail!(BlockSizeMismatch);
@@ -2610,11 +2617,7 @@ impl BlockIO for Guest {
         offset: Block,
         data: Bytes,
     ) -> Result<(), CrucibleError> {
-        let bs = self.get_block_size().await?;
-
-        if (data.len() % bs as usize) != 0 {
-            crucible_bail!(DataLenUnaligned);
-        }
+        let bs = self.check_data_size(data.len()).await?;
 
         if offset.block_size_in_bytes() as u64 != bs {
             crucible_bail!(BlockSizeMismatch);

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -1172,7 +1172,7 @@ pub mod repair_test {
         )
         .await;
 
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(512))
+        up.submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         // WriteUnwritten
@@ -1210,7 +1210,7 @@ pub mod repair_test {
         )
         .await;
 
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(512))
+        up.submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         // WriteUnwritten
@@ -1244,7 +1244,7 @@ pub mod repair_test {
         )
         .await;
 
-        up.submit_dummy_read(Block::new_512(3), Buffer::new(512))
+        up.submit_dummy_read(Block::new_512(3), Buffer::new(1, 512))
             .await;
 
         // WriteUnwritten
@@ -1329,7 +1329,7 @@ pub mod repair_test {
         )
         .await;
 
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(512 * 9))
+        up.submit_dummy_read(Block::new_512(0), Buffer::new(9, 512))
             .await;
 
         // WriteUnwritten
@@ -1392,7 +1392,7 @@ pub mod repair_test {
         finish_live_repair(&mut up, 1000).await;
 
         // Our default extent size is 3, so 9 blocks will span 3 extents
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(512 * 9))
+        up.submit_dummy_read(Block::new_512(0), Buffer::new(9, 512))
             .await;
 
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -38,7 +38,8 @@ impl IOSpan {
             block_size,
             phase: offset % block_size,
             buffer: Buffer::new(
-                affected_block_numbers.len() * block_size as usize,
+                affected_block_numbers.len(),
+                block_size as usize,
             ),
             affected_block_numbers,
         }

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -2577,7 +2577,7 @@ pub(crate) mod test {
 
         // op 1
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2615,7 +2615,7 @@ pub(crate) mod test {
 
         // op 3
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512 * 2))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(2, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2648,12 +2648,12 @@ pub(crate) mod test {
 
         // op 0
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         // op 1
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2688,12 +2688,12 @@ pub(crate) mod test {
 
         // op 1
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         // op 2
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2732,7 +2732,7 @@ pub(crate) mod test {
 
         // op 2
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512 * 2))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(2, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2859,7 +2859,7 @@ pub(crate) mod test {
 
         // op 0
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         // op 1
@@ -2894,7 +2894,7 @@ pub(crate) mod test {
 
         // op 0
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         // op 1
@@ -2908,7 +2908,7 @@ pub(crate) mod test {
 
         // op 2
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         let jobs = upstairs.downstairs.get_all_jobs();
@@ -2938,7 +2938,7 @@ pub(crate) mod test {
 
         // op 0
         upstairs
-            .submit_dummy_read(Block::new_512(0), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(0), Buffer::new(1, 512))
             .await;
 
         // op 1
@@ -2952,7 +2952,7 @@ pub(crate) mod test {
 
         // op 2
         upstairs
-            .submit_dummy_read(Block::new_512(1), Buffer::new(512 * 2))
+            .submit_dummy_read(Block::new_512(1), Buffer::new(2, 512))
             .await;
 
         // op 3
@@ -2966,7 +2966,7 @@ pub(crate) mod test {
 
         // op 4
         upstairs
-            .submit_dummy_read(Block::new_512(3), Buffer::new(512 * 2))
+            .submit_dummy_read(Block::new_512(3), Buffer::new(2, 512))
             .await;
 
         // op 5
@@ -3227,7 +3227,7 @@ pub(crate) mod test {
 
         // op 4
         upstairs
-            .submit_dummy_read(Block::new_512(99), Buffer::new(512))
+            .submit_dummy_read(Block::new_512(99), Buffer::new(1, 512))
             .await;
 
         let ds = &upstairs.downstairs;
@@ -3324,7 +3324,7 @@ pub(crate) mod test {
 
         // op 0
         upstairs
-            .submit_dummy_read(Block::new_512(95), Buffer::new(512 * 2))
+            .submit_dummy_read(Block::new_512(95), Buffer::new(2, 512))
             .await;
 
         // op 1
@@ -3685,7 +3685,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -3745,7 +3745,7 @@ pub(crate) mod test {
         set_all_active(&mut up.downstairs);
 
         let blocks = 16384 / 512;
-        let data = Buffer::new(512 * blocks);
+        let data = Buffer::new(blocks, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -3812,7 +3812,7 @@ pub(crate) mod test {
         set_all_active(&mut up.downstairs);
 
         let blocks = 16384 / 512;
-        let data = Buffer::new(512 * blocks);
+        let data = Buffer::new(blocks, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -3901,7 +3901,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -3980,7 +3980,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -4048,7 +4048,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -4101,7 +4101,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -4179,7 +4179,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -4259,7 +4259,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -4336,7 +4336,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {
@@ -4406,7 +4406,7 @@ pub(crate) mod test {
         up.force_active().unwrap();
         set_all_active(&mut up.downstairs);
 
-        let data = Buffer::new(512);
+        let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
         let (_tx, res) = BlockReqWaiter::pair();
         up.apply(UpstairsAction::Guest(BlockReq {


### PR DESCRIPTION
This PR changes the `struct Buffer` to enforce that it is always an exact multiple of blocks.

The property is enforced at construction: the only way to build or resize a `Buffer` is to provide a tuple of `(block_count, block_size)`.  Various implementors of `BlockIO` also now check that their reads and writes are block-aligned, returning the existing `CrucibleError::DataLenUnaligned` if that's not the case.

These changes are a step towards per-block ownership, but make sense as a standalone PR:

- This PR touches a bunch of lines, but is mostly mechanical changes
- The upcoming per-block ownership PR will touch fewer lines, but will be making trickier logical changes