### PR TITLE
Some DTrace updates.

### DIFF
--- a/tools/dtrace/get-ds-state.sh
+++ b/tools/dtrace/get-ds-state.sh
@@ -5,5 +5,5 @@
 for zzz in $(zoneadm list | grep propolis); do
     echo -n "$zzz "
     ppid=$(zlogin "$zzz" pgrep propolis-server)
-    dtrace -xstrsize=1k -q -n 'crucible_upstairs*:::up-status /pid==$1/ { printf("%6d %17s %17s %17s", pid, json(copyinstr(arg1), "ok.ds_state[0]"), json(copyinstr(arg1), "ok.ds_state[1]"), json(copyinstr(arg1), "ok.ds_state[2]")); exit(0); }' $ppid
+    dtrace -xstrsize=1k -p $ppid -q -n 'crucible_upstairs*:::up-status { printf("%6d %17s %17s %17s", pid, json(copyinstr(arg1), "ok.ds_state[0]"), json(copyinstr(arg1), "ok.ds_state[1]"), json(copyinstr(arg1), "ok.ds_state[2]")); exit(0); }'
 done

--- a/tools/dtrace/get-ds-state.sh
+++ b/tools/dtrace/get-ds-state.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# This script will display the downstairs states for any propolis zones it
+# finds running on a system.
+for zzz in $(zoneadm list | grep propolis); do
+    echo -n "$zzz "
+    ppid=$(zlogin "$zzz" pgrep propolis-server)
+    dtrace -xstrsize=1k -q -n 'crucible_upstairs*:::up-status /pid==$1/ { printf("%6d %17s %17s %17s", pid, json(copyinstr(arg1), "ok.ds_state[0]"), json(copyinstr(arg1), "ok.ds_state[1]"), json(copyinstr(arg1), "ok.ds_state[2]")); exit(0); }' $ppid
+done

--- a/tools/dtrace/get-lr-state.sh
+++ b/tools/dtrace/get-lr-state.sh
@@ -5,5 +5,5 @@
 for zzz in $(zoneadm list | grep propolis); do
     echo -n "$zzz "
     ppid=$(zlogin "$zzz" pgrep propolis-server)
-    dtrace -xstrsize=1k -q -n 'crucible_upstairs*:::up-status /pid==$1/ { printf("%6d %s %s %s %s %s %s", pid, json(copyinstr(arg1), "ok.ds_live_repair_completed[0]"), json(copyinstr(arg1), "ok.ds_live_repair_completed[1]"), json(copyinstr(arg1), "ok.ds_live_repair_completed[2]"), json(copyinstr(arg1), "ok.ds_live_repair_aborted[0]"), json(copyinstr(arg1), "ok.ds_live_repair_aborted[1]"), json(copyinstr(arg1), "ok.ds_live_repair_aborted[2]")); exit(0); }' $ppid
+    dtrace -xstrsize=1k -p $ppid -q -n 'crucible_upstairs*:::up-status { printf("%6d %s %s %s %s %s %s", pid, json(copyinstr(arg1), "ok.ds_live_repair_completed[0]"), json(copyinstr(arg1), "ok.ds_live_repair_completed[1]"), json(copyinstr(arg1), "ok.ds_live_repair_completed[2]"), json(copyinstr(arg1), "ok.ds_live_repair_aborted[0]"), json(copyinstr(arg1), "ok.ds_live_repair_aborted[1]"), json(copyinstr(arg1), "ok.ds_live_repair_aborted[2]")); exit(0); }'
 done

--- a/tools/dtrace/get-lr-state.sh
+++ b/tools/dtrace/get-lr-state.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# This script will log into every propolis zone it finds and get the
+# DTrace live repair counters from propolis-server in each zone.
+for zzz in $(zoneadm list | grep propolis); do
+    echo -n "$zzz "
+    ppid=$(zlogin "$zzz" pgrep propolis-server)
+    dtrace -xstrsize=1k -q -n 'crucible_upstairs*:::up-status /pid==$1/ { printf("%6d %s %s %s %s %s %s", pid, json(copyinstr(arg1), "ok.ds_live_repair_completed[0]"), json(copyinstr(arg1), "ok.ds_live_repair_completed[1]"), json(copyinstr(arg1), "ok.ds_live_repair_completed[2]"), json(copyinstr(arg1), "ok.ds_live_repair_aborted[0]"), json(copyinstr(arg1), "ok.ds_live_repair_aborted[1]"), json(copyinstr(arg1), "ok.ds_live_repair_aborted[2]")); exit(0); }' $ppid
+done


