### PR TITLE
Backpressure consolidation

### DIFF
--- a/upstairs/src/backpressure.rs
+++ b/upstairs/src/backpressure.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 use std::{
     sync::{
         atomic::{AtomicU64, Ordering},

--- a/upstairs/src/backpressure.rs
+++ b/upstairs/src/backpressure.rs
@@ -1,0 +1,121 @@
+// Copyright 2023 Oxide Computer Company
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+#[derive(Debug, Default)]
+pub(crate) struct BackpressureCounters {
+    /// The number of write bytes that haven't finished yet
+    ///
+    /// This is used to configure backpressure to the host, because writes
+    /// (uniquely) will return before actually being completed by a Downstairs
+    /// and can clog up the queues.
+    write_bytes_outstanding: AtomicU64,
+
+    /// Number of IO jobs in the downstairs queue
+    io_jobs: AtomicU64,
+
+    /// Cached value for backpressure
+    ///
+    /// This is written whenever we recompute backpressure, and read by the
+    /// `GuestIoHandle` when it wants to print updated stats.
+    backpressure_us: AtomicU64,
+}
+
+impl BackpressureCounters {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    pub fn write_bytes_outstanding(&self) -> u64 {
+        self.write_bytes_outstanding.load(Ordering::Relaxed)
+    }
+
+    pub fn backpressure_us(&self) -> u64 {
+        self.backpressure_us.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct BackpressureGuard {
+    bp: Arc<BackpressureCounters>,
+    write_bytes: u64,
+}
+
+impl BackpressureGuard {
+    pub fn new(bp: Arc<BackpressureCounters>, write_bytes: u64) -> Self {
+        bp.write_bytes_outstanding
+            .fetch_add(write_bytes, Ordering::Relaxed);
+        bp.io_jobs.fetch_add(1, Ordering::Relaxed);
+        Self { bp, write_bytes }
+    }
+}
+
+impl Drop for BackpressureGuard {
+    fn drop(&mut self) {
+        self.bp
+            .write_bytes_outstanding
+            .fetch_sub(self.write_bytes, Ordering::Relaxed);
+        self.bp.io_jobs.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+/// Configuration for host-side backpressure
+///
+/// Backpressure adds an artificial delay to host write messages (which are
+/// otherwise acked immediately, before actually being complete).  The delay is
+/// varied based on two metrics:
+///
+/// - number of write bytes outstanding
+/// - queue length as a fraction (where 1.0 is full)
+///
+/// These two metrics are used for quadratic backpressure, picking the larger of
+/// the two delays.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct BackpressureConfig {
+    /// When should backpressure start (in bytes)?
+    pub bytes_start: u64,
+    /// Scale for byte-based quadratic backpressure
+    pub bytes_scale: f64,
+
+    /// When should queue-based backpressure start?
+    pub queue_start: f64,
+    /// Maximum queue-based delay
+    pub queue_max_delay: Duration,
+}
+
+impl BackpressureConfig {
+    pub fn get_delay(&self, bp: &BackpressureCounters) -> Duration {
+        let bytes = bp.write_bytes_outstanding.load(Ordering::Relaxed);
+        let jobs = bp.io_jobs.load(Ordering::Relaxed);
+        let ratio = jobs as f64 / crate::IO_OUTSTANDING_MAX as f64;
+
+        // Check to see if the number of outstanding write bytes (between
+        // the upstairs and downstairs) is particularly high.  If so,
+        // apply some backpressure by delaying host operations, with a
+        // quadratically-increasing delay.
+        let d1 = (bytes.saturating_sub(self.bytes_start) as f64
+            * self.bytes_scale)
+            .powf(2.0) as u64;
+
+        // Compute an alternate delay based on queue length
+        let d2 = self
+            .queue_max_delay
+            .mul_f64(
+                ((ratio - self.queue_start).max(0.0)
+                    / (1.0 - self.queue_start))
+                    .powf(2.0),
+            )
+            .as_micros() as u64;
+
+        // Write the current value to the cache in BackpressureCounters
+        let bp_us = d1.max(d2);
+        bp.backpressure_us.store(bp_us, Ordering::Relaxed);
+
+        Duration::from_micros(bp_us)
+    }
+}

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -3417,11 +3417,11 @@ mod test {
             ddef,
             impacted_blocks,
             data: data.clone().into(),
-            res: None,
+            backpressure_guard: None,
             is_write_unwritten: false,
             cfg: cfg.clone(),
         };
-        let write_data = dr.run().unwrap();
+        let write_data = dr.run();
 
         let msg = ClientRequest::RawMessage(
             RawMessage::Write {
@@ -3517,11 +3517,11 @@ mod test {
             ddef,
             impacted_blocks,
             data: data.clone().into(),
-            res: None,
+            backpressure_guard: None,
             is_write_unwritten: true,
             cfg: cfg.clone(),
         };
-        let write_data = dr.run().unwrap();
+        let write_data = dr.run();
 
         let msg = ClientRequest::RawMessage(
             RawMessage::WriteUnwritten {

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -522,8 +522,8 @@ pub(crate) mod protocol_test {
 
             // Configure our guest without queue backpressure, to speed up tests
             // which require triggering a timeout
-            let (g, mut io) = Guest::new(Some(log.clone()));
-            io.disable_queue_backpressure();
+            let (mut g, io) = Guest::new(Some(log.clone()));
+            g.disable_queue_backpressure();
             let guest = Arc::new(g);
 
             let crucible_opts = CrucibleOpts {

--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -839,9 +839,9 @@ impl GuestIoHandle {
 
         // Check if we can consume right away
         let iop_limit_applies =
-            self.limits.iop_limit.is_some() && req.op.consumes_iops();
+            self.limits.iop_limit.is_some() && req.op().consumes_iops();
         let bw_limit_applies =
-            self.limits.bw_limit.is_some() && req.op.sz().is_some();
+            self.limits.bw_limit.is_some() && req.op().sz().is_some();
 
         if !iop_limit_applies && !bw_limit_applies {
             return UpstairsAction::Guest(req);
@@ -860,14 +860,14 @@ impl GuestIoHandle {
         // reached.
 
         if let Some(bw_limit) = self.limits.bw_limit {
-            if req.op.sz().is_some() && self.bw_tokens >= bw_limit {
+            if req.op().sz().is_some() && self.bw_tokens >= bw_limit {
                 bw_check_ok = false;
             }
         }
 
         if let Some(iop_limit_cfg) = &self.limits.iop_limit {
             let bytes_per_iops = iop_limit_cfg.bytes_per_iop;
-            if req.op.iops(bytes_per_iops).is_some()
+            if req.op().iops(bytes_per_iops).is_some()
                 && self.iop_tokens >= iop_limit_cfg.iop_limit
             {
                 iop_check_ok = false;
@@ -878,13 +878,13 @@ impl GuestIoHandle {
         // block req
         if bw_check_ok && iop_check_ok {
             if self.limits.bw_limit.is_some() {
-                if let Some(sz) = req.op.sz() {
+                if let Some(sz) = req.op().sz() {
                     self.bw_tokens += sz;
                 }
             }
 
             if let Some(cfg) = &self.limits.iop_limit {
-                if let Some(req_iops) = req.op.iops(cfg.bytes_per_iop) {
+                if let Some(req_iops) = req.op().iops(cfg.bytes_per_iop) {
                     self.iop_tokens += req_iops;
                 }
             }


### PR DESCRIPTION
This PR changes the way that backpressure is tracked.  Previously, we had to manually increment / decrement counters whenever jobs were created or destroyed (which could happen in multiple places).  In this PR, I introduce two things:

- An `Arc<BackpressureCounters>`, which is shared between the guest and upstairs and can be updated atomically
- A new `struct BackpressureGuard`, which does three things:
    - Stores an `Arc<BackpressureCounters>`, i.e. a handle to the global counter object
    - Upon construction, increments those counters
    - When dropped, decrements those counters

In other words, as long as the `BackpressureGuard` lives alongside the IO that it represents, we get updates to our counters for free.  To make this happen, I added a `backpressure_guard` field to the `struct DownstairsIO`, which lives as long as the IO operation is active.

One side effect of this change is that the "write bytes in flight" counter is now updated **immediately** upon receiving the job, rather than when encryption finishes.  This means that we can do our fast-ack before encryption as well, which wasn't possible before*.  In other words, we're removing the last known source of Accidental Backpressure in the system, and rely solely on Intentional Backpressure to delay writes.

This PR doesn't address #1167 and doesn't make the full set of changes recommended in [RFD 445](https://rfd.shared.oxide.computer/rfd/445); in particular, we still need to add the "mark Downstairs as failed if it has too much data in flight" change.

I still need to get some performance numbers, but this is ready for initial review.

*acking before encryption + updating the backpressure counters _after_ encryption is effectively adding lag to the backpressure control loop, and makes it go unstable.

