### PR TITLE
BlockReq -> BlockOp

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -64,7 +64,7 @@ pub enum CrucibleError {
     #[error("Error grabbing reader-writer {0} lock")]
     RwLockError(String),
 
-    #[error("BlockReqWaiter recv channel disconnected")]
+    #[error("BlockOpWaiter recv channel disconnected")]
     RecvDisconnected,
 
     #[error("SendError: {0}")]

--- a/upstairs/src/deferred.rs
+++ b/upstairs/src/deferred.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use crate::{
-    client::ConnectionId, upstairs::UpstairsConfig, BlockContext, BlockReq,
+    client::ConnectionId, upstairs::UpstairsConfig, BlockContext, BlockOp,
     BlockRes, ClientId, ImpactedBlocks, Message,
 };
 use bytes::BytesMut;
@@ -110,16 +110,16 @@ pub(crate) struct DeferredWrite {
     pub cfg: Arc<UpstairsConfig>,
 }
 
-/// Result of a deferred `BlockReq`
+/// Result of a deferred `BlockOp`
 ///
-/// In most cases, this is simply the original `BlockReq` (stored in
-/// `DeferredBlockReq::Other`).  The exception is `BlockReq::Write` and
-/// `BlockReq::WriteUnwritten`, which require encryption; in these cases,
-/// encryption is done off-thread and the result is a `DeferredBlockReq::Write`.
+/// In most cases, this is simply the original `BlockOp` (stored in
+/// `DeferredBlockOp::Other`).  The exception is `BlockOp::Write` and
+/// `BlockOp::WriteUnwritten`, which require encryption; in these cases,
+/// encryption is done off-thread and the result is a `DeferredBlockOp::Write`.
 #[derive(Debug)]
-pub(crate) enum DeferredBlockReq {
+pub(crate) enum DeferredBlockOp {
     Write(EncryptedWrite),
-    Other(BlockReq),
+    Other(BlockOp),
 }
 
 #[derive(Debug)]

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -110,10 +110,10 @@ pub(crate) struct Downstairs {
 /// We pass through all states (except `FinalFlush`) in order for each extent,
 /// then pass through the `FinalFlush` state before completion.  In each state,
 /// we're waiting for a particular job to finish, which is indicated by a
-/// `BlockReqWaiter`.
+/// `BlockOpWaiter`.
 ///
 /// Early states carry around reserved IDs (both `JobId` and guest work IDs), as
-/// well as a reserved `BlockReqWaiter` for the final flush.
+/// well as a reserved `BlockOpWaiter` for the final flush.
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum LiveRepairState {
     Closing {

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -46,7 +46,7 @@ pub mod block_io;
 pub use block_io::{FileBlockIO, ReqwestBlockIO};
 
 pub mod block_req;
-pub(crate) use block_req::{BlockReq, BlockReqWaiter, BlockRes};
+pub(crate) use block_req::{BlockOpWaiter, BlockRes};
 
 mod buffer;
 pub use buffer::Buffer; // used in BlockIO::Read, so it must be public
@@ -1568,28 +1568,28 @@ async fn test_return_iops() {
     let op = BlockOp::Read {
         offset: Block::new_512(1),
         data: Buffer::new(1, 512),
-        done: BlockReqWaiter::pair().1,
+        done: BlockOpWaiter::pair().1,
     };
     assert_eq!(op.iops(IOP_SZ).unwrap(), 1);
 
     let op = BlockOp::Read {
         offset: Block::new_512(1),
         data: Buffer::new(8, 512), // 4096 bytes
-        done: BlockReqWaiter::pair().1,
+        done: BlockOpWaiter::pair().1,
     };
     assert_eq!(op.iops(IOP_SZ).unwrap(), 1);
 
     let op = BlockOp::Read {
         offset: Block::new_512(1),
         data: Buffer::new(31, 512), // 15872 bytes < 16000
-        done: BlockReqWaiter::pair().1,
+        done: BlockOpWaiter::pair().1,
     };
     assert_eq!(op.iops(IOP_SZ).unwrap(), 1);
 
     let op = BlockOp::Read {
         offset: Block::new_512(1),
         data: Buffer::new(32, 512), // 16384 bytes > 16000
-        done: BlockReqWaiter::pair().1,
+        done: BlockOpWaiter::pair().1,
     };
     assert_eq!(op.iops(IOP_SZ).unwrap(), 2);
 }

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -6,16 +6,16 @@ use crate::{
     control::ControlRequest,
     deadline_secs,
     deferred::{
-        DeferredBlockReq, DeferredMessage, DeferredQueue, DeferredRead,
+        DeferredBlockOp, DeferredMessage, DeferredQueue, DeferredRead,
         DeferredWrite, EncryptedWrite,
     },
     downstairs::{Downstairs, DownstairsAction},
     extent_from_offset,
     guest::GuestBlockRes,
     stats::UpStatOuter,
-    Block, BlockOp, BlockReq, BlockRes, Buffer, ClientId, ClientMap,
-    CrucibleOpts, DsState, EncryptionContext, GuestIoHandle, Message,
-    RegionDefinition, RegionDefinitionStatus, SnapshotDetails, WQCounts,
+    Block, BlockOp, BlockRes, Buffer, ClientId, ClientMap, CrucibleOpts,
+    DsState, EncryptionContext, GuestIoHandle, Message, RegionDefinition,
+    RegionDefinitionStatus, SnapshotDetails, WQCounts,
 };
 use crucible_common::CrucibleError;
 use serde::{Deserialize, Serialize};
@@ -237,8 +237,8 @@ pub(crate) struct Upstairs {
     /// This is public so that others can clone it to get a controller handle
     pub(crate) control_tx: mpsc::Sender<ControlRequest>,
 
-    /// Stream of post-processed `BlockReq` futures
-    deferred_reqs: DeferredQueue<Option<DeferredBlockReq>>,
+    /// Stream of post-processed `BlockOp` futures
+    deferred_reqs: DeferredQueue<Option<DeferredBlockOp>>,
 
     /// Stream of decrypted `Message` futures
     deferred_msgs: DeferredQueue<DeferredMessage>,
@@ -248,10 +248,10 @@ pub(crate) struct Upstairs {
 #[derive(Debug)]
 pub(crate) enum UpstairsAction {
     Downstairs(DownstairsAction),
-    Guest(BlockReq),
+    Guest(BlockOp),
 
     /// A deferred block request has completed
-    DeferredBlockReq(DeferredBlockReq),
+    DeferredBlockOp(DeferredBlockOp),
 
     /// A deferred message has arrived
     DeferredMessage(DeferredMessage),
@@ -467,11 +467,11 @@ impl Upstairs {
             => {
                 match d {
                     // Normal operation: the deferred task gave us back a
-                    // DeferredBlockReq, which we need to handle.
-                    Some(Some(d)) => UpstairsAction::DeferredBlockReq(d),
+                    // DeferredBlockOp, which we need to handle.
+                    Some(Some(d)) => UpstairsAction::DeferredBlockOp(d),
 
                     // The innermost Option is None if the deferred task handled
-                    // the request on its own (and replied to the `BlockReq`
+                    // the request on its own (and replied to the `BlockOp`
                     // already). This happens if encryption fails, which would
                     // be odd, but possible?
                     Some(None) => UpstairsAction::NoOp,
@@ -531,7 +531,7 @@ impl Upstairs {
             UpstairsAction::GuestDropped => {
                 self.guest_dropped = true;
             }
-            UpstairsAction::DeferredBlockReq(req) => {
+            UpstairsAction::DeferredBlockOp(req) => {
                 self.counters.action_deferred_block += 1;
                 cdt::up__action_deferred_block!(|| (self
                     .counters
@@ -676,7 +676,7 @@ impl Upstairs {
     async fn await_deferred_reqs(&mut self) {
         while let Some(req) = self.deferred_reqs.next().await {
             let req = req.unwrap(); // the deferred request should not fail
-            self.apply(UpstairsAction::DeferredBlockReq(req)).await;
+            self.apply(UpstairsAction::DeferredBlockOp(req)).await;
         }
         assert!(self.deferred_reqs.is_empty());
     }
@@ -926,9 +926,9 @@ impl Upstairs {
         matches!(self.state, UpstairsState::Active)
     }
 
-    /// When a `BlockReq` arrives, defer it as a future
-    async fn defer_guest_request(&mut self, req: BlockReq) {
-        match req.op {
+    /// When a `BlockOp` arrives, defer it as a future
+    async fn defer_guest_request(&mut self, req: BlockOp) {
+        match req {
             // All Write operations are deferred, because they will offload
             // encryption to a separate thread pool.
             BlockOp::Write { offset, data, done } => {
@@ -942,7 +942,7 @@ impl Upstairs {
             // not writes) to preserve FIFO ordering
             _ if !self.deferred_reqs.is_empty() => {
                 self.deferred_reqs
-                    .push_immediate(Some(DeferredBlockReq::Other(req)));
+                    .push_immediate(Some(DeferredBlockOp::Other(req)));
             }
             // Otherwise, we can apply a non-write operation immediately, saving
             // a trip through the FuturesUnordered
@@ -962,10 +962,10 @@ impl Upstairs {
     /// This function can be called before the upstairs is active, so any
     /// operation that requires the upstairs to be active should check that
     /// and report an error.
-    async fn apply_guest_request(&mut self, req: DeferredBlockReq) {
+    async fn apply_guest_request(&mut self, req: DeferredBlockOp) {
         match req {
-            DeferredBlockReq::Write(req) => self.submit_write(req),
-            DeferredBlockReq::Other(req) => {
+            DeferredBlockOp::Write(req) => self.submit_write(req),
+            DeferredBlockOp::Other(req) => {
                 self.apply_guest_request_inner(req).await
             }
         }
@@ -974,13 +974,13 @@ impl Upstairs {
     /// Does the actual work for a (non-write) guest request
     ///
     /// # Panics
-    /// This function assumes that `BlockReq::Write` and
-    /// `BlockReq::WriteUnwritten` are always deferred and handled separately;
+    /// This function assumes that `BlockOp::Write` and
+    /// `BlockOp::WriteUnwritten` are always deferred and handled separately;
     /// it will panic if `req` matches either of them.
-    async fn apply_guest_request_inner(&mut self, req: BlockReq) {
+    async fn apply_guest_request_inner(&mut self, req: BlockOp) {
         // If any of the submit_* functions fail to send to the downstairs, they
         // return an error.  These are reported to the Guest.
-        match req.op {
+        match req {
             // These three options can be handled by this task directly,
             // and don't require the upstairs to be fully online.
             BlockOp::GoActive { done } => {
@@ -1392,7 +1392,7 @@ impl Upstairs {
         {
             let tx = self.deferred_reqs.push_oneshot();
             rayon::spawn(move || {
-                let out = w.run().map(DeferredBlockReq::Write);
+                let out = w.run().map(DeferredBlockOp::Write);
                 let _ = tx.send(out);
             });
         }
@@ -2069,7 +2069,7 @@ pub(crate) mod test {
         client::ClientStopReason,
         downstairs::test::set_all_active,
         test::{make_encrypted_upstairs, make_upstairs},
-        BlockContext, BlockOp, BlockReqWaiter, DsState, JobId,
+        BlockContext, BlockOp, BlockOpWaiter, DsState, JobId,
     };
     use bytes::BytesMut;
     use crucible_common::integrity_hash;
@@ -2150,9 +2150,9 @@ pub(crate) mod test {
 
         let mut up = Upstairs::test_default(None);
 
-        let (ds_done_brw, ds_done_res) = BlockReqWaiter::pair();
-        up.apply(UpstairsAction::Guest(BlockReq {
-            op: BlockOp::Deactivate { done: ds_done_res },
+        let (ds_done_brw, ds_done_res) = BlockOpWaiter::pair();
+        up.apply(UpstairsAction::Guest(BlockOp::Deactivate {
+            done: ds_done_res,
         }))
         .await;
 
@@ -2161,18 +2161,18 @@ pub(crate) mod test {
 
         up.force_active().unwrap();
 
-        let (ds_done_brw, ds_done_res) = BlockReqWaiter::pair();
-        up.apply(UpstairsAction::Guest(BlockReq {
-            op: BlockOp::Deactivate { done: ds_done_res },
+        let (ds_done_brw, ds_done_res) = BlockOpWaiter::pair();
+        up.apply(UpstairsAction::Guest(BlockOp::Deactivate {
+            done: ds_done_res,
         }))
         .await;
 
         let reply = ds_done_brw.wait().await;
         assert!(reply.is_ok());
 
-        let (ds_done_brw, ds_done_res) = BlockReqWaiter::pair();
-        up.apply(UpstairsAction::Guest(BlockReq {
-            op: BlockOp::Deactivate { done: ds_done_res },
+        let (ds_done_brw, ds_done_res) = BlockOpWaiter::pair();
+        up.apply(UpstairsAction::Guest(BlockOp::Deactivate {
+            done: ds_done_res,
         }))
         .await;
 
@@ -2192,9 +2192,9 @@ pub(crate) mod test {
         set_all_active(&mut up.downstairs);
 
         // The deactivate message should happen immediately
-        let (ds_done_brw, ds_done_res) = BlockReqWaiter::pair();
-        up.apply(UpstairsAction::Guest(BlockReq {
-            op: BlockOp::Deactivate { done: ds_done_res },
+        let (ds_done_brw, ds_done_res) = BlockOpWaiter::pair();
+        up.apply(UpstairsAction::Guest(BlockOp::Deactivate {
+            done: ds_done_res,
         }))
         .await;
 
@@ -3507,23 +3507,21 @@ pub(crate) mod test {
         // Build a write, put it on the work queue.
         let offset = Block::new_512(7);
         let data = BytesMut::from([1; 512].as_slice());
-        let (_write_res, done) = BlockReqWaiter::pair();
+        let (_write_res, done) = BlockOpWaiter::pair();
         let op = if is_write_unwritten {
             BlockOp::WriteUnwritten { offset, data, done }
         } else {
             BlockOp::Write { offset, data, done }
         };
-        up.apply(UpstairsAction::Guest(BlockReq { op })).await;
+        up.apply(UpstairsAction::Guest(op)).await;
         up.await_deferred_reqs().await;
         let id1 = JobId(1000); // We know that job IDs start at 1000
 
         // Create and enqueue the flush by setting deactivate
         let (mut deactivate_done_brw, deactivate_done_res) =
-            BlockReqWaiter::pair();
-        up.apply(UpstairsAction::Guest(BlockReq {
-            op: BlockOp::Deactivate {
-                done: deactivate_done_res,
-            },
+            BlockOpWaiter::pair();
+        up.apply(UpstairsAction::Guest(BlockOp::Deactivate {
+            done: deactivate_done_res,
         }))
         .await;
 
@@ -3631,11 +3629,9 @@ pub(crate) mod test {
 
         let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
-        let (_res, done) = BlockReqWaiter::pair();
-        up.apply(UpstairsAction::Guest(BlockReq {
-            op: BlockOp::Read { offset, data, done },
-        }))
-        .await;
+        let (_res, done) = BlockOpWaiter::pair();
+        up.apply(UpstairsAction::Guest(BlockOp::Read { offset, data, done }))
+            .await;
 
         // fake read response from downstairs that will successfully decrypt
         let mut data = Vec::from([1u8; 512]);
@@ -3692,11 +3688,9 @@ pub(crate) mod test {
         let blocks = 16384 / 512;
         let data = Buffer::new(blocks, 512);
         let offset = Block::new_512(7);
-        let (_res, done) = BlockReqWaiter::pair();
-        up.apply(UpstairsAction::Guest(BlockReq {
-            op: BlockOp::Read { offset, data, done },
-        }))
-        .await;
+        let (_res, done) = BlockOpWaiter::pair();
+        up.apply(UpstairsAction::Guest(BlockOp::Read { offset, data, done }))
+            .await;
 
         let mut data = Vec::from([1u8; 512]);
 
@@ -3763,11 +3757,9 @@ pub(crate) mod test {
         let blocks = 16384 / 512;
         let data = Buffer::new(blocks, 512);
         let offset = Block::new_512(7);
-        let (_res, done) = BlockReqWaiter::pair();
-        up.apply(UpstairsAction::Guest(BlockReq {
-            op: BlockOp::Read { offset, data, done },
-        }))
-        .await;
+        let (_res, done) = BlockOpWaiter::pair();
+        up.apply(UpstairsAction::Guest(BlockOp::Read { offset, data, done }))
+            .await;
 
         // fake read response from downstairs that will fail decryption
         let mut data = Vec::from([1u8; 512]);
@@ -3856,11 +3848,9 @@ pub(crate) mod test {
 
         let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
-        let (_res, done) = BlockReqWaiter::pair();
-        up.apply(UpstairsAction::Guest(BlockReq {
-            op: BlockOp::Read { offset, data, done },
-        }))
-        .await;
+        let (_res, done) = BlockOpWaiter::pair();
+        up.apply(UpstairsAction::Guest(BlockOp::Read { offset, data, done }))
+            .await;
 
         // fake read response from downstairs that will fail decryption
         let mut data = Vec::from([1u8; 512]);
@@ -3935,11 +3925,9 @@ pub(crate) mod test {
 
         let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
-        let (_res, done) = BlockReqWaiter::pair();
-        up.apply(UpstairsAction::Guest(BlockReq {
-            op: BlockOp::Read { offset, data, done },
-        }))
-        .await;
+        let (_res, done) = BlockOpWaiter::pair();
+        up.apply(UpstairsAction::Guest(BlockOp::Read { offset, data, done }))
+            .await;
 
         // fake read response from downstairs that will fail integrity hash
         // check
@@ -4003,11 +3991,9 @@ pub(crate) mod test {
 
         let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
-        let (_res, done) = BlockReqWaiter::pair();
-        up.apply(UpstairsAction::Guest(BlockReq {
-            op: BlockOp::Read { offset, data, done },
-        }))
-        .await;
+        let (_res, done) = BlockOpWaiter::pair();
+        up.apply(UpstairsAction::Guest(BlockOp::Read { offset, data, done }))
+            .await;
 
         // fake read response from downstairs that will fail integrity hash
         // check
@@ -4056,11 +4042,9 @@ pub(crate) mod test {
 
         let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
-        let (_res, done) = BlockReqWaiter::pair();
-        up.apply(UpstairsAction::Guest(BlockReq {
-            op: BlockOp::Read { offset, data, done },
-        }))
-        .await;
+        let (_res, done) = BlockOpWaiter::pair();
+        up.apply(UpstairsAction::Guest(BlockOp::Read { offset, data, done }))
+            .await;
 
         let data = BytesMut::from([1u8; 512].as_slice());
         let hash = integrity_hash(&[&data]);
@@ -4135,11 +4119,9 @@ pub(crate) mod test {
 
         let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
-        let (_res, done) = BlockReqWaiter::pair();
-        up.apply(UpstairsAction::Guest(BlockReq {
-            op: BlockOp::Read { offset, data, done },
-        }))
-        .await;
+        let (_res, done) = BlockOpWaiter::pair();
+        up.apply(UpstairsAction::Guest(BlockOp::Read { offset, data, done }))
+            .await;
 
         for client_id in [ClientId::new(0), ClientId::new(1)] {
             let data = BytesMut::from([1u8; 512].as_slice());
@@ -4216,11 +4198,9 @@ pub(crate) mod test {
 
         let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
-        let (_res, done) = BlockReqWaiter::pair();
-        up.apply(UpstairsAction::Guest(BlockReq {
-            op: BlockOp::Read { offset, data, done },
-        }))
-        .await;
+        let (_res, done) = BlockOpWaiter::pair();
+        up.apply(UpstairsAction::Guest(BlockOp::Read { offset, data, done }))
+            .await;
 
         let data = BytesMut::from([1u8; 512].as_slice());
         let hash = integrity_hash(&[&data]);
@@ -4294,11 +4274,9 @@ pub(crate) mod test {
 
         let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
-        let (_res, done) = BlockReqWaiter::pair();
-        up.apply(UpstairsAction::Guest(BlockReq {
-            op: BlockOp::Read { offset, data, done },
-        }))
-        .await;
+        let (_res, done) = BlockOpWaiter::pair();
+        up.apply(UpstairsAction::Guest(BlockOp::Read { offset, data, done }))
+            .await;
 
         // The first read has no block contexts, because it was unwritten
         let data = BytesMut::from([0u8; 512].as_slice());
@@ -4365,11 +4343,9 @@ pub(crate) mod test {
 
         let data = Buffer::new(1, 512);
         let offset = Block::new_512(7);
-        let (_res, done) = BlockReqWaiter::pair();
-        up.apply(UpstairsAction::Guest(BlockReq {
-            op: BlockOp::Read { offset, data, done },
-        }))
-        .await;
+        let (_res, done) = BlockOpWaiter::pair();
+        up.apply(UpstairsAction::Guest(BlockOp::Read { offset, data, done }))
+            .await;
 
         // The first read has no block contexts, because it was unwritten
         let data = BytesMut::from([0u8; 512].as_slice());


### PR DESCRIPTION
This is a purely mechanical follow-up to #1218 , which removes the vestigal `BlockReq` – it had atrophied to the point of simply wrapping a `BlockOp`, without any additional functionality.

I will accept bikeshed comments about whether the new object should be named `BlockReq` or `BlockOp`.