### PR DESCRIPTION
Updated upstairs_info.d to work better with multiple processes that have DTrace stats, and print a few more columns.

Sample:
```
   PID        DS STATE 0        DS STATE 1        DS STATE 2    UPW   DSW DELTA BAKPR   WRITE_BO   NEW0  NEW1  NEW2    IP0   IP1   IP2     D0    D1    D2     S0    S1    S2
  9634            active            active            active      0     0     0     0          0      0     0     0      0     0     0      0     0     0      0     0     0
  8148            active            active            active      0   320   159  6076  305135616      0     0     0      1   295     1    319    25   319      0     0     0
  8855            active            active            active      2   264   244  3358  240623616      0     0     0    101   167   236    163    97    28      0     0     0
   538            active            active            active      0     0     0     0          0      0     0     0      0     0     0      0     0     0      0     0     0
  9634            active            active            active      0     0     0     0          0      0     0     0      0     0     0      0     0     0      0     0     0
  8148            active            active            active      0   326   151  5677  296747008      0     0     0      1   288     1    325    38   325      0     0     0
  8855            active            active            active      2   269   249  3647  248512512      0     0     0    118   145   241    151   124    28      0     0     0
   538            active            active            active      0     0     0     0          0      0     0     0      0     0     0      0     0     0      0     0     0
  9634            active            active            active      0     0     0     0          0      0     0     0      0     0     0      0     0     0      0     0     0
  8148            active            active            active      0   316   148  6076  305135616      0     0     0      1   296     1    315    20   315      0     0     0
  8855            active            active            active      1   266   247  3265  238026752      0     0     0    131   110   233    135   156    33      0     0     0
   538            active            active            active      0     0     0     0          0      0     0     0      0     0     0      0     0     0      0     0     0
  9634            active            active            active      0     0     0     0          0      0     0     0      0     0     0      0     0     0      0     0     0
  8148            active            active            active      0   386   143  6753  318767104      0     0     0      1   309     2    385    77   384      0     0     0
  8855            active            active            active      2   271   252  3265  238026752      0     0     0    145    89   230    126   182    41      0     0     0
   538            active            active            active      0     0     0     0          0      0     0     0      0     0     0      0     0     0      0     0     0
```

Added a script to gather and display LiveRepair stats.                                                                                                                              
```                                                                                                                                                                   
root@BRM42220014:~# /tmp/get-lr-state.sh                                                                                                                              
oxz_propolis-server_34aa5f9c-d933-49fa-b38e-fc4607933d50  28022 0 0 0 0 0 0                                                                                           
oxz_propolis-server_3cef2a36-c2c3-49a6-bf38-f3d340264b1c   7737 0 0 0 0 0 0                                                                                           
oxz_propolis-server_3a1b039a-e41f-4968-a672-0d6900830219   8766 0 0 0 0 0 0                                                                                           
oxz_propolis-server_373e09ac-abcc-418d-a989-5184429042da   9984 0 0 0 0 0 0
oxz_propolis-server_491d90a6-813e-4b83-b158-7bf708dd91f5  10335 0 0 0 0 0 0
oxz_propolis-server_4d78774c-6818-4a2f-bceb-35ca5d9affa4  11016 0 0 0 0 0 0
oxz_propolis-server_f14ba802-0d1a-4320-b4a2-192f7a6d0c5e  11817 0 0 0 0 0 0
```

Added a script to gather and display downstairs states. 
```
root@BRM42220014:~# /tmp/get-ds-state.sh                                                                                                                              
oxz_propolis-server_34aa5f9c-d933-49fa-b38e-fc4607933d50  28022            active            active            active                                                 
oxz_propolis-server_3cef2a36-c2c3-49a6-bf38-f3d340264b1c   7737            active            active            active                                                 
oxz_propolis-server_3a1b039a-e41f-4968-a672-0d6900830219   8766            active            active            active                                                 
oxz_propolis-server_373e09ac-abcc-418d-a989-5184429042da   9984            active            active            active                                                 
oxz_propolis-server_491d90a6-813e-4b83-b158-7bf708dd91f5  10335            active            active            active                                                 
oxz_propolis-server_4d78774c-6818-4a2f-bceb-35ca5d9affa4  11016            active            active            active                                                 
oxz_propolis-server_f14ba802-0d1a-4320-b4a2-192f7a6d0c5e  11817            active            active            active
```                                                                                          

The scripts to gather stats can be used with `pilot host exec -c ...` to gather stats
on all the sleds in a system.

README.md updated