### PR TITLE
Bump Rust to 1.75 and fix new Clippy lints

### DIFF
--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -544,14 +544,10 @@ async fn handle_signals(
     mut signals: Signals,
     early_shutdown: oneshot::Sender<()>,
 ) {
-    while let Some(signal) = signals.next().await {
-        match signal {
-            SIGUSR1 => {
-                early_shutdown.send(()).unwrap();
-                break;
-            }
-            _ => unreachable!(),
-        }
+    match signals.next().await {
+        Some(SIGUSR1) => early_shutdown.send(()).unwrap(),
+        Some(_) => unreachable!(),
+        None => (), // signal sender is dropped
     }
 }
 

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -725,7 +725,7 @@ async fn show_extent_block(
         println!();
 
         print!("{}  ", String::from_utf8(vec![b'-'; 6])?);
-        for (_, _) in dvec.iter().enumerate() {
+        for _ in &dvec {
             print!("{} ", String::from_utf8(vec![b'-'; 24])?);
         }
         if !only_show_differences {
@@ -784,7 +784,7 @@ async fn show_extent_block(
         println!();
 
         print!("{}  ", String::from_utf8(vec![b'-'; 6])?);
-        for (_, _) in dvec.iter().enumerate() {
+        for _ in &dvec {
             print!("{} ", String::from_utf8(vec![b'-'; 32])?);
         }
         if !only_show_differences {
@@ -848,7 +848,7 @@ async fn show_extent_block(
         println!();
 
         print!("{}  ", String::from_utf8(vec![b'-'; 6])?);
-        for (_, _) in dvec.iter().enumerate() {
+        for _ in &dvec {
             print!("{} ", String::from_utf8(vec![b'-'; 16])?);
         }
         if !only_show_differences {

--- a/pantry/src/pantry.rs
+++ b/pantry/src/pantry.rs
@@ -307,10 +307,8 @@ impl PantryEntry {
         let volume_block_size =
             self.volume.check_data_size(size).await? as usize;
 
-        let mut buffer = crucible::Buffer::new(
-            size / volume_block_size as usize,
-            volume_block_size,
-        );
+        let mut buffer =
+            crucible::Buffer::new(size / volume_block_size, volume_block_size);
 
         self.volume
             .read_from_byte_offset(offset, &mut buffer)

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -150,7 +150,7 @@ impl ReadResponse {
     }
 
     pub fn first_hash(&self) -> Option<u64> {
-        self.block_contexts.get(0).map(|ctx| ctx.hash)
+        self.block_contexts.first().map(|ctx| ctx.hash)
     }
 
     pub fn encryption_contexts(&self) -> Vec<Option<&EncryptionContext>> {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.73"
+channel = "1.75"
 profile = "default"

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -116,12 +116,10 @@ pub(crate) mod up_test {
             assert_eq!(span.buffer()[i], 0);
         }
 
-        let mut data = vec![0u8; 64];
+        let mut data = [0u8; 64];
         span.read_from_blocks_into_buffer(&mut data[..]);
 
-        for i in 0..64 {
-            assert_eq!(data[i], 1);
-        }
+        assert_eq!(data, [1; 64]);
     }
 
     /*


### PR DESCRIPTION
This is equivalent to #831, but includes Clippy fixes to make the build happy.