### PR TITLE
Remove `MAX_ACTIVE_COUNT` flow control system

### DIFF
--- a/aws_benchmark/driver.sh
+++ b/aws_benchmark/driver.sh
@@ -34,9 +34,6 @@ cleanup
 # show results
 set -x
 
-# was job based flow control triggered?
-grep "flow control" results.txt || true
-
 # show IOPS measurements
 grep "IOPS mean " results.txt || true
 

--- a/cmon/src/main.rs
+++ b/cmon/src/main.rs
@@ -36,7 +36,6 @@ enum DtraceDisplay {
     LiveRepair,
     Connected,
     Replaced,
-    FlowControl,
     ExtentRepair,
 }
 
@@ -51,7 +50,6 @@ impl fmt::Display for DtraceDisplay {
             DtraceDisplay::LiveRepair => write!(f, "live_repair"),
             DtraceDisplay::Connected => write!(f, "connected"),
             DtraceDisplay::Replaced => write!(f, "replaced"),
-            DtraceDisplay::FlowControl => write!(f, "flow_control"),
             DtraceDisplay::ExtentRepair => write!(f, "extent_repair"),
         }
     }
@@ -190,9 +188,6 @@ fn print_dtrace_header(dd: &[DtraceDisplay]) {
             DtraceDisplay::Replaced => {
                 print!(" {:>4} {:>4} {:>4}", "RPL0", "RPL1", "RPL2");
             }
-            DtraceDisplay::FlowControl => {
-                print!(" {:>4} {:>4} {:>4}", "FC0", "FC1", "FC2");
-            }
             DtraceDisplay::ExtentRepair => {
                 print!(" {:>4} {:>4} {:>4}", "EXR0", "EXR1", "EXR2");
                 print!(" {:>4} {:>4} {:>4}", "EXC0", "EXC1", "EXC2");
@@ -287,14 +282,6 @@ fn print_dtrace_row(d_out: Arg, dd: &[DtraceDisplay]) {
                     d_out.ds_replaced[0],
                     d_out.ds_replaced[1],
                     d_out.ds_replaced[2],
-                );
-            }
-            DtraceDisplay::FlowControl => {
-                print!(
-                    " {:4} {:4} {:4}",
-                    d_out.ds_flow_control[0],
-                    d_out.ds_flow_control[1],
-                    d_out.ds_flow_control[2],
                 );
             }
             DtraceDisplay::ExtentRepair => {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -26,9 +26,14 @@ pub mod x509;
 
 pub const REPAIR_PORT_OFFSET: u16 = 4000;
 
-// Max number of submitted IOs between the upstairs and the downstairs, above
-// which flow control kicks in.
-pub const MAX_ACTIVE_COUNT: usize = 2600;
+/// Max number of outstanding IOs between the upstairs and the downstairs
+///
+/// If we exceed this value, the upstairs will give up and mark that downstairs
+/// as faulted.
+///
+/// This is exposed in `crucible-common` so that both sides can pick appropriate
+/// lengths for their `mpsc` queues.
+pub const IO_OUTSTANDING_MAX_JOBS: usize = 57000;
 
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -808,9 +808,7 @@ async fn main() -> Result<()> {
             println!("Run Demo test");
             let count = opt.count.unwrap_or(300);
             /*
-             * The count provided here should be greater than the flow
-             * control limit if we wish to test flow control.  Also, set
-             * lossy on a downstairs otherwise it will probably keep up.
+             * Set lossy on a downstairs otherwise it will probably keep up.
              */
             demo_workload(&guest, count, &mut region_info).await?;
         }

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -16,8 +16,8 @@ use std::time::Duration;
 use crucible_common::{
     build_logger, crucible_bail, deadline_secs,
     impacted_blocks::extent_from_offset, integrity_hash, mkdir_for_file,
-    verbose_timeout, Block, CrucibleError, RegionDefinition, MAX_ACTIVE_COUNT,
-    MAX_BLOCK_SIZE,
+    verbose_timeout, Block, CrucibleError, RegionDefinition,
+    IO_OUTSTANDING_MAX_JOBS, MAX_BLOCK_SIZE,
 };
 use crucible_protocol::{
     BlockContext, CrucibleDecoder, CrucibleEncoder, JobId, Message,
@@ -1117,10 +1117,11 @@ where
 
     // Give our work queue a little more space than we expect the upstairs
     // to ever send us.
-    let (job_channel_tx, job_channel_rx) = mpsc::channel(MAX_ACTIVE_COUNT + 50);
+    let (job_channel_tx, job_channel_rx) =
+        mpsc::channel(IO_OUTSTANDING_MAX_JOBS + 50);
 
     let (resp_channel_tx, resp_channel_rx) =
-        mpsc::channel(MAX_ACTIVE_COUNT + 50);
+        mpsc::channel(IO_OUTSTANDING_MAX_JOBS + 50);
     let mut framed_write_task = tokio::spawn(reply_task(resp_channel_rx, fw));
 
     /*
@@ -1179,7 +1180,7 @@ where
     };
 
     let (message_channel_tx, mut message_channel_rx) =
-        mpsc::channel(MAX_ACTIVE_COUNT + 50);
+        mpsc::channel(IO_OUTSTANDING_MAX_JOBS + 50);
     let mut pf_task = {
         let adc = ads.clone();
         let tx = job_channel_tx.clone();

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -20,7 +20,6 @@ use crate::{
     ReconciliationId, RegionDefinition, ReplaceResult, SnapshotDetails,
     WorkSummary,
 };
-use crucible_common::MAX_ACTIVE_COUNT;
 use crucible_protocol::{RawWrite, WriteHeader};
 
 use rand::prelude::*;
@@ -409,28 +408,10 @@ impl Downstairs {
         }
     }
 
-    pub(crate) async fn io_send(&mut self, client_id: ClientId) -> bool {
-        // Send as many jobs as possible to the downstairs, limited by
-        // `MAX_ACTIVE_COUNT`.
-        //
-        // This XXX is for coming back here and making a better job of
-        // flow control; see RFD 445 for details.
+    pub(crate) async fn io_send(&mut self, client_id: ClientId) {
+        // Send all jobs to the downstairs
         let client = &mut self.clients[client_id];
-        let (new_work, flow_control) = {
-            let active_count = client.io_state_count.in_progress as usize;
-            if active_count > MAX_ACTIVE_COUNT {
-                // Can't do any work
-                client.stats.flow_control += 1;
-                return true;
-            } else {
-                let n = MAX_ACTIVE_COUNT - active_count;
-                let (new_work, flow_control) = client.new_work(n);
-                if flow_control {
-                    client.stats.flow_control += 1;
-                }
-                (new_work, flow_control)
-            }
-        };
+        let new_work = client.new_work();
 
         /*
          * Now we have a list of all the job IDs that are new for our client id.
@@ -624,7 +605,6 @@ impl Downstairs {
             };
             self.clients[client_id].send(message).await
         }
-        flow_control
     }
 
     /// Mark this request as in progress for this client, and return the

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -14,12 +14,11 @@ pub(crate) mod protocol_test {
     use crate::Buffer;
     use crate::CrucibleError;
     use crate::IO_OUTSTANDING_MAX_BYTES;
-    use crate::IO_OUTSTANDING_MAX_JOBS;
-    use crate::MAX_ACTIVE_COUNT;
     use crucible_client_types::CrucibleOpts;
     use crucible_common::Block;
     use crucible_common::RegionDefinition;
     use crucible_common::RegionOptions;
+    use crucible_common::IO_OUTSTANDING_MAX_JOBS;
     use crucible_protocol::ClientId;
     use crucible_protocol::CrucibleDecoder;
     use crucible_protocol::CrucibleEncoder;
@@ -642,230 +641,6 @@ pub(crate) mod protocol_test {
         idx.map(|i| l.remove(i))
     }
 
-    /// Test that flow control kicks in at MAX_ACTIVE_COUNT jobs, and until the
-    /// downstairs responds Ok for a job, no more work is sent. Once three
-    /// downstairs responds with a read response for a certain job, then more
-    /// work is sent.
-    #[tokio::test]
-    async fn test_flow_control() -> Result<()> {
-        let harness = Arc::new(TestHarness::new().await?);
-
-        let (_jh1, mut ds1_messages) =
-            harness.ds1().await.spawn_message_receiver();
-        let (_jh2, mut ds2_messages) = harness.ds2.spawn_message_receiver();
-        let (_jh3, mut ds3_messages) = harness.ds3.spawn_message_receiver();
-
-        for _ in 0..MAX_ACTIVE_COUNT {
-            let harness = harness.clone();
-
-            // We must tokio::spawn here because `read` will wait for the
-            // response to come back before returning
-            tokio::spawn(async move {
-                let mut buffer = Buffer::new(1, 512);
-                harness
-                    .guest
-                    .read(Block::new_512(0), &mut buffer)
-                    .await
-                    .unwrap();
-            });
-        }
-
-        let mut job_ids = Vec::with_capacity(MAX_ACTIVE_COUNT);
-
-        for _ in 0..MAX_ACTIVE_COUNT {
-            match ds1_messages.recv().await.unwrap() {
-                Message::ReadRequest { job_id, .. } => {
-                    // Record the job ids of the read requests
-                    job_ids.push(job_id);
-                }
-
-                _ => bail!("saw non read request!"),
-            }
-
-            bail_assert!(matches!(
-                ds2_messages.recv().await.unwrap(),
-                Message::ReadRequest { .. },
-            ));
-
-            bail_assert!(matches!(
-                ds3_messages.recv().await.unwrap(),
-                Message::ReadRequest { .. },
-            ));
-        }
-
-        // Confirm that's all the Upstairs sent us - with the flush_timeout set
-        // to 24 hours, we shouldn't see anything else
-
-        bail_assert!(matches!(
-            ds1_messages.try_recv(),
-            Err(TryRecvError::Empty)
-        ));
-        bail_assert!(matches!(
-            ds2_messages.try_recv(),
-            Err(TryRecvError::Empty)
-        ));
-        bail_assert!(matches!(
-            ds3_messages.try_recv(),
-            Err(TryRecvError::Empty)
-        ));
-
-        // Performing any guest reads will not send them to the downstairs
-
-        {
-            let harness = harness.clone();
-
-            tokio::spawn(async move {
-                let mut buffer = Buffer::new(1, 512);
-                harness
-                    .guest
-                    .read(Block::new_512(0), &mut buffer)
-                    .await
-                    .unwrap();
-            });
-        }
-
-        bail_assert!(matches!(
-            ds1_messages.try_recv(),
-            Err(TryRecvError::Empty)
-        ));
-        bail_assert!(matches!(
-            ds2_messages.try_recv(),
-            Err(TryRecvError::Empty)
-        ));
-        bail_assert!(matches!(
-            ds3_messages.try_recv(),
-            Err(TryRecvError::Empty)
-        ));
-
-        // Once the downstairs respond with a ReadRequest for a job, then more
-        // work will be sent downstairs
-
-        let (block, data) = make_blank_read_response();
-        harness
-            .ds1()
-            .await
-            .fw
-            .lock()
-            .await
-            .send(Message::ReadResponse {
-                header: ReadResponseHeader {
-                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
-                    session_id: harness
-                        .ds1()
-                        .await
-                        .upstairs_session_id
-                        .lock()
-                        .await
-                        .unwrap(),
-                    job_id: job_ids[0],
-                    blocks: Ok(vec![block.clone()]),
-                },
-                data: data.clone(),
-            })
-            .await
-            .unwrap();
-
-        harness
-            .ds2
-            .fw
-            .lock()
-            .await
-            .send(Message::ReadResponse {
-                header: ReadResponseHeader {
-                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
-                    session_id: harness
-                        .ds2
-                        .upstairs_session_id
-                        .lock()
-                        .await
-                        .unwrap(),
-                    job_id: job_ids[0],
-                    blocks: Ok(vec![block.clone()]),
-                },
-                data: data.clone(),
-            })
-            .await
-            .unwrap();
-
-        harness
-            .ds3
-            .fw
-            .lock()
-            .await
-            .send(Message::ReadResponse {
-                header: ReadResponseHeader {
-                    upstairs_id: harness.guest.get_uuid().await.unwrap(),
-                    session_id: harness
-                        .ds3
-                        .upstairs_session_id
-                        .lock()
-                        .await
-                        .unwrap(),
-                    job_id: job_ids[0],
-                    blocks: Ok(vec![block.clone()]),
-                },
-                data: data.clone(),
-            })
-            .await
-            .unwrap();
-
-        // Assert that we now see one more read request
-        let mut ds1_final_read_request = None;
-        let mut ds2_final_read_request = None;
-        let mut ds3_final_read_request = None;
-
-        for _ in 0..3 {
-            if ds1_final_read_request.is_some()
-                && ds2_final_read_request.is_some()
-                && ds3_final_read_request.is_some()
-            {
-                break;
-            }
-
-            if let Ok(m) = ds1_messages.try_recv() {
-                ds1_final_read_request = Some(m);
-            }
-            if let Ok(m) = ds2_messages.try_recv() {
-                ds2_final_read_request = Some(m);
-            }
-            if let Ok(m) = ds3_messages.try_recv() {
-                ds3_final_read_request = Some(m);
-            }
-
-            tokio::time::sleep(Duration::from_secs(1)).await;
-        }
-
-        bail_assert!(matches!(
-            ds1_messages.try_recv(),
-            Err(TryRecvError::Empty)
-        ));
-        bail_assert!(matches!(
-            ds2_messages.try_recv(),
-            Err(TryRecvError::Empty)
-        ));
-        bail_assert!(matches!(
-            ds3_messages.try_recv(),
-            Err(TryRecvError::Empty)
-        ));
-
-        bail_assert!(matches!(
-            ds1_final_read_request.unwrap(),
-            Message::ReadRequest { .. },
-        ));
-
-        bail_assert!(matches!(
-            ds2_final_read_request.unwrap(),
-            Message::ReadRequest { .. },
-        ));
-
-        bail_assert!(matches!(
-            ds3_final_read_request.unwrap(),
-            Message::ReadRequest { .. },
-        ));
-
-        Ok(())
-    }
-
     /// Test that replay occurs after a downstairs disconnects and reconnects
     #[tokio::test]
     async fn test_replay_occurs() -> Result<()> {
@@ -953,10 +728,10 @@ pub(crate) mod protocol_test {
         let (_jh2, mut ds2_messages) = harness.ds2.spawn_message_receiver();
         let (_jh3, mut ds3_messages) = harness.ds3.spawn_message_receiver();
 
-        // Send 200 more than IO_OUTSTANDING_MAX_JOBS jobs. Flow control will kick in
-        // at MAX_ACTIVE_COUNT messages, so we need to be sending read responses
-        // while reads are being sent. After IO_OUTSTANDING_MAX_JOBS jobs, the
-        // Upstairs will set ds1 to faulted, and send it no more work.
+        // Send 200 more than IO_OUTSTANDING_MAX_JOBS jobs, sending read
+        // responses from two of the three downstairs. After we have sent
+        // IO_OUTSTANDING_MAX_JOBS jobs, the Upstairs will set ds1 to faulted,
+        // and send it no more work.
         const NUM_JOBS: usize = IO_OUTSTANDING_MAX_JOBS + 200;
         let mut job_ids = Vec::with_capacity(NUM_JOBS);
 
@@ -976,32 +751,11 @@ pub(crate) mod protocol_test {
                 });
             }
 
-            if i < MAX_ACTIVE_COUNT {
-                // Before flow control kicks in, assert we're seeing the read
-                // requests
-                bail_assert!(matches!(
-                    ds1_messages.recv().await.unwrap(),
-                    Message::ReadRequest { .. },
-                ));
-            } else {
-                // After flow control kicks in, we shouldn't see any more
-                // messages
-                match ds1_messages.try_recv() {
-                    Err(TryRecvError::Empty) => {}
-                    Err(TryRecvError::Disconnected) => {}
-                    x => {
-                        info!(
-                            harness.log,
-                            "Read {i} should return EMPTY, but we got:{:?}", x
-                        );
-
-                        bail!(
-                            "Read {i} should return EMPTY, but we got:{:?}",
-                            x
-                        );
-                    }
-                }
-            }
+            // Assert we're seeing the read requests
+            bail_assert!(matches!(
+                ds1_messages.recv().await.unwrap(),
+                Message::ReadRequest { .. },
+            ));
 
             match ds2_messages.recv().await.unwrap() {
                 Message::ReadRequest { job_id, .. } => {
@@ -1141,7 +895,7 @@ pub(crate) mod protocol_test {
         }
 
         // Send ds1 responses for the jobs it saw
-        for (i, job_id) in job_ids.iter().enumerate().take(MAX_ACTIVE_COUNT) {
+        for (i, job_id) in job_ids.iter().enumerate() {
             let (block, data) = make_blank_read_response();
             match harness
                 .ds1()
@@ -1271,7 +1025,7 @@ pub(crate) mod protocol_test {
             // dependency, and that later writes have that read as their
             // dependency (which works because the read already depended on the
             // ExtentLiveReopen job). Batch up responses to send after the live
-            // repair is done, otherwise flow control will kick in.
+            // repair is done.
 
             let mut responses = vec![Vec::new(); 3];
 
@@ -2050,34 +1804,11 @@ pub(crate) mod protocol_test {
                 });
             }
 
-            if i < MAX_ACTIVE_COUNT {
-                // Before flow control kicks in, assert we're seeing the write
-                // requests
-                bail_assert!(matches!(
-                    ds1_messages.recv().await.unwrap(),
-                    Message::Write { .. },
-                ));
-            } else {
-                // After flow control kicks in, we shouldn't see any more
-                // messages
-                match ds1_messages.try_recv() {
-                    // This can return either Empty or Disconnected, depending
-                    // on whether the upstairs has kicked us out.
-                    Err(TryRecvError::Empty) => {}
-                    Err(TryRecvError::Disconnected) => {}
-                    x => {
-                        info!(
-                            harness.log,
-                            "Read {i} should return EMPTY, but we got:{:?}", x
-                        );
-
-                        bail!(
-                            "Read {i} should return EMPTY, but we got:{:?}",
-                            x
-                        );
-                    }
-                }
-            }
+            // Assert we're seeing the write requests
+            bail_assert!(matches!(
+                ds1_messages.recv().await.unwrap(),
+                Message::Write { .. },
+            ));
 
             match ds2_messages.recv().await.unwrap() {
                 Message::Write {
@@ -2169,10 +1900,10 @@ pub(crate) mod protocol_test {
         let (_jh2, mut ds2_messages) = harness.ds2.spawn_message_receiver();
         let (_jh3, mut ds3_messages) = harness.ds3.spawn_message_receiver();
 
-        // Send 200 more than IO_OUTSTANDING_MAX_JOBS jobs. Flow control will
-        // kick in at MAX_ACTIVE_COUNT messages, so we need to be sending read
-        // responses while reads are being sent. After IO_OUTSTANDING_MAX_JOBS
-        // jobs, the Upstairs will set ds1 to faulted, and send it no more work.
+        // Send 200 more than IO_OUTSTANDING_MAX_JOBS jobs, sending read
+        // responses from two of the three downstairs. After we have sent
+        // IO_OUTSTANDING_MAX_JOBS jobs, the Upstairs will set ds1 to faulted,
+        // and send it no more work.
         const NUM_JOBS: usize = IO_OUTSTANDING_MAX_JOBS + 200;
         let mut job_ids = Vec::with_capacity(NUM_JOBS);
 
@@ -2192,32 +1923,11 @@ pub(crate) mod protocol_test {
                 });
             }
 
-            if i < MAX_ACTIVE_COUNT {
-                // Before flow control kicks in, assert we're seeing the read
-                // requests
-                bail_assert!(matches!(
-                    ds1_messages.recv().await.unwrap(),
-                    Message::ReadRequest { .. },
-                ));
-            } else {
-                // After flow control kicks in, we shouldn't see any more
-                // messages
-                match ds1_messages.try_recv() {
-                    Err(TryRecvError::Empty) => {}
-                    Err(TryRecvError::Disconnected) => {}
-                    x => {
-                        info!(
-                            harness.log,
-                            "Read {i} should return EMPTY, but we got:{:?}", x
-                        );
-
-                        bail!(
-                            "Read {i} should return EMPTY, but we got:{:?}",
-                            x
-                        );
-                    }
-                }
-            }
+            // Assert we're seeing the read requests
+            bail_assert!(matches!(
+                ds1_messages.recv().await.unwrap(),
+                Message::ReadRequest { .. },
+            ));
 
             match ds2_messages.recv().await.unwrap() {
                 Message::ReadRequest { job_id, .. } => {
@@ -2357,7 +2067,7 @@ pub(crate) mod protocol_test {
         }
 
         // Send ds1 responses for the jobs it saw
-        for (i, job_id) in job_ids.iter().enumerate().take(MAX_ACTIVE_COUNT) {
+        for (i, job_id) in job_ids.iter().enumerate() {
             let (block, data) = make_blank_read_response();
             match harness
                 .ds1()
@@ -2884,10 +2594,10 @@ pub(crate) mod protocol_test {
         let (_jh2, mut ds2_messages) = harness.ds2.spawn_message_receiver();
         let (_jh3, mut ds3_messages) = harness.ds3.spawn_message_receiver();
 
-        // Send 200 more than IO_OUTSTANDING_MAX_JOBS jobs. Flow control will
-        // kick in at MAX_ACTIVE_COUNT messages, so we need to be sending read
-        // responses while reads are being sent. After IO_OUTSTANDING_MAX_JOBS
-        // jobs, the Upstairs will set ds1 to faulted, and send it no more work.
+        // Send 200 more than IO_OUTSTANDING_MAX_JOBS jobs, sending read
+        // responses from two of the three downstairs. After we have sent
+        // IO_OUTSTANDING_MAX_JOBS jobs, the Upstairs will set ds1 to faulted,
+        // and send it no more work.
         const NUM_JOBS: usize = IO_OUTSTANDING_MAX_JOBS + 200;
         let mut job_ids = Vec::with_capacity(NUM_JOBS);
 
@@ -2907,32 +2617,11 @@ pub(crate) mod protocol_test {
                 });
             }
 
-            if i < MAX_ACTIVE_COUNT {
-                // Before flow control kicks in, assert we're seeing the read
-                // requests
-                bail_assert!(matches!(
-                    ds1_messages.recv().await.unwrap(),
-                    Message::ReadRequest { .. },
-                ));
-            } else {
-                // After flow control kicks in, we shouldn't see any more
-                // messages
-                match ds1_messages.try_recv() {
-                    Err(TryRecvError::Empty) => {}
-                    Err(TryRecvError::Disconnected) => {}
-                    x => {
-                        info!(
-                            harness.log,
-                            "Read {i} should return EMPTY, but we got:{:?}", x
-                        );
-
-                        bail!(
-                            "Read {i} should return EMPTY, but we got:{:?}",
-                            x
-                        );
-                    }
-                }
-            }
+            // Assert we're seeing the read requests
+            bail_assert!(matches!(
+                ds1_messages.recv().await.unwrap(),
+                Message::ReadRequest { .. },
+            ));
 
             match ds2_messages.recv().await.unwrap() {
                 Message::ReadRequest { job_id, .. } => {
@@ -3072,7 +2761,7 @@ pub(crate) mod protocol_test {
         }
 
         // Send ds1 responses for the jobs it saw
-        for (i, job_id) in job_ids.iter().enumerate().take(MAX_ACTIVE_COUNT) {
+        for (i, job_id) in job_ids.iter().enumerate() {
             let (block, data) = make_blank_read_response();
             match harness
                 .ds1()

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -751,11 +751,31 @@ pub(crate) mod protocol_test {
                 });
             }
 
-            // Assert we're seeing the read requests
-            bail_assert!(matches!(
-                ds1_messages.recv().await.unwrap(),
-                Message::ReadRequest { .. },
-            ));
+            if i < IO_OUTSTANDING_MAX_JOBS {
+                // Before we're kicked out, assert we're seeing the read
+                // requests
+                bail_assert!(matches!(
+                    ds1_messages.recv().await.unwrap(),
+                    Message::ReadRequest { .. },
+                ));
+            } else {
+                // After ds1 is kicked out, we shouldn't see any more messages
+                match ds1_messages.try_recv() {
+                    Err(TryRecvError::Empty) => {}
+                    Err(TryRecvError::Disconnected) => {}
+                    x => {
+                        info!(
+                            harness.log,
+                            "Read {i} should return EMPTY, but we got:{:?}", x
+                        );
+
+                        bail!(
+                            "Read {i} should return EMPTY, but we got:{:?}",
+                            x
+                        );
+                    }
+                }
+            }
 
             match ds2_messages.recv().await.unwrap() {
                 Message::ReadRequest { job_id, .. } => {
@@ -1783,7 +1803,8 @@ pub(crate) mod protocol_test {
 
         // Send enough bytes to hit the IO_OUTSTANDING_MAX_BYTES condition on
         // downstairs 1, which should mark it as faulted and kick it out.
-        let write_buf = BytesMut::from(vec![1; 50 * 1024].as_slice()); // 50 KiB
+        const WRITE_SIZE: usize = 50 * 1024; // 50 KiB
+        let write_buf = BytesMut::from(vec![1; WRITE_SIZE].as_slice()); // 50 KiB
         let num_jobs = IO_OUTSTANDING_MAX_BYTES as usize / write_buf.len() + 10;
         let mut job_ids = Vec::with_capacity(num_jobs);
         assert!(num_jobs < IO_OUTSTANDING_MAX_JOBS);
@@ -1804,11 +1825,31 @@ pub(crate) mod protocol_test {
                 });
             }
 
-            // Assert we're seeing the write requests
-            bail_assert!(matches!(
-                ds1_messages.recv().await.unwrap(),
-                Message::Write { .. },
-            ));
+            if (i + 1) * WRITE_SIZE < IO_OUTSTANDING_MAX_BYTES as usize {
+                // Before we're kicked out, assert we're seeing the read
+                // requests
+                bail_assert!(matches!(
+                    ds1_messages.recv().await.unwrap(),
+                    Message::Write { .. },
+                ));
+            } else {
+                // After ds1 is kicked out, we shouldn't see any more messages
+                match ds1_messages.try_recv() {
+                    Err(TryRecvError::Empty) => {}
+                    Err(TryRecvError::Disconnected) => {}
+                    x => {
+                        info!(
+                            harness.log,
+                            "Read {i} should return EMPTY, but we got:{:?}", x
+                        );
+
+                        bail!(
+                            "Read {i} should return EMPTY, but we got:{:?}",
+                            x
+                        );
+                    }
+                }
+            }
 
             match ds2_messages.recv().await.unwrap() {
                 Message::Write {
@@ -1923,11 +1964,31 @@ pub(crate) mod protocol_test {
                 });
             }
 
-            // Assert we're seeing the read requests
-            bail_assert!(matches!(
-                ds1_messages.recv().await.unwrap(),
-                Message::ReadRequest { .. },
-            ));
+            if i < IO_OUTSTANDING_MAX_JOBS {
+                // Before we're kicked out, assert we're seeing the read
+                // requests
+                bail_assert!(matches!(
+                    ds1_messages.recv().await.unwrap(),
+                    Message::ReadRequest { .. },
+                ));
+            } else {
+                // After ds1 is kicked out, we shouldn't see any more messages
+                match ds1_messages.try_recv() {
+                    Err(TryRecvError::Empty) => {}
+                    Err(TryRecvError::Disconnected) => {}
+                    x => {
+                        info!(
+                            harness.log,
+                            "Read {i} should return EMPTY, but we got:{:?}", x
+                        );
+
+                        bail!(
+                            "Read {i} should return EMPTY, but we got:{:?}",
+                            x
+                        );
+                    }
+                }
+            }
 
             match ds2_messages.recv().await.unwrap() {
                 Message::ReadRequest { job_id, .. } => {
@@ -2617,11 +2678,31 @@ pub(crate) mod protocol_test {
                 });
             }
 
-            // Assert we're seeing the read requests
-            bail_assert!(matches!(
-                ds1_messages.recv().await.unwrap(),
-                Message::ReadRequest { .. },
-            ));
+            if i < IO_OUTSTANDING_MAX_JOBS {
+                // Before we're kicked out, assert we're seeing the read
+                // requests
+                bail_assert!(matches!(
+                    ds1_messages.recv().await.unwrap(),
+                    Message::ReadRequest { .. },
+                ));
+            } else {
+                // After ds1 is kicked out, we shouldn't see any more messages
+                match ds1_messages.try_recv() {
+                    Err(TryRecvError::Empty) => {}
+                    Err(TryRecvError::Disconnected) => {}
+                    x => {
+                        info!(
+                            harness.log,
+                            "Read {i} should return EMPTY, but we got:{:?}", x
+                        );
+
+                        bail!(
+                            "Read {i} should return EMPTY, but we got:{:?}",
+                            x
+                        );
+                    }
+                }
+            }
 
             match ds2_messages.recv().await.unwrap() {
                 Message::ReadRequest { job_id, .. } => {

--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -13,7 +13,9 @@ use crate::{
     BlockIO, BlockOp, BlockReq, BlockReqReply, BlockReqWaiter, BlockRes,
     Buffer, JobId, ReplaceResult, UpstairsAction,
 };
-use crucible_common::{build_logger, crucible_bail, Block, CrucibleError};
+use crucible_common::{
+    build_logger, crucible_bail, Block, CrucibleError, IO_OUTSTANDING_MAX_JOBS,
+};
 use crucible_protocol::{ReadResponse, SnapshotDetails};
 
 use async_trait::async_trait;
@@ -975,7 +977,7 @@ impl GuestIoHandle {
 
     /// Set `self.backpressure_us` based on outstanding IO ratio
     pub fn set_backpressure(&self, bytes: u64, jobs: u64) {
-        let jobs_frac = jobs as f64 / crate::IO_OUTSTANDING_MAX_JOBS as f64;
+        let jobs_frac = jobs as f64 / IO_OUTSTANDING_MAX_JOBS as f64;
         let bytes_frac = bytes as f64 / crate::IO_OUTSTANDING_MAX_BYTES as f64;
 
         // Check to see if the number of outstanding write bytes (between

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -76,12 +76,6 @@ mod downstairs;
 mod upstairs;
 use upstairs::{UpCounters, UpstairsAction};
 
-/// Max number of outstanding IOs between the upstairs and the downstairs
-///
-/// If we exceed this value, the upstairs will give up and mark that downstairs
-/// as faulted.
-const IO_OUTSTANDING_MAX_JOBS: usize = 57000;
-
 /// Max number of write bytes between the upstairs and the downstairs
 ///
 /// If we exceed this value, the upstairs will give up and mark that downstairs
@@ -2016,8 +2010,6 @@ pub struct Arg {
     pub ds_connected: [usize; 3],
     /// Times this downstairs has been replaced.
     pub ds_replaced: [usize; 3],
-    /// Times flow control has been enabled on this downstairs.
-    pub ds_flow_control: [usize; 3],
     /// Times we have live repaired an extent on this downstairs.
     pub ds_extents_repaired: [usize; 3],
     /// Times we have live confirmed  an extent on this downstairs.

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -153,7 +153,7 @@ impl UpCounters {
 /// `Upstairs` into a known state afterwards.
 ///
 /// For example, we _always_ do things like
-/// - Send all pending IO (limited by the downstairs' `MAX_ACTIVE_COUNT`)
+/// - Send all pending IO to the client work tasks
 /// - Ack all ackable jobs to the guest
 /// - Step through the live-repair state machine (if it's running)
 /// - Check for client-side deactivation (if it's pending)
@@ -738,8 +738,6 @@ impl Upstairs {
             .collect_stats(|c| c.stats.live_repair_aborted);
         let ds_connected = self.downstairs.collect_stats(|c| c.stats.connected);
         let ds_replaced = self.downstairs.collect_stats(|c| c.stats.replaced);
-        let ds_flow_control =
-            self.downstairs.collect_stats(|c| c.stats.flow_control);
         let ds_extents_repaired =
             self.downstairs.collect_stats(|c| c.stats.extents_repaired);
         let ds_extents_confirmed =
@@ -768,7 +766,6 @@ impl Upstairs {
                 ds_live_repair_aborted,
                 ds_connected,
                 ds_replaced,
-                ds_flow_control,
                 ds_extents_repaired,
                 ds_extents_confirmed,
                 ds_delay_us,


### PR DESCRIPTION
Fixes #1191 by removing `MAX_ACTIVE_COUNT`, pushing all work into queues / sockets right away.

We are limited by our total limit on jobs and bytes in flight (`IO_OUTSTANDING_MAX_JOBS/BYTES`), so we can't run away to infinitely long queues.  In addition, backpressure tries to limit queues and bytes to reasonable values (although they must _eventually_ be able to hit `IO_OUTSTANDING_MAX_*`, so that we can detect and fault that Downstairs).