### PR TITLE
`crutest` cleaning; adding rand-read/write tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,6 +1225,7 @@ dependencies = [
  "dsc-client",
  "futures",
  "futures-core",
+ "human_bytes",
  "indicatif",
  "omicron-common",
  "oximeter",
@@ -2078,6 +2079,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "human_bytes"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
 
 [[package]]
 name = "hyper"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,6 +1239,7 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "signal-hook-tokio",
+ "slog",
  "statistical",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ futures-core = "0.3"
 hex = "0.4"
 http = "0.2.12"
 httptest = "0.15.5"
+human_bytes = "0.4.3"
 hyper = { version = "0.14", features = [ "full" ] }
 hyper-staticfile = "0.9"
 indicatif = { version = "0.17.8", features = ["rayon"] }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -333,6 +333,11 @@ impl std::fmt::Display for BuildInfo {
  * A common logger setup for all to use.
  */
 pub fn build_logger() -> slog::Logger {
+    build_logger_with_level(slog::Level::Info)
+}
+
+/// Build a logger with the specific log level
+pub fn build_logger_with_level(level: slog::Level) -> slog::Logger {
     let main_drain = if atty::is(atty::Stream::Stdout) {
         let decorator = slog_term::TermDecorator::new().build();
         let drain = slog_term::FullFormat::new(decorator).build().fuse();
@@ -350,7 +355,7 @@ pub fn build_logger() -> slog::Logger {
 
     let (dtrace_drain, probe_reg) = slog_dtrace::Dtrace::new();
 
-    let filtered_main = slog::LevelFilter::new(main_drain, slog::Level::Info);
+    let filtered_main = slog::LevelFilter::new(main_drain, level);
 
     let log = slog::Logger::root(
         slog::Duplicate::new(filtered_main.fuse(), dtrace_drain.fuse()).fuse(),

--- a/crutest/Cargo.toml
+++ b/crutest/Cargo.toml
@@ -17,6 +17,7 @@ crucible.workspace = true
 csv.workspace = true
 dropshot.workspace = true
 dsc-client.workspace = true
+human_bytes.workspace = true
 futures-core.workspace = true
 futures.workspace = true
 indicatif.workspace = true

--- a/crutest/Cargo.toml
+++ b/crutest/Cargo.toml
@@ -31,6 +31,7 @@ ringbuffer.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+slog.workspace = true
 signal-hook-tokio.workspace = true
 signal-hook.workspace = true
 statistical.workspace = true

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -887,7 +887,7 @@ async fn process_cli_command(
                 match perf_workload(
                     guest,
                     ri,
-                    &mut None,
+                    None,
                     count,
                     io_size,
                     io_depth,

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -333,6 +333,26 @@ struct RandReadWriteConfig {
     fill: bool,
 }
 
+impl RandReadWriteConfig {
+    fn new(
+        cfg: RandReadWriteWorkload,
+        encrypted: bool,
+        mode: RandReadWriteMode,
+    ) -> Self {
+        RandReadWriteConfig {
+            encrypted,
+            io_depth: cfg.io_depth,
+            blocks_per_io: cfg.io_size,
+            time_secs: cfg.time,
+            raw: cfg.raw,
+            sample_time_secs: cfg.sample_time,
+            subsample_count: cfg.subsample_count,
+            fill: cfg.fill,
+            mode,
+        }
+    }
+}
+
 /*
  * All the tests need this basic info about the region.
  * Not all tests make use of the write_log yet, but perhaps someday..
@@ -996,17 +1016,11 @@ async fn main() -> Result<()> {
             rand_read_write_workload(
                 &guest,
                 &mut region_info,
-                RandReadWriteConfig {
-                    encrypted: is_encrypted,
-                    io_depth: cfg.io_depth,
-                    blocks_per_io: cfg.io_size,
-                    time_secs: cfg.time,
-                    raw: cfg.raw,
-                    sample_time_secs: cfg.sample_time,
-                    subsample_count: cfg.subsample_count,
-                    fill: cfg.fill,
-                    mode: RandReadWriteMode::Read,
-                },
+                RandReadWriteConfig::new(
+                    cfg,
+                    is_encrypted,
+                    RandReadWriteMode::Read,
+                ),
             )
             .await?;
             if opt.quit {
@@ -1017,17 +1031,11 @@ async fn main() -> Result<()> {
             rand_read_write_workload(
                 &guest,
                 &mut region_info,
-                RandReadWriteConfig {
-                    encrypted: is_encrypted,
-                    io_depth: cfg.io_depth,
-                    blocks_per_io: cfg.io_size,
-                    time_secs: cfg.time,
-                    raw: cfg.raw,
-                    sample_time_secs: cfg.sample_time,
-                    subsample_count: cfg.subsample_count,
-                    fill: cfg.fill,
-                    mode: RandReadWriteMode::Write,
-                },
+                RandReadWriteConfig::new(
+                    cfg,
+                    is_encrypted,
+                    RandReadWriteMode::Write,
+                ),
             )
             .await?;
             if opt.quit {

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -92,6 +92,7 @@ enum Workload {
         #[clap(long, default_value_t = 2, action)]
         write_loops: usize,
     },
+    /// Measure performance with a random read workload
     RandRead {
         /// Size in blocks of each IO
         #[clap(long, default_value_t = 1, action)]
@@ -106,6 +107,7 @@ enum Workload {
         #[clap(long)]
         fill: bool,
     },
+    /// Measure performance with a random write workload
     RandWrite {
         /// Size in blocks of each IO
         #[clap(long, default_value_t = 1, action)]

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -39,7 +39,7 @@ use dsc_client::{types::DownstairsState, Client};
  */
 /// Client: A Crucible Upstairs test program
 #[allow(clippy::derive_partial_eq_without_eq, clippy::upper_case_acronyms)]
-#[derive(Debug, Parser, PartialEq)]
+#[derive(Debug, Parser)]
 #[clap(name = "workload", term_width = 80)]
 #[clap(about = "Workload the program will execute.", long_about = None)]
 enum Workload {
@@ -279,7 +279,7 @@ fn history_file<P: AsRef<Path>>(file: P) -> PathBuf {
     out
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::Args)]
+#[derive(Copy, Clone, Debug, clap::Args)]
 struct RandReadWriteWorkload {
     /// Size in blocks of each IO
     #[clap(long, default_value_t = 1, action)]
@@ -305,8 +305,8 @@ struct RandReadWriteWorkload {
     #[clap(short, long)]
     raw: bool,
     /// Time per sample printed to the output
-    #[clap(long, default_value_t = 1)]
-    sample_time: u64,
+    #[clap(long, default_value_t = 1.0)]
+    sample_time: f64,
     /// Number of subsamples per sample
     #[clap(long, default_value_t = 10)]
     subsample_count: u64,
@@ -332,7 +332,7 @@ struct RandReadWriteConfig {
     /// Total amount of time to run
     time_secs: u64,
     /// Rate at which we should print samples
-    sample_time_secs: u64,
+    sample_time_secs: f64,
     /// Number of subsamples for each `sample_time_secs`, for standard deviation
     subsample_count: u64,
     fill: bool,
@@ -697,7 +697,7 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    if opt.workload == Workload::Verify && opt.verify_in.is_none() {
+    if matches!(opt.workload, Workload::Verify) && opt.verify_in.is_none() {
         bail!("Verify requires verify_in file");
     }
 
@@ -852,7 +852,7 @@ async fn main() -> Result<()> {
          * option has in it.
          */
         let verify = {
-            if opt.workload == Workload::Verify {
+            if matches!(opt.workload, Workload::Verify) {
                 false
             } else {
                 opt.verify_at_start
@@ -2507,7 +2507,7 @@ async fn rand_read_write_workload(
     let mut prev = 0;
 
     let subsample_delay = Duration::from_secs_f64(
-        cfg.sample_time_secs as f64 / cfg.subsample_count as f64,
+        cfg.sample_time_secs / cfg.subsample_count as f64,
     );
     let mut samples = vec![];
     let mut first = true;

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -1559,7 +1559,7 @@ async fn fast_fill_workload(
 
                 guest.write(offset, data).await?;
 
-                block_index += next_io_blocks;
+                block_index += next_io_blocks + NUM_WORKERS * IO_SIZE;
                 let b = bytes_done.fetch_add(next_io_blocks, Ordering::Relaxed);
                 pb.set_position(b as u64);
             }

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -2511,12 +2511,14 @@ async fn rand_read_write_workload(
     );
     let mut samples = vec![];
     let mut first = true;
+    let mut next_time = std::time::Instant::now() + subsample_delay;
     while !stop.load(Ordering::Relaxed) {
         // Store speeds in bytes/sec, correcting for our sub-second sample time
         let start = samples.len();
         for _ in 0..cfg.subsample_count {
-            tokio::time::sleep(subsample_delay).await;
+            tokio::time::sleep_until(next_time.into()).await;
             let bytes = byte_count.load(Ordering::Acquire);
+            next_time += subsample_delay;
             samples.push((bytes - prev) as f64 / subsample_delay.as_secs_f64());
             prev = bytes;
         }

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -1522,7 +1522,7 @@ async fn fast_fill_workload(
 
     let tasks = futures::stream::FuturesUnordered::new();
     for i in 0..NUM_WORKERS {
-        let mut block_index = i * IO_SIZE * NUM_WORKERS;
+        let mut block_index = i * IO_SIZE;
         let guest = guest.clone();
         let write_log = write_log.clone();
         let bytes_done = bytes_done.clone();

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -226,22 +226,6 @@ pub type CrucibleBlockIOFuture<'a> = Pin<
     >,
 >;
 
-/// Await on the results of multiple BlockIO operations
-///
-/// Using [async_trait] with the BlockIO trait will perform Box::pin on the
-/// result of the async operation functions. `join_all` is provided here to
-/// consume a list of multiple BlockIO operations' futures and await them all.
-#[inline]
-pub async fn join_all<'a>(
-    iter: impl IntoIterator<Item = CrucibleBlockIOFuture<'a>>,
-) -> Result<(), CrucibleError> {
-    futures::future::join_all(iter)
-        .await
-        .into_iter()
-        .collect::<Result<Vec<()>, CrucibleError>>()
-        .map(|_| ())
-}
-
 #[derive(Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum ReplaceResult {
     Started,


### PR DESCRIPTION
This is a grab-bag of `crutest` improvements and features, with the goal of making benchmarking and performance evaluation easier.

# New features
Adding `rand-read` and `rand-write` workloads.  This is meant to mimic the `fio` workload, but running outside of the Propolis VM to remove one layer of abstraction.

# Medium optimization
Refactor `fill_workload` and `verify_volume` to use 8x worker tasks and run in parallel.  This is a significant speedup: for a 32 GiB region, running fill + verify goes from 7:47 down to 1:35.

# Minor tweaks
- Use `&Guest` instead of `Arc<&Guest>` in function arguments where possible
- Use `default_value_t` instead of `default_value` so that default arguments are checked at compile-time
- Make some functions take `&self` instead of `&mut self`
- Delete unused functions (`RegionInfo::set_wc_min`)
- Replace `Vec<Future<..>>` with `FuturesOrdered` in a few places, and remove our custom `join_all` function