### PR TITLE
16 tasks for tokio

### DIFF
--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -243,7 +243,7 @@ fn parse_duration(arg: &str) -> Result<Duration, std::num::ParseIntError> {
     Ok(Duration::from_millis(ms))
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "multi_thread", worker_threads = 16)]
 async fn main() -> Result<()> {
     let args = Args::try_parse()?;
 


### PR DESCRIPTION
LImits tokio tasks created to 16 (from the default of 128) for the downstairs.

See some info here on the improvements this allowed: https://github.com/oxidecomputer/crucible/issues/1184