### PR TITLE
Drop jobs from Offline downstairs.

### DIFF
--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -195,6 +195,9 @@ pub(crate) struct DownstairsClient {
 
     /// State for startup negotiation
     negotiation_state: NegotiationState,
+
+    /// Session ID for a clients connection to a downstairs.
+    connection_id: usize,
 }
 
 impl DownstairsClient {
@@ -231,6 +234,7 @@ impl DownstairsClient {
             region_metadata: None,
             repair_info: None,
             io_state_count: ClientIOStateCount::new(),
+            connection_id: 0,
         }
     }
 
@@ -267,6 +271,7 @@ impl DownstairsClient {
             region_metadata: None,
             repair_info: None,
             io_state_count: ClientIOStateCount::new(),
+            connection_id: 0,
         }
     }
 
@@ -604,6 +609,7 @@ impl DownstairsClient {
             self.state = DsState::New;
         }
 
+        self.connection_id += 1;
         // Restart with a short delay
         self.start_task(true, auto_promote);
     }
@@ -2185,13 +2191,13 @@ impl DownstairsClient {
         (self.io_state_count.new + self.io_state_count.in_progress) as usize
     }
 
-    /// Returns a unique ID for the current connect, or `None`
+    /// Returns a unique ID for the current connection, or `None`
     ///
     /// This can be used to disambiguate between messages returned from
     /// different connections to the same Downstairs.
     pub(crate) fn get_connection_id(&self) -> Option<u64> {
         if self.client_task.client_stop_tx.is_some() {
-            Some(self.stats.connected as u64)
+            Some(self.connection_id as u64)
         } else {
             None
         }

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -112,7 +112,7 @@ struct ClientTaskHandle {
     client_stop_tx: Option<oneshot::Sender<ClientStopReason>>,
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct ConnectionId(pub u64);
 
 impl std::fmt::Display for ConnectionId {
@@ -2213,9 +2213,9 @@ impl DownstairsClient {
     ///
     /// This can be used to disambiguate between messages returned from
     /// different connections to the same Downstairs.
-    pub(crate) fn get_connection_id(&self) -> Option<u64> {
+    pub(crate) fn get_connection_id(&self) -> Option<ConnectionId> {
         if self.client_task.client_stop_tx.is_some() {
-            Some(self.connection_id.0)
+            Some(self.connection_id)
         } else {
             None
         }

--- a/upstairs/src/deferred.rs
+++ b/upstairs/src/deferred.rs
@@ -3,8 +3,8 @@
 use std::sync::Arc;
 
 use crate::{
-    upstairs::UpstairsConfig, BlockContext, BlockReq, BlockRes, ClientId,
-    ImpactedBlocks, Message, SerializedWrite,
+    client::ConnectionId, upstairs::UpstairsConfig, BlockContext, BlockReq,
+    BlockRes, ClientId, ImpactedBlocks, Message, SerializedWrite,
 };
 use bytes::{Bytes, BytesMut};
 use crucible_common::{integrity_hash, CrucibleError, RegionDefinition};
@@ -241,7 +241,7 @@ pub(crate) struct DeferredMessage {
     pub client_id: ClientId,
 
     /// See `DeferredRead::connection_id`
-    pub connection_id: u64,
+    pub connection_id: ConnectionId,
 }
 
 /// Standalone data structure which can perform decryption
@@ -255,7 +255,7 @@ pub(crate) struct DeferredRead {
     /// complete after we have disconnected from the client, which would make
     /// handling the decrypted value incorrect (because it may have been skipped
     /// or re-sent).
-    pub connection_id: u64,
+    pub connection_id: ConnectionId,
 
     pub client_id: ClientId,
     pub cfg: Arc<UpstairsConfig>,

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -3046,26 +3046,6 @@ impl Downstairs {
                 );
                 return Err(CrucibleError::NoLongerActive);
             }
-            DsState::Offline => {
-                // If we have gone offline, it's possible that a job landed just
-                // before the downstairs went away.  If we have moved jobs to New, it
-                // means we plan to replay them and we can discard this job now.
-                if let Some(job) = self.ds_active.get(&ds_id) {
-                    if job.state[client_id] == IOState::New {
-                        warn!(
-                            self.clients[client_id].log,
-                            "Drop job {} because we are {}", ds_id, ds_state
-                        );
-                        return Err(CrucibleError::NoLongerActive);
-                    }
-                }
-                warn!(
-                    self.clients[client_id].log,
-                    "{} WARNING finish job {} when downstairs Offline",
-                    self.cfg.upstairs_id,
-                    ds_id,
-                );
-            }
             _ => {
                 warn!(
                     self.clients[client_id].log,


### PR DESCRIPTION
If we receive a job ACK from an offline downstairs, and that job has already been moved
back to New, then discard it as we know the replay will resend it when the downstairs 
comes back.


This is to fix https://github.com/oxidecomputer/crucible/issues/1155
