### PR TITLE
Fix outdated log message

### DIFF
--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1816,10 +1816,7 @@ impl Upstairs {
                 .iter()
                 .any(|c| c.state() != DsState::WaitQuorum);
             if not_ready {
-                info!(
-                    self.log,
-                    "Waiting for {} more clients to be ready", not_ready
-                );
+                info!(self.log, "Waiting for more clients to be ready");
                 return false;
             }
 


### PR DESCRIPTION
This used to be a counter, but is now a boolean, so the log message is silly:
```
Waiting for true more clients to be ready
```