### PR TITLE
Remove `ReadResponse` in favor of `RawReadResponse`

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -20,8 +20,7 @@ use crucible_common::{
 };
 use crucible_protocol::{
     BlockContext, CrucibleDecoder, CrucibleEncoder, JobId, Message,
-    ReadRequest, ReadResponse, ReconciliationId, SnapshotDetails,
-    CRUCIBLE_MESSAGE_VERSION,
+    ReadRequest, ReconciliationId, SnapshotDetails, CRUCIBLE_MESSAGE_VERSION,
 };
 use repair_client::Client;
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -877,7 +877,7 @@ impl std::fmt::Display for DsState {
 /*
  * A unit of work for downstairs that is put into the hashmap.
  */
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct DownstairsIO {
     ds_id: JobId, // This MUST match our hashmap index
 
@@ -903,7 +903,7 @@ struct DownstairsIO {
      * If the operation is a Read, this holds the resulting buffer
      * The hashes vec holds the valid hash(es) for the read.
      */
-    data: Option<Vec<ReadResponse>>,
+    data: Option<RawReadResponse>,
     read_response_hashes: Vec<Option<u64>>,
 
     /// Number of bytes that this job has contributed to guest backpressure
@@ -937,13 +937,11 @@ impl DownstairsIO {
             IOop::Write { data, .. } | IOop::WriteUnwritten { data, .. } => {
                 data.len()
             }
-            IOop::Read { .. } => {
-                if self.data.is_some() {
-                    let rrs = self.data.as_ref().unwrap();
-                    rrs.iter().map(|r| r.data.len()).sum()
-                } else {
-                    0
-                }
+            IOop::Read { requests, .. } => {
+                let Some(r) = requests.first() else {
+                    return 0;
+                };
+                r.offset.block_size_in_bytes() as usize * requests.len()
             }
             IOop::Flush { .. }
             | IOop::ExtentFlushClose { .. }


### PR DESCRIPTION
In #1206, we reorganized messages to put bulk data in a single place.  In other words, a read response is no longer split into a bunch of individual block-size buffers; it's all in a single contiguous allocation.

However, to minimize the size of the PR, we kept the existing `struct ReadResponse`, tweaking it to borrow from the contiguous allocation.

This PR removes the vestigal `ReadResponse` in favor of using the `RawReadResponse` everywhere.  This is a net LOC decrease, and means that we can copy into our guest buffer in a single `memcpy` (ownership permitting), instead of multiple block-sized copies.

The majority of changes (by LOC) are calls to `process_ds_completion`, which previous took a `Vec<ReadResponse>` and now takes a `RawReadResponse`.

The part of the change requiring close review is the [new `Buffer::write_read_response`](https://github.com/mkeeter/crucible/blob/19926c38575e6b43f976ee9be66ed252ac39a14c/upstairs/src/lib.rs#L1587), which takes care to avoid `memcpy` when possible.