### PR TITLE
test-replay.sh fix name of DTrace script

### DIFF
--- a/.github/buildomat/jobs/test-replay.sh
+++ b/.github/buildomat/jobs/test-replay.sh
@@ -58,7 +58,7 @@ iostat -T d -xn 1 > /tmp/debug/iostat.txt 2>&1 &
 mpstat -T d 1 > /tmp/debug/mpstat.txt 2>&1 &
 vmstat -T d -p 1 < /dev/null > /tmp/debug/paging.txt 2>&1 &
 pfexec dtrace -Z -s $input/scripts/perf-downstairs-tick.d > /tmp/debug/perf.txt 2>&1 &
-pfexec dtrace -Z -s $input/scripts/upstairs-info.d > /tmp/debug/upinfo.txt 2>&1 &
+pfexec dtrace -Z -s $input/scripts/upstairs_info.d > /tmp/debug/upinfo.txt 2>&1 &
 
 banner replay
 ptime -m bash "$input/scripts/test_replay.sh"


### PR DESCRIPTION
This was failing with:

```
dtrace: failed to open /input/build/work/scripts/upstairs-info.d: No such file or directory
```
