### PR TITLE
Reorganize messages to reduce copies

### DIFF
--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -298,7 +298,7 @@ async fn write_remainder_and_finalize<'a, T: BlockIO>(
     if uflow_remainder == 0 {
         // no need to RMW, just write
         w_buf.resize(n_read, 0);
-        let w_future = crucible.write(offset, w_buf.freeze());
+        let w_future = crucible.write(offset, w_buf);
         futures.push_back(w_future);
     } else {
         // RMW oof
@@ -323,7 +323,7 @@ async fn write_remainder_and_finalize<'a, T: BlockIO>(
             .copy_from_slice(&r_bytes[uflow_remainder as usize..]);
 
         // Issue the write
-        let w_future = crucible.write(offset, w_buf.freeze());
+        let w_future = crucible.write(offset, w_buf);
         futures.push_back(w_future);
     }
 
@@ -412,9 +412,7 @@ async fn cmd_write<T: BlockIO>(
         )?;
         total_bytes_written += bytes_read;
 
-        let w_bytes = Bytes::from(w_vec);
-
-        crucible.write(offset, w_bytes).await?;
+        crucible.write(offset, w_vec).await?;
 
         if bytes_read != alignment_bytes as usize {
             // underrun, exit early
@@ -478,7 +476,7 @@ async fn cmd_write<T: BlockIO>(
             return Ok(total_bytes_written);
         } else {
             // good to go for a write
-            let w_future = crucible.write(offset, w_buf.freeze());
+            let w_future = crucible.write(offset, w_buf);
             futures.push_back(w_future);
         }
 

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -537,7 +537,7 @@ async fn show_extent(
                 Region::open(dir, Default::default(), false, true, &log)
                     .await?;
 
-            let mut responses = region
+            let mut response = region
                 .region_read(
                     &[ReadRequest {
                         eid: cmp_extent as u64,
@@ -546,7 +546,13 @@ async fn show_extent(
                     JobId(0),
                 )
                 .await?;
-            let response = responses.pop().unwrap();
+            let b = response.blocks.pop().unwrap();
+            let response = ReadResponse {
+                eid: b.eid,
+                offset: b.offset,
+                data: response.data,
+                block_contexts: b.block_contexts,
+            };
 
             dvec.insert(index, response);
         }
@@ -652,7 +658,7 @@ async fn show_extent_block(
         let mut region =
             Region::open(dir, Default::default(), false, true, &log).await?;
 
-        let mut responses = region
+        let mut response = region
             .region_read(
                 &[ReadRequest {
                     eid: cmp_extent as u64,
@@ -664,7 +670,13 @@ async fn show_extent_block(
                 JobId(0),
             )
             .await?;
-        let response = responses.pop().unwrap();
+        let b = response.blocks.pop().unwrap();
+        let response = ReadResponse {
+            eid: b.eid,
+            offset: b.offset,
+            data: response.data,
+            block_contexts: b.block_contexts,
+        };
 
         dvec.insert(index, response);
     }

--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -820,7 +820,7 @@ pub(crate) fn check_input(
 ) -> Result<(), CrucibleError> {
     let block_size = extent_size.block_size_in_bytes() as u64;
     /*
-     * Only accept block sized operations
+     * Only accept block-aligned operations
      */
     if data.len() % block_size as usize != 0 {
         crucible_bail!(DataLenUnaligned);

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -7,7 +7,8 @@ use crate::{
     },
     integrity_hash, mkdir_for_file,
     region::{BatchedPwritev, JobOrReconciliationId},
-    Block, BlockContext, CrucibleError, JobId, RegionDefinition,
+    Block, BlockContext, CrucibleError, JobId, RawReadResponse,
+    RegionDefinition,
 };
 
 use crucible_protocol::ReadResponseBlockMetadata;
@@ -188,7 +189,7 @@ impl ExtentInner for RawInner {
         &mut self,
         job_id: JobId,
         requests: &[crucible_protocol::ReadRequest],
-        out: &mut crucible_protocol::RawReadResponse,
+        out: &mut RawReadResponse,
     ) -> Result<(), CrucibleError> {
         // This code batches up operations for contiguous regions of
         // ReadRequests, so we can perform larger read syscalls queries. This

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -7,16 +7,17 @@ use crate::{
     },
     integrity_hash, mkdir_for_file,
     region::{BatchedPwritev, JobOrReconciliationId},
-    Block, BlockContext, CrucibleError, JobId, ReadResponse, RegionDefinition,
+    Block, BlockContext, CrucibleError, JobId, RegionDefinition,
 };
 
+use crucible_protocol::ReadResponseBlockMetadata;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use slog::{error, Logger};
 
 use std::collections::HashSet;
 use std::fs::{File, OpenOptions};
-use std::io::{BufReader, IoSliceMut, Read};
+use std::io::{BufReader, Read};
 use std::os::fd::AsFd;
 use std::path::Path;
 
@@ -183,12 +184,12 @@ impl ExtentInner for RawInner {
         Ok(())
     }
 
-    fn read(
+    fn read_into(
         &mut self,
         job_id: JobId,
         requests: &[crucible_protocol::ReadRequest],
-        iov_max: usize,
-    ) -> Result<Vec<crucible_protocol::ReadResponse>, CrucibleError> {
+        out: &mut crucible_protocol::RawReadResponse,
+    ) -> Result<(), CrucibleError> {
         // This code batches up operations for contiguous regions of
         // ReadRequests, so we can perform larger read syscalls queries. This
         // significantly improves read throughput.
@@ -198,7 +199,8 @@ impl ExtentInner for RawInner {
         // request.
         let mut req_run_start = 0;
         let block_size = self.extent_size.block_size_in_bytes();
-        let mut responses = Vec::with_capacity(requests.len());
+
+        let mut buf = out.data.split_off(out.data.len());
         while req_run_start < requests.len() {
             let first_req = &requests[req_run_start];
 
@@ -207,14 +209,13 @@ impl ExtentInner for RawInner {
             // contiguous with the request before it. Since we're counting
             // pairs, and the number of pairs is one less than the number of
             // requests, we need to add 1 to get our actual run length.
-            let mut n_contiguous_requests = 1;
+            let mut n_contiguous_blocks = 1;
 
             for request_window in requests[req_run_start..].windows(2) {
-                if (request_window[0].offset.value + 1
-                    == request_window[1].offset.value)
-                    && ((n_contiguous_requests + 1) < iov_max)
+                if request_window[0].offset.value + 1
+                    == request_window[1].offset.value
                 {
-                    n_contiguous_requests += 1;
+                    n_contiguous_blocks += 1;
                 } else {
                     break;
                 }
@@ -222,35 +223,36 @@ impl ExtentInner for RawInner {
 
             // Create our responses and push them into the output. While we're
             // at it, check for overflows.
-            let resp_run_start = responses.len();
-            let mut iovecs = Vec::with_capacity(n_contiguous_requests);
-            for req in requests[req_run_start..][..n_contiguous_requests].iter()
-            {
-                let resp = ReadResponse::from_request(req, block_size as usize);
-                check_input(self.extent_size, req.offset, &resp.data)?;
-                responses.push(resp);
+            let resp_run_start = out.blocks.len();
+            for req in requests[req_run_start..][..n_contiguous_blocks].iter() {
+                let resp = ReadResponseBlockMetadata {
+                    eid: req.eid,
+                    offset: req.offset,
+                    block_contexts: Vec::with_capacity(1),
+                };
+                out.blocks.push(resp);
             }
 
-            // Create what amounts to an iovec for each response data buffer.
-            let mut expected_bytes = 0;
-            for resp in
-                &mut responses[resp_run_start..][..n_contiguous_requests]
-            {
-                expected_bytes += resp.data.len();
-                iovecs.push(IoSliceMut::new(&mut resp.data[..]));
-            }
+            // Calculate the number of expected bytes, then resize our buffer
+            //
+            // This should fill memory, but should not reallocate
+            let expected_bytes = n_contiguous_blocks * block_size as usize;
+            buf.resize(expected_bytes, 1);
+
+            let first_resp = &out.blocks[resp_run_start];
+            check_input(self.extent_size, first_resp.offset, &buf)?;
 
             // Finally we get to read the actual data. That's why we're here
             cdt::extent__read__file__start!(|| {
-                (job_id.0, self.extent_number, n_contiguous_requests as u64)
+                (job_id.0, self.extent_number, n_contiguous_blocks as u64)
             });
 
             // Perform the bulk read, then check against the expected number of
             // bytes.  We could do more robust error handling here (e.g.
             // retrying in a loop), but for now, simply bailing out seems wise.
-            let num_bytes = nix::sys::uio::preadv(
+            let num_bytes = nix::sys::uio::pread(
                 self.file.as_fd(),
-                &mut iovecs,
+                &mut buf,
                 first_req.offset.value as i64 * block_size as i64,
             )
             .map_err(|e| {
@@ -268,39 +270,46 @@ impl ExtentInner for RawInner {
             }
 
             cdt::extent__read__file__done!(|| {
-                (job_id.0, self.extent_number, n_contiguous_requests as u64)
+                (job_id.0, self.extent_number, n_contiguous_blocks as u64)
             });
+
+            // Reattach this chunk to the main `BytesMut` array
+            //
+            // This should be O(1), because we allocated enough space to not
+            // reallocate anywhere in the process.
+            let chunk = buf.split_to(expected_bytes);
+            out.data.unsplit(chunk);
 
             // Query the block metadata
             cdt::extent__read__get__contexts__start!(|| {
-                (job_id.0, self.extent_number, n_contiguous_requests as u64)
+                (job_id.0, self.extent_number, n_contiguous_blocks as u64)
             });
             let block_contexts = self.get_block_contexts(
                 first_req.offset.value,
-                n_contiguous_requests as u64,
+                n_contiguous_blocks as u64,
             )?;
             cdt::extent__read__get__contexts__done!(|| {
-                (job_id.0, self.extent_number, n_contiguous_requests as u64)
+                (job_id.0, self.extent_number, n_contiguous_blocks as u64)
             });
 
             // Now it's time to put block contexts into the responses.
             // We use into_iter here to move values out of enc_ctxts/hashes,
             // avoiding a clone(). For code consistency, we use iters for the
             // response and data chunks too. These iters will be the same length
-            // (equal to n_contiguous_requests) so zipping is fine
+            // (equal to n_contiguous_blocks) so zipping is fine
             let resp_iter =
-                responses[resp_run_start..][..n_contiguous_requests].iter_mut();
+                out.blocks[resp_run_start..][..n_contiguous_blocks].iter_mut();
             let ctx_iter = block_contexts.into_iter();
 
             for (resp, r_ctx) in resp_iter.zip(ctx_iter) {
-                resp.block_contexts =
-                    r_ctx.into_iter().map(|x| x.block_context).collect();
+                assert!(resp.block_contexts.is_empty());
+                resp.block_contexts
+                    .extend(r_ctx.into_iter().map(|x| x.block_context));
             }
 
-            req_run_start += n_contiguous_requests;
+            req_run_start += n_contiguous_blocks;
         }
-
-        Ok(responses)
+        Ok(())
     }
 
     fn flush(
@@ -1463,7 +1472,7 @@ mod test {
     use anyhow::Result;
     use bytes::{Bytes, BytesMut};
     use crucible_protocol::EncryptionContext;
-    use crucible_protocol::ReadRequest;
+    use crucible_protocol::{ReadRequest, ReadResponse};
     use rand::Rng;
     use tempfile::tempdir;
 
@@ -1719,7 +1728,7 @@ mod test {
                 eid: 0,
                 offset: Block::new_512(0),
             };
-            let resp = inner.read(JobId(21), &[read], IOV_MAX_TEST)?;
+            let resp = inner.read(JobId(21), &[read])?;
 
             // We should not get back our data, because block 0 was written.
             assert_ne!(
@@ -1753,7 +1762,7 @@ mod test {
                 eid: 0,
                 offset: Block::new_512(1),
             };
-            let resp = inner.read(JobId(31), &[read], IOV_MAX_TEST)?;
+            let resp = inner.read(JobId(31), &[read])?;
 
             // We should get back our data! Block 1 was never written.
             assert_eq!(
@@ -1976,7 +1985,7 @@ mod test {
                 eid: 0,
                 offset: Block::new_512(0),
             };
-            let resp = inner.read(JobId(31), &[read], IOV_MAX_TEST)?;
+            let resp = inner.read(JobId(31), &[read])?;
 
             // We should get back our data! Block 1 was never written.
             assert_eq!(
@@ -2481,7 +2490,7 @@ mod test {
             eid: 0,
             offset: Block::new_512(0),
         };
-        let resp = inner.read(JobId(31), &[read], IOV_MAX_TEST)?;
+        let resp = inner.read(JobId(31), &[read])?;
 
         let data = Bytes::from(vec![0x03; 512]);
         let hash = integrity_hash(&[&data[..]]);

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -4,7 +4,8 @@ use crate::{
     extent::{check_input, extent_path, DownstairsBlockContext, ExtentInner},
     integrity_hash,
     region::{BatchedPwritev, JobOrReconciliationId},
-    Block, BlockContext, CrucibleError, JobId, RegionDefinition,
+    Block, BlockContext, CrucibleError, JobId, RawReadResponse,
+    RegionDefinition,
 };
 use crucible_protocol::{EncryptionContext, ReadResponseBlockMetadata};
 
@@ -45,7 +46,7 @@ impl ExtentInner for SqliteInner {
         &mut self,
         job_id: JobId,
         requests: &[crucible_protocol::ReadRequest],
-        out: &mut crucible_protocol::RawReadResponse,
+        out: &mut RawReadResponse,
     ) -> Result<(), CrucibleError> {
         self.0.lock().unwrap().read_into(job_id, requests, out)
     }
@@ -281,7 +282,7 @@ impl SqliteMoreInner {
         &mut self,
         job_id: JobId,
         requests: &[crucible_protocol::ReadRequest],
-        out: &mut crucible_protocol::RawReadResponse,
+        out: &mut RawReadResponse,
     ) -> Result<(), CrucibleError> {
         // This code batches up operations for contiguous regions of
         // ReadRequests, so we can perform larger read syscalls and sqlite

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -21,8 +21,8 @@ use crucible_common::{
 };
 use crucible_protocol::{
     BlockContext, CrucibleDecoder, CrucibleEncoder, JobId, Message,
-    ReadRequest, ReadResponse, ReadResponseBlockMetadata, ReconciliationId,
-    SnapshotDetails, CRUCIBLE_MESSAGE_VERSION,
+    ReadRequest, ReadResponse, ReconciliationId, SnapshotDetails,
+    CRUCIBLE_MESSAGE_VERSION,
 };
 use repair_client::Client;
 
@@ -118,48 +118,6 @@ impl IOop {
             | IOop::ExtentLiveReopen { dependencies, .. }
             | IOop::ExtentLiveNoOp { dependencies } => dependencies,
         }
-    }
-}
-
-/// Read response data, containing data from all blocks
-#[derive(Debug)]
-pub struct RawReadResponse {
-    /// Per-block metadata
-    pub blocks: Vec<ReadResponseBlockMetadata>,
-    /// Raw data
-    pub data: bytes::BytesMut,
-}
-
-impl RawReadResponse {
-    /// Builds a new empty `RawReadResponse` with the given capacity
-    pub fn with_capacity(block_count: usize, block_size: u64) -> Self {
-        Self {
-            blocks: Vec::with_capacity(block_count),
-            data: bytes::BytesMut::with_capacity(
-                block_count * block_size as usize,
-            ),
-        }
-    }
-
-    /// Destructures into a `Vec<ReadResponse>`
-    ///
-    /// This is useful for backwards compatibility in unit tests
-    #[cfg(test)]
-    pub fn into_read_responses(mut self) -> Vec<ReadResponse> {
-        assert_eq!(self.data.len() % self.blocks.len(), 0);
-        let block_size = self.data.len() / self.blocks.len();
-        let mut out = Vec::with_capacity(self.blocks.len());
-        for b in self.blocks {
-            let data = self.data.split_to(block_size);
-            out.push(ReadResponse {
-                eid: b.eid,
-                offset: b.offset,
-                block_contexts: b.block_contexts,
-                data,
-            })
-        }
-        assert!(self.data.is_empty());
-        out
     }
 }
 

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -21,8 +21,8 @@ use crucible_common::{
 };
 use crucible_protocol::{
     BlockContext, CrucibleDecoder, CrucibleEncoder, JobId, Message,
-    ReadRequest, ReadResponse, ReconciliationId, SnapshotDetails,
-    CRUCIBLE_MESSAGE_VERSION,
+    ReadRequest, ReadResponse, ReadResponseBlockMetadata, ReconciliationId,
+    SnapshotDetails, CRUCIBLE_MESSAGE_VERSION,
 };
 use repair_client::Client;
 
@@ -118,6 +118,48 @@ impl IOop {
             | IOop::ExtentLiveReopen { dependencies, .. }
             | IOop::ExtentLiveNoOp { dependencies } => dependencies,
         }
+    }
+}
+
+/// Read response data, containing data from all blocks
+#[derive(Debug)]
+pub struct RawReadResponse {
+    /// Per-block metadata
+    pub blocks: Vec<ReadResponseBlockMetadata>,
+    /// Raw data
+    pub data: bytes::BytesMut,
+}
+
+impl RawReadResponse {
+    /// Builds a new empty `RawReadResponse` with the given capacity
+    pub fn with_capacity(block_count: usize, block_size: u64) -> Self {
+        Self {
+            blocks: Vec::with_capacity(block_count),
+            data: bytes::BytesMut::with_capacity(
+                block_count * block_size as usize,
+            ),
+        }
+    }
+
+    /// Destructures into a `Vec<ReadResponse>`
+    ///
+    /// This is useful for backwards compatibility in unit tests
+    #[cfg(test)]
+    pub fn into_read_responses(mut self) -> Vec<ReadResponse> {
+        assert_eq!(self.data.len() % self.blocks.len(), 0);
+        let block_size = self.data.len() / self.blocks.len();
+        let mut out = Vec::with_capacity(self.blocks.len());
+        for b in self.blocks {
+            let data = self.data.split_to(block_size);
+            out.push(ReadResponse {
+                eid: b.eid,
+                offset: b.offset,
+                block_contexts: b.block_contexts,
+                data,
+            })
+        }
+        assert!(self.data.is_empty());
+        out
     }
 }
 

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1672,7 +1672,7 @@ impl Downstairs {
                 );
 
                 let (blocks, data) = match responses {
-                    Ok(r) => (Ok(r.blocks), r.data.freeze()),
+                    Ok(r) => (Ok(r.blocks), r.data),
                     Err(e) => (Err(e), Default::default()),
                 };
                 Ok(Some(Message::ReadResponse {

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -2401,7 +2401,7 @@ impl Downstairs {
         let r = match m {
             Message::Write { header, data } => {
                 cdt::submit__write__start!(|| header.job_id.0);
-                let writes = header.into_writes(data);
+                let writes = header.get_writes(data);
 
                 let new_write = IOop::Write {
                     dependencies: header.dependencies,
@@ -2437,7 +2437,7 @@ impl Downstairs {
             }
             Message::WriteUnwritten { header, data } => {
                 cdt::submit__writeunwritten__start!(|| header.job_id.0);
-                let writes = header.into_writes(data);
+                let writes = header.get_writes(data);
 
                 let new_write = IOop::WriteUnwritten {
                     dependencies: header.dependencies,

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -167,7 +167,7 @@ pub async fn downstairs_export<P: AsRef<Path> + std::fmt::Debug>(
             if (extent_offset + block_offset) >= start_block {
                 blocks_copied += 1;
 
-                let mut responses = region
+                let response = region
                     .region_read(
                         &[ReadRequest {
                             eid: eid as u64,
@@ -179,7 +179,6 @@ pub async fn downstairs_export<P: AsRef<Path> + std::fmt::Debug>(
                         JobId(0),
                     )
                     .await?;
-                let response = responses.pop().unwrap();
 
                 out_file.write_all(&response.data).unwrap();
 
@@ -1672,11 +1671,18 @@ impl Downstairs {
                     responses.is_ok(),
                 );
 
+                let (blocks, data) = match responses {
+                    Ok(r) => (Ok(r.blocks), r.data.freeze()),
+                    Err(e) => (Err(e), Default::default()),
+                };
                 Ok(Some(Message::ReadResponse {
-                    upstairs_id: job.upstairs_connection.upstairs_id,
-                    session_id: job.upstairs_connection.session_id,
-                    job_id,
-                    responses,
+                    header: crucible_protocol::ReadResponseHeader {
+                        upstairs_id: job.upstairs_connection.upstairs_id,
+                        session_id: job.upstairs_connection.session_id,
+                        job_id,
+                        blocks,
+                    },
+                    data,
                 }))
             }
             IOop::WriteUnwritten { writes, .. } => {
@@ -2326,13 +2332,21 @@ impl Downstairs {
         // Initial check against upstairs and session ID
         match m {
             Message::Write {
-                upstairs_id,
-                session_id,
+                header:
+                    crucible_protocol::WriteHeader {
+                        upstairs_id,
+                        session_id,
+                        ..
+                    },
                 ..
             }
             | Message::WriteUnwritten {
-                upstairs_id,
-                session_id,
+                header:
+                    crucible_protocol::WriteHeader {
+                        upstairs_id,
+                        session_id,
+                        ..
+                    },
                 ..
             }
             | Message::Flush {
@@ -2385,22 +2399,18 @@ impl Downstairs {
         }
 
         let r = match m {
-            Message::Write {
-                job_id,
-                dependencies,
-                writes,
-                ..
-            } => {
-                cdt::submit__write__start!(|| job_id.0);
+            Message::Write { header, data } => {
+                cdt::submit__write__start!(|| header.job_id.0);
+                let writes = header.into_writes(data);
 
                 let new_write = IOop::Write {
-                    dependencies,
+                    dependencies: header.dependencies,
                     writes,
                 };
 
                 let mut d = ad.lock().await;
-                d.add_work(upstairs_connection, job_id, new_write)?;
-                Some(job_id)
+                d.add_work(upstairs_connection, header.job_id, new_write)?;
+                Some(header.job_id)
             }
             Message::Flush {
                 job_id,
@@ -2425,22 +2435,18 @@ impl Downstairs {
                 d.add_work(upstairs_connection, job_id, new_flush)?;
                 Some(job_id)
             }
-            Message::WriteUnwritten {
-                job_id,
-                dependencies,
-                writes,
-                ..
-            } => {
-                cdt::submit__writeunwritten__start!(|| job_id.0);
+            Message::WriteUnwritten { header, data } => {
+                cdt::submit__writeunwritten__start!(|| header.job_id.0);
+                let writes = header.into_writes(data);
 
                 let new_write = IOop::WriteUnwritten {
-                    dependencies,
+                    dependencies: header.dependencies,
                     writes,
                 };
 
                 let mut d = ad.lock().await;
-                d.add_work(upstairs_connection, job_id, new_write)?;
-                Some(job_id)
+                d.add_work(upstairs_connection, header.job_id, new_write)?;
+                Some(header.job_id)
             }
             Message::ReadRequest {
                 job_id,
@@ -5436,7 +5442,7 @@ mod test {
         let mut read_data = Vec::with_capacity(total_bytes as usize);
         for eid in 0..region.def().extent_count() {
             for offset in 0..region.def().extent_size().value {
-                let responses = region
+                let response = region
                     .region_read(
                         &[crucible_protocol::ReadRequest {
                             eid: eid.into(),
@@ -5446,13 +5452,13 @@ mod test {
                     )
                     .await?;
 
-                assert_eq!(responses.len(), 1);
+                assert_eq!(response.blocks.len(), 1);
 
-                let response = &responses[0];
-                assert_eq!(response.hashes().len(), 1);
+                let r = &response.blocks[0];
+                assert_eq!(r.hashes().len(), 1);
                 assert_eq!(
                     integrity_hash(&[&response.data[..]]),
-                    response.hashes()[0],
+                    r.hashes()[0],
                 );
 
                 read_data.extend_from_slice(&response.data[..]);

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -12,13 +12,16 @@ use futures::TryStreamExt;
 use tracing::instrument;
 
 use crucible_common::*;
-use crucible_protocol::{RawReadResponse, SnapshotDetails};
+use crucible_protocol::SnapshotDetails;
 use repair_client::Client;
 
 use super::*;
-use crate::extent::{
-    copy_dir, extent_dir, extent_file_name, move_replacement_extent,
-    replace_dir, sync_path, Extent, ExtentMeta, ExtentState, ExtentType,
+use crate::{
+    extent::{
+        copy_dir, extent_dir, extent_file_name, move_replacement_extent,
+        replace_dir, sync_path, Extent, ExtentMeta, ExtentState, ExtentType,
+    },
+    RawReadResponse,
 };
 
 /**

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -12,16 +12,13 @@ use futures::TryStreamExt;
 use tracing::instrument;
 
 use crucible_common::*;
-use crucible_protocol::SnapshotDetails;
+use crucible_protocol::{RawReadResponse, SnapshotDetails};
 use repair_client::Client;
 
 use super::*;
-use crate::{
-    extent::{
-        copy_dir, extent_dir, extent_file_name, move_replacement_extent,
-        replace_dir, sync_path, Extent, ExtentMeta, ExtentState, ExtentType,
-    },
-    RawReadResponse,
+use crate::extent::{
+    copy_dir, extent_dir, extent_file_name, move_replacement_extent,
+    replace_dir, sync_path, Extent, ExtentMeta, ExtentState, ExtentType,
 };
 
 /**
@@ -2030,10 +2027,9 @@ pub(crate) mod test {
                 ],
                 JobId(0),
             )
-            .await?
-            .into_read_responses();
-        assert_eq!(out[0].data.as_ref(), [1; 512]);
-        assert_eq!(out[1].data.as_ref(), [2; 512]);
+            .await?;
+        assert_eq!(&out.data[..512], [1; 512]);
+        assert_eq!(&out.data[512..], [2; 512]);
 
         Ok(())
     }
@@ -2132,10 +2128,9 @@ pub(crate) mod test {
                 ],
                 JobId(0),
             )
-            .await?
-            .into_read_responses();
-        assert_eq!(out[0].data.as_ref(), [1; 512]);
-        assert_eq!(out[1].data.as_ref(), [2; 512]);
+            .await?;
+        assert_eq!(&out.data[..512], [1; 512]);
+        assert_eq!(&out.data[512..], [2; 512]);
 
         Ok(())
     }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -8,7 +8,7 @@ mod test {
 
     use anyhow::*;
     use base64::{engine, Engine};
-    use crucible::{Bytes, *};
+    use crucible::*;
     use crucible_client_types::VolumeConstructionRequest;
     use crucible_downstairs::*;
     use crucible_pantry::pantry::Pantry;
@@ -415,7 +415,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -536,7 +536,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; 0]),
+                BytesMut::from(vec![0x55; 0].as_slice()),
             )
             .await?;
 
@@ -573,7 +573,7 @@ mod test {
         in_memory_data
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![11; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![11; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -614,14 +614,14 @@ mod test {
             volume
                 .write_unwritten(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                    Bytes::from(vec![55; BLOCK_SIZE * 10]),
+                    BytesMut::from(vec![55; BLOCK_SIZE * 10].as_slice()),
                 )
                 .await?;
         } else {
             volume
                 .write(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                    Bytes::from(vec![55; BLOCK_SIZE * 10]),
+                    BytesMut::from(vec![55; BLOCK_SIZE * 10].as_slice()),
                 )
                 .await?;
         }
@@ -662,7 +662,7 @@ mod test {
         in_memory_data
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![11; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![11; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -713,7 +713,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![55; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -798,7 +798,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x01; BLOCK_SIZE]),
+                BytesMut::from(vec![0x01; BLOCK_SIZE].as_slice()),
             )
             .await?;
 
@@ -891,7 +891,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -907,7 +907,7 @@ mod test {
         volume
             .write_unwritten(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x22; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![0x22; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -962,7 +962,7 @@ mod test {
         volume
             .write_unwritten(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -978,7 +978,7 @@ mod test {
         volume
             .write_unwritten(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x22; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![0x22; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -1035,7 +1035,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x33; BLOCK_SIZE]),
+                BytesMut::from(vec![0x33; BLOCK_SIZE].as_slice()),
             )
             .await?;
 
@@ -1043,7 +1043,7 @@ mod test {
         volume
             .write_unwritten(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -1119,7 +1119,7 @@ mod test {
         volume
             .write_unwritten(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; full_volume_size]),
+                BytesMut::from(vec![0x55; full_volume_size].as_slice()),
             )
             .await?;
 
@@ -1135,7 +1135,7 @@ mod test {
         volume
             .write_unwritten(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x22; full_volume_size]),
+                BytesMut::from(vec![0x22; full_volume_size].as_slice()),
             )
             .await?;
 
@@ -1207,7 +1207,7 @@ mod test {
         volume
             .write_unwritten(
                 Block::new(9, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE * 2]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
 
@@ -1225,7 +1225,7 @@ mod test {
         volume
             .write_unwritten(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x22; full_volume_size]),
+                BytesMut::from(vec![0x22; full_volume_size].as_slice()),
             )
             .await?;
 
@@ -1313,7 +1313,7 @@ mod test {
         volume
             .write_unwritten(
                 Block::new(9, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE * 2]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
 
@@ -1323,7 +1323,7 @@ mod test {
         volume
             .write_unwritten(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x22; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![0x22; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -1331,7 +1331,7 @@ mod test {
         volume
             .write(
                 Block::new(7, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x11; BLOCK_SIZE * 13]),
+                BytesMut::from(vec![0x11; BLOCK_SIZE * 13].as_slice()),
             )
             .await?;
 
@@ -1387,7 +1387,7 @@ mod test {
         in_memory_data
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![11; BLOCK_SIZE * 5]),
+                BytesMut::from(vec![11; BLOCK_SIZE * 5].as_slice()),
             )
             .await?;
 
@@ -1428,7 +1428,7 @@ mod test {
 
         // One big write!
         let write_offset = Block::new(0, BLOCK_SIZE.trailing_zeros());
-        let write_data = Bytes::from(vec![55; BLOCK_SIZE * 10]);
+        let write_data = BytesMut::from(vec![55; BLOCK_SIZE * 10].as_slice());
         if is_write_unwritten {
             volume.write(write_offset, write_data).await?;
         } else {
@@ -1475,7 +1475,7 @@ mod test {
         in_memory_data
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![11; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![11; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -1513,7 +1513,7 @@ mod test {
         volume
             .write_unwritten(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![55; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -1558,7 +1558,7 @@ mod test {
         in_memory_data
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![11; BLOCK_SIZE * 5]),
+                BytesMut::from(vec![11; BLOCK_SIZE * 5].as_slice()),
             )
             .await?;
 
@@ -1604,7 +1604,7 @@ mod test {
         volume
             .write_unwritten(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![55; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -1659,7 +1659,7 @@ mod test {
         in_memory_data
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![11; BLOCK_SIZE * 5]),
+                BytesMut::from(vec![11; BLOCK_SIZE * 5].as_slice()),
             )
             .await?;
 
@@ -1684,7 +1684,7 @@ mod test {
         volume
             .write(
                 Block::new(2, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![22; BLOCK_SIZE]),
+                BytesMut::from(vec![22; BLOCK_SIZE].as_slice()),
             )
             .await?;
 
@@ -1692,7 +1692,7 @@ mod test {
         volume
             .write(
                 Block::new(7, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![33; BLOCK_SIZE]),
+                BytesMut::from(vec![33; BLOCK_SIZE].as_slice()),
             )
             .await?;
 
@@ -1754,7 +1754,7 @@ mod test {
         in_memory_data
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![11; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![11; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -1787,7 +1787,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![55; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -1837,7 +1837,7 @@ mod test {
         in_memory_data
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![11; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![11; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -1887,7 +1887,7 @@ mod test {
         volume
             .write(
                 Block::new(9, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![22; BLOCK_SIZE * 2]),
+                BytesMut::from(vec![22; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
 
@@ -1903,7 +1903,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![33; BLOCK_SIZE * 2]),
+                BytesMut::from(vec![33; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
 
@@ -1963,7 +1963,7 @@ mod test {
         in_memory_data
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![11; BLOCK_SIZE * 15]),
+                BytesMut::from(vec![11; BLOCK_SIZE * 15].as_slice()),
             )
             .await?;
 
@@ -2014,7 +2014,7 @@ mod test {
         volume
             .write(
                 Block::new(9, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![22; BLOCK_SIZE * 2]),
+                BytesMut::from(vec![22; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
 
@@ -2031,7 +2031,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![33; BLOCK_SIZE * 2]),
+                BytesMut::from(vec![33; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
 
@@ -2040,7 +2040,7 @@ mod test {
         volume
             .write(
                 Block::new(14, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![44; BLOCK_SIZE * 2]),
+                BytesMut::from(vec![44; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
 
@@ -2186,7 +2186,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![55; BLOCK_SIZE * 5]),
+                BytesMut::from(vec![55; BLOCK_SIZE * 5].as_slice()),
             )
             .await?;
 
@@ -2246,7 +2246,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(random_buffer.clone()),
+                BytesMut::from(random_buffer.as_slice()),
             )
             .await?;
 
@@ -2287,7 +2287,7 @@ mod test {
             assert!(volume
                 .write(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                    Bytes::from(vec![0u8; BLOCK_SIZE]),
+                    BytesMut::from(vec![0u8; BLOCK_SIZE].as_slice()),
                 )
                 .await
                 .is_err());
@@ -2351,7 +2351,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0u8; BLOCK_SIZE]),
+                BytesMut::from(vec![0u8; BLOCK_SIZE].as_slice()),
             )
             .await?;
 
@@ -2418,7 +2418,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(random_buffer.clone()),
+                BytesMut::from(random_buffer.as_slice()),
             )
             .await?;
 
@@ -2467,7 +2467,7 @@ mod test {
             assert!(volume
                 .write(
                     Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                    Bytes::from(vec![0u8; BLOCK_SIZE]),
+                    BytesMut::from(vec![0u8; BLOCK_SIZE].as_slice()),
                 )
                 .await
                 .is_err());
@@ -2539,7 +2539,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0u8; BLOCK_SIZE]),
+                BytesMut::from(vec![0u8; BLOCK_SIZE].as_slice()),
             )
             .await?;
 
@@ -2603,7 +2603,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(random_buffer.clone()),
+                BytesMut::from(random_buffer.as_slice()),
             )
             .await?;
 
@@ -2689,7 +2689,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(random_buffer.clone()),
+                BytesMut::from(random_buffer.as_slice()),
             )
             .await?;
 
@@ -2804,7 +2804,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(random_buffer.clone()),
+                BytesMut::from(random_buffer.as_slice()),
             )
             .await?;
 
@@ -3114,7 +3114,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(random_buffer.clone()),
+                BytesMut::from(random_buffer.as_slice()),
             )
             .await?;
 
@@ -3209,7 +3209,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(random_buffer.clone()),
+                BytesMut::from(random_buffer.as_slice()),
             )
             .await?;
 
@@ -3533,7 +3533,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(random_buffer.clone()),
+                BytesMut::from(random_buffer.as_slice()),
             )
             .await?;
 
@@ -3665,7 +3665,7 @@ mod test {
                 volume
                     .write(
                         Block::new(*i as u64, BLOCK_SIZE.trailing_zeros()),
-                        Bytes::from(random_buffer.clone()),
+                        BytesMut::from(random_buffer.as_slice()),
                     )
                     .await?;
             }
@@ -3723,7 +3723,7 @@ mod test {
         guest
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -3784,7 +3784,7 @@ mod test {
         guest
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -3826,10 +3826,7 @@ mod test {
 
         // Write of length 0
         guest
-            .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(Vec::new()),
-            )
+            .write(Block::new(0, BLOCK_SIZE.trailing_zeros()), BytesMut::new())
             .await?;
 
         Ok(())
@@ -3855,7 +3852,7 @@ mod test {
         guest
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -3930,7 +3927,7 @@ mod test {
         let write_result = guest
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await;
         assert!(write_result.is_err());
@@ -4009,7 +4006,7 @@ mod test {
         guest
             .write_unwritten(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -4025,7 +4022,7 @@ mod test {
         guest
             .write_unwritten(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x99; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![0x99; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -4042,7 +4039,7 @@ mod test {
         guest
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x89; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![0x89; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
@@ -4081,7 +4078,7 @@ mod test {
         guest
             .write_unwritten(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE].as_slice()),
             )
             .await?;
 
@@ -4090,7 +4087,7 @@ mod test {
         guest
             .write_unwritten(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x99; BLOCK_SIZE * 3]),
+                BytesMut::from(vec![0x99; BLOCK_SIZE * 3].as_slice()),
             )
             .await?;
 
@@ -4138,7 +4135,7 @@ mod test {
         guest
             .write_unwritten(
                 Block::new(1, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE].as_slice()),
             )
             .await?;
 
@@ -4147,7 +4144,7 @@ mod test {
         guest
             .write_unwritten(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x99; BLOCK_SIZE * 3]),
+                BytesMut::from(vec![0x99; BLOCK_SIZE * 3].as_slice()),
             )
             .await?;
 
@@ -4196,7 +4193,7 @@ mod test {
         guest
             .write_unwritten(
                 Block::new(2, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE].as_slice()),
             )
             .await?;
 
@@ -4205,7 +4202,7 @@ mod test {
         guest
             .write_unwritten(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x99; BLOCK_SIZE * 3]),
+                BytesMut::from(vec![0x99; BLOCK_SIZE * 3].as_slice()),
             )
             .await?;
 
@@ -4249,7 +4246,7 @@ mod test {
         guest
             .write_unwritten(
                 Block::new(4, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE].as_slice()),
             )
             .await?;
 
@@ -4258,7 +4255,7 @@ mod test {
         guest
             .write_unwritten(
                 Block::new(4, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x99; BLOCK_SIZE * 2]),
+                BytesMut::from(vec![0x99; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
 
@@ -4302,7 +4299,7 @@ mod test {
         guest
             .write_unwritten(
                 Block::new(4, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE].as_slice()),
             )
             .await?;
 
@@ -4311,7 +4308,7 @@ mod test {
         guest
             .write_unwritten(
                 Block::new(4, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x99; BLOCK_SIZE * 2]),
+                BytesMut::from(vec![0x99; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
 
@@ -4352,7 +4349,7 @@ mod test {
         let res = guest
             .write(
                 Block::new(11, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE].as_slice()),
             )
             .await;
 
@@ -4387,7 +4384,7 @@ mod test {
         let res = guest
             .write(
                 Block::new(10, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE * 2]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE * 2].as_slice()),
             )
             .await;
 
@@ -5567,7 +5564,7 @@ mod test {
         volume
             .write(
                 Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                Bytes::from(vec![0x55; BLOCK_SIZE * 10]),
+                BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await
             .unwrap();

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -475,7 +475,7 @@ mod test {
             volume
                 .write(
                     Block::new(i, BLOCK_SIZE.trailing_zeros()),
-                    Bytes::from(data.clone()),
+                    BytesMut::from(data.as_slice()),
                 )
                 .await?;
 

--- a/pantry/src/pantry.rs
+++ b/pantry/src/pantry.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use anyhow::Result;
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use dropshot::HttpError;
 use sha2::Digest;
 use sha2::Sha256;
@@ -231,6 +231,7 @@ impl PantryEntry {
                 .bytes()
                 .await
                 .map_err(|e| CrucibleError::GenericError(e.to_string()))?;
+            let bytes = BytesMut::from(bytes.as_ref());
 
             if let Some(ref mut hasher) = hasher {
                 hasher.update(&bytes);
@@ -288,7 +289,8 @@ impl PantryEntry {
             );
         }
 
-        self.volume.write_to_byte_offset(offset, data.into()).await
+        let bytes = BytesMut::from(data.as_slice());
+        self.volume.write_to_byte_offset(offset, bytes).await
     }
 
     pub async fn bulk_read(

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -129,6 +129,27 @@ pub struct Write {
     pub block_context: BlockContext,
 }
 
+/// Write data, containing data from all blocks
+#[derive(Debug)]
+pub struct RawWrite {
+    /// Per-block metadata
+    pub blocks: Vec<WriteBlockMetadata>,
+    /// Raw data
+    pub data: bytes::BytesMut,
+}
+
+impl RawWrite {
+    /// Builds a new empty `RawWrite` with the given capacity
+    pub fn with_capacity(block_count: usize, block_size: u64) -> Self {
+        Self {
+            blocks: Vec::with_capacity(block_count),
+            data: bytes::BytesMut::with_capacity(
+                block_count * block_size as usize,
+            ),
+        }
+    }
+}
+
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct ReadRequest {

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -256,6 +256,9 @@ pub struct SnapshotDetails {
 pub enum MessageVersion {
     /// Changed `Write`, `WriteUnwritten`, and `ReadResponse` variants to have a
     /// clean split between header and bulk data, to reduce `memcpy`
+    ///
+    /// Removed `#[repr(u16)]` and explicit variant numbering from `Message`,
+    /// because those are misleading; they're ignored during serialization.
     V6 = 6,
 
     /// Switched to raw file extents
@@ -299,7 +302,6 @@ pub const CRUCIBLE_MESSAGE_VERSION: u32 = 6;
     Debug, PartialEq, Clone, Serialize, Deserialize, EnumDiscriminants,
 )]
 #[strum_discriminants(derive(Serialize, Deserialize))]
-#[repr(u16)]
 pub enum Message {
     /**
      * Initial negotiation messages
@@ -321,7 +323,7 @@ pub enum Message {
         encrypted: bool,
         // Additional Message versions this upstairs supports.
         alternate_versions: Vec<u32>,
-    } = 0,
+    },
     /**
      * This is the first message (when things are good) that the downstairs
      * will reply to the upstairs with.
@@ -331,7 +333,7 @@ pub enum Message {
         version: u32,
         // The IP:Port that repair commands will use to communicate.
         repair_addr: SocketAddr,
-    } = 1,
+    },
 
     /*
      * These messages indicate that there is an incompatibility between the
@@ -340,13 +342,13 @@ pub enum Message {
     VersionMismatch {
         // Version of Message this downstairs wanted.
         version: u32,
-    } = 2,
+    },
     ReadOnlyMismatch {
         expected: bool,
-    } = 3,
+    },
     EncryptedMismatch {
         expected: bool,
-    } = 4,
+    },
 
     /**
      * Forcefully tell this downstairs to promote us (an Upstairs) to

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -840,10 +840,13 @@ impl std::fmt::Display for Message {
 }
 
 /// Writer to efficiently encode and send a `Message`
+///
+/// In contrast with `CrucibleEncoder`, this writer will send bulk data in a
+/// separate syscall (rather than copying it into an intermediate buffer).
 pub struct MessageWriter<W> {
     writer: W,
 
-    /// Scratch space for `Message` encoding
+    /// Scratch space for full `Message` encoding
     scratch: BytesMut,
 
     /// Scratch space for the raw header

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -859,7 +859,7 @@ impl<W> MessageWriter<W>
 where
     W: tokio::io::AsyncWrite + std::marker::Unpin + std::marker::Send + 'static,
 {
-    /// Builds a new `WireMessageWriter`
+    /// Builds a new `MessageWriter`
     #[inline]
     pub fn new(writer: W) -> Self {
         Self {

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -648,12 +648,12 @@ pub struct WriteHeader {
 }
 
 impl WriteHeader {
-    /// Destructures into a list of block-size writes
+    /// Destructures into a list of block-size writes which borrow our data
     ///
     /// # Panics
     /// `buf.len()` must be an even multiple of `self.blocks.len()`, which is
     /// assumed to be the block size.
-    pub fn into_writes(&self, mut buf: bytes::Bytes) -> Vec<Write> {
+    pub fn get_writes(&self, mut buf: bytes::Bytes) -> Vec<Write> {
         assert_eq!(buf.len() % self.blocks.len(), 0);
         let block_size = buf.len() / self.blocks.len();
         let mut out = Vec::with_capacity(self.blocks.len());

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -1239,10 +1239,11 @@ impl Decoder for CrucibleDecoder {
         }
 
         // Slice the buffer so that it contains only our bincode-serialized
-        // `Message` (without any trailing data or the leading length).
+        // `Message` (without any trailing data or the leading 4-byte length).
         //
         // This leaves `src` pointing to the beginning of the next packet (which
-        // may not exist yet).
+        // may not exist yet), and `buf` pointing to just our bincode-serialized
+        // `Message`.
         let buf = src.split_to(len).split_off(4);
 
         // Deserialize just the discriminant.  This will let us decide whether

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -890,8 +890,8 @@ where
             &mut cursor,
             &(
                 0u32, // dummy length, to be patched later
-                0u32, // discriminant, to be patched later
-                &header,
+                discriminant,
+                header,
                 data.len(),
             ),
         )
@@ -900,9 +900,6 @@ where
         // Patch the length
         let len: u32 = (self.header.len() + data.len()).try_into().unwrap();
         self.header[0..4].copy_from_slice(&len.to_le_bytes());
-
-        // Patch the discriminant in the header
-        bincode::serialize_into(&mut self.header[4..8], &discriminant).unwrap();
 
         // write_all_vectored would save a syscall, but is nightly-only
         self.writer.write_all(&self.header).await?;

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -713,68 +713,6 @@ impl ReadResponseBlockMetadata {
     }
 }
 
-/// Read response data, containing data from all blocks
-#[derive(Debug)]
-pub struct RawReadResponse {
-    /// Per-block metadata
-    pub blocks: Vec<ReadResponseBlockMetadata>,
-    /// Raw data
-    pub data: bytes::BytesMut,
-}
-
-impl RawReadResponse {
-    /// Builds a new empty `RawReadResponse` with the given capacity
-    pub fn with_capacity(block_count: usize, block_size: u64) -> Self {
-        Self {
-            blocks: Vec::with_capacity(block_count),
-            data: bytes::BytesMut::with_capacity(
-                block_count * block_size as usize,
-            ),
-        }
-    }
-
-    /// Destructures into a `Vec<ReadResponse>`
-    ///
-    /// This is useful for backwards compatibility
-    pub fn into_read_responses(mut self) -> Vec<ReadResponse> {
-        assert_eq!(self.data.len() % self.blocks.len(), 0);
-        let block_size = self.data.len() / self.blocks.len();
-        let mut out = Vec::with_capacity(self.blocks.len());
-        for b in self.blocks {
-            let data = self.data.split_to(block_size);
-            out.push(ReadResponse {
-                eid: b.eid,
-                offset: b.offset,
-                block_contexts: b.block_contexts,
-                data,
-            })
-        }
-        assert!(self.data.is_empty());
-        out
-    }
-}
-
-/// Write data, containing data from all blocks
-#[derive(Debug)]
-pub struct RawWrite {
-    /// Per-block metadata
-    pub blocks: Vec<WriteBlockMetadata>,
-    /// Raw data
-    pub data: bytes::BytesMut,
-}
-
-impl RawWrite {
-    /// Builds a new empty `RawWrite` with the given capacity
-    pub fn with_capacity(block_count: usize, block_size: u64) -> Self {
-        Self {
-            blocks: Vec::with_capacity(block_count),
-            data: bytes::BytesMut::with_capacity(
-                block_count * block_size as usize,
-            ),
-        }
-    }
-}
-
 /*
  * If you just added or changed the Message enum above, you must also
  * increment the CRUCIBLE_MESSAGE_VERSION.  Go do that right now before you

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -169,6 +169,27 @@ impl ReadResponse {
     }
 }
 
+/// Read response data, containing data from all blocks
+#[derive(Debug)]
+pub struct RawReadResponse {
+    /// Per-block metadata
+    pub blocks: Vec<ReadResponseBlockMetadata>,
+    /// Raw data
+    pub data: bytes::BytesMut,
+}
+
+impl RawReadResponse {
+    /// Builds a new empty `RawReadResponse` with the given capacity
+    pub fn with_capacity(block_count: usize, block_size: u64) -> Self {
+        Self {
+            blocks: Vec::with_capacity(block_count),
+            data: bytes::BytesMut::with_capacity(
+                block_count * block_size as usize,
+            ),
+        }
+    }
+}
+
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BlockContext {

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -658,6 +658,11 @@ pub enum Message {
      */
     Unknown(u32, BytesMut),
 }
+/*
+ * If you just added or changed the Message enum above, you must also
+ * increment the CRUCIBLE_MESSAGE_VERSION.  Go do that right now before you
+ * forget.
+ */
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct WriteHeader {
@@ -756,12 +761,6 @@ impl ReadResponseBlockMetadata {
             .collect()
     }
 }
-
-/*
- * If you just added or changed the Message enum above, you must also
- * increment the CRUCIBLE_MESSAGE_VERSION.  Go do that right now before you
- * forget.
- */
 
 impl Message {
     /// Return true if this message contains an Error result

--- a/upstairs/src/block_io.rs
+++ b/upstairs/src/block_io.rs
@@ -81,7 +81,7 @@ impl BlockIO for FileBlockIO {
     async fn write(
         &self,
         offset: Block,
-        data: Bytes,
+        data: BytesMut,
     ) -> Result<(), CrucibleError> {
         self.check_data_size(data.len()).await?;
         let start = offset.value * self.block_size;
@@ -96,7 +96,7 @@ impl BlockIO for FileBlockIO {
     async fn write_unwritten(
         &self,
         _offset: Block,
-        _data: Bytes,
+        _data: BytesMut,
     ) -> Result<(), CrucibleError> {
         crucible_bail!(
             Unsupported,
@@ -262,7 +262,7 @@ impl BlockIO for ReqwestBlockIO {
     async fn write(
         &self,
         _offset: Block,
-        _data: Bytes,
+        _data: BytesMut,
     ) -> Result<(), CrucibleError> {
         crucible_bail!(Unsupported, "write unsupported for ReqwestBlockIO")
     }
@@ -270,7 +270,7 @@ impl BlockIO for ReqwestBlockIO {
     async fn write_unwritten(
         &self,
         _offset: Block,
-        _data: Bytes,
+        _data: BytesMut,
     ) -> Result<(), CrucibleError> {
         crucible_bail!(
             Unsupported,

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -2995,7 +2995,7 @@ pub(crate) fn validate_unencrypted_read_response(
             Err(CrucibleError::HashMismatch)
         }
     } else {
-        // No block context(s) in the
+        // No block context(s) in the response!
         //
         // Either this is a read of an unwritten block, or an attacker
         // removed the hashes from the db. Because the Upstairs will perform

--- a/upstairs/src/deferred.rs
+++ b/upstairs/src/deferred.rs
@@ -4,11 +4,11 @@ use std::sync::Arc;
 
 use crate::{
     client::ConnectionId, upstairs::UpstairsConfig, BlockContext, BlockReq,
-    BlockRes, ClientId, ImpactedBlocks, Message,
+    BlockRes, ClientId, ImpactedBlocks, Message, RawWrite,
 };
 use bytes::BytesMut;
 use crucible_common::{integrity_hash, CrucibleError, RegionDefinition};
-use crucible_protocol::{RawWrite, WriteBlockMetadata};
+use crucible_protocol::WriteBlockMetadata;
 use futures::{
     future::{ready, Either, Ready},
     stream::FuturesOrdered,

--- a/upstairs/src/deferred.rs
+++ b/upstairs/src/deferred.rs
@@ -4,11 +4,11 @@ use std::sync::Arc;
 
 use crate::{
     client::ConnectionId, upstairs::UpstairsConfig, BlockContext, BlockReq,
-    BlockRes, ClientId, ImpactedBlocks, Message, RawWrite,
+    BlockRes, ClientId, ImpactedBlocks, Message,
 };
 use bytes::BytesMut;
 use crucible_common::{integrity_hash, CrucibleError, RegionDefinition};
-use crucible_protocol::WriteBlockMetadata;
+use crucible_protocol::{RawWrite, WriteBlockMetadata};
 use futures::{
     future::{ready, Either, Ready},
     stream::FuturesOrdered,

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -476,7 +476,7 @@ impl Downstairs {
                             dependencies,
                             blocks,
                         },
-                        data: data.into(),
+                        data,
                     }
                 }
                 IOop::WriteUnwritten {
@@ -496,7 +496,7 @@ impl Downstairs {
                             dependencies,
                             blocks,
                         },
-                        data: data.into(),
+                        data,
                     }
                 }
                 IOop::Flush {
@@ -1762,13 +1762,13 @@ impl Downstairs {
         let awrite = if is_write_unwritten {
             IOop::WriteUnwritten {
                 dependencies,
-                data: write.data,
+                data: write.data.freeze(),
                 blocks: write.blocks,
             }
         } else {
             IOop::Write {
                 dependencies,
-                data: write.data,
+                data: write.data.freeze(),
                 blocks: write.blocks,
             }
         };

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -2272,7 +2272,7 @@ impl Downstairs {
         &mut self,
         guest_id: GuestWorkId,
         blocks: ImpactedBlocks,
-        serialized_write: RawWrite,
+        write: RawWrite,
         is_write_unwritten: bool,
     ) -> JobId {
         // If there is a live-repair in progress that intersects with this read,
@@ -2282,7 +2282,7 @@ impl Downstairs {
         self.create_and_enqueue_write_eob(
             blocks,
             guest_id,
-            serialized_write,
+            write,
             is_write_unwritten,
         )
     }

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -16,12 +16,12 @@ use crate::{
     AckStatus, ActiveJobs, AllocRingBuffer, ClientData, ClientIOStateCount,
     ClientId, ClientMap, CrucibleError, DownstairsIO, DownstairsMend, DsState,
     ExtentFix, ExtentRepairIDs, GuestWorkId, IOState, IOStateCount, IOop,
-    ImpactedBlocks, JobId, Message, ReadRequest, ReadResponse, ReconcileIO,
-    ReconciliationId, RegionDefinition, ReplaceResult, SnapshotDetails,
-    WorkSummary,
+    ImpactedBlocks, JobId, Message, RawWrite, ReadRequest, ReadResponse,
+    ReconcileIO, ReconciliationId, RegionDefinition, ReplaceResult,
+    SnapshotDetails, WorkSummary,
 };
 use crucible_common::MAX_ACTIVE_COUNT;
-use crucible_protocol::{RawWrite, WriteHeader};
+use crucible_protocol::WriteHeader;
 
 use rand::prelude::*;
 use ringbuffer::RingBuffer;
@@ -1715,7 +1715,7 @@ impl Downstairs {
         use crate::impacted_blocks::ImpactedAddr;
         use crucible_common::Block;
         use crucible_protocol::{BlockContext, WriteBlockMetadata};
-        let request = crucible_protocol::RawWrite {
+        let request = RawWrite {
             data: bytes::BytesMut::from(vec![1].as_slice()),
             blocks: vec![WriteBlockMetadata {
                 eid: 0,

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::{
     cdt,
-    client::{ClientAction, ClientRequest, ClientStopReason, DownstairsClient},
+    client::{ClientAction, ClientStopReason, DownstairsClient},
     guest::GuestWork,
     live_repair::ExtentInfo,
     stats::UpStatOuter,
@@ -16,11 +16,12 @@ use crate::{
     AckStatus, ActiveJobs, AllocRingBuffer, ClientData, ClientIOStateCount,
     ClientId, ClientMap, CrucibleError, DownstairsIO, DownstairsMend, DsState,
     ExtentFix, ExtentRepairIDs, GuestWorkId, IOState, IOStateCount, IOop,
-    ImpactedBlocks, JobId, Message, RawMessage, ReadRequest, ReadResponse,
-    ReconcileIO, ReconciliationId, RegionDefinition, ReplaceResult,
-    SerializedWrite, SnapshotDetails, WorkSummary,
+    ImpactedBlocks, JobId, Message, ReadRequest, ReadResponse, ReconcileIO,
+    ReconciliationId, RegionDefinition, ReplaceResult, SnapshotDetails,
+    WorkSummary,
 };
 use crucible_common::MAX_ACTIVE_COUNT;
+use crucible_protocol::{RawWrite, WriteHeader};
 
 use rand::prelude::*;
 use ringbuffer::RingBuffer;
@@ -461,32 +462,42 @@ impl Downstairs {
             };
 
             let message = match job {
-                IOop::Write { dependencies, data } => {
+                IOop::Write {
+                    dependencies,
+                    blocks,
+                    data,
+                } => {
                     cdt::ds__write__io__start!(|| (new_id.0, client_id.get()));
-                    ClientRequest::RawMessage(
-                        RawMessage::Write {
+                    Message::Write {
+                        header: WriteHeader {
                             upstairs_id: self.cfg.upstairs_id,
                             session_id: self.cfg.session_id,
                             job_id: new_id,
                             dependencies,
+                            blocks,
                         },
-                        data.data,
-                    )
+                        data: data.into(),
+                    }
                 }
-                IOop::WriteUnwritten { dependencies, data } => {
+                IOop::WriteUnwritten {
+                    blocks,
+                    dependencies,
+                    data,
+                } => {
                     cdt::ds__write__unwritten__io__start!(|| (
                         new_id.0,
                         client_id.get()
                     ));
-                    ClientRequest::RawMessage(
-                        RawMessage::WriteUnwritten {
+                    Message::WriteUnwritten {
+                        header: WriteHeader {
                             upstairs_id: self.cfg.upstairs_id,
                             session_id: self.cfg.session_id,
                             job_id: new_id,
                             dependencies,
+                            blocks,
                         },
-                        data.data,
-                    )
+                        data: data.into(),
+                    }
                 }
                 IOop::Flush {
                     dependencies,
@@ -496,7 +507,7 @@ impl Downstairs {
                     extent_limit,
                 } => {
                     cdt::ds__flush__io__start!(|| (new_id.0, client_id.get()));
-                    ClientRequest::Message(Message::Flush {
+                    Message::Flush {
                         upstairs_id: self.cfg.upstairs_id,
                         session_id: self.cfg.session_id,
                         job_id: new_id,
@@ -505,20 +516,20 @@ impl Downstairs {
                         gen_number,
                         snapshot_details,
                         extent_limit,
-                    })
+                    }
                 }
                 IOop::Read {
                     dependencies,
                     requests,
                 } => {
                     cdt::ds__read__io__start!(|| (new_id.0, client_id.get()));
-                    ClientRequest::Message(Message::ReadRequest {
+                    Message::ReadRequest {
                         upstairs_id: self.cfg.upstairs_id,
                         session_id: self.cfg.session_id,
                         job_id: new_id,
                         dependencies,
                         requests,
-                    })
+                    }
                 }
                 IOop::ExtentFlushClose {
                     dependencies,
@@ -534,15 +545,15 @@ impl Downstairs {
                     ));
                     if repair_downstairs.contains(&client_id) {
                         // We are the downstairs being repaired, so just close.
-                        ClientRequest::Message(Message::ExtentLiveClose {
+                        Message::ExtentLiveClose {
                             upstairs_id: self.cfg.upstairs_id,
                             session_id: self.cfg.session_id,
                             job_id: new_id,
                             dependencies,
                             extent_id: extent,
-                        })
+                        }
                     } else {
-                        ClientRequest::Message(Message::ExtentLiveFlushClose {
+                        Message::ExtentLiveFlushClose {
                             upstairs_id: self.cfg.upstairs_id,
                             session_id: self.cfg.session_id,
                             job_id: new_id,
@@ -550,7 +561,7 @@ impl Downstairs {
                             extent_id: extent,
                             flush_number,
                             gen_number,
-                        })
+                        }
                     }
                 }
                 IOop::ExtentLiveRepair {
@@ -566,7 +577,7 @@ impl Downstairs {
                         extent
                     ));
                     if repair_downstairs.contains(&client_id) {
-                        ClientRequest::Message(Message::ExtentLiveRepair {
+                        Message::ExtentLiveRepair {
                             upstairs_id: self.cfg.upstairs_id,
                             session_id: self.cfg.session_id,
                             job_id: new_id,
@@ -574,14 +585,14 @@ impl Downstairs {
                             extent_id: extent,
                             source_client_id: source_downstairs,
                             source_repair_address,
-                        })
+                        }
                     } else {
-                        ClientRequest::Message(Message::ExtentLiveNoOp {
+                        Message::ExtentLiveNoOp {
                             upstairs_id: self.cfg.upstairs_id,
                             session_id: self.cfg.session_id,
                             job_id: new_id,
                             dependencies,
-                        })
+                        }
                     }
                 }
                 IOop::ExtentLiveReopen {
@@ -593,22 +604,22 @@ impl Downstairs {
                         client_id.get(),
                         extent
                     ));
-                    ClientRequest::Message(Message::ExtentLiveReopen {
+                    Message::ExtentLiveReopen {
                         upstairs_id: self.cfg.upstairs_id,
                         session_id: self.cfg.session_id,
                         job_id: new_id,
                         dependencies,
                         extent_id: extent,
-                    })
+                    }
                 }
                 IOop::ExtentLiveNoOp { dependencies } => {
                     cdt::ds__noop__start!(|| (new_id.0, client_id.get()));
-                    ClientRequest::Message(Message::ExtentLiveNoOp {
+                    Message::ExtentLiveNoOp {
                         upstairs_id: self.cfg.upstairs_id,
                         session_id: self.cfg.session_id,
                         job_id: new_id,
                         dependencies,
-                    })
+                    }
                 }
             };
             self.clients[client_id].send(message).await
@@ -1703,15 +1714,17 @@ impl Downstairs {
     ) -> JobId {
         use crate::impacted_blocks::ImpactedAddr;
         use crucible_common::Block;
-        use crucible_protocol::BlockContext;
-        let request = crucible_protocol::Write {
-            eid: 0,
-            offset: Block::new_512(7),
-            data: bytes::Bytes::from(vec![1]),
-            block_context: BlockContext {
-                encryption_context: None,
-                hash: 0,
-            },
+        use crucible_protocol::{BlockContext, WriteBlockMetadata};
+        let request = crucible_protocol::RawWrite {
+            data: bytes::BytesMut::from(vec![1].as_slice()),
+            blocks: vec![WriteBlockMetadata {
+                eid: 0,
+                offset: Block::new_512(7),
+                block_context: BlockContext {
+                    encryption_context: None,
+                    hash: 0,
+                },
+            }],
         };
         let iblocks = ImpactedBlocks::new(
             ImpactedAddr {
@@ -1726,7 +1739,7 @@ impl Downstairs {
         self.create_and_enqueue_write_eob(
             iblocks,
             GuestWorkId(10),
-            SerializedWrite::from_writes(vec![request.clone()]),
+            request,
             is_write_unwritten,
         )
     }
@@ -1735,7 +1748,7 @@ impl Downstairs {
         &mut self,
         blocks: ImpactedBlocks,
         gw_id: GuestWorkId,
-        data: SerializedWrite,
+        write: RawWrite,
         is_write_unwritten: bool,
     ) -> JobId {
         let ds_id = self.next_id();
@@ -1747,9 +1760,17 @@ impl Downstairs {
         debug!(self.log, "IO Write {} has deps {:?}", ds_id, dependencies);
 
         let awrite = if is_write_unwritten {
-            IOop::WriteUnwritten { dependencies, data }
+            IOop::WriteUnwritten {
+                dependencies,
+                data: write.data,
+                blocks: write.blocks,
+            }
         } else {
-            IOop::Write { dependencies, data }
+            IOop::Write {
+                dependencies,
+                data: write.data,
+                blocks: write.blocks,
+            }
         };
 
         let io = DownstairsIO {
@@ -2251,7 +2272,7 @@ impl Downstairs {
         &mut self,
         guest_id: GuestWorkId,
         blocks: ImpactedBlocks,
-        serialized_write: SerializedWrite,
+        serialized_write: RawWrite,
         is_write_unwritten: bool,
     ) -> JobId {
         // If there is a live-repair in progress that intersects with this read,
@@ -2327,7 +2348,7 @@ impl Downstairs {
         // counter for backpressure calculations.
         match &io.work {
             IOop::Write { data, .. } | IOop::WriteUnwritten { data, .. } => {
-                self.write_bytes_outstanding += data.io_size_bytes as u64;
+                self.write_bytes_outstanding += data.len() as u64;
             }
             _ => (),
         };
@@ -2711,9 +2732,7 @@ impl Downstairs {
                 // Update pending bytes when this job is retired
                 let change = match &job.work {
                     IOop::Write { data, .. }
-                    | IOop::WriteUnwritten { data, .. } => {
-                        data.io_size_bytes as u64
-                    }
+                    | IOop::WriteUnwritten { data, .. } => data.len() as u64,
                     _ => 0,
                 };
                 self.write_bytes_outstanding =
@@ -2766,13 +2785,13 @@ impl Downstairs {
                     let num_blocks = requests.len();
                     (job_type, num_blocks)
                 }
-                IOop::Write { data, .. } => {
+                IOop::Write { blocks, .. } => {
                     let job_type = "Write".to_string();
-                    (job_type, data.num_blocks)
+                    (job_type, blocks.len())
                 }
-                IOop::WriteUnwritten { data, .. } => {
+                IOop::WriteUnwritten { blocks, .. } => {
                     let job_type = "WriteU".to_string();
-                    (job_type, data.num_blocks)
+                    (job_type, blocks.len())
                 }
                 IOop::Flush { .. } => {
                     let job_type = "Flush".to_string();
@@ -2911,13 +2930,13 @@ impl Downstairs {
                     None,
                 )
             }
-            Message::ReadResponse {
-                upstairs_id,
-                session_id,
-                job_id,
-                responses,
-            } => {
-                cdt::ds__read__io__done!(|| (job_id.0, client_id.get()));
+            Message::ReadResponse { header, data } => {
+                cdt::ds__read__io__done!(|| (header.job_id.0, client_id.get()));
+                let upstairs_id = header.upstairs_id;
+                let session_id = header.session_id;
+                let job_id = header.job_id;
+                let responses = header.into_read_responses(data);
+
                 (upstairs_id, session_id, job_id, responses, None)
             }
 
@@ -3445,7 +3464,7 @@ impl Downstairs {
         self.submit_write(
             gwid,
             blocks,
-            SerializedWrite::from_writes(writes.collect()),
+            RawWrite::from_writes(writes.collect()),
             is_write_unwritten,
         )
     }

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -16,12 +16,12 @@ use crate::{
     AckStatus, ActiveJobs, AllocRingBuffer, ClientData, ClientIOStateCount,
     ClientId, ClientMap, CrucibleError, DownstairsIO, DownstairsMend, DsState,
     ExtentFix, ExtentRepairIDs, GuestWorkId, IOState, IOStateCount, IOop,
-    ImpactedBlocks, JobId, Message, RawWrite, ReadRequest, ReadResponse,
-    ReconcileIO, ReconciliationId, RegionDefinition, ReplaceResult,
-    SnapshotDetails, WorkSummary,
+    ImpactedBlocks, JobId, Message, ReadRequest, ReadResponse, ReconcileIO,
+    ReconciliationId, RegionDefinition, ReplaceResult, SnapshotDetails,
+    WorkSummary,
 };
 use crucible_common::MAX_ACTIVE_COUNT;
-use crucible_protocol::WriteHeader;
+use crucible_protocol::{RawWrite, WriteHeader};
 
 use rand::prelude::*;
 use ringbuffer::RingBuffer;

--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -17,7 +17,7 @@ use crucible_common::{build_logger, crucible_bail, Block, CrucibleError};
 use crucible_protocol::{ReadResponse, SnapshotDetails};
 
 use async_trait::async_trait;
-use bytes::Bytes;
+use bytes::BytesMut;
 use ringbuffer::{AllocRingBuffer, RingBuffer};
 use slog::{info, warn, Logger};
 use tokio::sync::{mpsc, Mutex};
@@ -644,7 +644,7 @@ impl BlockIO for Guest {
     async fn write(
         &self,
         mut offset: Block,
-        mut data: Bytes,
+        mut data: BytesMut,
     ) -> Result<(), CrucibleError> {
         let bs = self.check_data_size(data.len()).await?;
 
@@ -682,7 +682,7 @@ impl BlockIO for Guest {
     async fn write_unwritten(
         &self,
         offset: Block,
-        data: Bytes,
+        data: BytesMut,
     ) -> Result<(), CrucibleError> {
         let bs = self.check_data_size(data.len()).await?;
 

--- a/upstairs/src/in_memory.rs
+++ b/upstairs/src/in_memory.rs
@@ -83,7 +83,7 @@ impl BlockIO for InMemoryBlockIO {
     async fn write(
         &self,
         offset: Block,
-        data: Bytes,
+        data: BytesMut,
     ) -> Result<(), CrucibleError> {
         let bs = self.check_data_size(data.len()).await? as usize;
         let mut inner = self.inner.lock().await;
@@ -101,7 +101,7 @@ impl BlockIO for InMemoryBlockIO {
     async fn write_unwritten(
         &self,
         offset: Block,
-        data: Bytes,
+        data: BytesMut,
     ) -> Result<(), CrucibleError> {
         let bs = self.check_data_size(data.len()).await? as usize;
         let mut inner = self.inner.lock().await;

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1064,27 +1064,6 @@ impl ReconcileIO {
     }
 }
 
-/// Write data, containing data from all blocks
-#[derive(Debug)]
-pub struct RawWrite {
-    /// Per-block metadata
-    pub blocks: Vec<WriteBlockMetadata>,
-    /// Raw data
-    pub data: bytes::BytesMut,
-}
-
-impl RawWrite {
-    /// Builds a new empty `RawWrite` with the given capacity
-    pub fn with_capacity(block_count: usize, block_size: u64) -> Self {
-        Self {
-            blocks: Vec::with_capacity(block_count),
-            data: bytes::BytesMut::with_capacity(
-                block_count * block_size as usize,
-            ),
-        }
-    }
-}
-
 /*
  * Crucible to storage IO operations.
  */

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1094,12 +1094,12 @@ enum IOop {
     Write {
         dependencies: Vec<JobId>, // Jobs that must finish before this
         blocks: Vec<WriteBlockMetadata>,
-        data: bytes::BytesMut,
+        data: bytes::Bytes,
     },
     WriteUnwritten {
         dependencies: Vec<JobId>, // Jobs that must finish before this
         blocks: Vec<WriteBlockMetadata>,
-        data: bytes::BytesMut,
+        data: bytes::Bytes,
     },
     Read {
         dependencies: Vec<JobId>, // Jobs that must finish before this

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1064,6 +1064,27 @@ impl ReconcileIO {
     }
 }
 
+/// Write data, containing data from all blocks
+#[derive(Debug)]
+pub struct RawWrite {
+    /// Per-block metadata
+    pub blocks: Vec<WriteBlockMetadata>,
+    /// Raw data
+    pub data: bytes::BytesMut,
+}
+
+impl RawWrite {
+    /// Builds a new empty `RawWrite` with the given capacity
+    pub fn with_capacity(block_count: usize, block_size: u64) -> Self {
+        Self {
+            blocks: Vec::with_capacity(block_count),
+            data: bytes::BytesMut::with_capacity(
+                block_count * block_size as usize,
+            ),
+        }
+    }
+}
+
 /*
  * Crucible to storage IO operations.
  */

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -121,13 +121,13 @@ pub trait BlockIO: Sync {
     async fn write(
         &self,
         offset: Block,
-        data: Bytes,
+        data: BytesMut,
     ) -> Result<(), CrucibleError>;
 
     async fn write_unwritten(
         &self,
         offset: Block,
-        data: Bytes,
+        data: BytesMut,
     ) -> Result<(), CrucibleError>;
 
     async fn flush(
@@ -188,7 +188,7 @@ pub trait BlockIO: Sync {
     async fn write_to_byte_offset(
         &self,
         offset: u64,
-        data: Bytes,
+        data: BytesMut,
     ) -> Result<(), CrucibleError> {
         if !self.query_is_active().await? {
             return Err(CrucibleError::UpstairsInactive);
@@ -935,7 +935,7 @@ impl DownstairsIO {
     pub fn io_size(&self) -> usize {
         match &self.work {
             IOop::Write { data, .. } | IOop::WriteUnwritten { data, .. } => {
-                data.io_size_bytes
+                data.len()
             }
             IOop::Read { .. } => {
                 if self.data.is_some() {
@@ -1064,88 +1064,6 @@ impl ReconcileIO {
     }
 }
 
-/// Pre-serialized write, to avoid extra memory copies / allocation
-///
-/// The actual data to be written on the wire is in `self.data`; everything else
-/// is metadata used for logging, etc.
-#[derive(Debug, Clone, PartialEq)]
-pub struct SerializedWrite {
-    /// Number of blocks written (used for logging)
-    num_blocks: usize,
-
-    /// Extents to be written
-    eids: Vec<u64>,
-
-    /// Number of bytes written
-    io_size_bytes: usize,
-
-    /// Pre-serialized write data, to avoid extra memcpys
-    data: bytes::Bytes,
-}
-
-impl SerializedWrite {
-    /// Helper function to build a `SerializedWrite` from a list of `Writes`
-    ///
-    /// This is only used during unit tests; normally, the conversion is
-    /// performed during the handling of the write request.
-    #[cfg(test)]
-    fn from_writes(writes: Vec<Write>) -> Self {
-        use bytes::BufMut;
-
-        let out = BytesMut::new();
-        let mut w = out.writer();
-        bincode::serialize_into(&mut w, &writes).unwrap();
-
-        let mut eids: Vec<_> = writes.iter().map(|w| w.eid).collect();
-        eids.dedup();
-
-        let num_blocks = writes.len();
-        let io_size_bytes = writes.iter().map(|w| w.data.len()).sum();
-
-        Self {
-            num_blocks,
-            io_size_bytes,
-            eids,
-            data: w.into_inner().freeze(),
-        }
-    }
-}
-
-/// Raw message header, which is used for zero-copy serialization
-///
-/// These variants must contain the same fields as their `Message` equivalents
-/// in the same order.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[repr(u16)]
-enum RawMessage {
-    Write {
-        upstairs_id: Uuid,
-        session_id: Uuid,
-        job_id: JobId,
-        dependencies: Vec<JobId>,
-    },
-    WriteUnwritten {
-        upstairs_id: Uuid,
-        session_id: Uuid,
-        job_id: JobId,
-        dependencies: Vec<JobId>,
-    },
-}
-
-impl crucible_protocol::RawMessageDiscriminant for RawMessage {
-    /// Returns the discriminant used by the equivalent `Message`
-    ///
-    /// This is hard-coded and exhaustively checked by a unit test.
-    fn discriminant(&self) -> MessageDiscriminants {
-        match self {
-            RawMessage::Write { .. } => MessageDiscriminants::Write,
-            RawMessage::WriteUnwritten { .. } => {
-                MessageDiscriminants::WriteUnwritten
-            }
-        }
-    }
-}
-
 /*
  * Crucible to storage IO operations.
  */
@@ -1154,11 +1072,13 @@ impl crucible_protocol::RawMessageDiscriminant for RawMessage {
 enum IOop {
     Write {
         dependencies: Vec<JobId>, // Jobs that must finish before this
-        data: SerializedWrite,
+        blocks: Vec<WriteBlockMetadata>,
+        data: bytes::BytesMut,
     },
     WriteUnwritten {
         dependencies: Vec<JobId>, // Jobs that must finish before this
-        data: SerializedWrite,
+        blocks: Vec<WriteBlockMetadata>,
+        data: bytes::BytesMut,
     },
     Read {
         dependencies: Vec<JobId>, // Jobs that must finish before this
@@ -1241,13 +1161,21 @@ impl IOop {
                 let num_blocks = requests.len();
                 (job_type, num_blocks, dependencies.clone())
             }
-            IOop::Write { dependencies, data } => {
+            IOop::Write {
+                dependencies,
+                blocks,
+                ..
+            } => {
                 let job_type = "Write".to_string();
-                (job_type, data.num_blocks, dependencies.clone())
+                (job_type, blocks.len(), dependencies.clone())
             }
-            IOop::WriteUnwritten { dependencies, data } => {
+            IOop::WriteUnwritten {
+                dependencies,
+                blocks,
+                ..
+            } => {
                 let job_type = "WriteU".to_string();
-                (job_type, data.num_blocks, dependencies.clone())
+                (job_type, blocks.len(), dependencies.clone())
             }
             IOop::Flush {
                 dependencies,
@@ -1309,9 +1237,9 @@ impl IOop {
             // repaired is handled with dependencies, and IOs should arrive
             // here with those dependencies already set.
             match &self {
-                IOop::Write { data, .. }
-                | IOop::WriteUnwritten { data, .. } => {
-                    data.eids.iter().any(|eid| *eid <= extent_limit)
+                IOop::Write { blocks, .. }
+                | IOop::WriteUnwritten { blocks, .. } => {
+                    blocks.iter().any(|b| b.eid <= extent_limit)
                 }
                 IOop::Flush { .. } => {
                     // If we have set extent limit, then we go ahead and
@@ -1337,7 +1265,7 @@ impl IOop {
     fn job_bytes(&self) -> u64 {
         match &self {
             IOop::Write { data, .. } | IOop::WriteUnwritten { data, .. } => {
-                data.io_size_bytes as u64
+                data.len() as u64
             }
             IOop::Read { requests, .. } => {
                 requests
@@ -1929,11 +1857,11 @@ pub enum BlockOp {
     },
     Write {
         offset: Block,
-        data: Bytes,
+        data: BytesMut,
     },
     WriteUnwritten {
         offset: Block,
-        data: Bytes,
+        data: BytesMut,
     },
     Flush {
         snapshot_details: Option<SnapshotDetails>,

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -1165,7 +1165,7 @@ pub mod repair_test {
 
         up.submit_dummy_write(
             Block::new_512(0),
-            Bytes::from(vec![0xff; 512]),
+            BytesMut::from(vec![0xff; 512].as_slice()),
             false,
         );
 
@@ -1174,7 +1174,7 @@ pub mod repair_test {
         // WriteUnwritten
         up.submit_dummy_write(
             Block::new_512(0),
-            Bytes::from(vec![0xff; 512]),
+            BytesMut::from(vec![0xff; 512].as_slice()),
             true,
         );
 
@@ -1200,7 +1200,7 @@ pub mod repair_test {
 
         up.submit_dummy_write(
             Block::new_512(0),
-            Bytes::from(vec![0xff; 512]),
+            BytesMut::from(vec![0xff; 512].as_slice()),
             false,
         );
 
@@ -1209,7 +1209,7 @@ pub mod repair_test {
         // WriteUnwritten
         up.submit_dummy_write(
             Block::new_512(0),
-            Bytes::from(vec![0xff; 512]),
+            BytesMut::from(vec![0xff; 512].as_slice()),
             true,
         );
 
@@ -1231,7 +1231,7 @@ pub mod repair_test {
 
         up.submit_dummy_write(
             Block::new_512(3),
-            Bytes::from(vec![0xff; 512]),
+            BytesMut::from(vec![0xff; 512].as_slice()),
             false,
         );
 
@@ -1240,7 +1240,7 @@ pub mod repair_test {
         // WriteUnwritten
         up.submit_dummy_write(
             Block::new_512(3),
-            Bytes::from(vec![0xff; 512]),
+            BytesMut::from(vec![0xff; 512].as_slice()),
             true,
         );
 
@@ -1313,7 +1313,7 @@ pub mod repair_test {
         // Our default extent size is 3, so 9 blocks will span 3 extents
         up.submit_dummy_write(
             Block::new_512(0),
-            Bytes::from(vec![0xff; 512 * 9]),
+            BytesMut::from(vec![0xff; 512 * 9].as_slice()),
             false,
         );
 
@@ -1322,7 +1322,7 @@ pub mod repair_test {
         // WriteUnwritten
         up.submit_dummy_write(
             Block::new_512(0),
-            Bytes::from(vec![0xff; 512 * 9]),
+            BytesMut::from(vec![0xff; 512 * 9].as_slice()),
             true,
         );
 
@@ -1440,7 +1440,7 @@ pub mod repair_test {
         // Our default extent size is 3, so 9 blocks will span 3 extents
         up.submit_dummy_write(
             Block::new_512(0),
-            Bytes::from(vec![0xff; 512 * 9]),
+            BytesMut::from(vec![0xff; 512 * 9].as_slice()),
             false,
         );
 
@@ -1504,7 +1504,7 @@ pub mod repair_test {
         // Our default extent size is 3, so block 3 will be on extent 1
         up.submit_dummy_write(
             Block::new_512(0),
-            Bytes::from(vec![0xff; 512 * 9]),
+            BytesMut::from(vec![0xff; 512 * 9].as_slice()),
             false,
         );
 

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -96,7 +96,7 @@ impl IOSpan {
                     self.affected_block_numbers[0],
                     self.block_size.trailing_zeros(),
                 ),
-                self.buffer.into_bytes(),
+                self.buffer.into_bytes_mut(),
             )
             .await
     }
@@ -376,7 +376,7 @@ impl<T: BlockIO> CruciblePseudoFile<T> {
                 self.block_size.trailing_zeros(),
             );
             let bytes = BytesMut::from(buf);
-            self.block_io.write(offset, bytes.freeze()).await?;
+            self.block_io.write(offset, bytes).await?;
         }
 
         // TODO: can't increment offset past the device size

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -769,13 +769,13 @@ pub(crate) mod up_test {
             IOop::WriteUnwritten {
                 dependencies: vec![],
                 blocks,
-                data,
+                data: data.freeze(),
             }
         } else {
             IOop::Write {
                 dependencies: vec![],
                 blocks,
-                data,
+                data: data.freeze(),
             }
         }
     }

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -397,7 +397,8 @@ pub(crate) mod up_test {
 
         // Validate it
         let successful_hash = validate_encrypted_read_response(
-            &mut read_response,
+            &mut read_response.block_contexts,
+            &mut read_response.data,
             &Arc::new(context),
             &csl(),
         )?;
@@ -477,7 +478,8 @@ pub(crate) mod up_test {
 
         // Validate it
         let successful_hash = validate_encrypted_read_response(
-            &mut read_response,
+            &mut read_response.block_contexts,
+            &mut read_response.data,
             &Arc::new(context),
             &csl(),
         )?;
@@ -530,7 +532,8 @@ pub(crate) mod up_test {
 
         // Validate it
         let successful_hash = validate_encrypted_read_response(
-            &mut read_response,
+            &mut read_response.block_contexts,
+            &mut read_response.data,
             &Arc::new(context),
             &csl(),
         )?;
@@ -565,8 +568,11 @@ pub(crate) mod up_test {
         };
 
         // Validate it
-        let successful_hash =
-            validate_unencrypted_read_response(&mut read_response, &csl())?;
+        let successful_hash = validate_unencrypted_read_response(
+            &mut read_response.block_contexts,
+            &mut read_response.data,
+            &csl(),
+        )?;
 
         assert_eq!(successful_hash, Some(read_response_hash));
         assert_eq!(read_response.data, original_data);
@@ -591,8 +597,11 @@ pub(crate) mod up_test {
         };
 
         // Validate it
-        let successful_hash =
-            validate_unencrypted_read_response(&mut read_response, &csl())?;
+        let successful_hash = validate_unencrypted_read_response(
+            &mut read_response.block_contexts,
+            &mut read_response.data,
+            &csl(),
+        )?;
 
         assert_eq!(successful_hash, None);
         assert_eq!(read_response.data, original_data);
@@ -642,8 +651,11 @@ pub(crate) mod up_test {
         };
 
         // Validate it
-        let successful_hash =
-            validate_unencrypted_read_response(&mut read_response, &csl())?;
+        let successful_hash = validate_unencrypted_read_response(
+            &mut read_response.block_contexts,
+            &mut read_response.data,
+            &csl(),
+        )?;
 
         assert_eq!(successful_hash, Some(read_response_hash));
         assert_eq!(read_response.data, original_data);
@@ -686,8 +698,11 @@ pub(crate) mod up_test {
         };
 
         // Validate it
-        let successful_hash =
-            validate_unencrypted_read_response(&mut read_response, &csl())?;
+        let successful_hash = validate_unencrypted_read_response(
+            &mut read_response.block_contexts,
+            &mut read_response.data,
+            &csl(),
+        )?;
 
         assert_eq!(successful_hash, Some(read_response_hash));
         assert_eq!(read_response.data, original_data);
@@ -739,27 +754,28 @@ pub(crate) mod up_test {
 
     // Construct an IOop::Write or IOop::WriteUnwritten at the given extent
     fn write_at_extent(eid: u64, wu: bool) -> IOop {
-        let request = crucible_protocol::Write {
+        let request = crucible_protocol::WriteBlockMetadata {
             eid,
             offset: Block::new_512(7),
-            data: Bytes::from(vec![1]),
             block_context: BlockContext {
                 encryption_context: None,
                 hash: 0,
             },
         };
-
-        let writes = vec![request];
+        let data = BytesMut::from(vec![1].as_slice());
+        let blocks = vec![request];
 
         if wu {
             IOop::WriteUnwritten {
                 dependencies: vec![],
-                data: SerializedWrite::from_writes(writes),
+                blocks,
+                data,
             }
         } else {
             IOop::Write {
                 dependencies: vec![],
-                data: SerializedWrite::from_writes(writes),
+                blocks,
+                data,
             }
         }
     }

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -4273,7 +4273,7 @@ pub(crate) mod test {
         // Send back a second response with more data (2 blocks instead of 1);
         // the first block matches.
         let data = BytesMut::from([1u8; 512 * 2].as_slice());
-        let hash = integrity_hash(&[&data]);
+        let hash = integrity_hash(&[&data[0..512]]);
         let response = ReadResponseBlockMetadata {
             eid: 0,
             offset,

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -4341,7 +4341,7 @@ pub(crate) mod test {
                     job_id: JobId(1000),
                     blocks: r1,
                 },
-                data,
+                data: data.clone(),
             }),
         }))
         .await;


### PR DESCRIPTION
#1183 , #1087, and #1196 all have a similar theme: we replace `bincode::serialize/deserialize` with manually constructing (deconstructing) objects in-place from a `Bytes` or `BytesMut` buffer, to reduce unnecessary `memcpy` calls.  This matters for **bulk** data, i.e. writes and read responses, and we see significant performance improvements in each of those PRs.

The downside is that we must implement the `bincode` serialization format by hand: we're manually building a `bincode`-compatible set of bytes into a buffer, without the help of `bincode::serialize`.  This _works_ and should keep working (the `bincode` format is well-specified), but is difficult to read / write / modify and requires close inspection to verify its correctness.

Doing this packing is tricky because the relevant `Message` variants interleave bulk and per-block data.  For example, `Message::Write` is defined as follows:

```rust
enum Message {
    // Message::Write must contain the same fields in the same order as
    // RawMessage::Write which is used for zero-copy serialization.
    Write {
        upstairs_id: Uuid,
        session_id: Uuid,
        job_id: JobId,
        dependencies: Vec<JobId>,
        writes: Vec<Write>,
    },
    // ... other variants
}

pub struct Write {
    pub eid: u64,
    pub offset: Block,
    pub data: bytes::Bytes,

    pub block_context: BlockContext,
}
```

You can see that the bulk data in `Write::data` is interleaved between per-block metadata.

This PR takes a different approach, obviating all three of the previous PRs.  We reorganize the relevant `Message` variants to separate out the bulk data into a standalone `Bytes` array:

```rust
enum Message {
    Write {
        header: WriteHeader,
        data: bytes::Bytes,
    },
    // ... other variants
}

pub struct WriteHeader {
    pub upstairs_id: Uuid,
    pub session_id: Uuid,
    pub job_id: JobId,
    pub dependencies: Vec<JobId>,
    pub blocks: Vec<WriteBlockMetadata>,
}

pub struct WriteBlockMetadata {
    pub eid: u64,
    pub offset: Block,
    pub block_context: BlockContext,
}
```

This makes (almost) zero-copy serialization and deserialization straightforward: for types with bulk data, we serialize the `(message length, discriminant, header, data length)` tuple using `bincode`, then send the trailing data as a separate `send` syscall (without copying it).  Here's the relevant code within `MessageWriter`:
```rust
impl MessageWriter {
    /// Sends the given message down the wire
    #[inline]
    pub async fn send(&mut self, m: Message) -> Result<(), CrucibleError> {
        use tokio::io::AsyncWriteExt;

        let discriminant = MessageDiscriminants::from(&m);
        match m {
            Message::Write { header, data } => {
                self.send_raw(discriminant, header, data).await
            }
            Message::WriteUnwritten { header, data } => {
                self.send_raw(discriminant, header, data).await
            }
            Message::ReadResponse { header, data } => {
                self.send_raw(discriminant, header, data).await
            }
            m => {
                // Serialize into our local BytesMut, to avoid allocation churn
                self.scratch.clear();
                let mut e = CrucibleEncoder::new();
                e.encode(m, &mut self.scratch)?;
                self.writer.write_all(&self.scratch).await?;
                Ok(())
            }
        }
    }

    async fn send_raw<H: Serialize, B: AsRef<[u8]>>(
        &mut self,
        discriminant: MessageDiscriminants,
        header: H,
        data: B,
    ) -> Result<(), CrucibleError> {
        let data = data.as_ref();
        use tokio::io::AsyncWriteExt;

        self.header.clear();
        let mut cursor = std::io::Cursor::new(&mut self.header);
        bincode::serialize_into(
            &mut cursor,
            &(
                0u32, // dummy length, to be patched later
                discriminant,
                header,
                data.len(),
            ),
        )
        .unwrap();

        // Patch the length
        let len: u32 = (self.header.len() + data.len()).try_into().unwrap();
        self.header[0..4].copy_from_slice(&len.to_le_bytes());

        // write_all_vectored would save a syscall, but is nightly-only
        self.writer.write_all(&self.header).await?;
        self.writer.write_all(data).await?;

        Ok(())
    }
}
```

Deserialization is similarly straightforward.

Philosophically, this is still "manual implement `bincode`", but we're implementing a much more obvious subset of the protocol.

The rest of the PR is making those changes for the three relevant `Message` variants (`Write`, `WriteUnwritten`, `Read`), then fixing everything that breaks.

# So, what does this give us?

In general, `memcpy` disappears from the flamegraphs.

For example, we can now do writes with **zero** `memcpy` calls:

- The `Guest` provides a `BytesMut` buffer
- We encrypt in-place
- We use that buffer as the `data` field in `Message::write`
- That buffer is shoved into the socket

Similarly, reads can now use `pread` instead of `preadv`, because contiguous block data is no longer scattered between multiple `crucible_protocol::Read` objects.

--------------------------------------------------------------------------------

# Performance checks

This seems to be a significant improvement for reads, and _maybe_ a small improvement for writes.

## Propolis + Crucible main (`6f7884a`)
```
1M WRITE: bw=552MiB/s (579MB/s), 552MiB/s-552MiB/s (579MB/s-579MB/s), io=32.5GiB (34.8GB), run=60174-60174msec
4K WRITE: bw=29.1MiB/s (30.5MB/s), 29.1MiB/s-29.1MiB/s (30.5MB/s-30.5MB/s), io=1748MiB (1833MB), run=60025-60025msec
1M WRITE: bw=639MiB/s (670MB/s), 639MiB/s-639MiB/s (670MB/s-670MB/s), io=37.5GiB (40.3GB), run=60053-60053msec
4M WRITE: bw=549MiB/s (576MB/s), 549MiB/s-549MiB/s (576MB/s-576MB/s), io=32.3GiB (34.7GB), run=60172-60172msec
4K READ: bw=32.9MiB/s (34.5MB/s), 32.9MiB/s-32.9MiB/s (34.5MB/s-34.5MB/s), io=1976MiB (2072MB), run=60003-60003msec
1M READ: bw=608MiB/s (637MB/s), 608MiB/s-608MiB/s (637MB/s-637MB/s), io=35.6GiB (38.3GB), run=60034-60034msec
4M READ: bw=704MiB/s (738MB/s), 704MiB/s-704MiB/s (738MB/s-738MB/s), io=41.4GiB (44.4GB), run=60140-60140msec
```

## Propolis + Crucible on this branch (`6f7884a`)
```
4M WRITE: bw=546MiB/s (572MB/s), 546MiB/s-546MiB/s (572MB/s-572MB/s), io=32.1GiB (34.5GB), run=60247-60247msec
4K WRITE: bw=28.6MiB/s (30.0MB/s), 28.6MiB/s-28.6MiB/s (30.0MB/s-30.0MB/s), io=1719MiB (1803MB), run=60010-60010msec
1M WRITE: bw=670MiB/s (703MB/s), 670MiB/s-670MiB/s (703MB/s-703MB/s), io=39.3GiB (42.2GB), run=60047-60047msec
4M WRITE: bw=556MiB/s (583MB/s), 556MiB/s-556MiB/s (583MB/s-583MB/s), io=32.7GiB (35.1GB), run=60185-60185msec
4K READ: bw=33.0MiB/s (34.6MB/s), 33.0MiB/s-33.0MiB/s (34.6MB/s-34.6MB/s), io=1978MiB (2074MB), run=60003-60003msec
1M READ: bw=725MiB/s (761MB/s), 725MiB/s-725MiB/s (761MB/s-761MB/s), io=42.5GiB (45.7GB), run=60029-60029msec
4M READ: bw=787MiB/s (825MB/s), 787MiB/s-787MiB/s (825MB/s-825MB/s), io=46.2GiB (49.6GB), run=60137-60137msec
```

These write performance numbers are less than I saw on #1196, but I can no longer reproduce those values; maybe we just got extremely lucky during that run?

# This is a breaking message format change
We're always updating entire racks, so that's probably fine!

# Yes, this requires Propolis changes
They're staged in [`mkeeter/propolis/crucible-packed-tree`](https://github.com/mkeeter/propolis/tree/crucible-packed-data)