### PR TITLE
Tweak CI scripts to fix warnings

### DIFF
--- a/.github/workflows/hakari.yml
+++ b/.github/workflows/hakari.yml
@@ -18,20 +18,11 @@ jobs:
       RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
       - name: Install cargo-hakari
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-hakari
       - name: Check workspace-hack Cargo.toml is up-to-date
-        uses: actions-rs/cargo@v1
-        with:
-          command: hakari
-          args: generate --diff
+        run: cargo hakari generate --diff
       - name: Check all crates depend on workspace-hack
-        uses: actions-rs/cargo@v1
-        with:
-          command: hakari
-          args: manage-deps --dry-run
+        run: cargo hakari manage-deps --dry-run

--- a/.github/workflows/hakari.yml
+++ b/.github/workflows/hakari.yml
@@ -1,5 +1,3 @@
-# This workflow file serves as an example for cargo-hakari CI integration.
-
 on:
   push:
     branches:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,27 +22,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-    - uses: dtolnay/rust-toolchain@1.66
     - name: Test build documentation
       run: cargo doc
   build-and-test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-    - uses: dtolnay/rust-toolchain@1.66
     - name: Build
       run: cargo build --verbose
     - name: Install latest nextest release
       uses: taiki-e/install-action@nextest
     - name: Test nextest all
-      uses: actions-rs/cargo@v1
-      with:
-        command: nextest
-        args: run --verbose
+      run: cargo nextest run --verbose
   clippy:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-    - uses: dtolnay/rust-toolchain@1.66
     - name: Test Libraries
       run: cargo clippy --all-targets


### PR DESCRIPTION
Right now, we're getting various warnings when running Github Actions, mostly about things using Node 16 (which is [soon to be deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/))

I went through and did a quick cleanup pass:

- `cargo` is installed on the CI machines by default, so we don't need `actions-rs/toolchain@v1` (which is archived / unmaintained)
- We have an explicit `rust-toolchain.yml` committed, so we don't need `dtolnay/rust-toolchain@1.66`

(now I'm double-checking these changes by opening this PR, which should trigger CI 😄)