### PR TITLE
Bump rustls-pemfile to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,7 +862,7 @@ dependencies = [
  "dropshot",
  "nix",
  "rusqlite",
- "rustls-pemfile",
+ "rustls-pemfile 2.0.0",
  "schemars",
  "serde",
  "serde_json",
@@ -1424,7 +1424,7 @@ dependencies = [
  "percent-encoding",
  "proc-macro2",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "schemars",
  "serde",
  "serde_json",
@@ -3733,7 +3733,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3894,6 +3894,22 @@ checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.5",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
+dependencies = [
+ "base64 0.21.5",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9d979b3ce68192e42760c7810125eb6cf2ea10efae545a156063e61f314e2a"
 
 [[package]]
 name = "rustls-webpki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ reedline = "0.27.1"
 reqwest = { version = "0.11", features = ["default", "blocking", "json", "stream"] }
 ringbuffer = "0.15.0"
 rusqlite = { version = "0.30" }
-rustls-pemfile = { version = "1.0.4" }
+rustls-pemfile = { version = "2.0.0" }
 schemars = { version = "0.8", features = [ "chrono", "uuid1" ] }
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"

--- a/common/src/x509.rs
+++ b/common/src/x509.rs
@@ -12,16 +12,18 @@ use tokio_rustls::rustls::{
 
 pub fn load_certs(path: &str) -> io::Result<Vec<Certificate>> {
     certs(&mut BufReader::new(File::open(path)?))
+        .map(|v| v.map(|c| Certificate(c.to_vec())))
+        .collect::<Result<Vec<Certificate>, _>>()
         .map_err(|_| {
             io::Error::new(io::ErrorKind::InvalidInput, "invalid cert")
         })
-        .map(|mut certs| certs.drain(..).map(Certificate).collect())
 }
 
 pub fn load_rsa_keys(path: &str) -> io::Result<Vec<PrivateKey>> {
     rsa_private_keys(&mut BufReader::new(File::open(path)?))
+        .map(|v| v.map(|c| PrivateKey(c.secret_pkcs1_der().to_owned())))
+        .collect::<Result<Vec<PrivateKey>, _>>()
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid key"))
-        .map(|mut keys| keys.drain(..).map(PrivateKey).collect())
 }
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
This replaces the Renovate bot PR (#1057)

The signature of `certs` and `rsa_private_keys` changed from returning a `Result<Vec<..>, Error>` to a `Vec<Result<.., Error>>`, so we had to tweak the combinators.

The inner type also changed to a strong type (instead of `Vec<u8>`), but we can pull the raw data out.