### PR TITLE
Per client, queue-based backpressure

### DIFF
--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -1296,8 +1296,6 @@ impl DownstairsClient {
             return false;
         }
 
-        job.reply_time[self.client_id] = Some(std::time::Instant::now());
-
         let mut jobs_completed_ok = job.state_count().completed_ok();
         let mut ackable = false;
 

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -643,6 +643,10 @@ impl DownstairsClient {
         }
 
         self.connection_id.update();
+
+        // Clear per-client delay, because we're starting a new session
+        self.set_delay_us(0);
+
         // Restart with a short delay
         self.start_task(true, auto_promote);
     }

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -644,9 +644,6 @@ impl DownstairsClient {
 
         self.connection_id.update();
 
-        // Clear per-client delay, because we're starting a new session
-        self.set_delay_us(0);
-
         // Restart with a short delay
         self.start_task(true, auto_promote);
     }

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -2248,6 +2248,11 @@ impl DownstairsClient {
     pub(crate) fn set_delay_us(&self, delay: u64) {
         self.client_delay_us.store(delay, Ordering::Relaxed);
     }
+
+    /// Looks up the per-client delay
+    pub(crate) fn get_delay_us(&self) -> u64 {
+        self.client_delay_us.load(Ordering::Relaxed)
+    }
 }
 
 /// How to handle "promote to active" requests

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -3552,7 +3552,7 @@ impl Downstairs {
         (gw, ds)
     }
 
