### PR TITLE
Activate the NBD server's psuedo file

### DIFF
--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -97,8 +97,8 @@ async fn main() -> Result<()> {
 
     // NBD server
 
-    guest.activate().await?;
     let mut cpf = crucible::CruciblePseudoFile::from(guest)?;
+    cpf.activate().await?;
 
     let listener = TcpListener::bind("127.0.0.1:10809").unwrap();
 


### PR DESCRIPTION
I don't know if any of you are using nbd_server but this corrects the reported `cpf.sz()` (i.e. not zero) and has let me use a filesystem on crucible via nbd for my own shenanigans