### PR TITLE
Remove mutexes from Downstairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,7 @@ dependencies = [
  "oximeter-producer",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "rayon",
  "repair-client",
  "reqwest",
  "ringbuffer",

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -32,6 +32,7 @@ opentelemetry.workspace = true
 oximeter-producer.workspace = true
 oximeter.workspace = true
 rand.workspace = true
+rayon.workspace = true
 repair-client.workspace = true
 reqwest.workspace = true
 ringbuffer.workspace = true

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -59,8 +59,7 @@ pub async fn dump_region(
          * directory index and the value is the ExtentMeta for that region.
          */
         for e in &region.extents {
-            let e = e.lock().await;
-            let e = match &*e {
+            let e = match e {
                 extent::ExtentState::Opened(extent) => extent,
                 extent::ExtentState::Closed => panic!("dump on closed extent!"),
             };
@@ -534,7 +533,7 @@ async fn show_extent(
          */
         for (index, dir) in region_dir.iter().enumerate() {
             // Open Region read only
-            let region =
+            let mut region =
                 Region::open(dir, Default::default(), false, true, &log)
                     .await?;
 
@@ -650,7 +649,7 @@ async fn show_extent_block(
      */
     for (index, dir) in region_dir.iter().enumerate() {
         // Open Region read only
-        let region =
+        let mut region =
             Region::open(dir, Default::default(), false, true, &log).await?;
 
         let mut responses = region

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -849,7 +849,7 @@ async fn proc_frame(
             gen_number,
         } => {
             let msg = {
-                let d = ad.lock().await;
+                let mut d = ad.lock().await;
                 debug!(
                     d.log,
                     "{} Flush extent {} with f:{} g:{}",
@@ -885,7 +885,7 @@ async fn proc_frame(
             extent_id,
         } => {
             let msg = {
-                let d = ad.lock().await;
+                let mut d = ad.lock().await;
                 debug!(d.log, "{} Close extent {}", repair_id, extent_id);
                 match d.region.close_extent(extent_id).await {
                     Ok(_) => Message::RepairAckId { repair_id },


### PR DESCRIPTION
Right now, a job going through the Downstairs has to lock three async mutexes:

- The main `Arc<Mutex<Downstairs>>`
- For a specific extent, an `Arc<Mutex<ExtentState>>`
- Within that extent, a `Mutex<Box<dyn ExtentInner>>`

Only the first one is necessary: once we have exclusive ownership over the `Downstairs`, no one else can mess with it, so the other mutexes aren't protecting us from anything.  This PR removes the other two locks.

Removing these async locks makes _many_ functions synchronous, so most of the changes are mechanically removing `async` / `await` from places where it's no longer needed.

There's only one tricky part:

Because we hold a `&Extent` across yield points, it must be `Send` (and therefore `Extent` must be `Sync`).  It turns out that `rustqlite::Connection` is **not** `Sync`, because it uses a `RefCell` internally.  Previously, storing the `dyn ExtentInner` in a `Mutex` let us get away with this.

I went for the simplest-possible fix: wrapping the entire `SqliteInner` in a `std::sync::Mutex`.  This is still one fewer mutex lock than the previous code, and it means we don't have to change any other code.

There's **one thing that needs fixing** before merging: this PR switches the flush from parallel -> serial, which reduced performance in a quick benchmark.  Still, the rest should be ready to look over!