### PR TITLE
Add per-client backpressure

### DIFF
--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -643,6 +643,10 @@ impl DownstairsClient {
         }
 
         self.connection_id.update();
+
+        // Clear per-client delay, because we're starting a new session
+        self.set_delay_us(0);
+
         // Restart with a short delay
         self.start_task(true, auto_promote);
     }

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -644,9 +644,6 @@ impl DownstairsClient {
 
         self.connection_id.update();
 
-        // Clear per-client delay, because we're starting a new session
-        self.set_delay_us(0);
-
         // Restart with a short delay
         self.start_task(true, auto_promote);
     }

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -2248,6 +2248,11 @@ impl DownstairsClient {
     pub(crate) fn set_delay_us(&self, delay: u64) {
         self.client_delay_us.store(delay, Ordering::Relaxed);
     }
+
+    /// Looks up the per-client delay
+    pub(crate) fn get_delay_us(&self) -> u64 {
+        self.client_delay_us.load(Ordering::Relaxed)
+    }
 }
 
 /// How to handle "promote to active" requests

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -659,6 +659,11 @@ impl Downstairs {
         // Restart the IO task for that specific client
         self.clients[client_id].reinitialize(auto_promote);
 
+        for i in ClientId::iter() {
+            // Clear per-client delay, because we're starting a new session
+            self.clients[i].set_delay_us(0);
+        }
+
         // Special-case: if a Downstairs goes away midway through initial
         // reconciliation, then we have to manually abort reconciliation.
         if self.clients.iter().any(|c| c.state() == DsState::Reconcile) {

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -889,6 +889,9 @@ struct DownstairsIO {
     /// Map of work status, tracked on a per-client basis
     state: ClientData<IOState>,
 
+    /// At what time did we hear a reply?
+    reply_time: ClientData<Option<std::time::Instant>>,
+
     /*
      * Has this been acked to the guest yet?
      */

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2027,6 +2027,8 @@ pub struct Arg {
     pub ds_extents_repaired: [usize; 3],
     /// Times we have live confirmed  an extent on this downstairs.
     pub ds_extents_confirmed: [usize; 3],
+    /// Per-client delay to keep them roughly in sync
+    pub ds_delay_us: [usize; 3],
     /// Times we skipped repairing a downstairs because we are read_only.
     pub ds_ro_lr_skipped: [usize; 3],
 }

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -738,6 +738,8 @@ impl Upstairs {
             self.downstairs.collect_stats(|c| c.stats.extents_repaired);
         let ds_extents_confirmed =
             self.downstairs.collect_stats(|c| c.stats.extents_confirmed);
+        let ds_delay_us =
+            self.downstairs.collect_stats(|c| c.get_delay_us() as usize);
         let ds_ro_lr_skipped =
             self.downstairs.collect_stats(|c| c.stats.ro_lr_skipped);
 
@@ -762,6 +764,7 @@ impl Upstairs {
                 ds_flow_control,
                 ds_extents_repaired,
                 ds_extents_confirmed,
+                ds_delay_us,
                 ds_ro_lr_skipped,
             };
             ("stats", arg)


### PR DESCRIPTION
Fixes #1167 

This PR adds per-client delays to prevent queues from becoming arbitrarily long during read-heavy workflows.

In our current code, because we only need one reply to ack a read, the fastest Downstairs will consistently beat the others.  This means that the queues for the shorter two Downstairs will keep getting longer and longer (so the fastest Downstairs will keep winning), and those queues could eventually hit the `IO_OUTSTANDING_MAX` limit (which means the Upstairs would mark the slower Downstairs as faulted).

This PR adds monitoring of the difference between Downstairs reply times with a new `reply_times: ClientData<Instant>` in the `struct DownstairsIO`.  If the difference between fastest and slowest is significant (> 10 ms), then we add an artificial delay to the fastest downstairs.

Compared to `main`, this slows down reads, but keeps the queues relatively bounded.  Here's performance before:
```
1M WRITE: bw=692MiB/s (726MB/s), 692MiB/s-692MiB/s (726MB/s-726MB/s), io=40.7GiB (43.7GB), run=60146-60146msec
4K WRITE: bw=28.4MiB/s (29.8MB/s), 28.4MiB/s-28.4MiB/s (29.8MB/s-29.8MB/s), io=1707MiB (1789MB), run=60005-60005msec
1M WRITE: bw=713MiB/s (748MB/s), 713MiB/s-713MiB/s (748MB/s-748MB/s), io=41.8GiB (44.9GB), run=60051-60051msec
4M WRITE: bw=713MiB/s (748MB/s), 713MiB/s-713MiB/s (748MB/s-748MB/s), io=41.9GiB (45.0GB), run=60181-60181msec
4K READ: bw=29.0MiB/s (30.4MB/s), 29.0MiB/s-29.0MiB/s (30.4MB/s-30.4MB/s), io=1741MiB (1826MB), run=60004-60004msec
1M READ: bw=603MiB/s (632MB/s), 603MiB/s-603MiB/s (632MB/s-632MB/s), io=35.3GiB (37.9GB), run=60038-60038msec
4M READ: bw=738MiB/s (774MB/s), 738MiB/s-738MiB/s (774MB/s-774MB/s), io=43.3GiB (46.5GB), run=60135-60135msec
```
![upstairs_info_prev](https://github.com/oxidecomputer/crucible/assets/745333/e4988e6e-ac74-4ae4-8643-1893599bf1a1)

(notice pending jobs creeping up in the 1M and 4M read sections of the graph)

...and after:
```
1M WRITE: bw=687MiB/s (721MB/s), 687MiB/s-687MiB/s (721MB/s-721MB/s), io=40.4GiB (43.4GB), run=60198-60198msec
4K WRITE: bw=29.4MiB/s (30.8MB/s), 29.4MiB/s-29.4MiB/s (30.8MB/s-30.8MB/s), io=1765MiB (1850MB), run=60008-60008msec
1M WRITE: bw=714MiB/s (749MB/s), 714MiB/s-714MiB/s (749MB/s-749MB/s), io=41.9GiB (44.9GB), run=60029-60029msec
4M WRITE: bw=697MiB/s (731MB/s), 697MiB/s-697MiB/s (731MB/s-731MB/s), io=40.9GiB (44.0GB), run=60134-60134msec
4K READ: bw=28.8MiB/s (30.2MB/s), 28.8MiB/s-28.8MiB/s (30.2MB/s-30.2MB/s), io=1731MiB (1815MB), run=60003-60003msec
1M READ: bw=562MiB/s (589MB/s), 562MiB/s-562MiB/s (589MB/s-589MB/s), io=32.9GiB (35.4GB), run=60038-60038msec
4M READ: bw=561MiB/s (588MB/s), 561MiB/s-561MiB/s (588MB/s-588MB/s), io=32.9GiB (35.4GB), run=60162-60162msec
```
![upstairs_info_pr](https://github.com/oxidecomputer/crucible/assets/745333/1d3652a3-9d6a-41d3-9a57-537ad5f80485)

I don't think we can avoid slowing down reads in the steady-state: the whole point is to keep the queues bounded, which necessarily means matching the speed of the slowest Downstairs.  However, burst performance should be unaffected, because the delays only kick in at > 10 ms of discrepancy (which takes some amount of time to wind up).

Note that we **don't** delay writes!  This took a little convincing, but I believe it's correct: during write-heavy workloads, we're already limited by global backpressure (both jobs and bytes-in-flight), so it's already impossible for a queue to grow without bounds.