### PR TITLE
Make `gw_ds_complete` less public

### DIFF
--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -147,7 +147,7 @@ impl GtoS {
 
 /// Strongly-typed ID for guest work (stored in the [`GuestWork`] map)
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
-pub struct GuestWorkId(pub u64);
+pub(crate) struct GuestWorkId(pub u64);
 
 impl std::fmt::Display for GuestWorkId {
     fn fmt(
@@ -244,7 +244,7 @@ impl GuestWork {
      * This may include moving data buffers from completed reads.
      */
     #[instrument]
-    pub async fn gw_ds_complete(
+    pub(crate) async fn gw_ds_complete(
         &mut self,
         gw_id: GuestWorkId,
         ds_id: JobId,

--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -147,7 +147,7 @@ impl GtoS {
 
 /// Strongly-typed ID for guest work (stored in the [`GuestWork`] map)
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
-pub(crate) struct GuestWorkId(pub u64);
+pub struct GuestWorkId(pub u64);
 
 impl std::fmt::Display for GuestWorkId {
     fn fmt(


### PR DESCRIPTION
I'm a little confused by this – `crucible` compiles just fine, but using it in `propolis-standalone` gives a compile-time error message:

```
error[E0446]: crate-private type `GuestWorkId` in public interface
   --> /home/matt/crucible/upstairs/src/guest.rs:246:5
    |
150 | pub(crate) struct GuestWorkId(pub u64);
    | ----------------------------- `GuestWorkId` declared as crate-private
...
246 |     #[instrument]
    |     ^^^^^^^^^^^^^ can't leak crate-private type
    |
    = note: this error originates in the attribute macro `instrument` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0446`.
```