### PR TITLE
Fault if too many bytes are in flight

### DIFF
--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -2346,6 +2346,9 @@ pub(crate) enum ClientStopReason {
     /// Too many jobs in the queue
     TooManyOutstandingJobs,
 
+    /// Too many bytes in the queue
+    TooManyOutstandingBytes,
+
     /// The upstairs has requested that we deactivate
     Deactivated,
 }

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -2510,21 +2510,20 @@ impl Downstairs {
                 self.log,
                 "downstairs failed, too many outstanding jobs {work_count}"
             );
-            true
+            Some(ClientStopReason::TooManyOutstandingJobs)
         } else if byte_count as u64 > crate::IO_OUTSTANDING_MAX_BYTES {
             warn!(
                 self.log,
                 "downstairs failed, too many outstanding bytes {byte_count}"
             );
-            true
+            Some(ClientStopReason::TooManyOutstandingBytes)
         } else {
-            false
+            None
         };
 
-        if failed {
+        if let Some(err) = failed {
             self.skip_all_jobs(client_id);
-            self.clients[client_id]
-                .fault(up_state, ClientStopReason::TooManyOutstandingJobs);
+            self.clients[client_id].fault(up_state, err);
         }
     }
 

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -13,7 +13,8 @@ pub(crate) mod protocol_test {
     use crate::BlockIO;
     use crate::Buffer;
     use crate::CrucibleError;
-    use crate::IO_OUTSTANDING_MAX;
+    use crate::IO_OUTSTANDING_MAX_BYTES;
+    use crate::IO_OUTSTANDING_MAX_JOBS;
     use crate::MAX_ACTIVE_COUNT;
     use crucible_client_types::CrucibleOpts;
     use crucible_common::Block;
@@ -520,10 +521,11 @@ pub(crate) mod protocol_test {
                 ds3.set_read_only();
             }
 
-            // Configure our guest without queue backpressure, to speed up tests
-            // which require triggering a timeout
+            // Configure our guest without backpressure, to speed up tests which
+            // require triggering a timeout
             let (g, mut io) = Guest::new(Some(log.clone()));
             io.disable_queue_backpressure();
+            io.disable_byte_backpressure();
             let guest = Arc::new(g);
 
             let crucible_opts = CrucibleOpts {
@@ -937,11 +939,11 @@ pub(crate) mod protocol_test {
         let (_jh2, mut ds2_messages) = harness.ds2.spawn_message_receiver();
         let (_jh3, mut ds3_messages) = harness.ds3.spawn_message_receiver();
 
-        // Send 200 more than IO_OUTSTANDING_MAX jobs. Flow control will kick in
+        // Send 200 more than IO_OUTSTANDING_MAX_JOBS jobs. Flow control will kick in
         // at MAX_ACTIVE_COUNT messages, so we need to be sending read responses
-        // while reads are being sent. After IO_OUTSTANDING_MAX jobs, the
+        // while reads are being sent. After IO_OUTSTANDING_MAX_JOBS jobs, the
         // Upstairs will set ds1 to faulted, and send it no more work.
-        const NUM_JOBS: usize = IO_OUTSTANDING_MAX + 200;
+        const NUM_JOBS: usize = IO_OUTSTANDING_MAX_JOBS + 200;
         let mut job_ids = Vec::with_capacity(NUM_JOBS);
 
         for i in 0..NUM_JOBS {
@@ -1966,6 +1968,145 @@ pub(crate) mod protocol_test {
         Ok(())
     }
 
+    /// Test that we will mark a Downstairs as failed if we hit the byte limit
+    #[tokio::test]
+    async fn test_byte_fault_condition() -> Result<()> {
+        let harness = Arc::new(TestHarness::new().await?);
+
+        let (_jh1, mut ds1_messages) =
+            harness.ds1().await.spawn_message_receiver();
+        let (_jh2, mut ds2_messages) = harness.ds2.spawn_message_receiver();
+        let (_jh3, mut ds3_messages) = harness.ds3.spawn_message_receiver();
+
+        // Send enough bytes to hit the IO_OUTSTANDING_MAX_BYTES condition on
+        // downstairs 1, which should mark it as faulted and kick it out.
+        let write_buf = Bytes::from(vec![1; 50 * 1024]); // 1 MiB
+        let num_jobs = IO_OUTSTANDING_MAX_BYTES as usize / write_buf.len() + 10;
+        let mut job_ids = Vec::with_capacity(num_jobs);
+        assert!(num_jobs < IO_OUTSTANDING_MAX_JOBS);
+
+        for i in 0..num_jobs {
+            {
+                let harness = harness.clone();
+
+                // We must tokio::spawn here because `read` will wait for the
+                // response to come back before returning
+                let write_buf = write_buf.clone();
+                tokio::spawn(async move {
+                    harness
+                        .guest
+                        .write(Block::new_512(0), write_buf)
+                        .await
+                        .unwrap();
+                });
+            }
+
+            if i < MAX_ACTIVE_COUNT {
+                // Before flow control kicks in, assert we're seeing the read
+                // requests
+                bail_assert!(matches!(
+                    ds1_messages.recv().await.unwrap(),
+                    Message::Write { .. },
+                ));
+            } else {
+                // After flow control kicks in, we shouldn't see any more
+                // messages
+                match ds1_messages.try_recv() {
+                    // This can return either Empty or Disconnected, depending
+                    // on whether the upstairs has kicked us out.
+                    Err(TryRecvError::Empty) => {}
+                    Err(TryRecvError::Disconnected) => {}
+                    x => {
+                        info!(
+                            harness.log,
+                            "Read {i} should return EMPTY, but we got:{:?}", x
+                        );
+
+                        bail!(
+                            "Read {i} should return EMPTY, but we got:{:?}",
+                            x
+                        );
+                    }
+                }
+            }
+
+            match ds2_messages.recv().await.unwrap() {
+                Message::Write { job_id, .. } => {
+                    // Record the job ids of the read requests
+                    job_ids.push(job_id);
+                }
+
+                _ => bail!("saw non read request!"),
+            }
+
+            bail_assert!(matches!(
+                ds3_messages.recv().await.unwrap(),
+                Message::Write { .. },
+            ));
+
+            // Respond with read responses for downstairs 2 and 3
+            harness
+                .ds2
+                .fw
+                .lock()
+                .await
+                .send(Message::WriteAck {
+                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
+                    session_id: harness
+                        .ds2
+                        .upstairs_session_id
+                        .lock()
+                        .await
+                        .unwrap(),
+                    job_id: job_ids[i],
+                    result: Ok(()),
+                })
+                .await
+                .unwrap();
+
+            harness
+                .ds3
+                .fw
+                .lock()
+                .await
+                .send(Message::WriteAck {
+                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
+                    session_id: harness
+                        .ds3
+                        .upstairs_session_id
+                        .lock()
+                        .await
+                        .unwrap(),
+                    job_id: job_ids[i],
+
+                    result: Ok(()),
+                })
+                .await
+                .unwrap();
+        }
+
+        // Confirm that's all the Upstairs sent us (only ds2 and ds3) - with the
+        // flush_timeout set to 24 hours, we shouldn't see anything else
+        bail_assert!(matches!(
+            ds2_messages.try_recv(),
+            Err(TryRecvError::Empty)
+        ));
+        bail_assert!(matches!(
+            ds3_messages.try_recv(),
+            Err(TryRecvError::Empty)
+        ));
+
+        // Assert the Upstairs isn't sending ds1 more work, because it is
+        // Faulted
+        let v = ds1_messages.try_recv();
+        assert_eq!(
+            v,
+            Err(TryRecvError::Disconnected),
+            "ds1 message queue must be disconnected"
+        );
+        Ok(())
+    }
+
     /// Test that an error during the live repair doesn't halt indefinitely
     #[tokio::test]
     async fn test_error_during_live_repair_no_halt() -> Result<()> {
@@ -1976,11 +2117,11 @@ pub(crate) mod protocol_test {
         let (_jh2, mut ds2_messages) = harness.ds2.spawn_message_receiver();
         let (_jh3, mut ds3_messages) = harness.ds3.spawn_message_receiver();
 
-        // Send 200 more than IO_OUTSTANDING_MAX jobs. Flow control will kick in
-        // at MAX_ACTIVE_COUNT messages, so we need to be sending read responses
-        // while reads are being sent. After IO_OUTSTANDING_MAX jobs, the
-        // Upstairs will set ds1 to faulted, and send it no more work.
-        const NUM_JOBS: usize = IO_OUTSTANDING_MAX + 200;
+        // Send 200 more than IO_OUTSTANDING_MAX_JOBS jobs. Flow control will
+        // kick in at MAX_ACTIVE_COUNT messages, so we need to be sending read
+        // responses while reads are being sent. After IO_OUTSTANDING_MAX_JOBS
+        // jobs, the Upstairs will set ds1 to faulted, and send it no more work.
+        const NUM_JOBS: usize = IO_OUTSTANDING_MAX_JOBS + 200;
         let mut job_ids = Vec::with_capacity(NUM_JOBS);
 
         for i in 0..NUM_JOBS {
@@ -2680,11 +2821,11 @@ pub(crate) mod protocol_test {
         let (_jh2, mut ds2_messages) = harness.ds2.spawn_message_receiver();
         let (_jh3, mut ds3_messages) = harness.ds3.spawn_message_receiver();
 
-        // Send 200 more than IO_OUTSTANDING_MAX jobs. Flow control will kick in
-        // at MAX_ACTIVE_COUNT messages, so we need to be sending read responses
-        // while reads are being sent. After IO_OUTSTANDING_MAX jobs, the
-        // Upstairs will set ds1 to faulted, and send it no more work.
-        const NUM_JOBS: usize = IO_OUTSTANDING_MAX + 200;
+        // Send 200 more than IO_OUTSTANDING_MAX_JOBS jobs. Flow control will
+        // kick in at MAX_ACTIVE_COUNT messages, so we need to be sending read
+        // responses while reads are being sent. After IO_OUTSTANDING_MAX_JOBS
+        // jobs, the Upstairs will set ds1 to faulted, and send it no more work.
+        const NUM_JOBS: usize = IO_OUTSTANDING_MAX_JOBS + 200;
         let mut job_ids = Vec::with_capacity(NUM_JOBS);
 
         for i in 0..NUM_JOBS {

--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -332,17 +332,15 @@ pub struct Guest {
 /// otherwise acked immediately, before actually being complete).  The delay is
 /// varied based on two metrics:
 ///
-/// - number of write bytes outstanding
+/// - number of write bytes outstanding (as a fraction of max)
 /// - queue length as a fraction (where 1.0 is full)
 ///
 /// These two metrics are used for quadratic backpressure, picking the larger of
 /// the two delays.
 #[derive(Copy, Clone, Debug)]
 struct BackpressureConfig {
-    /// When should backpressure start (in bytes)?
-    bytes_start: u64,
-    /// Scale for byte-based quadratic backpressure
-    bytes_scale: f64,
+    /// When should backpressure start?
+    bytes_start: f64,
     /// Maximum bytes-based backpressure
     bytes_max_delay: Duration,
 
@@ -396,8 +394,7 @@ impl Guest {
             backpressure_us: backpressure_us.clone(),
             backpressure_config: BackpressureConfig {
                 // Byte-based backpressure
-                bytes_start: 100 * 1024u64.pow(2), // Start at 100 MiB
-                bytes_scale: 6e-8, // Delay of 15ms at 2 GiB in-flight
+                bytes_start: 0.05,
                 bytes_max_delay: Duration::from_millis(15),
 
                 // Queue-based backpressure
@@ -944,30 +941,36 @@ impl GuestIoHandle {
     }
 
     /// Set `self.backpressure_us` based on outstanding IO ratio
-    pub fn set_backpressure(&self, bytes: u64, ratio: f64) {
+    pub fn set_backpressure(&self, bytes: u64, jobs: u64) {
+        let jobs_frac = jobs as f64 / crate::IO_OUTSTANDING_MAX_JOBS as f64;
+        let bytes_frac = bytes as f64 / crate::IO_OUTSTANDING_MAX_BYTES as f64;
+
         // Check to see if the number of outstanding write bytes (between
         // the upstairs and downstairs) is particularly high.  If so,
         // apply some backpressure by delaying host operations, with a
         // quadratically-increasing delay.
-        let d1 = (self.backpressure_config.bytes_max_delay.as_micros() as u64)
-            .min(
-                (bytes.saturating_sub(self.backpressure_config.bytes_start)
-                    as f64
-                    * self.backpressure_config.bytes_scale)
-                    .powf(2.0) as u64,
-            );
+        let delay_bytes = self
+            .backpressure_config
+            .bytes_max_delay
+            .mul_f64(
+                ((bytes_frac - self.backpressure_config.bytes_start).max(0.0)
+                    / (1.0 - self.backpressure_config.bytes_start))
+                    .powf(2.0),
+            )
+            .as_micros() as u64;
 
         // Compute an alternate delay based on queue length
-        let d2 = self
+        let delay_jobs = self
             .backpressure_config
             .queue_max_delay
             .mul_f64(
-                ((ratio - self.backpressure_config.queue_start).max(0.0)
+                ((jobs_frac - self.backpressure_config.queue_start).max(0.0)
                     / (1.0 - self.backpressure_config.queue_start))
                     .powf(2.0),
             )
             .as_micros() as u64;
-        self.backpressure_us.store(d1.max(d2), Ordering::SeqCst);
+        self.backpressure_us
+            .store(delay_jobs.max(delay_bytes), Ordering::SeqCst);
     }
 
     pub fn set_iop_limit(&mut self, bytes_per_iop: usize, limit: usize) {

--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -934,6 +934,11 @@ impl GuestIoHandle {
     }
 
     #[cfg(test)]
+    pub fn disable_byte_backpressure(&mut self) {
+        self.backpressure_config.bytes_max_delay = Duration::ZERO;
+    }
+
+    #[cfg(test)]
     pub fn is_queue_backpressure_disabled(&self) -> bool {
         self.backpressure_config.queue_max_delay == Duration::ZERO
     }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -77,9 +77,17 @@ mod downstairs;
 mod upstairs;
 use upstairs::{UpCounters, UpstairsAction};
 
-// Max number of outstanding IOs between the upstairs and the downstairs
-// before we give up and mark that downstairs faulted.
-const IO_OUTSTANDING_MAX: usize = 57000;
+/// Max number of outstanding IOs between the upstairs and the downstairs
+///
+/// If we exceed this value, the upstairs will give up and mark that downstairs
+/// as faulted.
+const IO_OUTSTANDING_MAX_JOBS: usize = 57000;
+
+/// Max number of write bytes between the upstairs and the downstairs
+///
+/// If we exceed this value, the upstairs will give up and mark that downstairs
+/// as faulted.
+const IO_OUTSTANDING_MAX_BYTES: u64 = 1024 * 1024 * 1024; // 1 GiB
 
 /// The BlockIO trait behaves like a physical NVMe disk (or a virtio virtual
 /// disk): there is no contract about what order operations that are submitted

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -2030,9 +2030,10 @@ impl Upstairs {
             .map(|c| c.total_live_work())
             .max()
             .unwrap_or(0);
-        let ratio = dsw_max as f64 / crate::IO_OUTSTANDING_MAX_JOBS as f64;
-        self.guest
-            .set_backpressure(self.downstairs.write_bytes_outstanding(), ratio);
+        self.guest.set_backpressure(
+            self.downstairs.write_bytes_outstanding(),
+            dsw_max as u64,
+        );
 
         self.downstairs.set_client_backpressure();
     }

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -2030,7 +2030,7 @@ impl Upstairs {
             .map(|c| c.total_live_work())
             .max()
             .unwrap_or(0);
-        let ratio = dsw_max as f64 / crate::IO_OUTSTANDING_MAX as f64;
+        let ratio = dsw_max as f64 / crate::IO_OUTSTANDING_MAX_JOBS as f64;
         self.guest
             .set_backpressure(self.downstairs.write_bytes_outstanding(), ratio);
 


### PR DESCRIPTION
As recommended in [RFD 445](https://rfd.shared.oxide.computer/rfd/445#_problematic_bytes_in_flight_delay), this PR adds a fault condition if too many bytes pile up in flight for any particular downstairs.

This adds a nice symmetry to the system: both backpressure and per-downstairs faults consider both jobs and bytes in flight.