### PR TITLE
Don't let df failures ruin the buildomat tests

### DIFF
--- a/.github/buildomat/jobs/test-crudd-benchmark.sh
+++ b/.github/buildomat/jobs/test-crudd-benchmark.sh
@@ -53,7 +53,7 @@ jobpid=$$; (sleep $(( 2 * 60 * 60 )); ps -ef; zfs list;kill $jobpid) &
 echo "Setup debug logging"
 mkdir /tmp/debug
 psrinfo -v > /tmp/debug/psrinfo.txt
-df -h > /tmp/debug/df.txt
+df -h > /tmp/debug/df.txt || true
 prstat -d d -mLc 1 > /tmp/debug/prstat.txt 2>&1 &
 iostat -T d -xn 1 > /tmp/debug/iostat.txt 2>&1 &
 mpstat -T d 1 > /tmp/debug/mpstat.txt 2>&1 &

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -50,7 +50,7 @@ jobpid=$$; (sleep $(( 40 * 60 )); ps -ef; zfs list;kill $jobpid) &
 echo "Setup debug logging"
 mkdir /tmp/debug
 psrinfo -v > /tmp/debug/psrinfo.txt
-df -h > /tmp/debug/df.txt
+df -h > /tmp/debug/df.txt || true
 prstat -d d -mLc 1 > /tmp/debug/prstat.txt 2>&1 &
 iostat -T d -xn 1 > /tmp/debug/iostat.txt 2>&1 &
 mpstat -T d 1 > /tmp/debug/mpstat.txt 2>&1 &

--- a/.github/buildomat/jobs/test-replay.sh
+++ b/.github/buildomat/jobs/test-replay.sh
@@ -52,7 +52,7 @@ jobpid=$$; (sleep 10800; ps -ef; zfs list;kill $jobpid) &
 echo "Setup debug logging"
 mkdir /tmp/debug
 psrinfo -v > /tmp/debug/psrinfo.txt
-df -h > /tmp/debug/df.txt
+df -h > /tmp/debug/df.txt || true
 prstat -d d -mLc 1 > /tmp/debug/prstat.txt 2>&1 &
 iostat -T d -xn 1 > /tmp/debug/iostat.txt 2>&1 &
 mpstat -T d 1 > /tmp/debug/mpstat.txt 2>&1 &


### PR DESCRIPTION
`df -h` can return error if a mounted filesystem is not visible to the caller.
Don't allow a failure in `df` to ruin the buildomat test script.