-    pub(crate) fn set_client_backpressure(&mut self) {
+    pub(crate) fn set_client_backpressure(&self) {
         let mut jobs = vec![];
         let mut bytes = vec![];
         for c in self.clients.iter() {
@@ -3564,7 +3564,7 @@ impl Downstairs {
         // If none of the clients are active, then disable per-client
         // backpressure
         if jobs.is_empty() {
-            for c in self.clients.iter_mut() {
+            for c in self.clients.iter() {
                 c.set_delay_us(0);
             }
             return;

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -3,6 +3,7 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
     net::SocketAddr,
     sync::Arc,
+    time::Duration,
 };
 
 use crate::{
@@ -38,6 +39,9 @@ pub(crate) struct Downstairs {
 
     /// Per-client data
     pub(crate) clients: ClientData<DownstairsClient>,
+
+    /// Per-client backpressure configuration
+    backpressure_config: DownstairsBackpressureConfig,
 
     /// The active list of IO for the downstairs.
     pub(crate) ds_active: ActiveJobs,
@@ -220,6 +224,23 @@ impl Downstairs {
         let clients = clients.map(Option::unwrap);
         Self {
             clients: ClientData(clients),
+            backpressure_config: DownstairsBackpressureConfig {
+                // start byte-based backpressure at 25 MiB of difference
+                bytes_start: 25 * 1024 * 1024, // 25 MiB
+                // bytes_scale is chosen to have 10 ms of delay at 100 MiB of
+                // discrepancy
+                bytes_scale: 1e-6,
+
+                // start job-based backpressure at 200 jobs of discrepancy
+                jobs_start: 100,
+                // job_scale is chosen to have 10 ms of delay at 200 jobs of
+                // discrepancy
+                jobs_scale: 0.5,
+
+                // max delay is 10 ms.  This is meant to be a gentle nudge, not
+                // a giant shove, and even 10 ms may be too high.
+                max_delay: Duration::from_millis(10),
+            },
             cfg,
             next_flush: 0,
             ds_active: ActiveJobs::new(),
@@ -1331,7 +1352,6 @@ impl Downstairs {
             guest_id: gw_id,
             work: noop_ioop,
             state: ClientData::new(IOState::New),
-            reply_time: ClientData::new(None),
             acked: false,
             replay: false,
             data: None,
@@ -1455,7 +1475,6 @@ impl Downstairs {
             guest_id: gw_id,
             work: repair_ioop,
             state: ClientData::new(IOState::New),
-            reply_time: ClientData::new(None),
             acked: false,
             replay: false,
             data: None,
@@ -1596,7 +1615,6 @@ impl Downstairs {
             guest_id: gw_id,
             work: reopen_ioop,
             state: ClientData::new(IOState::New),
-            reply_time: ClientData::new(None),
             acked: false,
             replay: false,
             data: None,
@@ -1670,7 +1688,6 @@ impl Downstairs {
             guest_id: gw_id,
             work: aread,
             state: ClientData::new(IOState::New),
-            reply_time: ClientData::new(None),
             acked: false,
             replay: false,
             data: None,
@@ -1741,7 +1758,6 @@ impl Downstairs {
             guest_id: gw_id,
             work: awrite,
             state: ClientData::new(IOState::New),
-            reply_time: ClientData::new(None),
             acked: false,
             replay: false,
             data: None,
@@ -1772,7 +1788,6 @@ impl Downstairs {
             guest_id: gw_id,
             work: close_ioop,
             state: ClientData::new(IOState::New),
-            reply_time: ClientData::new(None),
             acked: false,
             replay: false,
             data: None,
@@ -2098,7 +2113,6 @@ impl Downstairs {
             guest_id: gw_id,
             work: flush,
             state: ClientData::new(IOState::New),
-            reply_time: ClientData::new(None),
             acked: false,
             replay: false,
             data: None,
@@ -2223,7 +2237,6 @@ impl Downstairs {
             guest_id,
             work: aread,
             state: ClientData::new(IOState::New),
-            reply_time: ClientData::new(None),
             acked: false,
             replay: false,
             data: None,
@@ -3181,30 +3194,6 @@ impl Downstairs {
             self.ackable_work.insert(ds_id);
         }
 
-        if job.reply_time.iter().all(Option::is_some) && !job.replay {
-            let fastest_id = ClientId::iter()
-                .min_by_key(|i| job.reply_time[*i].unwrap())
-                .unwrap();
-            let slowest_time = *job.reply_time.iter().flatten().max().unwrap();
-
-            // Apply a delay to the fastest client, and clear the delay for the
-            // other two clients.
-            for i in ClientId::iter() {
-                let delay_time_us: u64 = if i == fastest_id {
-                    // 0 delay below 10ms of lead time, then linearly increasing
-                    // to a maximum of 10 ms.  These are all roughly-eyeballed
-                    // numbers!
-                    let dt = slowest_time - job.reply_time[i].unwrap();
-                    let lead_time_us: u64 = dt.as_micros().try_into().unwrap();
-                    (lead_time_us.saturating_sub(10_000) / 100).min(10_000)
-                } else {
-                    0
-                };
-
-                self.clients[i].set_delay_us(delay_time_us);
-            }
-        }
-
         /*
          * If all 3 jobs are done, we can check here to see if we can
          * remove this job from the DS list. If we have completed the ack
@@ -3562,6 +3551,104 @@ impl Downstairs {
 
         (gw, ds)
     }
+
+    pub(crate) fn set_client_backpressure(&mut self) {
+        let mut jobs = vec![];
+        let mut bytes = vec![];
+        for c in self.clients.iter() {
+            if matches!(c.state(), DsState::Active) {
+                jobs.push(c.total_live_work());
+                bytes.push(c.total_bytes_outstanding());
+            }
+        }
+        // If none of the clients are active, then disable per-client
+        // backpressure
+        if jobs.is_empty() {
+            for c in self.clients.iter_mut() {
+                c.set_delay_us(0);
+            }
+            return;
+        }
+
+        // The "slowest" Downstairs will have the highest values for jobs and
+        // bytes, which we calculate here.  Then, we'll apply delays to clients
+        // based on those values.
+        let max_jobs = jobs.into_iter().max().unwrap();
+        let max_bytes = bytes.into_iter().max().unwrap();
+
+        let mut delays = ClientData::new(None);
+        for i in ClientId::iter() {
+            let c = &self.clients[i];
+            if matches!(c.state(), DsState::Active) {
+                // These values represent how much **faster** we are than the
+                // slowest downstairs, and hence cause us to exert backpressure
+                // on this client (to slow it down).
+                let job_gap = (max_jobs - c.total_live_work()) as u64;
+                let bytes_gap =
+                    (max_bytes - c.total_bytes_outstanding()) as u64;
+
+                let job_delay_us = (job_gap
+                    .saturating_sub(self.backpressure_config.jobs_start)
+                    as f64
+                    * self.backpressure_config.jobs_scale)
+                    .powf(2.0);
+
+                let bytes_delay_us = (bytes_gap
+                    .saturating_sub(self.backpressure_config.bytes_start)
+                    as f64
+                    * self.backpressure_config.bytes_scale)
+                    .powf(2.0);
+
+                let delay_us = (job_delay_us.max(bytes_delay_us) as u64)
+                    .min(self.backpressure_config.max_delay.as_micros() as u64);
+
+                delays[i] = Some(delay_us);
+            }
+        }
+        // Cancel out any common delay, because it wouldn't be useful.
+        //
+        // (Seeing common delay would be unusual, because it would indicate that
+        // one Downstairs is ahead by the bytes-based metric and another is
+        // ahead by the jobs-based metric)
+        let min_delay = *delays.iter().flatten().min().unwrap();
+        delays.iter_mut().flatten().for_each(|c| *c -= min_delay);
+
+        // Apply delay to clients
+        for i in ClientId::iter() {
+            if let Some(delay) = delays[i] {
+                self.clients[i].set_delay_us(delay);
+            } else {
+                self.clients[i].set_delay_us(0);
+            }
+        }
+    }
+}
+
+/// Configuration for per-client backpressure
+///
+/// Per-client backpressure adds an artificial delay to the client queues, to
+/// keep the three clients relatively in sync.  The delay is varied based on two
+/// metrics:
+///
+/// - number of write bytes outstanding
+/// - queue length
+///
+/// These metrics are _relative_ to the slowest downstairs; the goal is to slow
+/// down the faster Downstairs to keep the gap bounded.
+#[derive(Copy, Clone, Debug)]
+struct DownstairsBackpressureConfig {
+    /// When should backpressure start (in bytes)?
+    bytes_start: u64,
+    /// Scale for byte-based quadratic backpressure
+    bytes_scale: f64,
+
+    /// When should job-count-based backpressure start?
+    jobs_start: u64,
+    /// Scale for job-count-based quadratic backpressure
+    jobs_scale: f64,
+
+    /// Maximum delay
+    max_delay: Duration,
 }
 
 #[cfg(test)]

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -2306,6 +2306,8 @@ impl Downstairs {
                 self.clients[cid].enqueue(&mut io, last_repair_extent);
             if matches!(job_state, IOState::Skipped) {
                 skipped += 1;
+            } else {
+                assert_eq!(job_state, IOState::New);
             }
         }
 

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -3552,6 +3552,11 @@ impl Downstairs {
         (gw, ds)
     }
 
+    #[cfg(test)]
+    pub(crate) fn disable_client_backpressure(&mut self) {
+        self.backpressure_config.max_delay = Duration::ZERO;
+    }
+
     pub(crate) fn set_client_backpressure(&self) {
         let mut jobs = vec![];
         let mut bytes = vec![];

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -659,6 +659,11 @@ impl Downstairs {
         // Restart the IO task for that specific client
         self.clients[client_id].reinitialize(auto_promote);
 
+        for i in ClientId::iter() {
+            // Clear per-client delay, because we're starting a new session
+            self.clients[i].set_delay_us(0);
+        }
+
         // Special-case: if a Downstairs goes away midway through initial
         // reconciliation, then we have to manually abort reconciliation.
         if self.clients.iter().any(|c| c.state() == DsState::Reconcile) {

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -226,16 +226,16 @@ impl Downstairs {
             clients: ClientData(clients),
             backpressure_config: DownstairsBackpressureConfig {
                 // start byte-based backpressure at 25 MiB of difference
-                bytes_start: 25 * 1024 * 1024, // 25 MiB
-                // bytes_scale is chosen to have 10 ms of delay at 100 MiB of
+                bytes_start: 25 * 1024 * 1024,
+                // bytes_scale is chosen to have 1.5 ms of delay at 100 MiB of
                 // discrepancy
-                bytes_scale: 1e-6,
+                bytes_scale: 5e-7,
 
-                // start job-based backpressure at 200 jobs of discrepancy
+                // start job-based backpressure at 100 jobs of discrepancy
                 jobs_start: 100,
-                // job_scale is chosen to have 10 ms of delay at 200 jobs of
-                // discrepancy
-                jobs_scale: 0.5,
+                // job_scale is chosen to have 1 ms of of per-job delay at 900
+                // jobs of discrepancy
+                jobs_scale: 0.04,
 
                 // max delay is 10 ms.  This is meant to be a gentle nudge, not
                 // a giant shove, and even 10 ms may be too high.

--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -918,6 +918,11 @@ impl GuestIoHandle {
         self.backpressure_config.queue_max_delay = Duration::ZERO;
     }
 
+    #[cfg(test)]
+    pub fn is_queue_backpressure_disabled(&self) -> bool {
+        self.backpressure_config.queue_max_delay == Duration::ZERO
+    }
+
     /// Set `self.backpressure_us` based on outstanding IO ratio
     pub fn set_backpressure(&self, bytes: u64, ratio: f64) {
         // Check to see if the number of outstanding write bytes (between

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -889,6 +889,9 @@ struct DownstairsIO {
     /// Map of work status, tracked on a per-client basis
     state: ClientData<IOState>,
 
+    /// At what time did we hear a reply?
+    reply_time: ClientData<Option<std::time::Instant>>,
+
     /*
      * Has this been acked to the guest yet?
      */

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -889,9 +889,6 @@ struct DownstairsIO {
     /// Map of work status, tracked on a per-client basis
     state: ClientData<IOState>,
 
-    /// At what time did we hear a reply?
-    reply_time: ClientData<Option<std::time::Instant>>,
-
     /*
      * Has this been acked to the guest yet?
      */

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2090,12 +2090,20 @@ pub fn up_main(
         None
     };
 
+    #[cfg(test)]
+    let disable_backpressure = guest.is_queue_backpressure_disabled();
+
     /*
      * Build the Upstairs struct that we use to share data between
      * the different async tasks
      */
     let mut up =
         upstairs::Upstairs::new(&opt, gen, region_def, guest, tls_context);
+
+    #[cfg(test)]
+    if disable_backpressure {
+        up.disable_client_backpressure();
+    }
 
     if let Some(pr) = producer_registry {
         let ups = up.stats.clone();

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2027,6 +2027,8 @@ pub struct Arg {
     pub ds_extents_repaired: [usize; 3],
     /// Times we have live confirmed  an extent on this downstairs.
     pub ds_extents_confirmed: [usize; 3],
+    /// Per-client delay to keep them roughly in sync
+    pub ds_delay_us: [usize; 3],
     /// Times we skipped repairing a downstairs because we are read_only.
     pub ds_ro_lr_skipped: [usize; 3],
 }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1334,6 +1334,23 @@ impl IOop {
             false
         }
     }
+
+    /// Returns the number of bytes written or read in this job
+    fn job_bytes(&self) -> u64 {
+        match &self {
+            IOop::Write { data, .. } | IOop::WriteUnwritten { data, .. } => {
+                data.io_size_bytes as u64
+            }
+            IOop::Read { requests, .. } => {
+                requests
+                    .first()
+                    .map(|r| r.offset.block_size_in_bytes())
+                    .unwrap_or(0) as u64
+                    * requests.len() as u64
+            }
+            _ => 0,
+        }
+    }
 }
 
 /*

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -2019,6 +2019,7 @@ impl Upstairs {
             .reinitialize(client_id, auto_promote, &self.state);
     }
 
+    /// Sets both guest and per-client backpressure
     fn set_backpressure(&self) {
         let dsw_max = self
             .downstairs
@@ -2030,6 +2031,8 @@ impl Upstairs {
         let ratio = dsw_max as f64 / crate::IO_OUTSTANDING_MAX as f64;
         self.guest
             .set_backpressure(self.downstairs.write_bytes_outstanding(), ratio);
+
+        self.downstairs.set_client_backpressure();
     }
 
     /// Returns the `RegionDefinition`

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -397,6 +397,11 @@ impl Upstairs {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn disable_client_backpressure(&mut self) {
+        self.downstairs.disable_client_backpressure();
+    }
+
     /// Build an Upstairs for simple tests
     #[cfg(test)]
     pub fn test_default(ddef: Option<RegionDefinition>) -> Self {

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -738,6 +738,8 @@ impl Upstairs {
             self.downstairs.collect_stats(|c| c.stats.extents_repaired);
         let ds_extents_confirmed =
             self.downstairs.collect_stats(|c| c.stats.extents_confirmed);
+        let ds_delay_us =
+            self.downstairs.collect_stats(|c| c.get_delay_us() as usize);
         let ds_ro_lr_skipped =
             self.downstairs.collect_stats(|c| c.stats.ro_lr_skipped);
 
@@ -762,6 +764,7 @@ impl Upstairs {
                 ds_flow_control,
                 ds_extents_repaired,
                 ds_extents_confirmed,
+                ds_delay_us,
                 ds_ro_lr_skipped,
             };
             ("stats", arg)


### PR DESCRIPTION
Fixes #1167, and is an alternative to #1181

This PR adds per-client delays to prevent queues from becoming arbitrarily long during read-heavy workflows.  These delays are based either per-client queue lengths and bytes in flight (whichever is worst compared to the slowest client), which is analogous to the guest backpressure implementation.

Compared to `main`, this keeps the queues relatively bounded, and is at least similar in performance (hard to tell, because there significant run-to-run variability).  Here's performance before:
```
1M WRITE: bw=692MiB/s (726MB/s), 692MiB/s-692MiB/s (726MB/s-726MB/s), io=40.7GiB (43.7GB), run=60146-60146msec
4K WRITE: bw=28.4MiB/s (29.8MB/s), 28.4MiB/s-28.4MiB/s (29.8MB/s-29.8MB/s), io=1707MiB (1789MB), run=60005-60005msec
1M WRITE: bw=713MiB/s (748MB/s), 713MiB/s-713MiB/s (748MB/s-748MB/s), io=41.8GiB (44.9GB), run=60051-60051msec
4M WRITE: bw=713MiB/s (748MB/s), 713MiB/s-713MiB/s (748MB/s-748MB/s), io=41.9GiB (45.0GB), run=60181-60181msec
4K READ: bw=29.0MiB/s (30.4MB/s), 29.0MiB/s-29.0MiB/s (30.4MB/s-30.4MB/s), io=1741MiB (1826MB), run=60004-60004msec
1M READ: bw=603MiB/s (632MB/s), 603MiB/s-603MiB/s (632MB/s-632MB/s), io=35.3GiB (37.9GB), run=60038-60038msec
4M READ: bw=738MiB/s (774MB/s), 738MiB/s-738MiB/s (774MB/s-774MB/s), io=43.3GiB (46.5GB), run=60135-60135msec
```
![upstairs_info_prev](https://github.com/oxidecomputer/crucible/assets/745333/e4988e6e-ac74-4ae4-8643-1893599bf1a1)

(notice pending jobs creeping up in the 1M and 4M read sections of the graph)

...and after:
```
1M WRITE: bw=728MiB/s (763MB/s), 728MiB/s-728MiB/s (763MB/s-763MB/s), io=42.7GiB (45.9GB), run=60100-60100msec
4K WRITE: bw=28.7MiB/s (30.1MB/s), 28.7MiB/s-28.7MiB/s (30.1MB/s-30.1MB/s), io=1721MiB (1804MB), run=60013-60013msec
1M WRITE: bw=737MiB/s (773MB/s), 737MiB/s-737MiB/s (773MB/s-773MB/s), io=43.2GiB (46.4GB), run=60034-60034msec
4M WRITE: bw=730MiB/s (765MB/s), 730MiB/s-730MiB/s (765MB/s-765MB/s), io=42.8GiB (46.0GB), run=60099-60099msec
4K READ: bw=29.0MiB/s (30.4MB/s), 29.0MiB/s-29.0MiB/s (30.4MB/s-30.4MB/s), io=1739MiB (1823MB), run=60004-60004msec
1M READ: bw=598MiB/s (627MB/s), 598MiB/s-598MiB/s (627MB/s-627MB/s), io=35.0GiB (37.6GB), run=60042-60042msec
4M READ: bw=754MiB/s (791MB/s), 754MiB/s-754MiB/s (791MB/s-791MB/s), io=44.3GiB (47.6GB), run=60137-60137msec
```
![new](https://github.com/oxidecomputer/crucible/assets/745333/220051de-eac0-486b-9ff8-46a275027080)

Delay is greyed out during the write section because it isn't applied to writes.  During write-heavy workloads, we're already limited by global backpressure (both jobs and bytes-in-flight), so it's already impossible for a queue to grow without bounds.
