### PR TITLE
Switch to per-block ownership

### DIFF
--- a/upstairs/src/in_memory.rs
+++ b/upstairs/src/in_memory.rs
@@ -70,7 +70,7 @@ impl BlockIO for InMemoryBlockIO {
 
         let start = offset.value as usize * bs;
 
-        data.write_with_ownership(
+        data.write_if_owned(
             0,
             &inner.bytes[start..][..data.len()],
             &inner.owned[offset.value as usize..][..data.len() / bs],

--- a/upstairs/src/in_memory.rs
+++ b/upstairs/src/in_memory.rs
@@ -4,6 +4,8 @@ use super::*;
 
 struct Inner {
     bytes: Vec<u8>,
+
+    /// Ownership is tracked per block
     owned: Vec<bool>,
 }
 
@@ -16,12 +18,15 @@ pub struct InMemoryBlockIO {
 
 impl InMemoryBlockIO {
     pub fn new(id: Uuid, block_size: u64, total_size: usize) -> Self {
+        // TODO: make this take (block_count, block_size) so that it matches
+        // Buffer; this requires changing a bunch of call sites.
+        assert_eq!(total_size % block_size as usize, 0);
         Self {
             uuid: id,
             block_size,
             inner: Mutex::new(Inner {
                 bytes: vec![0; total_size],
-                owned: vec![false; total_size],
+                owned: vec![false; total_size / block_size as usize],
             }),
         }
     }
@@ -60,15 +65,15 @@ impl BlockIO for InMemoryBlockIO {
         offset: Block,
         data: &mut Buffer,
     ) -> Result<(), CrucibleError> {
-        self.check_data_size(data.len()).await?;
+        let bs = self.check_data_size(data.len()).await? as usize;
         let inner = self.inner.lock().await;
 
-        let start = offset.value as usize * self.block_size as usize;
+        let start = offset.value as usize * bs;
 
         data.write_with_ownership(
             0,
             &inner.bytes[start..][..data.len()],
-            &inner.owned[start..][..data.len()],
+            &inner.owned[offset.value as usize..][..data.len() / bs],
         );
 
         Ok(())
@@ -80,14 +85,14 @@ impl BlockIO for InMemoryBlockIO {
         offset: Block,
         data: Bytes,
     ) -> Result<(), CrucibleError> {
-        self.check_data_size(data.len()).await?;
+        let bs = self.check_data_size(data.len()).await? as usize;
         let mut inner = self.inner.lock().await;
 
-        let start = offset.value as usize * self.block_size as usize;
-
-        for i in 0..data.len() {
-            inner.bytes[start + i] = data[i];
-            inner.owned[start + i] = true;
+        let start_block = offset.value as usize;
+        for (b, chunk) in data.chunks(bs).enumerate() {
+            let block = start_block + b;
+            inner.owned[block] = true;
+            inner.bytes[block * bs..][..bs].copy_from_slice(chunk);
         }
 
         Ok(())
@@ -98,15 +103,15 @@ impl BlockIO for InMemoryBlockIO {
         offset: Block,
         data: Bytes,
     ) -> Result<(), CrucibleError> {
-        self.check_data_size(data.len()).await?;
+        let bs = self.check_data_size(data.len()).await? as usize;
         let mut inner = self.inner.lock().await;
 
-        let start = offset.value as usize * self.block_size as usize;
-
-        for i in 0..data.len() {
-            if !inner.owned[start + i] {
-                inner.bytes[start + i] = data[i];
-                inner.owned[start + i] = true;
+        let start_block = offset.value as usize;
+        for (b, chunk) in data.chunks(bs).enumerate() {
+            let block = start_block + b;
+            if !inner.owned[block] {
+                inner.owned[block] = true;
+                inner.bytes[block * bs..][..bs].copy_from_slice(chunk);
             }
         }
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1713,7 +1713,7 @@ impl Buffer {
         &self.data[b * self.block_size..][..self.block_size]
     }
 
-    /// Returns a reference to a particular block
+    /// Returns a mutable reference to a particular block
     pub fn block_mut(&mut self, b: usize) -> &mut [u8] {
         &mut self.data[b * self.block_size..][..self.block_size]
     }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1602,7 +1602,7 @@ impl Buffer {
 
         let start_block = offset / self.block_size;
         for (b, chunk) in data.chunks(self.block_size).enumerate() {
-            assert_eq!(chunk.len(), self.block_size);
+            debug_assert_eq!(chunk.len(), self.block_size);
             if owned[b] {
                 let block = start_block + b;
                 self.owned[block] = true;
@@ -1630,9 +1630,9 @@ impl Buffer {
         assert_eq!(offset % self.block_size, 0);
         assert_eq!(response.data.len(), self.block_size);
         if !response.block_contexts.is_empty() {
-            self.block_mut(offset / self.block_size)
-                .copy_from_slice(&response.data);
-            self.owned[offset / self.block_size] = true;
+            let block = offset / self.block_size;
+            self.owned[block] = true;
+            self.block_mut(block).copy_from_slice(&response.data);
         }
     }
 
@@ -1654,7 +1654,7 @@ impl Buffer {
 
         let start_block = offset / self.block_size;
         for (b, chunk) in data.chunks_mut(self.block_size).enumerate() {
-            assert_eq!(chunk.len(), self.block_size);
+            debug_assert_eq!(chunk.len(), self.block_size);
             let block = start_block + b;
             if self.owned[block] {
                 chunk.copy_from_slice(self.block(block));

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1578,7 +1578,7 @@ impl Buffer {
             .fill(true);
     }
 
-    /// Writes both data and ownership to the buffer
+    /// Writes data to the buffer where `owned` is true
     ///
     /// If `owned[i]` is `false`, then that block is not written
     ///
@@ -1589,7 +1589,7 @@ impl Buffer {
     /// - `data` and `owned` must be the same size
     ///
     /// If any of these conditions are not met, the function will panic.
-    pub(crate) fn write_with_ownership(
+    pub(crate) fn write_if_owned(
         &mut self,
         offset: usize,
         data: &[u8],

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1638,7 +1638,8 @@ impl Buffer {
 
     /// Reads buffer data into the given array
     ///
-    /// Values in blocks with `self.owned` are left unmodified
+    /// Only blocks with `self.owned` are changed; other blocks are left
+    /// unmodified.
     ///
     /// # Panics
     /// - The offset must be block-aligned

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -2083,7 +2083,7 @@ mod test {
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
-        assert_eq!(buffer.owned_ref(), &[false; 1024]);
+        assert_eq!(buffer.owned_ref(), &[false, false]);
 
         // Ownership is set by writing to blocks
 
@@ -2105,10 +2105,7 @@ mod test {
         expected.extend(vec![0u8; 512]);
 
         assert_eq!(&*buffer, &expected);
-
-        let mut expected_ownership = vec![true; 512];
-        expected_ownership.extend(vec![false; 512]);
-
+        let expected_ownership = [true, false];
         assert_eq!(buffer.owned_ref(), &expected_ownership);
 
         // Ownership through a volume should be the same!!


### PR DESCRIPTION
~This PR is staged on top of #1105 and #1106, so only the last commit (409d225275846508745aad14d4014074f453a83e) is new.~

At last, we're ready to switch to per-block (instead of per-byte) ownership!  This means that buffers take up 50% less RAM, and do significantly less work during reads.

### Before (from #1094)
```
4K READ: bw=52.1MiB/s (54.6MB/s), 52.1MiB/s-52.1MiB/s (54.6MB/s-54.6MB/s), io=3126MiB (3278MB), run=60002-60002msec
1M READ: bw=355MiB/s (372MB/s), 355MiB/s-355MiB/s (372MB/s-372MB/s), io=20.8GiB (22.4GB), run=60080-60080msec
4M READ: bw=352MiB/s (369MB/s), 352MiB/s-352MiB/s (369MB/s-369MB/s), io=20.7GiB (22.2GB), run=60273-60273msec
```

### After
```
4K READ: bw=50.8MiB/s (53.2MB/s), 50.8MiB/s-50.8MiB/s (53.2MB/s-53.2MB/s), io=3046MiB (3194MB), run=60002-60002msec
1M READ: bw=644MiB/s (675MB/s), 644MiB/s-644MiB/s (675MB/s-675MB/s), io=37.8GiB (40.6GB), run=60038-60038msec
4M READ: bw=576MiB/s (604MB/s), 576MiB/s-576MiB/s (604MB/s-604MB/s), io=33.9GiB (36.4GB), run=60176-60176msec
```

Here's the Propolis patch to make it work:
```diff
diff --git a/lib/propolis/src/block/crucible.rs b/lib/propolis/src/block/crucible.rs
index 3a403e7..233a1e7 100644
--- a/lib/propolis/src/block/crucible.rs
+++ b/lib/propolis/src/block/crucible.rs
@@ -34,6 +34,9 @@ impl WorkerState {
     async fn process_loop(&self, acc_mem: MemAccessor) {
         let read_only = self.info.read_only;
         let skip_flush = self.skip_flush;
+
+        // Build an empty buffer, which will be resized before any operation
+        let mut buffer = Buffer::with_capacity(0, 0);
         loop {
             let req = match self.attachment.wait_for_req().await {
                 Some(r) => r,
@@ -49,6 +52,7 @@ impl WorkerState {
                     skip_flush,
                     &req,
                     &memctx,
+                    &mut buffer,
                 )
                 .await
                 {
@@ -336,6 +340,7 @@ async fn process_request(
     skip_flush: bool,
     req: &block::Request,
     mem: &MemCtx,
+    buffer: &mut Buffer,
 ) -> Result<(), Error> {
     match req.oper() {
         block::Operation::Read(off, len) => {
@@ -343,17 +348,17 @@ async fn process_request(
                 req.mappings(mem).ok_or_else(|| Error::BadGuestRegion)?;

             let offset = block.byte_offset_to_block(off as u64).await?;
+            let bs = block.check_data_size(len).await? as usize;

             // Perform one large read from crucible, and write from data into
             // mappings
-            let data = Buffer::new(len);
-            let _ = block.read(offset, data.clone()).await?;
+            buffer.reset(len / bs, bs);
+            block.read(offset, buffer).await?;

-            let source = data.as_vec().await;
             let mut nwritten = 0;
             for mapping in maps {
                 nwritten += mapping.write_bytes(
-                    &source[nwritten..(nwritten + mapping.len())],
+                    &buffer[nwritten..(nwritten + mapping.len())],
                 )?;
             }
```
(also includes changes from #1094)