### PR TITLE
Start byte-based backpressure earlier

### DIFF
--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -343,6 +343,8 @@ struct BackpressureConfig {
     bytes_start: u64,
     /// Scale for byte-based quadratic backpressure
     bytes_scale: f64,
+    /// Maximum bytes-based backpressure
+    bytes_max_delay: Duration,
 
     /// When should queue-based backpressure start?
     queue_start: f64,
@@ -393,8 +395,12 @@ impl Guest {
             bw_tokens: 0,
             backpressure_us: backpressure_us.clone(),
             backpressure_config: BackpressureConfig {
-                bytes_start: 1024u64.pow(3), // Start at 1 GiB
-                bytes_scale: 9.3e-8,         // Delay of 10ms at 2 GiB in-flight
+                // Byte-based backpressure
+                bytes_start: 100 * 1024u64.pow(2), // Start at 100 MiB
+                bytes_scale: 6e-8, // Delay of 15ms at 2 GiB in-flight
+                bytes_max_delay: Duration::from_millis(15),
+
+                // Queue-based backpressure
                 queue_start: 0.05,
                 queue_max_delay: Duration::from_millis(5),
             },
@@ -918,10 +924,13 @@ impl GuestIoHandle {
         // the upstairs and downstairs) is particularly high.  If so,
         // apply some backpressure by delaying host operations, with a
         // quadratically-increasing delay.
-        let d1 = (bytes.saturating_sub(self.backpressure_config.bytes_start)
-            as f64
-            * self.backpressure_config.bytes_scale)
-            .powf(2.0) as u64;
+        let d1 = (self.backpressure_config.bytes_max_delay.as_micros() as u64)
+            .min(
+                (bytes.saturating_sub(self.backpressure_config.bytes_start)
+                    as f64
+                    * self.backpressure_config.bytes_scale)
+                    .powf(2.0) as u64,
+            );
 
         // Compute an alternate delay based on queue length
         let d2 = self


### PR DESCRIPTION
This PR implements a suggestion from RFD 445 of having byte-based backpressure start earlier (see the section titled [Whither latency?](https://rfd.shared.oxide.computer/rfd/445#_whither_latency)).

It also caps the max byte-based backpressure, so that we'd timeout sooner if a Downstairs goes away during a large-write workload (see [Problematic Bytes-In-Flight Delay](https://rfd.shared.oxide.computer/rfd/445#_problematic_bytes_in_flight_delay))

Previously, the system stabilized at about 1.8 GiB of in-flight data.  With the tuning in this PR, it stabilizes at around 500-600 MiB instead.  This means that when we switch from writes to reads, we doesn't need to wait as long!

I see no performance impacts.  For reference, here's a quick `fio` test run:
```
1M WRITE: bw=723MiB/s (758MB/s), 723MiB/s-723MiB/s (758MB/s-758MB/s), io=42.5GiB (45.6GB), run=60099-60099msec
4K WRITE: bw=28.3MiB/s (29.7MB/s), 28.3MiB/s-28.3MiB/s (29.7MB/s-29.7MB/s), io=1698MiB (1781MB), run=60009-60009msec
1M WRITE: bw=772MiB/s (810MB/s), 772MiB/s-772MiB/s (810MB/s-810MB/s), io=45.3GiB (48.6GB), run=60025-60025msec
4M WRITE: bw=754MiB/s (791MB/s), 754MiB/s-754MiB/s (791MB/s-791MB/s), io=44.3GiB (47.5GB), run=60107-60107msec
4K READ: bw=27.5MiB/s (28.9MB/s), 27.5MiB/s-27.5MiB/s (28.9MB/s-28.9MB/s), io=1653MiB (1733MB), run=60003-60003msec
1M READ: bw=629MiB/s (659MB/s), 629MiB/s-629MiB/s (659MB/s-659MB/s), io=36.9GiB (39.6GB), run=60036-60036msec
4M READ: bw=737MiB/s (773MB/s), 737MiB/s-737MiB/s (773MB/s-773MB/s), io=43.3GiB (46.5GB), run=60130-60130msec
```

This is roughly the same as [numbers from `main` here](https://github.com/oxidecomputer/crucible/issues/1167#issuecomment-1960375374).

(#1167 remains unaddressed by these changes)