### PR TITLE
Do not panic on reinitialize of a downstairs client.

### DIFF
--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -258,7 +258,7 @@ impl DownstairsClient {
         .await;
     }
 
-    pub(crate) fn halt_io_task(&mut self, r: ClientStopReason) {
+    fn halt_io_task(&mut self, r: ClientStopReason) {
         if let Some(t) = self.client_task.client_stop_tx.take() {
             if let Err(_e) = t.send(r) {
                 warn!(self.log, "failed to send stop request")

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -7,9 +7,7 @@ use std::{
 
 use crate::{
     cdt,
-    client::{
-        ClientAction, ClientRunResult, ClientStopReason, DownstairsClient,
-    },
+    client::{ClientAction, ClientStopReason, DownstairsClient},
     live_repair::ExtentInfo,
     stats::UpStatOuter,
     upstairs::{UpstairsConfig, UpstairsState},
@@ -660,7 +658,6 @@ impl Downstairs {
         &mut self,
         client_id: ClientId,
         auto_promote: bool,
-        reason: ClientRunResult,
         up_state: &UpstairsState,
     ) {
         let prev_state = self.clients[client_id].state();
@@ -682,15 +679,6 @@ impl Downstairs {
         if matches!(prev_state, DsState::LiveRepair | DsState::Active)
             && matches!(new_state, DsState::Faulted)
         {
-            if matches!(reason, ClientRunResult::RequestedStop(..)) {
-                // It's invalid for the upstairs to request that the IO task
-                // stop _without_ changing its state to something that causes
-                // jobs to be skipped.
-                panic!(
-                    "caller must change state from {prev_state} \
-                     when requesting a stop"
-                );
-            }
             self.skip_all_jobs(client_id);
         }
 

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -2011,12 +2011,8 @@ impl Upstairs {
             | UpstairsState::Deactivating { .. } => false,
         };
 
-        self.downstairs.reinitialize(
-            client_id,
-            auto_promote,
-            reason,
-            &self.state,
-        );
+        self.downstairs
+            .reinitialize(client_id, auto_promote, &self.state);
     }
 
     fn set_backpressure(&self) {


### PR DESCRIPTION
Remove the panic during task reinitialize because of a timeout decided by the upstairs.  
We also don't need to send the reason to reinit any longer.

This along with the timeout fix will prevent https://github.com/oxidecomputer/crucible/issues/1103
