### PR TITLE
Sneak in a work queue dump on the repair API

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -349,9 +349,9 @@ pub async fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
  */
 pub fn show_work(ds: &mut Downstairs) {
     let active_upstairs_connections = ds.active_upstairs();
-    println!(
-        "Active Upstairs connections: {:?}",
-        active_upstairs_connections
+    info!(
+        ds.log,
+        "Active Upstairs connections: {:?}", active_upstairs_connections
     );
 
     for upstairs_connection in active_upstairs_connections {
@@ -360,9 +360,13 @@ pub fn show_work(ds: &mut Downstairs) {
         let mut kvec: Vec<JobId> = work.active.keys().cloned().collect();
 
         if kvec.is_empty() {
-            println!("Crucible Downstairs work queue:  Empty");
+            info!(ds.log, "Crucible Downstairs work queue:  Empty");
         } else {
-            println!("Crucible Downstairs work queue:");
+            info!(ds.log, "Crucible Downstairs work queue:");
+            info!(
+                ds.log,
+                "{:8} {:>7} {:>5} {}", "  JOB_ID", "IO_TYPE", "STATE", "DEPS"
+            );
             kvec.sort_unstable();
             for id in kvec.iter() {
                 let dsw = work.active.get(id).unwrap();
@@ -389,16 +393,15 @@ pub fn show_work(ds: &mut Downstairs) {
                         ("NoOp", dependencies)
                     }
                 };
-                println!(
-                    "DSW:[{:04}] {:>07} {:>05} deps:{:?}",
-                    id, dsw_type, dsw.state, dep_list,
+                info!(
+                    ds.log,
+                    "{:8} {:>7}  {:>5} {:?}", id, dsw_type, dsw.state, dep_list,
                 );
             }
         }
 
-        println!("Done tasks {:?}", work.completed);
-        println!("last_flush: {:?}", work.last_flush);
-        println!("--------------------------------------");
+        info!(ds.log, "Completed work {:?}", work.completed);
+        info!(ds.log, "Last flush: {:?}", work.last_flush);
     }
 }
 

--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -41,6 +41,7 @@ fn build_api() -> ApiDescription<Arc<FileServerContext>> {
     api.register(get_region_info).unwrap();
     api.register(get_region_mode).unwrap();
     api.register(extent_repair_ready).unwrap();
+    api.register(get_work).unwrap();
 
     api
 }
@@ -308,6 +309,21 @@ async fn get_region_mode(
     let read_only = rqctx.context().read_only;
 
     Ok(HttpResponseOk(read_only))
+}
+
+/// Work queue
+#[endpoint {
+    method = GET,
+    path = "/work",
+}]
+async fn get_work(
+    rqctx: RequestContext<Arc<FileServerContext>>,
+) -> Result<HttpResponseOk<bool>, HttpError> {
+    let downstairs = &rqctx.context().downstairs;
+    let mut ds = downstairs.lock().await;
+
+    show_work(&mut ds);
+    Ok(HttpResponseOk(true))
 }
 
 #[cfg(test)]

--- a/openapi/downstairs-repair.json
+++ b/openapi/downstairs-repair.json
@@ -166,6 +166,31 @@
           }
         }
       }
+    },
+    "/work": {
+      "get": {
+        "summary": "Work queue",
+        "operationId": "get_work",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Boolean",
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
     }
   },
   "components": {


### PR DESCRIPTION
Added a debug endpoint to the repair API that will dump the current downstairs work queue to whatever log the downstairs is using.  This allows us to see what the downstairs is doing (or not doing), but does not require
spinning up a new endpoint as we can re-use the existing repair port.


Here is an example of what it looks like:
```
05:24:49.918Z INFO crucible: Active Upstairs connections: [UpstairsConnection { upstairs_id: e81bf3da-224d-4f93-8dc1-bb21f40c1377, session_id: b504a459-ddc6-4eb1-a3b3-b516e5d79
42d, gen: 52 }]
05:24:49.918Z INFO crucible: Crucible Downstairs work queue:
05:24:49.918Z INFO crucible:   JOB_ID IO_TYPE STATE DEPS
05:24:49.918Z INFO crucible:  1365345    Read   New [JobId(1365343)]
05:24:49.918Z INFO crucible:  1365346    Read   New [JobId(1365343)]
05:24:49.918Z INFO crucible:  1365347    Read   New [JobId(1365343)]
05:24:49.918Z INFO crucible:  1365348    Read   New [JobId(1365343)]
05:24:49.918Z INFO crucible:  1365349    Read   New [JobId(1365343)]
05:24:49.918Z INFO crucible:  1365350    Read   New [JobId(1365343)]
05:24:49.918Z INFO crucible:  1365351    Read   New [JobId(1365343)]
05:24:49.918Z INFO crucible:  1365352    Read   New [JobId(1365343)]
05:24:49.918Z INFO crucible:  1365353    Read   New [JobId(1365343)]
05:24:49.918Z INFO crucible:  1365354    Read   New [JobId(1365343)]
05:24:49.918Z INFO crucible:  1365355    Read   New [JobId(1365343)]
05:24:49.918Z INFO crucible:  1365356    Read   New [JobId(1365343)]
05:24:49.918Z INFO crucible:  1365357    Read   New [JobId(1365343)]
05:24:49.918Z INFO crucible:  1365358    Read   New [JobId(1365343)]
05:24:49.918Z INFO crucible: Completed work [JobId(1365344)]
05:24:49.918Z INFO crucible: Last flush: JobId(1365343)
05:24:49.918Z INFO crucible: request completed
```

Here is another example with a repair in progress where we are waiting for that NoOP:
```
05:24:47.716Z INFO crucible: accepted connection                                        
    local_addr = 0.0.0.0:22810                                                          
    remote_addr = 127.0.0.1:57835                                                                                                                                               
    task = repair                                                                       
05:24:47.716Z INFO crucible: Active Upstairs connections: [UpstairsConnection { upstairs_id: e81bf3da-224d-4f93-8dc1-bb21f40c1377, session_id: b504a459-ddc6-4eb1-a3b3-b516e5d79
42d, gen: 52 }]                                                                         
05:24:47.716Z INFO crucible: Crucible Downstairs work queue:                            
05:24:47.716Z INFO crucible:   JOB_ID IO_TYPE STATE DEPS                                
05:24:47.716Z INFO crucible:  1347663  ReOpen  DepW [JobId(1347662)]                    
05:24:47.716Z INFO crucible:  1347863    Read  DepW [JobId(1347663)]                                                                                                            
05:24:47.716Z INFO crucible:  1347893   Write  DepW [JobId(1347863)]                    
05:24:47.716Z INFO crucible: Completed work [JobId(1347600), JobId(1347601), ... JobId(1347901), JobId(1347902), JobId(1347903)]
05:24:47.716Z INFO crucible: Last flush: JobId(1347599)                                 
05:24:47.716Z INFO crucible: request completed
```