### PR TITLE
Reduce serialization during Downstairs reads

### DIFF
--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -537,8 +537,8 @@ async fn show_extent(
                 Region::open(dir, Default::default(), false, true, &log)
                     .await?;
 
-            let mut responses = region
-                .region_read(
+            let raw = region
+                .region_read_raw(
                     &[ReadRequest {
                         eid: cmp_extent as u64,
                         offset: Block::new_with_ddef(block, &region.def()),
@@ -546,7 +546,9 @@ async fn show_extent(
                     JobId(0),
                 )
                 .await?;
-            let response = responses.pop().unwrap();
+            let responses: Result<Vec<ReadResponse>, CrucibleError> =
+                bincode::deserialize(&raw)?;
+            let response = responses?.pop().unwrap();
 
             dvec.insert(index, response);
         }
@@ -652,8 +654,8 @@ async fn show_extent_block(
         let mut region =
             Region::open(dir, Default::default(), false, true, &log).await?;
 
-        let mut responses = region
-            .region_read(
+        let raw = region
+            .region_read_raw(
                 &[ReadRequest {
                     eid: cmp_extent as u64,
                     offset: Block::new_with_ddef(
@@ -664,7 +666,9 @@ async fn show_extent_block(
                 JobId(0),
             )
             .await?;
-        let response = responses.pop().unwrap();
+        let responses: Result<Vec<ReadResponse>, CrucibleError> =
+            bincode::deserialize(&raw)?;
+        let response = responses?.pop().unwrap();
 
         dvec.insert(index, response);
     }

--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -540,7 +540,7 @@ impl Extent {
 
     /// Read the real data off underlying storage, and get block metadata. If
     /// an error occurs while processing any of the requests, the state of
-    /// `responses` is undefined.
+    /// `out` is undefined.
     #[instrument]
     pub async fn read(
         &mut self,

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -430,18 +430,6 @@ impl ExtentInner for RawInner {
         let out = RawInner::get_block_contexts(self, block, count)?;
         Ok(out.into_iter().map(|v| v.into_iter().collect()).collect())
     }
-
-    fn read(
-        &mut self,
-        job_id: JobId,
-        requests: &[crucible_protocol::ReadRequest],
-        iov_max: usize,
-    ) -> Result<Vec<crucible_protocol::ReadResponse>, CrucibleError> {
-        let mut b = BytesMut::new();
-        b.put_u64_le(requests.len() as u64);
-        self.read_raw(job_id, requests, iov_max, &mut b)?;
-        Ok(bincode::deserialize(&b).unwrap())
-    }
 }
 
 impl RawInner {

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -677,6 +677,11 @@ impl Message {
 /// Message to be sent down the wire
 #[derive(Debug)]
 pub enum WireMessage<M> {
+    /// Normal message to be sent down the wire
+    ///
+    /// This is serialized with the existing [`CrucibleEncoder`]
+    Message(Message),
+
     /// Pre-serialized message to be sent down the wire
     ///
     /// This is sent by sending
@@ -686,9 +691,6 @@ pub enum WireMessage<M> {
     ///
     /// The values of `M` and the byte array must match the equivalent
     /// [`Message`] serialized with a [`CrucibleEncoder`].
-    Message(Message),
-
-    /// Pre-serialized message to be sent down the wire
     RawMessage(M, bytes::Bytes),
 }
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -677,11 +677,6 @@ impl Message {
 /// Message to be sent down the wire
 #[derive(Debug)]
 pub enum WireMessage<M> {
-    /// Normal message to be sent down the wire
-    ///
-    /// This is serialized with the existing [`CrucibleEncoder`]
-    Message(Message),
-
     /// Pre-serialized message to be sent down the wire
     ///
     /// This is sent by sending
@@ -691,6 +686,9 @@ pub enum WireMessage<M> {
     ///
     /// The values of `M` and the byte array must match the equivalent
     /// [`Message`] serialized with a [`CrucibleEncoder`].
+    Message(Message),
+
+    /// Pre-serialized message to be sent down the wire
     RawMessage(M, bytes::Bytes),
 }
 


### PR DESCRIPTION
(This PR is staged on top of #1182, and is therefore marked as a draft; you should ignore all changes in `crucible-protocol` and `crucible-upstairs`)

#1087 changed how we handle writes Upstairs to avoid memcpy'ing bulk data in `Message::Write/WriteUnwritten`.  This PR does the same thing for `Message::ReadResponse` in the Downstairs.

Just like #1087, it's Unfortunately Messy: we have to do the `bincode` encoding by hand at the same time that we're reading data from the file, to avoid an extra copy operation.

The benefits are what you'd expect: the 11% of our runtime spent in `memcpy` disappears, and things get faster.

Here's the flamegraph before these changes...
![ds_main](https://github.com/oxidecomputer/crucible/assets/745333/8c012922-1180-4009-9d44-d71bd6ca525d)
([interactive version](https://github.com/oxidecomputer/crucible/assets/745333/8c012922-1180-4009-9d44-d71bd6ca525d))

...and after
![ds_zc](https://github.com/oxidecomputer/crucible/assets/745333/45fb7415-9789-4a76-9751-7020e6fe3dc7)
([interactive version](https://github.com/oxidecomputer/crucible/assets/745333/45fb7415-9789-4a76-9751-7020e6fe3dc7))

Running my usual `fio` sweep, I see noticeable improvements in large read performance.

### Before
```
4K READ: bw=27.8MiB/s (29.1MB/s), 27.8MiB/s-27.8MiB/s (29.1MB/s-29.1MB/s), io=1667MiB (1748MB), run=60003-60003msec
1M READ: bw=525MiB/s (550MB/s), 525MiB/s-525MiB/s (550MB/s-550MB/s), io=30.8GiB (33.0GB), run=60048-60048msec
4M READ: bw=596MiB/s (625MB/s), 596MiB/s-596MiB/s (625MB/s-625MB/s), io=35.0GiB (37.6GB), run=60138-60138msec
```
### After
```
4K READ: bw=27.8MiB/s (29.2MB/s), 27.8MiB/s-27.8MiB/s (29.2MB/s-29.2MB/s), io=1670MiB (1751MB), run=60027-60027msec
1M READ: bw=675MiB/s (708MB/s), 675MiB/s-675MiB/s (708MB/s-708MB/s), io=39.6GiB (42.5GB), run=60035-60035msec
4M READ: bw=756MiB/s (793MB/s), 756MiB/s-756MiB/s (793MB/s-793MB/s), io=44.4GiB (47.7GB), run=60127-60127msec
```
(The Upstairs includes the changes from #1181, which is why initial performance is slower than you may expect)