### PR TITLE
Minor Downstairs cleanup

### DIFF
--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -231,11 +231,6 @@ fn parse_duration(arg: &str) -> Result<Duration, std::num::ParseIntError> {
 async fn main() -> Result<()> {
     let args = Args::try_parse()?;
 
-    /*
-     * Everyone needs a region
-     */
-    let mut region;
-
     let log = build_logger();
 
     match args {
@@ -295,8 +290,7 @@ async fn main() -> Result<()> {
                 no_color,
                 log,
             )
-            .await?;
-            Ok(())
+            .await
         }
         Args::Export {
             count,
@@ -305,7 +299,7 @@ async fn main() -> Result<()> {
             skip,
         } => {
             // Open Region read only
-            region = region::Region::open(
+            let mut region = region::Region::open(
                 data,
                 Default::default(),
                 true,
@@ -314,8 +308,7 @@ async fn main() -> Result<()> {
             )
             .await?;
 
-            downstairs_export(&mut region, export_path, skip, count).await?;
-            Ok(())
+            downstairs_export(&mut region, export_path, skip, count).await
         }
         Args::Run {
             address,
@@ -464,9 +457,7 @@ async fn main() -> Result<()> {
                 DynoFlushConfig::None
             };
 
-            dynamometer(region, num_writes, samples, flush_config).await?;
-
-            Ok(())
+            dynamometer(region, num_writes, samples, flush_config).await
         }
     }
 }

--- a/downstairs/src/stats.rs
+++ b/downstairs/src/stats.rs
@@ -70,7 +70,7 @@ impl DsCountStat {
 // share it with the producer trait.
 #[derive(Clone, Debug)]
 pub struct DsStatOuter {
-    pub ds_stat_wrap: Arc<Mutex<DsCountStat>>,
+    pub ds_stat_wrap: Arc<std::sync::Mutex<DsCountStat>>,
 }
 
 impl DsStatOuter {
@@ -79,23 +79,23 @@ impl DsStatOuter {
      * one of these methods will be called.  Each method will get the
      * correct field of DsCountStat to record the update.
      */
-    pub async fn add_connection(&mut self) {
-        let mut dss = self.ds_stat_wrap.lock().await;
+    pub fn add_connection(&mut self) {
+        let mut dss = self.ds_stat_wrap.lock().unwrap();
         let datum = dss.up_connect_count.datum_mut();
         *datum += 1;
     }
-    pub async fn add_write(&mut self) {
-        let mut dss = self.ds_stat_wrap.lock().await;
+    pub fn add_write(&mut self) {
+        let mut dss = self.ds_stat_wrap.lock().unwrap();
         let datum = dss.write_count.datum_mut();
         *datum += 1;
     }
-    pub async fn add_read(&mut self) {
-        let mut dss = self.ds_stat_wrap.lock().await;
+    pub fn add_read(&mut self) {
+        let mut dss = self.ds_stat_wrap.lock().unwrap();
         let datum = dss.read_count.datum_mut();
         *datum += 1;
     }
-    pub async fn add_flush(&mut self) {
-        let mut dss = self.ds_stat_wrap.lock().await;
+    pub fn add_flush(&mut self) {
+        let mut dss = self.ds_stat_wrap.lock().unwrap();
         let datum = dss.flush_count.datum_mut();
         *datum += 1;
     }
@@ -110,7 +110,7 @@ impl Producer for DsStatOuter {
     fn produce(
         &mut self,
     ) -> Result<Box<dyn Iterator<Item = Sample> + 'static>, MetricsError> {
-        let dss = executor::block_on(self.ds_stat_wrap.lock());
+        let dss = self.ds_stat_wrap.lock().unwrap();
 
         let name = &dss.stat_name;
         let data = vec![


### PR DESCRIPTION
- `tokio::sync::mpsc::Sender` is `Clone`, so there's no need to wrap it in an `Arc` or `Mutex`
- We only ever send one message on the `terminate_sender` queue, so use a `tokio::sync::oneshot`
- Since we now mix `mpsc` and `oneshot`, use qualified names for `channel(..)`, `Sender`, and `Receiver`
- Small style tweaks in `downstairs/src/main.rs`