### PR TITLE
Switch from `Vec` → `BytesMut` in `Buffer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,6 +1041,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "base64",
+ "bytes",
  "chrono",
  "clap",
  "crucible",

--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -180,7 +180,7 @@ async fn cmd_read<T: BlockIO + std::marker::Send + 'static>(
         // So say we have an offset of 5. we're misaligned by 5 bytes, so we
         // read 5 bytes we don't need. we skip those 5 bytes then write
         // the rest to the output
-        let bytes = buffer.into_vec();
+        let bytes = buffer.into_bytes_mut();
         output.write_all(
             &bytes[offset_misalignment as usize
                 ..(offset_misalignment + alignment_bytes) as usize],
@@ -318,7 +318,7 @@ async fn write_remainder_and_finalize<'a, T: BlockIO>(
         crucible.read(uflow_offset, &mut uflow_r_buf).await?;
 
         // Copy it into w_buf
-        let r_bytes = uflow_r_buf.into_vec();
+        let r_bytes = uflow_r_buf.into_bytes();
         w_buf[n_read..n_read + uflow_backfill]
             .copy_from_slice(&r_bytes[uflow_remainder as usize..]);
 
@@ -404,7 +404,7 @@ async fn cmd_write<T: BlockIO>(
         let offset = Block::new(block_idx, native_block_size.trailing_zeros());
         crucible.read(offset, &mut buffer).await?;
 
-        let mut w_vec = buffer.into_vec();
+        let mut w_vec = buffer.into_bytes_mut();
         // Write our data into the buffer
         let bytes_read = input.read(
             &mut w_vec[offset_misalignment as usize

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -219,7 +219,7 @@ async fn cli_read(
     ri: &mut RegionInfo,
     block_index: usize,
     size: usize,
-) -> Result<Vec<u8>, CrucibleError> {
+) -> Result<Bytes, CrucibleError> {
     /*
      * Convert offset to its byte value.
      */
@@ -229,7 +229,7 @@ async fn cli_read(
     println!("Read  at block {:5}, len:{:7}", offset.value, data.len());
     guest.read(offset, &mut data).await?;
 
-    let mut dl = data.into_vec();
+    let mut dl = data.into_bytes();
     match validate_vec(
         dl.clone(),
         block_index,

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -1117,7 +1117,7 @@ async fn verify_volume(
         );
         guest.read(offset, &mut data).await?;
 
-        let dl = data.into_vec();
+        let dl = data.into_bytes();
         match validate_vec(
             dl,
             block_index,
@@ -1228,13 +1228,15 @@ enum ValidateStatus {
  * range:       If the validation should consider the write log range
  *              for acceptable values in the data buffer.
  */
-fn validate_vec(
-    data: Vec<u8>,
+fn validate_vec<V: AsRef<[u8]>>(
+    data: V,
     block_index: usize,
     wl: &mut WriteLog,
     bs: u64,
     range: bool,
 ) -> ValidateStatus {
+    let data = data.as_ref();
+
     let bs = bs as usize;
     assert_eq!(data.len() % bs, 0);
     if data.is_empty() {
@@ -1356,7 +1358,7 @@ async fn balloon_workload(
                 crucible::Buffer::repeat(255, size, ri.block_size as usize);
             guest.read(offset, &mut data).await?;
 
-            let dl = data.into_vec();
+            let dl = data.into_bytes();
             match validate_vec(
                 dl,
                 block_index,
@@ -1596,7 +1598,7 @@ async fn generic_workload(
                 guest.read(offset, &mut data).await?;
 
                 let data_len = data.len();
-                let dl = data.into_vec();
+                let dl = data.into_bytes();
                 match validate_vec(
                     dl,
                     block_index,
@@ -2229,7 +2231,7 @@ async fn one_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
     println!("Read  at block {:5}, len:{:7}", offset.value, data.len());
     guest.read(offset, &mut data).await?;
 
-    let dl = data.into_vec();
+    let dl = data.into_bytes();
     match validate_vec(dl, block_index, &mut ri.write_log, ri.block_size, false)
     {
         ValidateStatus::Bad | ValidateStatus::InRange => {
@@ -2381,7 +2383,7 @@ async fn write_flush_read_workload(
             crucible::Buffer::repeat(255, size, ri.block_size as usize);
         guest.read(offset, &mut data).await?;
 
-        let dl = data.into_vec();
+        let dl = data.into_bytes();
         match validate_vec(
             dl,
             block_index,
@@ -2697,7 +2699,7 @@ async fn span_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
     println!("Sending a read spanning two extents");
     guest.read(offset, &mut data).await?;
 
-    let dl = data.into_vec();
+    let dl = data.into_bytes();
     match validate_vec(dl, block_index, &mut ri.write_log, ri.block_size, false)
     {
         ValidateStatus::Bad | ValidateStatus::InRange => {
@@ -2734,7 +2736,7 @@ async fn big_workload(guest: &Arc<Guest>, ri: &mut RegionInfo) -> Result<()> {
         let mut data = crucible::Buffer::repeat(255, 1, ri.block_size as usize);
         guest.read(offset, &mut data).await?;
 
-        let dl = data.into_vec();
+        let dl = data.into_bytes();
         match validate_vec(
             dl,
             block_index,

--- a/crutest/src/protocol.rs
+++ b/crutest/src/protocol.rs
@@ -41,7 +41,7 @@ pub enum CliMessage {
     Perf(usize, usize, usize, usize, usize),
     Read(usize, usize),
     RandRead,
-    ReadResponse(usize, Result<Vec<u8>, CrucibleError>),
+    ReadResponse(usize, Result<Bytes, CrucibleError>),
     RandWrite,
     Replace(SocketAddr, SocketAddr),
     ReplaceResult(Result<ReplaceResult, CrucibleError>),

--- a/pantry/Cargo.toml
+++ b/pantry/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
+bytes.workspace = true
 base64.workspace = true
 chrono.workspace = true
 clap.workspace = true

--- a/pantry/src/pantry.rs
+++ b/pantry/src/pantry.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use anyhow::Result;
+use bytes::Bytes;
 use dropshot::HttpError;
 use sha2::Digest;
 use sha2::Sha256;
@@ -294,7 +295,7 @@ impl PantryEntry {
         &self,
         offset: u64,
         size: usize,
-    ) -> Result<Vec<u8>, CrucibleError> {
+    ) -> Result<Bytes, CrucibleError> {
         if size > Self::MAX_CHUNK_SIZE {
             crucible_bail!(
                 InvalidNumberOfBlocks,
@@ -314,7 +315,7 @@ impl PantryEntry {
             .read_from_byte_offset(offset, &mut buffer)
             .await?;
 
-        Ok(buffer.into_vec())
+        Ok(buffer.into_bytes())
     }
 
     pub async fn scrub(&self) -> Result<(), CrucibleError> {
@@ -601,7 +602,7 @@ impl Pantry {
         volume_id: String,
         offset: u64,
         size: usize,
-    ) -> Result<Vec<u8>, HttpError> {
+    ) -> Result<Bytes, HttpError> {
         let entry = self.entry(volume_id).await?;
         entry.bulk_read(offset, size).await.map_err(|e| e.into())
     }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1565,16 +1565,9 @@ impl Buffer {
 
     /// Builds a new buffer that repeats the given value
     pub fn repeat(v: u8, block_count: usize, block_size: usize) -> Self {
-        let len = block_count * block_size;
-        let mut data = BytesMut::with_capacity(len);
-        data.resize(len, v);
-        let mut owned = BytesMut::with_capacity(block_count);
-        owned.resize(block_count, 0);
-        Buffer {
-            block_size,
-            data,
-            owned,
-        }
+        let mut out = Self::default();
+        out.reset_with(v, block_count, block_size);
+        out
     }
 
     pub fn with_capacity(block_count: usize, block_size: usize) -> Buffer {
@@ -1749,14 +1742,18 @@ impl Buffer {
         &self.owned
     }
 
-    pub fn reset(&mut self, block_count: usize, block_size: usize) {
+    fn reset_with(&mut self, v: u8, block_count: usize, block_size: usize) {
         self.data.clear();
         self.owned.clear();
 
         let len = block_count * block_size;
-        self.data.resize(len, 0u8);
+        self.data.resize(len, v);
         self.owned.resize(block_count, 0);
         self.block_size = block_size;
+    }
+
+    pub fn reset(&mut self, block_count: usize, block_size: usize) {
+        self.reset_with(0, block_count, block_size);
     }
 
     /// Returns a reference to a particular block

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -2087,7 +2087,7 @@ mod test {
             .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
             .await?;
 
-        assert_eq!(buffer.owned_ref(), &[false, false]);
+        assert_eq!(buffer.owned_ref(), &[0, 0]);
 
         // Ownership is set by writing to blocks
 
@@ -2109,7 +2109,7 @@ mod test {
         expected.extend(vec![0u8; 512]);
 
         assert_eq!(&*buffer, &expected);
-        let expected_ownership = [true, false];
+        let expected_ownership = [1, 0];
         assert_eq!(buffer.owned_ref(), &expected_ownership);
 
         // Ownership through a volume should be the same!!


### PR DESCRIPTION
https://github.com/oxidecomputer/crucible/pull/1094 has removed the locks from `Buffer`, meaning we can use a `BytesMut` instead of a `Vec`.

This opens up the possibility to automatically split large read operations, _à la_ https://github.com/oxidecomputer/crucible/pull/1198 (which isn't possible with the `Vec`-based `Buffer`).