### PR TITLE
Automatically split > 1 MiB writes

### DIFF
--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -633,11 +633,7 @@ impl BlockIO for Guest {
         const MDTS: usize = 1024 * 1024; // 1 MiB
 
         while !data.is_empty() {
-            let buf = if data.len() > MDTS {
-                data.split_to(MDTS)
-            } else {
-                data.split_to(data.len())
-            };
+            let buf = data.split_to(MDTS.min(data.len()));
             assert_eq!(buf.len() as u64 % bs, 0);
             let offset_change = buf.len() as u64 / bs;
             let wio = BlockOp::Write { offset, data: buf };


### PR DESCRIPTION
In #1192 , we noticed that arbitrarily-large writes can overwhelm our backpressure implementation, because they take longer than our maximum backpressure.

This PR automatically splits large writes into 1 MiB chunks.  Propolis already does this, so I don't see any performance impacts, but it means that we'll be robust against stuff like "`crudd` tries to send unreasonably large write jobs".