### PR TITLE
Do not 500 on snapshot delete for deleted region

### DIFF
--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -464,7 +464,7 @@ impl DataFile {
             path.into_os_string().into_string().unwrap(),
         ) {
             Ok(dataset) => dataset,
-            Err(_e) => {
+            Err(e) => {
                 // This branch can only be entered if `zfs list` for that
                 // dataset path failed to return anything.
 
@@ -482,18 +482,21 @@ impl DataFile {
                             // This is a bug: according to the agent's datafile,
                             // the region exists, but according to zfs list, it
                             // does not
-                            bail!("Agent thinks region {} exists but zfs list does not!", request.id.0);
+                            bail!("Agent thinks region {} exists but zfs list does not! {e}", request.id.0);
                         }
 
                         State::Failed => {
                             // Something has set the region to state failed, so
                             // we can't delete this snapshot.
-                            bail!("Region {} is in state failed", request.id.0);
+                            bail!(
+                                "Region {} is in state failed! {e}",
+                                request.id.0
+                            );
                         }
                     }
                 } else {
                     // In here, the region never existed!
-                    bail!("Inside region {} snapshot {} delete, region never existed!", request.id.0, request.name);
+                    bail!("Inside region {} snapshot {} delete, region never existed! {e}", request.id.0, request.name);
                 }
             }
         };

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -98,7 +98,9 @@ impl ZFSDataset {
             .output()?;
 
         if !cmd.status.success() {
-            bail!("zfs list failed!");
+            let stderr =
+                String::from_utf8_lossy(&cmd.stderr).trim_end().to_string();
+            bail!("zfs list failed! {stderr}");
         }
 
         Ok(ZFSDataset {

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -83,7 +83,10 @@ pub struct ZFSDataset {
 }
 
 impl ZFSDataset {
-    // From either dataset name or path, create the ZFSDataset object
+    /// From either dataset name or path, create the ZFSDataset object.
+    ///
+    /// Fails if the dataset name does not exist, or the path does not exist (or
+    /// belong to a dataset).
     pub fn new(dataset: String) -> Result<ZFSDataset> {
         // Validate the argument is a dataset
         let cmd = std::process::Command::new("zfs")


### PR DESCRIPTION
The code path that validates a snapshot delete request checks that a region exists, and returns 404 if it does not:

    match rc.context().get(&p.id) {
        Some(_) => (),
        None => {
            return Err(HttpError::for_not_found(
                None,
                format!("region {:?} not found", p.id),
            ));
        }
    }

However there's a flaw in this check: if the region existed but was deleted, this will not return a 404, and proceed into `delete_snapshot`.

`delete_snapshot` will check if a running snapshot exists, and if it does will bail out: it's an invalid request to delete a snapshot for which there's a read-only downstairs running for.

However, the very next thing the code does is try to make a ZFSDataset object out of the region's data path. If the region was deleted this will lead to `zfs list` exiting with a non-zero return code, and will bubble up to the user as a 500.

Catch ZFSDataset returning Err, and if the region existed but was deleted, we can assume the snapshot was deleted prior to this (as the agent would not allow otherwise). If the region existed and isn't deleted, and `zfs list` for that region path failed, then the agent's datafile doesn't match reality.