### PR TITLE
Automatically split > 1 MiB read jobs

### DIFF
--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -609,7 +609,9 @@ impl BlockIO for Guest {
             //
             // [][-chunk-][--------buffer-------]
             // ^ data
-            let chunk = buffer.split_to(MDTS.min(buffer.len()));
+            let num_bytes = MDTS.min(buffer.len());
+            assert_eq!(num_bytes % bs as usize, 0);
+            let chunk = buffer.split_to(num_bytes / bs as usize);
             assert_eq!(chunk.len() as u64 % bs, 0);
 
             let offset_change = chunk.len() as u64 / bs;

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1816,10 +1816,10 @@ impl Buffer {
     ///
     /// If the two `Buffer` objects were previously contiguous and not mutated
     /// in a way that causes re-allocation i.e., if other was created by calling
-    /// `split_off` on this `BytesMut`, then this is an `O(1)` operation that
+    /// `split_off` on this `Buffer`, then this is an `O(1)` operation that
     /// just decreases a reference count and sets a few indices. Otherwise, this
     /// method calls `extend_from_slice` on both the data and ownership
-    /// `BytesMut`.
+    /// `Buffer`.
     ///
     /// # Panics
     /// If `self.block_size != other.block_size`

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1529,10 +1529,6 @@ impl fmt::Display for AckStatus {
 /*
  * Provides a strongly-owned Buffer that Read operations will write into.
  *
- * Originally BytesMut was used here, but it didn't guarantee that memory was
- * shared between cloned BytesMut objects. Additionally, we added the idea of
- * ownership and that necessitated another field.
- *
  * Ownership of a block is defined as true if that block has been written to: we
  * say a block is "owned" if the bytes were written to by something, rather than
  * having been initialized to zero. For an Upstairs, a block is owned if it was

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1785,7 +1785,7 @@ impl Buffer {
     ///
     /// This is an `O(1)` operation that just increases the reference count and
     /// sets a few indices.
-    pub fn split_off(&mut self, block_index: usize) -> Self {
+    pub(crate) fn split_off(&mut self, block_index: usize) -> Self {
         let data = self.data.split_off(block_index * self.block_size);
         let owned = self.owned.split_off(block_index);
         Self {
@@ -1802,7 +1802,7 @@ impl Buffer {
     ///
     /// This is an `O(1)` operation that just increases the reference count and
     /// sets a few indices.
-    pub fn split_to(&mut self, block_index: usize) -> Self {
+    pub(crate) fn split_to(&mut self, block_index: usize) -> Self {
         let data = self.data.split_to(block_index * self.block_size);
         let owned = self.owned.split_to(block_index);
         Self {
@@ -1823,7 +1823,7 @@ impl Buffer {
     ///
     /// # Panics
     /// If `self.block_size != other.block_size`
-    pub fn unsplit(&mut self, other: Buffer) {
+    pub(crate) fn unsplit(&mut self, other: Buffer) {
         assert_eq!(self.block_size, other.block_size);
         self.data.unsplit(other.data);
         self.owned.unsplit(other.owned);

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1782,20 +1782,16 @@ impl Buffer {
             .zip(self.data.chunks(self.block_size))
     }
 
-    /// Splits the buffer into two at the given index.
+    /// Splits the buffer into two at the given block index.
     ///
-    /// Afterwards `self` contains elements `[0, at)`, and the returned `Buffer`
-    /// contains elements `[at, capacity)`.
+    /// Afterwards `self` contains blocks `[0, block_index)`, and the returned
+    /// `Buffer` contains blocks `[block_index, capacity)`.
     ///
     /// This is an `O(1)` operation that just increases the reference count and
     /// sets a few indices.
-    ///
-    /// # Panics
-    /// The `index` must be an even multiple of block size
-    pub fn split_off(&mut self, index: usize) -> Self {
-        assert_eq!(index % self.block_size, 0);
-        let data = self.data.split_off(index);
-        let owned = self.owned.split_off(index / self.block_size);
+    pub fn split_off(&mut self, block_index: usize) -> Self {
+        let data = self.data.split_off(block_index * self.block_size);
+        let owned = self.owned.split_off(block_index);
         Self {
             block_size: self.block_size,
             data,
@@ -1803,20 +1799,16 @@ impl Buffer {
         }
     }
 
-    /// Splits the buffer into two at the given index.
+    /// Splits the buffer into two at the given block index.
     ///
-    /// Afterwards `self` contains elements `[at, len)`, and the returned
-    /// `Buffer` contains elements `[0, at)`.
+    /// Afterwards `self` contains blocks `[block_index, len)`, and the returned
+    /// `Buffer` contains blocks `[0, block_index)`.
     ///
     /// This is an `O(1)` operation that just increases the reference count and
     /// sets a few indices.
-    ///
-    /// # Panics
-    /// The `index` must be an even multiple of block size
-    pub fn split_to(&mut self, index: usize) -> Self {
-        assert_eq!(index % self.block_size, 0);
-        let data = self.data.split_to(index);
-        let owned = self.owned.split_to(index / self.block_size);
+    pub fn split_to(&mut self, block_index: usize) -> Self {
+        let data = self.data.split_to(block_index * self.block_size);
+        let owned = self.owned.split_to(block_index);
         Self {
             block_size: self.block_size,
             data,


### PR DESCRIPTION
Analogous to #1198 , but for reads instead.

This improves the interaction between large reads and per-queue backpressure.

I also added a unit test for large (> 1 MiB) IOs in `crucible-integration-tests`