### PR TITLE
Bump nix to 0.27.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f3f22f1a586604e62efd23f78218f3ccdecf7a33c4500db2d37d85a24fe994"
 dependencies = [
- "nix",
+ "nix 0.26.4",
  "terminfo",
  "thiserror",
  "which",
@@ -705,7 +705,7 @@ dependencies = [
  "autocfg 1.1.0",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.9.0",
+ "memoffset",
  "scopeguard",
 ]
 
@@ -860,7 +860,7 @@ dependencies = [
  "atty",
  "crucible-workspace-hack",
  "dropshot",
- "nix",
+ "nix 0.27.1",
  "rusqlite",
  "rustls-pemfile",
  "schemars",
@@ -918,7 +918,7 @@ dependencies = [
  "itertools 0.12.0",
  "libc",
  "mime_guess",
- "nix",
+ "nix 0.27.1",
  "omicron-common",
  "openapi-lint",
  "openapiv3",
@@ -2341,15 +2341,6 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg 1.1.0",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
@@ -2484,8 +2475,17 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset 0.7.1",
- "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ itertools = "0.12.0"
 libc = "0.2"
 mime_guess = "2.0.4"
 nbd = "0.2.3"
-nix = { version = "0.26", features = [ "feature", "uio" ] }
+nix = { version = "0.27", features = [ "feature", "uio" ] }
 num_enum = "0.7"
 num-derive = "0.4"
 num-traits = "0.2"

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -15,7 +15,7 @@ use slog::{error, Logger};
 use std::collections::{BTreeMap, HashSet};
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, IoSliceMut, Read, Seek, SeekFrom};
-use std::os::fd::AsRawFd;
+use std::os::fd::AsFd;
 use std::path::Path;
 
 #[derive(Debug)]
@@ -217,7 +217,7 @@ impl ExtentInner for SqliteInner {
             });
 
             nix::sys::uio::preadv(
-                self.file.as_raw_fd(),
+                self.file.as_fd(),
                 &mut iovecs,
                 first_req.offset.value as i64 * block_size as i64,
             )
@@ -437,7 +437,7 @@ impl ExtentInner for SqliteInner {
 
         // Now, batch writes into iovecs and use pwritev to write them all out.
         let mut batched_pwritev = BatchedPwritev::new(
-            self.file.as_raw_fd(),
+            self.file.as_fd(),
             writes.len(),
             self.extent_size.block_size_in_bytes() as u64,
             iov_max,

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -1077,7 +1077,7 @@ struct BatchedPwritevState<'a> {
 }
 
 pub(crate) struct BatchedPwritev<'a> {
-    fd: std::os::fd::RawFd,
+    fd: std::os::fd::BorrowedFd<'a>,
     capacity: usize,
     state: Option<BatchedPwritevState<'a>>,
     block_size: u64,
@@ -1086,7 +1086,7 @@ pub(crate) struct BatchedPwritev<'a> {
 
 impl<'a> BatchedPwritev<'a> {
     pub fn new(
-        fd: std::os::fd::RawFd,
+        fd: std::os::fd::BorrowedFd<'a>,
         capacity: usize,
         block_size: u64,
         iov_max: usize,


### PR DESCRIPTION
This replaces the Renovate PR (#914) for bumping `nix` to 0.27.1

It switches to using the new `AsFd` trait, instead of `AsRawFd`