### PR TITLE
Correctly (and robustly) count bytes

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -906,6 +906,9 @@ struct DownstairsIO {
      */
     data: Option<Vec<ReadResponse>>,
     read_response_hashes: Vec<Option<u64>>,
+
+    /// Number of bytes that this job has contributed to guest backpressure
+    backpressure_bytes: Option<u64>,
 }
 
 impl DownstairsIO {


### PR DESCRIPTION
In #1208, we changed backpressure to stop counting jobs once they had been completed, rather than retired.  This was to accurately reflect jobs in flight, rather than "how long has it been since a flush".

However, we messed up the accounting, leading to #1236:

- Once a job was completed (or skipped) by all 3x Downstairs, its contribution to backpressure was subtracted out
- If a job was replayed, its contribution to backpressure **was not** added back
- A replayed job could be completed **again**.  If it had previously been completed, the second completion would cause the backpressure counter to underflow, which we detect and panic

This PR adds a `backpressure_bytes: Option<u64>` member to the `DownstairsIO` to make this accounting more fool-proof.  This member tracks whether a job currently counts for backpressure, meaning we can make completion and requeueing idempotent.

I also add a fail-safe check at job retirement, which prints an error message if we messed something up.