### PR TITLE
Use FIOFFS on illumos instead of fsync

### DIFF
--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -71,3 +71,4 @@ asm = ["usdt/asm"]
 default = []
 zfs_snapshot = []
 integration-tests = [] # Enables creating SQLite volumes
+omicron-build = []

--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -42,6 +42,15 @@ pub(crate) trait ExtentInner: Send + Debug {
         job_id: JobOrReconciliationId,
     ) -> Result<(), CrucibleError>;
 
+    /// After both user data and any extent metadata have been flushed to
+    /// durable storage, perform accounting or clean-up.
+    fn post_flush(
+        &mut self,
+        new_flush: u64,
+        new_gen: u64,
+        job_id: JobOrReconciliationId,
+    ) -> Result<(), CrucibleError>;
+
     fn read(
         &mut self,
         job_id: JobId,
@@ -588,6 +597,18 @@ impl Extent {
         }
 
         inner.flush(new_flush, new_gen, job_id)
+    }
+
+    #[instrument]
+    pub(crate) async fn post_flush<I: Into<JobOrReconciliationId> + Debug>(
+        &self,
+        new_flush: u64,
+        new_gen: u64,
+        id: I, // only used for logging
+    ) -> Result<(), CrucibleError> {
+        let job_id = id.into();
+        let mut inner = self.inner.lock().await;
+        inner.post_flush(new_flush, new_gen, job_id)
     }
 
     pub async fn get_meta_info(&self) -> ExtentMeta {

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -807,7 +807,7 @@ impl Region {
      */
     #[instrument]
     pub(crate) async fn region_flush_extent<
-        I: Into<JobOrReconciliationId> + Debug,
+        I: Into<JobOrReconciliationId> + Debug + Copy,
     >(
         &self,
         eid: usize,
@@ -824,9 +824,12 @@ impl Region {
         );
 
         let extent = self.get_opened_extent(eid).await;
+
         extent
             .flush(flush_number, gen_number, job_id, &self.log)
             .await?;
+
+        extent.post_flush(flush_number, gen_number, job_id).await?;
 
         Ok(())
     }
@@ -903,6 +906,37 @@ impl Region {
             // the results were all collected above, each extent flush has
             // completed at this point.
             result??;
+        }
+
+        if cfg!(feature = "omicron-build") {
+            use std::io;
+            use std::os::fd::AsRawFd;
+            use std::ptr;
+
+            // "file system flush", defined in illumos' sys/filio.h
+            const FIOFFS: libc::c_int = 0x20000000 | (0x66 /*'f'*/ << 8) | 0x42 /*66*/;
+
+            // Open the region's mountpoint
+            let file = File::open(&self.dir)?;
+
+            let rc = unsafe {
+                libc::ioctl(
+                    file.as_raw_fd(),
+                    FIOFFS as _,
+                    ptr::null_mut::<i32>(),
+                )
+            };
+
+            if rc != 0 {
+                return Err(io::Error::last_os_error().into());
+            }
+        }
+
+        // After the bits have been committed to durable storage, execute any post flush routine
+        // that needs to happen
+        for eid in &dirty_extents {
+            let extent = self.get_opened_extent(*eid).await;
+            extent.post_flush(flush_number, gen_number, job_id).await?;
         }
 
         // Now everything has succeeded, we can remove these extents from the


### PR DESCRIPTION
illumos supports sending a FIOFFS ioctl to a ZFS dataset in order to sync _all_ outstanding IO. Use this ioctl in `region_flush` for the whole region dataset instead of calling `sync_all` for each extent file. This is hidden behind a new `omicron-build` feature, which is true for our production builds.

This necessitated separating flush (which commits bits to durable storage and is a no-op if `omicron-build` is used) and `post_flush` (which performs clean up or any other kind of accounting). Splitting this up exposed a bug in the sqlite implementation of ExtentInner: it wasn't checking to see if the extent was dirty and wasn't calling `set_flush_number` before calling `sync_all` on the user data file.