### PR TITLE
Add generic 'message or raw message' code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,6 +1097,7 @@ dependencies = [
  "schemars",
  "serde",
  "strum_macros 0.25.3",
+ "tokio",
  "tokio-util",
  "uuid",
 ]

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -15,5 +15,6 @@ schemars.workspace = true
 serde.workspace = true
 strum_macros.workspace = true
 tokio-util.workspace = true
+tokio.workspace = true
 uuid.workspace = true
 crucible-workspace-hack.workspace = true

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -678,8 +678,19 @@ impl Message {
 #[derive(Debug)]
 pub enum WireMessage<M> {
     /// Normal message to be sent down the wire
+    ///
+    /// This is serialized with the existing [`CrucibleEncoder`]
     Message(Message),
+
     /// Pre-serialized message to be sent down the wire
+    ///
+    /// This is sent by sending
+    /// - total len (u32)
+    /// - M (serialized with bincode)
+    /// - The raw contents of the byte array
+    ///
+    /// The values of `M` and the byte array must match the equivalent
+    /// [`Message`] serialized with a [`CrucibleEncoder`].
     RawMessage(M, bytes::Bytes),
 }
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -674,6 +674,88 @@ impl Message {
     }
 }
 
+/// Message to be sent down the wire
+#[derive(Debug)]
+pub enum WireMessage<M> {
+    /// Normal message to be sent down the wire
+    Message(Message),
+    /// Pre-serialized message to be sent down the wire
+    RawMessage(M, bytes::Bytes),
+}
+
+impl<M> From<Message> for WireMessage<M> {
+    fn from(m: Message) -> Self {
+        WireMessage::Message(m)
+    }
+}
+
+/// Trait for a type that can be used in `WireMessage::RawMessage`
+pub trait RawMessageDiscriminant {
+    fn discriminant(&self) -> MessageDiscriminants;
+}
+
+/// Writer to encode and send a `WireMessage`
+pub struct WireMessageWriter<W, T>(W, std::marker::PhantomData<T>);
+
+impl<W, T> WireMessageWriter<W, T>
+where
+    W: tokio::io::AsyncWrite + std::marker::Unpin + std::marker::Send + 'static,
+    T: Serialize + RawMessageDiscriminant,
+{
+    /// Builds a new `WireMessageWriter`
+    #[inline]
+    pub fn new(w: W) -> Self {
+        Self(w, std::marker::PhantomData)
+    }
+
+    /// Removes the inner type
+    #[inline]
+    pub fn into_inner(self) -> W {
+        self.0
+    }
+
+    /// Sends the given message down the wire
+    #[inline]
+    pub async fn send<M: Into<WireMessage<T>>>(
+        &mut self,
+        m: M,
+    ) -> Result<(), CrucibleError> {
+        use tokio::io::AsyncWriteExt;
+        let m = m.into();
+        match m {
+            WireMessage::Message(m) => {
+                let mut out = bytes::BytesMut::new();
+                let mut e = CrucibleEncoder::new();
+                e.encode(m, &mut out)?;
+                self.0.write_all(&out).await?;
+            }
+            WireMessage::RawMessage(m, data) => {
+                // Manual implementation of CrucibleEncoder, for situations
+                // where the bulk of the message has already been
+                // pre-serialized.
+                let mut header = bincode::serialize(&(
+                    0u32, // dummy length, to be patched later
+                    &m,
+                ))
+                .unwrap();
+
+                // Patch the length
+                let len: u32 = (header.len() + data.len()).try_into().unwrap();
+                header[0..4].copy_from_slice(&len.to_le_bytes());
+
+                // Patch the discriminant
+                bincode::serialize_into(&mut header[4..8], &m.discriminant())
+                    .unwrap();
+
+                // write_all_vectored would save a syscall, but is nightly-only
+                self.0.write_all(&header).await?;
+                self.0.write_all(&data).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug)]
 pub struct CrucibleEncoder {}
 

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -2,80 +2,31 @@
 use crate::{
     cdt, deadline_secs, integrity_hash, live_repair::ExtentInfo,
     upstairs::UpstairsConfig, upstairs::UpstairsState, ClientIOStateCount,
-    ClientId, CrucibleDecoder, CrucibleEncoder, CrucibleError, DownstairsIO,
-    DsState, EncryptionContext, IOState, IOop, JobId, Message, RawMessage,
-    ReadResponse, ReconcileIO, RegionDefinitionStatus, RegionMetadata,
-    MAX_ACTIVE_COUNT,
+    ClientId, CrucibleDecoder, CrucibleError, DownstairsIO, DsState,
+    EncryptionContext, IOState, IOop, JobId, Message, RawMessage, ReadResponse,
+    ReconcileIO, RegionDefinitionStatus, RegionMetadata, MAX_ACTIVE_COUNT,
 };
 use crucible_common::x509::TLSContext;
-use crucible_protocol::{ReconciliationId, CRUCIBLE_MESSAGE_VERSION};
+use crucible_protocol::{
+    ReconciliationId, WireMessage, WireMessageWriter, CRUCIBLE_MESSAGE_VERSION,
+};
 
 use std::{collections::BTreeSet, net::SocketAddr, sync::Arc};
 
 use futures::StreamExt;
 use slog::{debug, error, info, o, warn, Logger};
 use tokio::{
-    io::AsyncWriteExt,
     net::{TcpSocket, TcpStream},
     sync::{mpsc, oneshot},
     time::sleep_until,
 };
-use tokio_util::codec::{Encoder, FramedRead};
+use tokio_util::codec::FramedRead;
 use uuid::Uuid;
 
 const TIMEOUT_SECS: f32 = 50.0;
 const PING_INTERVAL_SECS: f32 = 5.0;
 
-#[derive(Debug)]
-pub(crate) enum ClientRequest {
-    /// Normal message to be sent down the wire
-    Message(Message),
-    /// Pre-serialized message to be sent down the wire
-    RawMessage(RawMessage, bytes::Bytes),
-}
-
-impl ClientRequest {
-    /// Write the given message to an `AsyncWrite` sink
-    async fn write<W>(&self, fw: &mut W) -> Result<(), CrucibleError>
-    where
-        W: tokio::io::AsyncWrite
-            + std::marker::Unpin
-            + std::marker::Send
-            + 'static,
-    {
-        match self {
-            ClientRequest::Message(m) => {
-                let mut out = bytes::BytesMut::new();
-                let mut e = CrucibleEncoder::new();
-                e.encode(m, &mut out)?;
-                fw.write_all(&out).await?;
-            }
-            ClientRequest::RawMessage(m, data) => {
-                // Manual implementation of CrucibleEncoder, for situations
-                // where the bulk of the message has already been
-                // pre-serialized.
-                let mut header = bincode::serialize(&(
-                    0u32, // dummy length, to be patched later
-                    &m,
-                ))
-                .unwrap();
-
-                // Patch the length
-                let len: u32 = (header.len() + data.len()).try_into().unwrap();
-                header[0..4].copy_from_slice(&len.to_le_bytes());
-
-                // Patch the discriminant
-                bincode::serialize_into(&mut header[4..8], &m.discriminant())
-                    .unwrap();
-
-                // write_all_vectored would save a syscall, but is nightly-only
-                fw.write_all(&header).await?;
-                fw.write_all(data).await?;
-            }
-        }
-        Ok(())
-    }
-}
+pub type ClientRequest = WireMessage<RawMessage>;
 
 /// Handle to a running I/O task
 ///
@@ -329,7 +280,7 @@ impl DownstairsClient {
 
     /// Send a `Message::HereIAm` via the client IO task
     pub(crate) async fn send_here_i_am(&mut self) {
-        self.send_message(Message::HereIAm {
+        self.send(Message::HereIAm {
             version: CRUCIBLE_MESSAGE_VERSION,
             upstairs_id: self.cfg.upstairs_id,
             session_id: self.cfg.session_id,
@@ -381,18 +332,15 @@ impl DownstairsClient {
         self.new_jobs.insert(work);
     }
 
-    pub(crate) async fn send_message(&mut self, m: Message) {
-        self.send(ClientRequest::Message(m)).await
-    }
-
-    pub(crate) async fn send(&mut self, m: ClientRequest) {
+    pub(crate) async fn send<M: Into<ClientRequest>>(&mut self, m: M) {
         // Normally, the client task continues running until
         // `self.client_task.client_request_tx` is dropped; as such, we should
         // always be able to send it a message.
         //
         // However, during Tokio shutdown, tasks may stop in arbitrary order.
         // We log an error but don't panic, because panicking is uncouth.
-        if let Err(e) = self.client_task.client_request_tx.send(m).await {
+        if let Err(e) = self.client_task.client_request_tx.send(m.into()).await
+        {
             error!(
                 self.log,
                 "failed to send message: {e};
@@ -818,7 +766,7 @@ impl DownstairsClient {
                 // If the client task has stopped, then print a warning but
                 // otherwise continue (because we'll be cleaned up by the
                 // JoinHandle watcher).
-                self.send_message(Message::PromoteToActive {
+                self.send(Message::PromoteToActive {
                     upstairs_id: self.cfg.upstairs_id,
                     session_id: self.cfg.session_id,
                     gen: self.cfg.generation(),
@@ -1714,7 +1662,7 @@ impl DownstairsClient {
                 self.repair_addr = Some(repair_addr);
                 match self.promote_state {
                     Some(PromoteState::Waiting) => {
-                        self.send_message(Message::PromoteToActive {
+                        self.send(Message::PromoteToActive {
                             upstairs_id: self.cfg.upstairs_id,
                             session_id: self.cfg.session_id,
                             gen: self.cfg.generation(),
@@ -1853,7 +1801,7 @@ impl DownstairsClient {
                 }
 
                 self.negotiation_state = NegotiationState::WaitForRegionInfo;
-                self.send_message(Message::RegionInfoPlease).await;
+                self.send(Message::RegionInfoPlease).await;
             }
             Message::RegionInfo { region_def } => {
                 if self.negotiation_state != NegotiationState::WaitForRegionInfo
@@ -1984,7 +1932,7 @@ impl DownstairsClient {
                         );
                         self.negotiation_state = NegotiationState::GetLastFlush;
 
-                        self.send_message(Message::LastFlush {
+                        self.send(Message::LastFlush {
                             last_flush_number: lf,
                         })
                         .await;
@@ -1997,7 +1945,7 @@ impl DownstairsClient {
                          */
                         self.negotiation_state =
                             NegotiationState::GetExtentVersions;
-                        self.send_message(Message::ExtentVersionsPlease).await;
+                        self.send(Message::ExtentVersionsPlease).await;
                     }
                     DsState::Replacing => {
                         warn!(
@@ -2154,7 +2102,7 @@ impl DownstairsClient {
                 assert!(!dest_clients.is_empty());
                 if dest_clients.iter().any(|d| *d == self.client_id) {
                     info!(self.log, "sending reconcile request {repair_id:?}");
-                    self.send_message(job.op.clone()).await;
+                    self.send(job.op.clone()).await;
                 } else {
                     // Skip this job for this Downstairs, since only the target
                     // clients need to do the reconcile.
@@ -2171,7 +2119,7 @@ impl DownstairsClient {
             } => {
                 if *client_id == self.client_id {
                     info!(self.log, "sending flush request {repair_id:?}");
-                    self.send_message(job.op.clone()).await;
+                    self.send(job.op.clone()).await;
                 } else {
                     info!(self.log, "skipping flush request {repair_id:?}");
                     // Skip this job for this Downstairs, since it's narrowly
@@ -2183,7 +2131,7 @@ impl DownstairsClient {
             }
             Message::ExtentReopen { .. } | Message::ExtentClose { .. } => {
                 // All other reconcile ops are sent as-is
-                self.send_message(job.op.clone()).await;
+                self.send(job.op.clone()).await;
             }
             m => panic!("invalid reconciliation request {m:?}"),
         }
@@ -2578,18 +2526,20 @@ impl ClientIoTask {
             let sock = connector.connect(server_name, tcp).await.unwrap();
             let (read, write) = tokio::io::split(sock);
             let fr = FramedRead::new(read, CrucibleDecoder::new());
-            self.cmd_loop(fr, write).await
+            let fw = WireMessageWriter::new(write);
+            self.cmd_loop(fr, fw).await
         } else {
             let (read, write) = tcp.into_split();
             let fr = FramedRead::new(read, CrucibleDecoder::new());
-            self.cmd_loop(fr, write).await
+            let fw = WireMessageWriter::new(write);
+            self.cmd_loop(fr, fw).await
         }
     }
 
     async fn cmd_loop<R, W>(
         &mut self,
         fr: FramedRead<R, crucible_protocol::CrucibleDecoder>,
-        mut fw: W,
+        mut fw: WireMessageWriter<W, RawMessage>,
     ) -> ClientRunResult
     where
         R: tokio::io::AsyncRead
@@ -2683,7 +2633,7 @@ impl ClientIoTask {
     /// stop immediately.
     async fn write<W>(
         &mut self,
-        fw: &mut W,
+        fw: &mut WireMessageWriter<W, RawMessage>,
         m: ClientRequest,
     ) -> Result<(), ClientRunResult>
     where
@@ -2695,7 +2645,7 @@ impl ClientIoTask {
         // There's some duplication between this function and `cmd_loop` above,
         // but it's not obvious whether there's a cleaner way to organize stuff.
         tokio::select! {
-            r = m.write(fw) => {
+            r = fw.send(m) => {
                 if let Err(e) = r {
                     Err(ClientRunResult::WriteFailed(e.into()))
                 } else {
@@ -3434,11 +3384,12 @@ mod test {
         );
 
         // Write the raw message to an in-memory buffer
-        let mut cursor = std::io::Cursor::new(vec![]);
-        msg.write(&mut cursor).await.unwrap();
+        let cursor = std::io::Cursor::new(vec![]);
+        let mut w = WireMessageWriter::new(cursor);
+        w.send(msg).await.unwrap();
 
         let mut out = bytes::BytesMut::new();
-        out.extend(cursor.into_inner());
+        out.extend(w.into_inner().into_inner());
 
         let mut decoder = CrucibleDecoder::new();
         let out = decoder.decode(&mut out).unwrap().unwrap();
@@ -3534,11 +3485,12 @@ mod test {
         );
 
         // Write the raw message to an in-memory buffer
-        let mut cursor = std::io::Cursor::new(vec![]);
-        msg.write(&mut cursor).await.unwrap();
+        let cursor = std::io::Cursor::new(vec![]);
+        let mut w = WireMessageWriter::new(cursor);
+        w.send(msg).await.unwrap();
 
         let mut out = bytes::BytesMut::new();
-        out.extend(cursor.into_inner());
+        out.extend(w.into_inner().into_inner());
 
         let mut decoder = CrucibleDecoder::new();
         let out = decoder.decode(&mut out).unwrap().unwrap();

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1131,7 +1131,7 @@ enum RawMessage {
     },
 }
 
-impl RawMessage {
+impl crucible_protocol::RawMessageDiscriminant for RawMessage {
     /// Returns the discriminant used by the equivalent `Message`
     ///
     /// This is hard-coded and exhaustively checked by a unit test.


### PR DESCRIPTION
This PR adds a generic implementation of the 'Message or raw message' serializer used for reduced-mempcy serialization (#1087), then updates `crucible-upstairs` to use the new implementation.

It also more generally reduces allocations in the socket write path by reusing the same `BytesMut` (for `Message` serialization) or a `Vec` (for raw message headers).  This may have a small performance impact; I didn't measure it.

These changes are a building block for faster serialization of Downstairs `ReadResponse`, but I pulled them into a standalone PR for ease of review.