### PR TITLE
    New downstairs clone subcommand.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3847,6 +3847,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "chrono",
+ "crucible-common",
  "crucible-workspace-hack",
  "percent-encoding",
  "progenitor",
@@ -3854,6 +3855,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -159,8 +159,8 @@ pub enum CrucibleError {
     #[error("missing block context for non-empty block")]
     MissingBlockContext,
 
-    #[error("Incompatable RegionDefinition {0}")]
-    RegionIncompatable(String),
+    #[error("Incompatible RegionDefinition {0}")]
+    RegionIncompatible(String),
 }
 
 impl From<std::io::Error> for CrucibleError {
@@ -366,7 +366,7 @@ impl From<CrucibleError> for dropshot::HttpError {
             | CrucibleError::ModifyingReadOnlyRegion
             | CrucibleError::OffsetInvalid
             | CrucibleError::OffsetUnaligned
-            | CrucibleError::RegionIncompatable(_)
+            | CrucibleError::RegionIncompatible(_)
             | CrucibleError::ReplaceRequestInvalid(_)
             | CrucibleError::SnapshotExistsAlready(_)
             | CrucibleError::Unsupported(_) => {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -158,6 +158,9 @@ pub enum CrucibleError {
 
     #[error("missing block context for non-empty block")]
     MissingBlockContext,
+
+    #[error("Incompatable RegionDefinition {0}")]
+    RegionIncompatable(String),
 }
 
 impl From<std::io::Error> for CrucibleError {
@@ -363,6 +366,7 @@ impl From<CrucibleError> for dropshot::HttpError {
             | CrucibleError::ModifyingReadOnlyRegion
             | CrucibleError::OffsetInvalid
             | CrucibleError::OffsetUnaligned
+            | CrucibleError::RegionIncompatable(_)
             | CrucibleError::ReplaceRequestInvalid(_)
             | CrucibleError::SnapshotExistsAlready(_)
             | CrucibleError::Unsupported(_) => {

--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -180,10 +180,10 @@ impl RegionDefinition {
         })
     }
 
-    // Compare two RegionDefinitions and verify they are compatable.
-    // Compatable is valid if all fields are the same, expect for the
+    // Compare two RegionDefinitions and verify they are compatible.
+    // compatible is valid if all fields are the same, expect for the
     // UUID. The UUID should be different.
-    pub fn compatable(
+    pub fn compatible(
         self,
         other: RegionDefinition,
     ) -> Result<(), CrucibleError> {
@@ -567,15 +567,15 @@ mod test {
         let rd2 = test_rd();
 
         // Basic positive test first.
-        assert_eq!(rd1.compatable(rd2), Ok(()));
+        assert_eq!(rd1.compatible(rd2), Ok(()));
 
         rd1.block_size = 4096;
-        assert!(rd1.compatable(rd2).is_err());
+        assert!(rd1.compatible(rd2).is_err());
 
         let rd1 = test_rd();
         let mut rd2 = test_rd();
         rd2.block_size = 4096;
-        assert!(rd1.compatable(rd2).is_err());
+        assert!(rd1.compatible(rd2).is_err());
     }
 
     #[test]
@@ -584,12 +584,12 @@ mod test {
         let rd2 = test_rd();
 
         rd1.extent_size = Block::new(2, 9);
-        assert!(rd1.compatable(rd2).is_err());
+        assert!(rd1.compatible(rd2).is_err());
 
         let rd1 = test_rd();
         let mut rd2 = test_rd();
         rd2.extent_size = Block::new(2, 9);
-        assert!(rd1.compatable(rd2).is_err());
+        assert!(rd1.compatible(rd2).is_err());
     }
 
     #[test]
@@ -598,12 +598,12 @@ mod test {
         let rd2 = test_rd();
 
         rd1.extent_count = 9;
-        assert!(rd1.compatable(rd2).is_err());
+        assert!(rd1.compatible(rd2).is_err());
 
         let rd1 = test_rd();
         let mut rd2 = test_rd();
         rd2.extent_count = 9;
-        assert!(rd1.compatable(rd2).is_err());
+        assert!(rd1.compatible(rd2).is_err());
     }
 
     #[test]
@@ -613,7 +613,7 @@ mod test {
         let rd2 = test_rd();
 
         rd1.uuid = rd2.uuid;
-        assert!(rd1.compatable(rd2).is_err());
+        assert!(rd1.compatible(rd2).is_err());
     }
 
     #[test]
@@ -622,12 +622,12 @@ mod test {
         let rd2 = test_rd();
 
         rd1.encrypted = true;
-        assert!(rd1.compatable(rd2).is_err());
+        assert!(rd1.compatible(rd2).is_err());
 
         let rd1 = test_rd();
         let mut rd2 = test_rd();
         rd2.encrypted = true;
-        assert!(rd1.compatable(rd2).is_err());
+        assert!(rd1.compatible(rd2).is_err());
     }
 
     #[test]
@@ -636,12 +636,12 @@ mod test {
         let rd2 = test_rd();
 
         rd1.database_read_version = DATABASE_READ_VERSION + 1;
-        assert!(rd1.compatable(rd2).is_err());
+        assert!(rd1.compatible(rd2).is_err());
 
         let rd1 = test_rd();
         let mut rd2 = test_rd();
         rd2.database_read_version = DATABASE_READ_VERSION + 1;
-        assert!(rd1.compatable(rd2).is_err());
+        assert!(rd1.compatible(rd2).is_err());
     }
 
     #[test]
@@ -650,11 +650,11 @@ mod test {
         let rd2 = test_rd();
 
         rd1.database_write_version = DATABASE_WRITE_VERSION + 1;
-        assert!(rd1.compatable(rd2).is_err());
+        assert!(rd1.compatible(rd2).is_err());
 
         let rd1 = test_rd();
         let mut rd2 = test_rd();
         rd2.database_write_version = DATABASE_WRITE_VERSION + 1;
-        assert!(rd1.compatable(rd2).is_err());
+        assert!(rd1.compatible(rd2).is_err());
     }
 }

--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -189,39 +189,39 @@ impl RegionDefinition {
     ) -> Result<(), CrucibleError> {
         // These fields should be the same.
         if self.block_size != other.block_size {
-            return Err(CrucibleError::RegionIncompatable(
+            return Err(CrucibleError::RegionIncompatible(
                 "block_size".to_string(),
             ));
         }
         if self.extent_size != other.extent_size {
-            return Err(CrucibleError::RegionIncompatable(
+            return Err(CrucibleError::RegionIncompatible(
                 "extent_size".to_string(),
             ));
         }
         if self.extent_count != other.extent_count {
-            return Err(CrucibleError::RegionIncompatable(
+            return Err(CrucibleError::RegionIncompatible(
                 "extent_count".to_string(),
             ));
         }
         if self.encrypted != other.encrypted {
-            return Err(CrucibleError::RegionIncompatable(
+            return Err(CrucibleError::RegionIncompatible(
                 "encrypted".to_string(),
             ));
         }
         if self.database_read_version != other.database_read_version {
-            return Err(CrucibleError::RegionIncompatable(
+            return Err(CrucibleError::RegionIncompatible(
                 "database_read_version".to_string(),
             ));
         }
         if self.database_write_version != other.database_write_version {
-            return Err(CrucibleError::RegionIncompatable(
+            return Err(CrucibleError::RegionIncompatible(
                 "database_write_version".to_string(),
             ));
         }
 
         // If the UUIDs are the same, this is invalid.
         if self.uuid == other.uuid {
-            return Err(CrucibleError::RegionIncompatable(
+            return Err(CrucibleError::RegionIncompatible(
                 "UUIDs are the same".to_string(),
             ));
         }

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 
 use crucible::*;
 use crucible_common::{build_logger, Block, CrucibleError, MAX_BLOCK_SIZE};
+use repair_client::Client;
 
 use anyhow::{bail, Result};
 use bytes::BytesMut;
@@ -935,7 +936,7 @@ where
                 );
                 match d
                     .region
-                    .repair_extent(extent_id, source_repair_address)
+                    .repair_extent(extent_id, source_repair_address, false)
                     .await
                 {
                     Ok(()) => Message::RepairAckId { repair_id },
@@ -2304,7 +2305,7 @@ impl Downstairs {
                     Err(CrucibleError::UpstairsInactive)
                 } else {
                     self.region
-                        .repair_extent(*extent, *source_repair_address)
+                        .repair_extent(*extent, *source_repair_address, false)
                         .await
                 };
                 debug!(
@@ -3291,7 +3292,7 @@ pub async fn start_downstairs(
          * it and wait for another connection. Downstairs can handle
          * multiple Upstairs connecting but only one active one.
          */
-        info!(log, "listening on {}", listen_on);
+        info!(log, "downstairs listening on {}", listen_on);
         loop {
             let (sock, raddr) = listener.accept().await?;
 
@@ -3348,6 +3349,72 @@ pub async fn start_downstairs(
     });
 
     Ok(join_handle)
+}
+
+/// Clone the extent files in a region from another running downstairs.
+///
+/// Use the reconcile/repair extent methods to copy another downstairs.
+/// The source downstairs must have the same RegionDefinition as we do,
+/// and both downstairs must be running in read only mode.
+pub async fn start_clone(
+    d: Arc<Mutex<Downstairs>>,
+    source: SocketAddr,
+) -> Result<()> {
+    let info = crucible_common::BuildInfo::default();
+    let log = d.lock().await.log.new(o!("task" => "main".to_string()));
+    info!(log, "Crucible Version: {}", info);
+    info!(
+        log,
+        "Upstairs <-> Downstairs Message Version: {}", CRUCIBLE_MESSAGE_VERSION
+    );
+
+    info!(log, "Connecting to {source} to obtain our extent files.");
+
+    let url = format!("http://{:?}", source);
+    let repair_server = Client::new(&url);
+    let source_def = match repair_server.get_region_info().await {
+        Ok(def) => def.into_inner(),
+        Err(e) => {
+            bail!("Failed to get source region definition: {e}");
+        }
+    };
+    info!(log, "The source RegionDefinition is: {:?}", source_def);
+
+    let source_ro_mode = match repair_server.get_region_mode().await {
+        Ok(ro) => ro.into_inner(),
+        Err(e) => {
+            bail!("Failed to get source mode: {e}");
+        }
+    };
+
+    info!(log, "The source mode is: {:?}", source_ro_mode);
+    if !source_ro_mode {
+        bail!("Source downstairs is not read only");
+    }
+
+    let mut ds = d.lock().await;
+
+    let my_def = ds.region.def();
+    info!(log, "my def is {:?}", my_def);
+
+    if let Err(e) = my_def.compatable(source_def) {
+        bail!("Incompatible region definitions: {e}");
+    }
+
+    if let Err(e) = ds.region.close_all_extents().await {
+        bail!("Failed to close all extents: {e}");
+    }
+
+    for eid in 0..my_def.extent_count() as usize {
+        info!(log, "Repair extent {eid}");
+
+        if let Err(e) = ds.region.repair_extent(eid, source, true).await {
+            bail!("repair extent {eid} returned: {e}");
+        }
+    }
+    info!(log, "Region has been cloned");
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -3356,12 +3356,12 @@ pub async fn start_downstairs(
 /// Use the reconcile/repair extent methods to copy another downstairs.
 /// The source downstairs must have the same RegionDefinition as we do,
 /// and both downstairs must be running in read only mode.
-pub async fn start_clone(
+pub async fn clone_region(
     d: Arc<Mutex<Downstairs>>,
     source: SocketAddr,
 ) -> Result<()> {
     let info = crucible_common::BuildInfo::default();
-    let log = d.lock().await.log.new(o!("task" => "main".to_string()));
+    let log = d.lock().await.log.new(o!("task" => "clone".to_string()));
     info!(log, "Crucible Version: {}", info);
     info!(
         log,

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -3397,7 +3397,7 @@ pub async fn clone_region(
     let my_def = ds.region.def();
     info!(log, "my def is {:?}", my_def);
 
-    if let Err(e) = my_def.compatable(source_def) {
+    if let Err(e) = my_def.compatible(source_def) {
         bail!("Incompatible region definitions: {e}");
     }
 
@@ -6479,7 +6479,7 @@ mod test {
         Ok(())
     }
     #[tokio::test]
-    async fn test_version_uprev_compatable() -> Result<()> {
+    async fn test_version_uprev_compatible() -> Result<()> {
         // Test sending the +1 version to the DS, but also include the
         // current version on the supported list.  The downstairs should
         // see that and respond with the version it does support.

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -260,16 +260,6 @@ async fn main() -> Result<()> {
             source,
             trace_endpoint,
         } => {
-            /*
-             * If any of our async tasks in our runtime panic, then we should
-             * exit the program right away.
-             */
-            let default_panic = std::panic::take_hook();
-            std::panic::set_hook(Box::new(move |info| {
-                default_panic(info);
-                std::process::exit(1);
-            }));
-
             // Instrumentation is shared.
             if let Some(endpoint) = trace_endpoint {
                 let tracer = opentelemetry_jaeger::new_agent_pipeline()

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -41,6 +41,22 @@ impl std::str::FromStr for Mode {
 #[derive(Debug, Parser)]
 #[clap(about = "disk-side storage component")]
 enum Args {
+    /// Clone the extents from another region into this region.
+    ///
+    /// The other downstairs should be running read-only.  All data in
+    /// the region here will be replaced.
+    Clone {
+        /// Directory where the region is located.
+        #[clap(short, long, name = "DIRECTORY", action)]
+        data: PathBuf,
+
+        /// Source IP:Port where the extent files will come from.
+        #[clap(short, long, action)]
+        source: SocketAddr,
+
+        #[clap(short, long, action)]
+        trace_endpoint: Option<String>,
+    },
     Create {
         #[clap(long, default_value = "512", action)]
         block_size: u64,
@@ -239,6 +255,51 @@ async fn main() -> Result<()> {
     let log = build_logger();
 
     match args {
+        Args::Clone {
+            data,
+            source,
+            trace_endpoint,
+        } => {
+            /*
+             * If any of our async tasks in our runtime panic, then we should
+             * exit the program right away.
+             */
+            let default_panic = std::panic::take_hook();
+            std::panic::set_hook(Box::new(move |info| {
+                default_panic(info);
+                std::process::exit(1);
+            }));
+
+            // Instrumentation is shared.
+            if let Some(endpoint) = trace_endpoint {
+                let tracer = opentelemetry_jaeger::new_agent_pipeline()
+                    .with_endpoint(endpoint) // usually port 6831
+                    .with_service_name("downstairs")
+                    .install_simple()
+                    .expect("Error initializing Jaeger exporter");
+
+                let telemetry =
+                    tracing_opentelemetry::layer().with_tracer(tracer);
+
+                tracing_subscriber::registry()
+                    .with(telemetry)
+                    .try_init()
+                    .expect("Error init tracing subscriber");
+            }
+
+            let d = build_downstairs_for_region(
+                &data,
+                false,
+                false,
+                false,
+                false,
+                true, // read_only
+                Some(log),
+            )
+            .await?;
+
+            start_clone(d, source).await
+        }
         Args::Create {
             block_size,
             data,

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -298,7 +298,7 @@ async fn main() -> Result<()> {
             )
             .await?;
 
-            start_clone(d, source).await
+            clone_region(d, source).await
         }
         Args::Create {
             block_size,

--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -269,7 +269,7 @@ async fn get_region_info(
     Ok(HttpResponseOk(region_definition))
 }
 
-/// Return the RegionDefinition describing our region.
+/// Return the region-mode describing our region.
 #[endpoint {
     method = GET,
     path = "/region-mode",

--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -16,7 +16,6 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 
 use super::*;
-//use crucible_common::RegionDefinition;
 use crate::extent::{extent_dir, extent_file_name, extent_path, ExtentType};
 
 /**

--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -70,16 +70,7 @@ pub async fn repair_main(
     let ds = ds.lock().await;
     let region_dir = ds.region.dir.clone();
     let read_only = ds.read_only;
-    let rd = region::config_path(region_dir.clone());
-    let region_definition = match read_json(&rd) {
-        Ok(def) => def,
-        Err(e) => {
-            return Err(format!(
-                "Can't get region definition from {:?}: {:?}",
-                rd, e
-            ));
-        }
-    };
+    let region_definition = ds.region.def();
     drop(ds);
 
     info!(log, "Repair listens on {} for path:{:?}", addr, region_dir);

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -2820,7 +2820,7 @@ mod test {
 
     #[tokio::test]
     async fn integration_test_clone_diff_ec() -> Result<()> {
-        // Test downstairs replacement.
+        // Test downstairs region clone.
         // Verify different extent count will fail.
 
         let mut ds_one = TestDownstairs::new(
@@ -2856,7 +2856,7 @@ mod test {
 
     #[tokio::test]
     async fn integration_test_clone_diff_es() -> Result<()> {
-        // Test downstairs replacement.
+        // Test downstairs region clone.
         // Verify different extent size will fail.
 
         let mut ds_one = TestDownstairs::new(
@@ -2892,8 +2892,8 @@ mod test {
 
     #[tokio::test]
     async fn integration_test_clone_not_ro() -> Result<()> {
-        // Test downstairs replacement.
-        // Verify you can't replace from a RW downstairs
+        // Test downstairs region clone.
+        // Verify you can't clone from a RW downstairs
 
         let ds_one = TestDownstairs::new(
             "127.0.0.1".parse().unwrap(),
@@ -2927,7 +2927,7 @@ mod test {
 
     #[tokio::test]
     async fn integration_test_clone_diff_encrypted() -> Result<()> {
-        // Test downstairs replacement.
+        // Test downstairs region clone.
         // Verify downstairs encryption state must match.
 
         let ds_one = TestDownstairs::new(

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -167,7 +167,7 @@ mod test {
             )
             .await?;
 
-            start_clone(self.downstairs.clone(), source).await
+            clone_region(self.downstairs.clone(), source).await
         }
 
         pub async fn address(&self) -> SocketAddr {

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -150,9 +150,35 @@ mod test {
             Ok(())
         }
 
+        // Take a downstairs and start it with clone option.  This should
+        // attempt to clone extents from the provided source IP:Port downstairs.
+        //
+        // The Result is returned to the caller.
+        pub async fn reboot_clone(&mut self, source: SocketAddr) -> Result<()> {
+            let log = csl();
+            self.downstairs = build_downstairs_for_region(
+                self.tempdir.path(),
+                false, /* lossy */
+                false, /* read errors */
+                false, /* write errors */
+                false, /* flush errors */
+                true,
+                Some(log.clone()),
+            )
+            .await?;
+
+            start_clone(self.downstairs.clone(), source).await
+        }
+
         pub async fn address(&self) -> SocketAddr {
             // If start_downstairs returned Ok, then address will be populated
             self.downstairs.lock().await.address.unwrap()
+        }
+
+        // Return the repair address for a running downstairs
+        pub async fn repair_address(&self) -> SocketAddr {
+            // If start_downstairs returned Ok, then address will be populated
+            self.downstairs.lock().await.repair_address.unwrap()
         }
     }
 
@@ -2571,6 +2597,370 @@ mod test {
     }
 
     #[tokio::test]
+    async fn integration_test_clone_raw() -> Result<()> {
+        // Test downstairs region clone.
+        // Create three downstairs with raw backend, write some data to them.
+        // Restart them all read only.
+        // Create a new downstairs.
+        // Clone a read only downstairs to the new downstairs
+        // Make a new volume with two old and the one new downstairs and verify
+        // the original data we wrote.
+        const BLOCK_SIZE: usize = 512;
+
+        // boot three downstairs, write some data to them, then change to
+        // read-only.
+        let mut test_downstairs_set = TestDownstairsSet::small(false).await?;
+
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
+        volume
+            .add_subvolume_create_guest(
+                test_downstairs_set.opts(),
+                volume::RegionExtentInfo {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: test_downstairs_set.blocks_per_extent(),
+                    extent_count: test_downstairs_set.extent_count(),
+                },
+                1,
+                None,
+            )
+            .await?;
+
+        volume.activate().await?;
+
+        let random_buffer = {
+            let mut random_buffer =
+                vec![0u8; volume.total_size().await? as usize];
+            rand::thread_rng().fill(&mut random_buffer[..]);
+            random_buffer
+        };
+
+        volume
+            .write(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(random_buffer.clone()),
+            )
+            .await?;
+
+        volume.deactivate().await.unwrap();
+        drop(volume);
+
+        // Restart all the downstairs read only
+        test_downstairs_set.reboot_read_only().await?;
+
+        // Make the new downstairs
+        let mut new_ds = TestDownstairs::new(
+            "127.0.0.1".parse().unwrap(),
+            true,
+            true,
+            5,
+            2,
+            false,
+            Backend::RawFile,
+        )
+        .await
+        .unwrap();
+
+        // Clone an original downstairs to our new downstairs
+        let clone_source =
+            test_downstairs_set.downstairs1.repair_address().await;
+        new_ds.reboot_clone(clone_source).await.unwrap();
+
+        // Restart the new downstairs read only.
+        new_ds.reboot_read_only().await.unwrap();
+        let new_target = new_ds.address().await;
+
+        // Take our original opts, and replace a target with the downstairs
+        // we just cloned.
+        let mut new_opts = test_downstairs_set.opts();
+        new_opts.target[0] = new_target;
+
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
+        volume
+            .add_subvolume_create_guest(
+                new_opts,
+                volume::RegionExtentInfo {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: test_downstairs_set.blocks_per_extent(),
+                    extent_count: test_downstairs_set.extent_count(),
+                },
+                3,
+                None,
+            )
+            .await?;
+
+        volume.activate().await?;
+
+        // Verify our volume still has the random data we wrote.
+        let volume_size = volume.total_size().await? as usize;
+        let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
+            .await?;
+
+        assert_eq!(&buffer[BLOCK_SIZE..], &random_buffer[BLOCK_SIZE..]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn integration_test_clone_sql() -> Result<()> {
+        // Test downstairs region clone.
+        // Create three downstairs with sql backend, write some data to them.
+        // Restart them all read only.
+        // Create a new downstairs.
+        // Clone a read only downstairs to the new downstairs
+        // Make a new volume with two old and the one new downstairs and verify
+        // the original data we wrote.
+        const BLOCK_SIZE: usize = 512;
+
+        // boot three downstairs, write some data to them, then change to
+        // read-only.
+        let mut test_downstairs_set =
+            TestDownstairsSet::small_sqlite(false).await?;
+
+        // This must be a SQLite extent!
+        assert!(test_downstairs_set
+            .downstairs1
+            .tempdir
+            .path()
+            .join("00/000/000.db")
+            .exists());
+
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
+        volume
+            .add_subvolume_create_guest(
+                test_downstairs_set.opts(),
+                volume::RegionExtentInfo {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: test_downstairs_set.blocks_per_extent(),
+                    extent_count: test_downstairs_set.extent_count(),
+                },
+                1,
+                None,
+            )
+            .await?;
+
+        volume.activate().await?;
+
+        let random_buffer = {
+            let mut random_buffer =
+                vec![0u8; volume.total_size().await? as usize];
+            rand::thread_rng().fill(&mut random_buffer[..]);
+            random_buffer
+        };
+
+        volume
+            .write(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(random_buffer.clone()),
+            )
+            .await?;
+
+        volume.deactivate().await.unwrap();
+        drop(volume);
+
+        // Restart the original downstairs read only.
+        test_downstairs_set.reboot_read_only().await?;
+
+        // Make the new downstairs
+        let mut new_ds = TestDownstairs::new(
+            "127.0.0.1".parse().unwrap(),
+            true,
+            true,
+            5,
+            2,
+            false,
+            Backend::RawFile,
+        )
+        .await
+        .unwrap();
+
+        // Clone a read only downstairs to our new downstairs.
+        let clone_source =
+            test_downstairs_set.downstairs1.repair_address().await;
+        new_ds.reboot_clone(clone_source).await.unwrap();
+
+        new_ds.reboot_read_only().await.unwrap();
+        let new_target = new_ds.address().await;
+
+        // The cloned region should have the .db file
+        assert!(new_ds.tempdir.path().join("00/000/000.db").exists());
+
+        // Replace one of the targets in our original with the new downstairs.
+        let mut new_opts = test_downstairs_set.opts();
+        new_opts.target[0] = new_target;
+
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
+        volume
+            .add_subvolume_create_guest(
+                new_opts,
+                volume::RegionExtentInfo {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: test_downstairs_set.blocks_per_extent(),
+                    extent_count: test_downstairs_set.extent_count(),
+                },
+                3,
+                None,
+            )
+            .await?;
+
+        volume.activate().await?;
+
+        // Verify our volume still has the random data we wrote.
+        let volume_size = volume.total_size().await? as usize;
+        let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
+            .await?;
+
+        assert_eq!(&buffer[BLOCK_SIZE..], &random_buffer[BLOCK_SIZE..]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn integration_test_clone_diff_ec() -> Result<()> {
+        // Test downstairs replacement.
+        // Verify different extent count will fail.
+
+        let mut ds_one = TestDownstairs::new(
+            "127.0.0.1".parse().unwrap(),
+            true,
+            true,
+            5,
+            3,
+            false,
+            Backend::RawFile,
+        )
+        .await
+        .unwrap();
+
+        ds_one.reboot_read_only().await.unwrap();
+        let clone_source = ds_one.repair_address().await;
+
+        let mut ds_two = TestDownstairs::new(
+            "127.0.0.1".parse().unwrap(),
+            true,
+            true,
+            5,
+            2, // <- Different than above
+            false,
+            Backend::RawFile,
+        )
+        .await
+        .unwrap();
+
+        assert!(ds_two.reboot_clone(clone_source).await.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn integration_test_clone_diff_es() -> Result<()> {
+        // Test downstairs replacement.
+        // Verify different extent size will fail.
+
+        let mut ds_one = TestDownstairs::new(
+            "127.0.0.1".parse().unwrap(),
+            true,
+            true,
+            9,
+            2,
+            false,
+            Backend::RawFile,
+        )
+        .await
+        .unwrap();
+
+        ds_one.reboot_read_only().await.unwrap();
+        let clone_source = ds_one.repair_address().await;
+
+        let mut ds_two = TestDownstairs::new(
+            "127.0.0.1".parse().unwrap(),
+            true,
+            true,
+            5, // <- Different than above
+            2,
+            false,
+            Backend::RawFile,
+        )
+        .await
+        .unwrap();
+
+        assert!(ds_two.reboot_clone(clone_source).await.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn integration_test_clone_not_ro() -> Result<()> {
+        // Test downstairs replacement.
+        // Verify you can't replace from a RW downstairs
+
+        let ds_one = TestDownstairs::new(
+            "127.0.0.1".parse().unwrap(),
+            true,
+            false, // <- RO is false.
+            5,
+            2,
+            false,
+            Backend::RawFile,
+        )
+        .await
+        .unwrap();
+
+        let clone_source = ds_one.repair_address().await;
+
+        let mut ds_two = TestDownstairs::new(
+            "127.0.0.1".parse().unwrap(),
+            true,
+            true,
+            5,
+            2,
+            false,
+            Backend::RawFile,
+        )
+        .await
+        .unwrap();
+
+        assert!(ds_two.reboot_clone(clone_source).await.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn integration_test_clone_diff_encrypted() -> Result<()> {
+        // Test downstairs replacement.
+        // Verify downstairs encryption state must match.
+
+        let ds_one = TestDownstairs::new(
+            "127.0.0.1".parse().unwrap(),
+            false,
+            true,
+            5,
+            2,
+            false,
+            Backend::RawFile,
+        )
+        .await
+        .unwrap();
+
+        let clone_source = ds_one.repair_address().await;
+
+        let mut ds_two = TestDownstairs::new(
+            "127.0.0.1".parse().unwrap(),
+            true, // <- Encrypted is different
+            true,
+            5,
+            2,
+            false,
+            Backend::RawFile,
+        )
+        .await
+        .unwrap();
+
+        assert!(ds_two.reboot_clone(clone_source).await.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn integration_test_volume_replace_downstairs() -> Result<()> {
         // Replace a downstairs with a new one
         const BLOCK_SIZE: usize = 512;
@@ -2632,6 +3022,142 @@ mod test {
                     test_downstairs_set.opts().id,
                     test_downstairs_set.downstairs1_address().await,
                     new_downstairs.address().await,
+                )
+                .await
+                .unwrap()
+            {
+                ReplaceResult::StartedAlready => {
+                    println!("Waiting for replacement to finish");
+                }
+                ReplaceResult::CompletedAlready => {
+                    println!("Downstairs replacement completed");
+                    break;
+                }
+                x => {
+                    panic!("Bad result from replace_downstairs: {:?}", x);
+                }
+            }
+        }
+
+        // Read back what we wrote.
+        let volume_size = volume.total_size().await? as usize;
+        assert_eq!(volume_size % BLOCK_SIZE, 0);
+        let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
+        volume
+            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
+            .await?;
+
+        assert_eq!(&buffer[BLOCK_SIZE..], &random_buffer[BLOCK_SIZE..]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn integration_test_volume_clone_replace_ro_downstairs() -> Result<()>
+    {
+        // Replace a read only downstairs with a new one, that we cloned
+        // from the original ro downstairs.
+        const BLOCK_SIZE: usize = 512;
+
+        // boot three downstairs, write some data to them, then change to
+        // read-only.
+        let mut test_downstairs_set = TestDownstairsSet::small(false).await?;
+
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
+        volume
+            .add_subvolume_create_guest(
+                test_downstairs_set.opts(),
+                volume::RegionExtentInfo {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: test_downstairs_set.blocks_per_extent(),
+                    extent_count: test_downstairs_set.extent_count(),
+                },
+                1,
+                None,
+            )
+            .await?;
+
+        volume.activate().await?;
+
+        let random_buffer = {
+            let mut random_buffer =
+                vec![0u8; volume.total_size().await? as usize];
+            rand::thread_rng().fill(&mut random_buffer[..]);
+            random_buffer
+        };
+
+        volume
+            .write(
+                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                Bytes::from(random_buffer.clone()),
+            )
+            .await?;
+
+        volume.deactivate().await.unwrap();
+
+        // Restart the three downstairs in read only mode.
+        test_downstairs_set.reboot_read_only().await?;
+
+        // Restart our volume with the restarted read-only downstairs.
+        let mut volume = Volume::new(BLOCK_SIZE as u64, csl());
+        volume
+            .add_subvolume_create_guest(
+                test_downstairs_set.opts(),
+                volume::RegionExtentInfo {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: test_downstairs_set.blocks_per_extent(),
+                    extent_count: test_downstairs_set.extent_count(),
+                },
+                2,
+                None,
+            )
+            .await?;
+
+        volume.activate().await?;
+
+        // Make the new downstairs, but don't start it
+        let mut new_ds = TestDownstairs::new(
+            "127.0.0.1".parse().unwrap(),
+            true,
+            true,
+            5,
+            2,
+            false,
+            Backend::RawFile,
+        )
+        .await
+        .unwrap();
+
+        let clone_source =
+            test_downstairs_set.downstairs1.repair_address().await;
+
+        // Clone a read only downstairs into the new downstairs region.
+        new_ds.reboot_clone(clone_source).await.unwrap();
+        // Start the new downstairs read only.
+        new_ds.reboot_read_only().await.unwrap();
+
+        // Replace a downstairs in our RO volume with the new downstairs we
+        // just cloned.
+        let res = volume
+            .replace_downstairs(
+                test_downstairs_set.opts().id,
+                test_downstairs_set.downstairs1.address().await,
+                new_ds.address().await,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res, ReplaceResult::Started);
+
+        // We can use the result from calling replace_downstairs to
+        // intuit status on progress of the replacement.
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+            match volume
+                .replace_downstairs(
+                    test_downstairs_set.opts().id,
+                    test_downstairs_set.downstairs1.address().await,
+                    new_ds.address().await,
                 )
                 .await
                 .unwrap()

--- a/openapi/downstairs-repair.json
+++ b/openapi/downstairs-repair.json
@@ -107,7 +107,7 @@
     },
     "/region-mode": {
       "get": {
-        "summary": "Return the RegionDefinition describing our region.",
+        "summary": "Return the region-mode describing our region.",
         "operationId": "get_region_mode",
         "responses": {
           "200": {

--- a/openapi/downstairs-repair.json
+++ b/openapi/downstairs-repair.json
@@ -80,10 +80,78 @@
           }
         }
       }
+    },
+    "/region-info": {
+      "get": {
+        "summary": "Return the RegionDefinition describing our region.",
+        "operationId": "get_region_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegionDefinition"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/region-mode": {
+      "get": {
+        "summary": "Return the RegionDefinition describing our region.",
+        "operationId": "get_region_mode",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Boolean",
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
     }
   },
   "components": {
     "schemas": {
+      "Block": {
+        "type": "object",
+        "properties": {
+          "shift": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "value": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "shift",
+          "value"
+        ]
+      },
       "Error": {
         "description": "Error information from a response.",
         "type": "object",
@@ -101,6 +169,61 @@
         "required": [
           "message",
           "request_id"
+        ]
+      },
+      "RegionDefinition": {
+        "type": "object",
+        "properties": {
+          "block_size": {
+            "description": "The size of each block in bytes. Must be a power of 2, minimum 512.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "database_read_version": {
+            "description": "The database version format for reading an extent database file.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "database_write_version": {
+            "description": "The database version format for writing an extent database file.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "encrypted": {
+            "description": "region data will be encrypted",
+            "type": "boolean"
+          },
+          "extent_count": {
+            "description": "How many whole extents comprise this region?",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "extent_size": {
+            "description": "How many blocks should appear in each extent?",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Block"
+              }
+            ]
+          },
+          "uuid": {
+            "description": "UUID for this region",
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "block_size",
+          "database_read_version",
+          "database_write_version",
+          "encrypted",
+          "extent_count",
+          "extent_size",
+          "uuid"
         ]
       },
       "FileType": {

--- a/repair-client/Cargo.toml
+++ b/repair-client/Cargo.toml
@@ -13,4 +13,6 @@ reqwest.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+crucible-common.workspace = true
 crucible-workspace-hack.workspace = true
+uuid.workspace = true

--- a/repair-client/src/lib.rs
+++ b/repair-client/src/lib.rs
@@ -5,4 +5,7 @@ use progenitor::generate_api;
 generate_api!(
     spec = "../openapi/downstairs-repair.json",
     derives = [schemars::JsonSchema],
+    replace = {
+        RegionDefinition = crucible_common::RegionDefinition,
+    }
 );

--- a/tools/README.md
+++ b/tools/README.md
@@ -35,6 +35,8 @@ downstairs UUID and is intended to provide a sample to build off of.
 
 ## test_ds.sh
 Test import then export for crucible downstairs.
+Then, test the clone subcommand and verify that the cloned downstairs
+exports the same file as the original downstairs.
 
 ## test_nightly.sh
 This runs a selection of tests from this directory and reports their

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -2394,6 +2394,9 @@ impl Downstairs {
             self.log,
             "{id} request to replace downstairs {old} with {new}"
         );
+        for (i, c) in self.clients.iter().enumerate() {
+            info!(self.log, "Have target: {:?} at {:?}", c.target_addr, i);
+        }
 
         // We check all targets first to not only find our current target,
         // but to be sure our new target is not an already active target

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -2394,9 +2394,6 @@ impl Downstairs {
             self.log,
             "{id} request to replace downstairs {old} with {new}"
         );
-        for (i, c) in self.clients.iter().enumerate() {
-            info!(self.log, "Have target: {:?} at {:?}", c.target_addr, i);
-        }
 
         // We check all targets first to not only find our current target,
         // but to be sure our new target is not an already active target


### PR DESCRIPTION
Add support for a new downstairs clone subcommand.
    
This enables a downstairs to "clone" another downstairs using the
repair endpoint.  It requires the source downstairs to be read only
and will destroy whatever data exists on the destination downstairs.
    
Support for cloning SQLite backend downstairs is supported, and I had
to bring back some of the old repair code that supported the additional
files for that.  The resulting clone'd downstairs will still have a SQLite
backend.
    
Found an fixed a bug where the incorrect file types were returned
during a repair that contained SQLite files.

A bunch more tests were added to cover the clone process, and new
API endpoints were added to the downstairs repair server.

The is the base layer we need to support replacement of read only parents.

For that the workflow up in omicron will be to:
* Identify a good working downstairs we can clone from.
* Get the repair port for that good downstairs.
* Create a new downstairs region on a good disk with the same region size, but
don't run the downstairs once the region is created.
* Call the downstairs clone using the region created and the repair port from
the good downstairs.
* Wait for the clone to finish.
* Restart the new downstairs in RO mode.
* Replace the failed donwstairs with the cloned downstairs.
