### PR TITLE
Verify extent under repair is valid after copying files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,6 +988,7 @@ dependencies = [
  "hex",
  "httptest",
  "rand 0.8.5",
+ "repair-client",
  "reqwest",
  "serde",
  "serde_json",

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -26,6 +26,7 @@ futures.workspace = true
 hex.workspace = true
 httptest.workspace = true
 rand.workspace = true
+repair-client.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/openapi/downstairs-repair.json
+++ b/openapi/downstairs-repair.json
@@ -46,6 +46,43 @@
         }
       }
     },
+    "/extent/{eid}/repair-ready": {
+      "get": {
+        "summary": "Return true if the provided extent is closed or the region is read only",
+        "operationId": "extent_repair_ready",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "eid",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Boolean",
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/newextent/{eid}/{file_type}": {
       "get": {
         "operationId": "get_extent_file",

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -1247,8 +1247,8 @@ impl DownstairsClient {
         if old_state != IOState::InProgress {
             // This job is in an unexpected state.
             panic!(
-                "[{}] Job {} completed while not InProgress: {:?}",
-                self.client_id, ds_id, old_state
+                "[{}] Job {} completed while not InProgress: {:?} {:?}",
+                self.client_id, ds_id, old_state, job
             );
         }
 


### PR DESCRIPTION
Added a call to the downstairs repair API that will verify that an extent is closed (or the region is read only), 
meaning the extent is okay to copy.

This prevents a rare but possible condition where an extent is closed when a remote side contacts it for repair, but is re-opened before the extent file copy starts.  This leaves the resulting copy as invalid.

During the pstop/prun tests, I saw this once where the pstop to a downstairs happened just after we had
pulled over the list of files to verify, but before the actual files were copied over.  The details of that
are described here: https://github.com/oxidecomputer/crucible/issues/1146