### PR TITLE
Deactivate the read only parent after a scrub

### DIFF
--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -445,6 +445,13 @@ impl Volume {
                 pause_millis,
             );
             self.flush(None).await?;
+            info!(self.log, "Deactivate read only parent {}", self.uuid,);
+            if let Err(e) = read_only_parent.deactivate().await {
+                warn!(
+                    self.log,
+                    "deactivate ROP on {} failed with {}", self.uuid, e
+                );
+            }
         } else {
             info!(self.log, "Scrub for {} not required", self.uuid);
         }


### PR DESCRIPTION
If the scrub on a read only parent finishes without error, then send a 
deactivate to force a disconnect from all the downstairs.

This should fix https://github.com/oxidecomputer/crucible/issues/1090