### PR TITLE
Make three smaller timeouts instead of one large one.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,6 +870,7 @@ dependencies = [
  "tempfile",
  "test-strategy",
  "thiserror",
+ "tokio",
  "tokio-rustls 0.24.1",
  "toml 0.8.10",
  "twox-hash",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -21,6 +21,7 @@ slog-dtrace.workspace = true
 slog-term.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 tokio-rustls.workspace = true
 toml.workspace = true
 twox-hash.workspace = true

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -12,6 +12,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slog::Drain;
 use tempfile::NamedTempFile;
+use tokio::time::{Duration, Instant};
 
 mod region;
 pub use region::{
@@ -412,4 +413,10 @@ impl From<CrucibleError> for dropshot::HttpError {
             }
         }
     }
+}
+
+pub fn deadline_secs(secs: f32) -> Instant {
+    Instant::now()
+        .checked_add(Duration::from_secs_f32(secs))
+        .unwrap()
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -420,3 +420,11 @@ pub fn deadline_secs(secs: f32) -> Instant {
         .checked_add(Duration::from_secs_f32(secs))
         .unwrap()
 }
+
+pub async fn verbose_timeout(secs: f32, n: usize, log: slog::Logger) {
+    let d = Duration::from_secs_f32(secs);
+    for i in 0..n {
+        tokio::time::sleep(d).await;
+        slog::warn!(log, "timeout {}/{n}", i + 1,);
+    }
+}

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -25,7 +25,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slog::{error, info, o, warn, Logger};
 use tokio::sync::{mpsc, oneshot, Mutex, RwLock};
-use tokio::time::Instant;
 use tracing::instrument;
 use usdt::register_probes;
 use uuid::Uuid;
@@ -397,12 +396,6 @@ mod cdt {
     fn volume__write__done(_: u32, _: Uuid) {}
     fn volume__writeunwritten__done(_: u32, _: Uuid) {}
     fn volume__flush__done(_: u32, _: Uuid) {}
-}
-
-pub fn deadline_secs(secs: f32) -> Instant {
-    Instant::now()
-        .checked_add(Duration::from_secs_f32(secs))
-        .unwrap()
 }
 
 /// Array of data associated with three clients, indexed by `ClientId`

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -7,6 +7,7 @@ use async_recursion::async_recursion;
 use oximeter::types::ProducerRegistry;
 use std::ops::Range;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use tokio::time::Instant;
 
 use crucible_client_types::VolumeConstructionRequest;
 


### PR DESCRIPTION
Updated the Upstairs <-> Downstairs message timeout to have three smaller timeouts 
before triggering a disconnect due to inactivity.  Log a message on each smaller timeout.

The timeout was changed from 50 seconds to 45 (3x15), but I don't expect that to make
much of a difference.

Moved deadline_secs() to a common location for both upstairs and downstairs to use.  
This resulted in a little shuffling of included libraries as well.

The messages the upstairs logs for a downstairs timeout now look like this:
```
15:41:34.545Z WARN crucible: Nothing received from downstairs, timeout 1/3                                                             
     = downstairs                                                                                                                      
    client = 0                                                                                                                         
    session_id = bfe20188-ad31-4cbd-897c-2083976c7ac4                                                                                  
15:41:49.545Z WARN crucible: Nothing received from downstairs, timeout 2/3                                                             
     = downstairs                                                                                                                      
    client = 0                                                                                                                         
    session_id = bfe20188-ad31-4cbd-897c-2083976c7ac4                                                                                  
15:42:04.547Z WARN crucible: Nothing received from downstairs, timeout 3/3                                                             
     = downstairs                                                                                                                      
    client = 0                                                                                                                         
    session_id = bfe20188-ad31-4cbd-897c-2083976c7ac4                                                                                  
15:42:04.547Z WARN crucible: client task is sending Done(Timeout)                                                                      
     = downstairs                                                                                                                          
     client = 0                                                                                                                         
    session_id = bfe20188-ad31-4cbd-897c-2083976c7ac4
```

From the downstairs, when the upstairs goes quiet, we see this:
```
15:42:55.556Z WARN crucible: Nothing received from upstairs, timeout 1/3
    task = main
15:43:10.558Z WARN crucible: Nothing received from upstairs, timeout 2/3
    task = main
15:43:25.559Z WARN crucible: Nothing received from upstairs, timeout 3/3
    task = main
15:43:25.559Z ERRO crucible: connection (127.0.0.1:41938) Exits with error: inactivity timeout
```
