### PR TITLE
Discard deferred msgs

### DIFF
--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -2184,6 +2184,18 @@ impl DownstairsClient {
     pub(crate) fn total_live_work(&self) -> usize {
         (self.io_state_count.new + self.io_state_count.in_progress) as usize
     }
+
+    /// Returns a unique ID for the current connect, or `None`
+    ///
+    /// This can be used to disambiguate between messages returned from
+    /// different connections to the same Downstairs.
+    pub(crate) fn get_connection_id(&self) -> Option<u64> {
+        if self.client_task.client_stop_tx.is_some() {
+            Some(self.stats.connected as u64)
+        } else {
+            None
+        }
+    }
 }
 
 /// How to handle "promote to active" requests

--- a/upstairs/src/deferred.rs
+++ b/upstairs/src/deferred.rs
@@ -239,12 +239,23 @@ pub(crate) struct DeferredMessage {
     pub hashes: Vec<Option<u64>>,
 
     pub client_id: ClientId,
+
+    /// See `DeferredRead::connection_id`
+    pub connection_id: u64,
 }
 
 /// Standalone data structure which can perform decryption
 pub(crate) struct DeferredRead {
     /// Message, which must be a `ReadResponse`
     pub message: Message,
+
+    /// Unique ID for this particular connection to the downstairs
+    ///
+    /// This is needed because -- if read decryption is deferred -- it may
+    /// complete after we have disconnected from the client, which would make
+    /// handling the decrypted value incorrect (because it may have been skipped
+    /// or re-sent).
+    pub connection_id: u64,
 
     pub client_id: ClientId,
     pub cfg: Arc<UpstairsConfig>,
@@ -288,6 +299,7 @@ impl DeferredRead {
         DeferredMessage {
             client_id: self.client_id,
             message: self.message,
+            connection_id: self.connection_id,
             hashes,
         }
     }

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -489,7 +489,7 @@ pub mod repair_test {
         info!(up.log, "repair job should have got here, move it forward");
         // The repair (NoOp) job should have shown up.  Move it forward.
         for cid in ClientId::iter() {
-            if cid != err_ds {
+            if cid != err_ds && cid != or_ds {
                 info!(up.log, "replying to repair job on {cid}");
                 reply_to_repair_job(&mut up, ds_repair_id, cid, Ok(()), None)
                     .await;
@@ -501,7 +501,7 @@ pub mod repair_test {
         // next.
         info!(up.log, "Now move the NoOp job forward");
         for cid in ClientId::iter() {
-            if cid != err_ds {
+            if cid != err_ds && cid != or_ds {
                 info!(up.log, "replying to NoOp job on {cid}");
                 reply_to_repair_job(&mut up, ds_noop_id, cid, Ok(()), None)
                     .await;
@@ -511,7 +511,7 @@ pub mod repair_test {
         // The reopen job should already be on the queue, move it forward.
         info!(up.log, "Finally, move the ReOpen job forward");
         for cid in ClientId::iter() {
-            if cid != err_ds {
+            if cid != err_ds && cid != or_ds {
                 info!(up.log, "replying to ReOpen job on {cid}");
                 reply_to_repair_job(&mut up, ds_reopen_id, cid, Ok(()), None)
                     .await;
@@ -814,7 +814,7 @@ pub mod repair_test {
 
         info!(up.log, "Now ACK the reopen job");
         for cid in ClientId::iter() {
-            if cid != err_ds {
+            if cid != err_ds && cid != or_ds {
                 reply_to_repair_job(&mut up, ds_reopen_id, cid, Ok(()), None)
                     .await;
             }


### PR DESCRIPTION
This fixes another occurrence of the panic thought to be addressed in #1126: 
```
Feb 02 00:44:11.050 WARN 63a91608-1f7f-41a4-bd21-76371c72a2d0 WARNING finish job 1083 when downstairs state: Offline, client: 1, : downstairs, session_id: 610eadbf-df34-44b5-8520-b4e88207bf54
thread 'test::integration_test_problematic_downstairs' panicked at upstairs/src/client.rs:1249:13:
[1] Job 1083 completed while not InProgress: New
stack backtrace:
   0: rust_begin_unwind
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:645:5
   1: core::panicking::panic_fmt
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/panicking.rs:72:14
   2: crucible::client::DownstairsClient::process_io_completion
             at /Users/mjk/oxide/crucible/upstairs/src/client.rs:1249:13
   3: crucible::downstairs::Downstairs::process_io_completion_inner
             at /Users/mjk/oxide/crucible/upstairs/src/downstairs.rs:3177:12
   4: crucible::downstairs::Downstairs::process_io_completion
             at /Users/mjk/oxide/crucible/upstairs/src/downstairs.rs:3063:9
   5: crucible::upstairs::Upstairs::on_client_message::{{closure}}
             at /Users/mjk/oxide/crucible/upstairs/src/upstairs.rs:1616:25
   6: crucible::upstairs::Upstairs::apply::{{closure}}
             at /Users/mjk/oxide/crucible/upstairs/src/upstairs.rs:540:43
   7: crucible::upstairs::Upstairs::run::{{closure}}
             at /Users/mjk/oxide/crucible/upstairs/src/upstairs.rs:429:32
   8: crucible::up_main::{{closure}}
             at /Users/mjk/oxide/crucible/upstairs/src/lib.rs:2962:58
   9: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/future/future.rs:125:9
  10: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /Users/mjk/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.35.1/src/runtime/task/core.rs:328:17
  11: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /Users/mjk/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.35.1/src/loom/std/unsafe_cell.rs:16:9
```

That fix was insufficient because messages from an about-to-be-disconnected client can be deferred (for decryption), and therefore still arrive in the main task after the client connection is closed.

The fix is to tag every message with its connection index, which is just `DownstairsStats::connected` for that particular client.  Then, when processing deferred messages, skip them if the connection index has changed.

This change also revealed a bug in our live-repair tests!  After we send an error, both the error-sending and the under-repair Downstairs will be moved to `DsState::Faulted`; therefore, we shouldn't be sending a reply from the latter.