### PR TITLE
Fast deserialization

### DIFF
--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -1174,8 +1174,8 @@ impl Decoder for CrucibleDecoder {
         // This leaves `src` at the start of the next message (if present)
         let buf = src.split_to(len).split_off(4);
 
-        // We'll examine the message's tag to see whether we can use an
-        // optimizezd deserialization routine.
+        // We'll examine the message's tag to see whether we should use a
+        // reduced-memcpy deserialization routine.
         let tag: MessageDiscriminants = bincode::deserialize(&buf)?;
         let message = match tag {
             MessageDiscriminants::Write


### PR DESCRIPTION
#1087 and #1183 eliminated `memcpy` during serialization, by building the `bincode`-encoded buffers in place.

This PR does the equivalent optimization on **deserialization** side.

This isn't _too_ hard, although it uses the same awkward "implement `bincode` manually" strategy.  The `Decoder` trait provides us with a `Bytes` object, so we can carefully slice it into chunks; we deserialize fixed-sized data, but rely on `Byte` slicing for bulk write and read response data.

# Performance changes
This is a significant speedup for large writes, and (maybe) a speedup for large reads.

## This branch (`3f7ba87a`)
```
4M WRITE: bw=795MiB/s (833MB/s), 795MiB/s-795MiB/s (833MB/s-833MB/s), io=46.6GiB (50.1GB), run=60098-60098msec
4K WRITE: bw=21.9MiB/s (23.0MB/s), 21.9MiB/s-21.9MiB/s (23.0MB/s-23.0MB/s), io=1317MiB (1381MB), run=60007-60007msec
1M WRITE: bw=849MiB/s (890MB/s), 849MiB/s-849MiB/s (890MB/s-890MB/s), io=49.7GiB (53.4GB), run=60026-60026msec
4M WRITE: bw=876MiB/s (919MB/s), 876MiB/s-876MiB/s (919MB/s-919MB/s), io=51.4GiB (55.2GB), run=60099-60099msec
4K READ: bw=27.7MiB/s (29.0MB/s), 27.7MiB/s-27.7MiB/s (29.0MB/s-29.0MB/s), io=1662MiB (1743MB), run=60003-60003msec
1M READ: bw=592MiB/s (621MB/s), 592MiB/s-592MiB/s (621MB/s-621MB/s), io=34.7GiB (37.3GB), run=60041-60041msec
4M READ: bw=740MiB/s (776MB/s), 740MiB/s-740MiB/s (776MB/s-776MB/s), io=43.5GiB (46.7GB), run=60124-60124msec
```

## Comparing against `main` (`52970ba122`)
```
4M WRITE: bw=617MiB/s (647MB/s), 617MiB/s-617MiB/s (647MB/s-647MB/s), io=36.2GiB (38.9GB), run=60137-60137msec
4K WRITE: bw=27.8MiB/s (29.1MB/s), 27.8MiB/s-27.8MiB/s (29.1MB/s-29.1MB/s), io=1667MiB (1748MB), run=60008-60008msec
1M WRITE: bw=633MiB/s (663MB/s), 633MiB/s-633MiB/s (663MB/s-663MB/s), io=37.1GiB (39.8GB), run=60026-60026msec
4M WRITE: bw=628MiB/s (659MB/s), 628MiB/s-628MiB/s (659MB/s-659MB/s), io=36.9GiB (39.7GB), run=60194-60194msec
4K READ: bw=33.8MiB/s (35.5MB/s), 33.8MiB/s-33.8MiB/s (35.5MB/s-35.5MB/s), io=2030MiB (2129MB), run=60003-60003msec
1M READ: bw=593MiB/s (621MB/s), 593MiB/s-593MiB/s (621MB/s-621MB/s), io=34.7GiB (37.3GB), run=60040-60040msec
4M READ: bw=607MiB/s (637MB/s), 607MiB/s-607MiB/s (637MB/s-637MB/s), io=35.7GiB (38.3GB), run=60152-60152msec
```

# Flamegraphs
We expect these changes to eliminate `memcpy` in the Downstairs write and Upstairs read path.  Sure enough, the change is noticeable in the flamegraphs (doing 1M reads and writes).

## Upstairs reads on `main`
<img width="1918" alt="up_read_main" src="https://github.com/oxidecomputer/crucible/assets/745333/86ebb45a-c1f7-4ad5-88cc-8ebe86cfda1c">

## Upstairs reads on this branch
<img width="1919" alt="up_read_fast" src="https://github.com/oxidecomputer/crucible/assets/745333/a3d9b476-4fb1-4140-99aa-9a70f4dd3332">

## Downstairs writes on `main`
<img width="1919" alt="ds_write_main" src="https://github.com/oxidecomputer/crucible/assets/745333/18847993-8636-44dd-97af-a6bfefab58e9">

## Downstairs writes on this branch
<img width="1917" alt="ds_write_fast" src="https://github.com/oxidecomputer/crucible/assets/745333/515bc173-7633-4288-bcf6-e48beea4485d">
