### PR TITLE
Added next job ID to dtrace counter probe

### DIFF
--- a/tools/dtrace/upstairs_info.d
+++ b/tools/dtrace/upstairs_info.d
@@ -49,7 +49,7 @@ crucible_upstairs*:::up-status
     /*
      * Job ID delta and backpressure
      */
-    current_str = json(copyinstr(arg1), "ok.next_job");
+    current_str = json(copyinstr(arg1), "ok.next_job_id");
     current = strtoll(current_str, 10);
     if (last == 0)
         delta = current;

--- a/tools/dtrace/upstairs_info.d
+++ b/tools/dtrace/upstairs_info.d
@@ -9,6 +9,7 @@
 dtrace:::BEGIN
 {
     show = 21;
+    last = 0;
 }
 
 /*
@@ -19,12 +20,11 @@ tick-1s
 /show > 20/
 {
     printf("%17s %17s %17s", "DS STATE 0", "DS STATE 1", "DS STATE 2");
-    printf("  %5s %5s %5s", "UPW", "DSW", "BAKPR");
+    printf("  %5s %5s %5s %5s", "UPW", "DSW", "DELTA", "BAKPR");
     printf("  %5s %5s %5s", "NEW0", "NEW1", "NEW2");
     printf("  %5s %5s %5s", "IP0", "IP1", "IP2");
     printf("  %5s %5s %5s", "D0", "D1", "D2");
     printf("  %5s %5s %5s", "S0", "S1", "S2");
-    printf("  %2s %2s %2s", "E0", "E1", "E2");
     printf("\n");
     show = 0;
 }
@@ -45,6 +45,19 @@ crucible_upstairs*:::up-status
     printf(" ");
     printf(" %5s", json(copyinstr(arg1), "ok.up_count"));
     printf(" %5s", json(copyinstr(arg1), "ok.ds_count"));
+
+    /*
+     * Job ID delta and backpressure
+     */
+    current_str = json(copyinstr(arg1), "ok.next_job");
+    current = strtoll(current_str, 10);
+    if (last == 0)
+        delta = current;
+    else
+        delta = current - last;
+
+    last = current;
+    printf(" %5d", delta);
     printf(" %5s", json(copyinstr(arg1), "ok.up_backpressure"));
 
     /*
@@ -78,14 +91,6 @@ crucible_upstairs*:::up-status
     printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.skipped[0]"));
     printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.skipped[1]"));
     printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.skipped[2]"));
-
-    /*
-     * Jobs that are done with errors on the work list for each downstairs
-     */
-    printf(" ");
-    printf(" %2s", json(copyinstr(arg1), "ok.ds_io_count.error[0]"));
-    printf(" %2s", json(copyinstr(arg1), "ok.ds_io_count.error[1]"));
-    printf(" %2s", json(copyinstr(arg1), "ok.ds_io_count.error[2]"));
 
     printf("\n");
 }

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -805,7 +805,6 @@ impl Downstairs {
     }
 
     /// What would next_id return, if we called it?
-    #[cfg(test)]
     pub(crate) fn peek_next_id(&self) -> JobId {
         self.next_id
     }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2024,6 +2024,8 @@ pub struct Arg {
     pub up_count: u32,
     /// Apply loop counter
     pub up_counters: UpCounters,
+    /// Next JobID
+    pub next_job: JobId,
     /// Backpressure value
     pub up_backpressure: u64,
     /// Jobs on the downstairs work queue.

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -2025,7 +2025,7 @@ pub struct Arg {
     /// Apply loop counter
     pub up_counters: UpCounters,
     /// Next JobID
-    pub next_job: JobId,
+    pub next_job_id: JobId,
     /// Backpressure value
     pub up_backpressure: u64,
     /// Jobs on the downstairs work queue.

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -722,7 +722,7 @@ impl Upstairs {
     fn on_stat_update(&self) {
         let up_count = self.guest.guest_work.len() as u32;
         let up_counters = self.counters;
-        let next_job = self.downstairs.peek_next_id();
+        let next_job_id = self.downstairs.peek_next_id();
         let ds_count = self.downstairs.active_count() as u32;
         let ds_state = self.downstairs.collect_stats(|c| c.state());
 
@@ -755,7 +755,7 @@ impl Upstairs {
             let arg = Arg {
                 up_count,
                 up_counters,
-                next_job,
+                next_job_id,
                 up_backpressure,
                 write_bytes_out,
                 ds_count,

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -722,7 +722,7 @@ impl Upstairs {
     fn on_stat_update(&self) {
         let up_count = self.guest.guest_work.len() as u32;
         let up_counters = self.counters;
-
+        let next_job = self.downstairs.peek_next_id();
         let ds_count = self.downstairs.active_count() as u32;
         let ds_state = self.downstairs.collect_stats(|c| c.state());
 
@@ -755,6 +755,7 @@ impl Upstairs {
             let arg = Arg {
                 up_count,
                 up_counters,
+                next_job,
                 up_backpressure,
                 write_bytes_out,
                 ds_count,


### PR DESCRIPTION
Added to the dtrace counter probe the next JobID that the upstairs will use.  
This allows a caller to determine how many jobs have been issued since the last probe.

Update the `upstairs_info.d` script to show this.

Here is an example:
```
       DS STATE 0        DS STATE 1        DS STATE 2    UPW   DSW DELTA BAKPR   NEW0  NEW1  NEW2    IP0   IP1   IP2     D0    D1    D2     S0    S1    S2     
          faulted            active            active     31  3610  9842     0      0     0     0      0    61    61      0  3549  3549   3610     0     0 
          faulted            active            active     31  5641 12902     0      0     0     0      0    61    61      0  5580  5580   5641     0     0 
          faulted            active            active      7   787 14289     0      0     0     0      0    12     8      0   775   779    787     0     0     
          faulted            active            active      6  6061 14455     0      0     0     0      0    36    36      0  6025  6025   6061     0     0 
          faulted            active            active     31  5672 13382     0      0     0     0      0    82    82      0  5590  5590   5672     0     0     
          faulted            active            active     31  6531 14282     0      0     0     0      0    61    61      0  6470  6470   6531     0     0     
          faulted            active            active      4  7340 12842     0      0     0     0      0    34    34      0  7306  7306   7340     0     0 
```

We can see the `JobID` is updating on every tick, meaning new jobs are being created.

Another example where we can see the actual number of jobs flowing through which might not
be obvious from the low counts in other columns.
```
       DS STATE 0        DS STATE 1        DS STATE 2    UPW   DSW DELTA BAKPR   NEW0  NEW1  NEW2    IP0   IP1   IP2     D0    D1    D2     S0    S1    S2
           active            active            active      1     7  2395     0      0     0     0      1     1     1      6     6     6      0     0     0
           active            active            active      1    12  2163     0      0     0     0      0     1     1     12    11    11      0     0     0
           active            active            active      1     5  2261     0      0     0     0      1     1     1      4     4     4      0     0     0
           active            active            active      0     7  2288     0      0     0     0      1     1     1      6     6     6      0     0     0
           active            active            active      0     5  2267     0      0     0     0      2     2     2      3     3     3      0     0     0
           active            active            active      1     7  2210     0      0     0     0      1     1     1      6     6     6      0     0     0
           active            active            active      1     9  3041     0      0     0     0      1     1     1      8     8     8      0     0     0
           active            active            active      1     3  3106     0      0     0     0      1     2     1      2     1     2      0     0     0
           active            active            active      0     9  3166     0      0     0     0      0     0     0      9     9     9      0     0     0
```
