### PR TITLE
Ignore client messages after stopping the IO task

### DIFF
--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -289,17 +289,17 @@ impl DownstairsClient {
     /// This function will wait forever if we have asked for the client task to
     /// stop, so it should only be called in a higher-level `select!`.
     pub(crate) async fn select(&mut self) -> ClientAction {
-        tokio::select! {
-            d = self.client_task.client_response_rx.recv(),
-                if self.client_task.client_stop_tx.is_some() =>
+        loop {
+            let out = match self.client_task.client_response_rx.recv().await {
+                Some(c) => c.into(),
+                None => break ClientAction::ChannelClosed,
+            };
+            // Ignore client responses if we have told the client to exit (we
+            // still propagate other ClientAction variants, e.g. TaskStopped).
+            if self.client_task.client_stop_tx.is_some()
+                || !matches!(out, ClientAction::Response(..))
             {
-                match d {
-                    Some(c) => c.into(),
-                    None => ClientAction::ChannelClosed,
-                }
-            }
-            _ = futures::future::pending() => {
-                unreachable!()
+                break out;
             }
         }
     }


### PR DESCRIPTION
This protects us from a subtle race condition:

- The main task decides to stop the client task (e.g. because we've hit `IO_OUTSTANDING_MAX`)
  - It sends a stop request down the `tokio::sync::oneshot` channel
  - Then, it marks all jobs as skipped, which may result in discarding some of them
- The IO task receives a message from the downstairs
  - It passes this message to the main task
  - This message is a reply to one of the jobs that we skipped
  - The main task gets mad
  
I think this is may be the failure seen here:
```
{"msg":"cea05089-f330-4222-81d2-9c03095dfb2b WARNING finish job 125586 when downstairs state: Offline","v":0,"name":"propolis-server","level":40,"time":"2024-01-30T01:48:01.555693836Z","hostname":"oxz_propolis-server_edb3b1a5-7a60-441f-bfb0-a8cafae99226","pid":22206,"client":"2","":"downstairs","session_id":"9be1d7cc-2bf0-48cd-a496-d34f9c8245ec","component":"crucible-cea05089-f330-4222-81d2-9c03095dfb2b"}
thread 'tokio-runtime-worker' panicked at /home/build/.cargo/git/checkouts/crucible-f3b5bdecdc6486d6/2d4bc11/upstairs/src/client.rs:1237:13:
[2] Job 125586 completed while not InProgress: New
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

(from `/staff/core/crucible-unsorted/oxz_propolis-server_edb3b1a5.log`)