### PR TITLE
Add client id to error message

### DIFF
--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -3151,7 +3151,7 @@ impl Downstairs {
         let Some(job) = self.ds_active.get_mut(&ds_id) else {
             error!(
                 self.clients[client_id].log,
-                "IO completion error: missing {ds_id} "
+                "[{client_id}] IO completion error: missing {ds_id} "
             );
             /*
              * This assertion is only true for a limited time after


### PR DESCRIPTION
I saw a panic again on latest.
It would help if the error message confirmed what client the error came from.