### PR TITLE
Add a clone option to downstairs create

### DIFF
--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -47,7 +47,7 @@ enum Args {
     /// the region here will be replaced.
     Clone {
         /// Directory where the region is located.
-        #[clap(short, long, name = "DIRECTORY", action)]
+        #[clap(short, long, value_name = "DIRECTORY", action)]
         data: PathBuf,
 
         /// Source IP:Port where the extent files will come from.
@@ -63,7 +63,7 @@ enum Args {
         block_size: u64,
 
         /// Directory where the region files we be located.
-        #[clap(short, long, name = "DIRECTORY", action)]
+        #[clap(short, long, value_name = "DIRECTORY", action)]
         data: PathBuf,
 
         /// Number of blocks per extent file.
@@ -78,14 +78,14 @@ enum Args {
         #[clap(
             short,
             long,
-            name = "FILE",
+            value_name = "FILE",
             action,
             conflicts_with = "clone_source"
         )]
         import_path: Option<PathBuf>,
 
         /// UUID for the region.
-        #[clap(short, long, name = "UUID", action)]
+        #[clap(short, long, value_name = "UUID", action)]
         uuid: Uuid,
 
         /// Will the region be encrypted.
@@ -95,7 +95,12 @@ enum Args {
         /// Clone another downstairs after creating.
         ///
         /// IP:Port where the extent files will come from.
-        #[clap(long, action, conflicts_with = "import-path")]
+        #[clap(
+            long,
+            value_name = "SOURCE",
+            action,
+            conflicts_with = "import_path"
+        )]
         clone_source: Option<SocketAddr>,
     },
     /*
@@ -109,7 +114,7 @@ enum Args {
         /*
          * Directories containing a region.
          */
-        #[clap(short, long, name = "DIRECTORY", action)]
+        #[clap(short, long, value_name = "DIRECTORY", action)]
         data: Vec<PathBuf>,
 
         /*
@@ -138,16 +143,16 @@ enum Args {
         /*
          * Number of blocks to export.
          */
-        #[clap(long, default_value = "0", name = "COUNT", action)]
+        #[clap(long, default_value = "0", value_name = "COUNT", action)]
         count: u64,
 
-        #[clap(short, long, name = "DIRECTORY", action)]
+        #[clap(short, long, value_name = "DIRECTORY", action)]
         data: PathBuf,
 
-        #[clap(short, long, name = "OUT_FILE", action)]
+        #[clap(short, long, value_name = "OUT_FILE", action)]
         export_path: PathBuf,
 
-        #[clap(short, long, default_value = "0", name = "SKIP", action)]
+        #[clap(short, long, default_value = "0", value_name = "SKIP", action)]
         skip: u64,
     },
     Run {
@@ -156,13 +161,13 @@ enum Args {
             short,
             long,
             default_value = "0.0.0.0",
-            name = "ADDRESS",
+            value_name = "ADDRESS",
             action
         )]
         address: IpAddr,
 
         /// Directory where the region is located.
-        #[clap(short, long, name = "DIRECTORY", action)]
+        #[clap(short, long, value_name = "DIRECTORY", action)]
         data: PathBuf,
 
         /// Test option, makes the search for new work sleep and sometimes
@@ -175,7 +180,7 @@ enum Args {
          * oximeter server, the downstairs will publish stats.
          */
         /// Use this address:port to send stats to an Oximeter server.
-        #[clap(long, name = "OXIMETER_ADDRESS:PORT", action)]
+        #[clap(long, value_name = "OXIMETER_ADDRESS:PORT", action)]
         oximeter: Option<SocketAddr>,
 
         /// Listen on this port for the upstairs to connect to us.
@@ -223,7 +228,7 @@ enum Args {
         #[clap(long, default_value_t = 512)]
         block_size: u64,
 
-        #[clap(short, long, name = "DIRECTORY")]
+        #[clap(short, long, value_name = "DIRECTORY")]
         data: PathBuf,
 
         #[clap(long, default_value_t = 100)]

--- a/tools/test_ds.sh
+++ b/tools/test_ds.sh
@@ -36,6 +36,7 @@ exp="${testdir}/exported_file"
 imp="${testdir}/import"
 clone_dir="${testdir}/clone"
 clone_exp="${testdir}/clone_export_file"
+create_clone_dir="${testdir}/create_clone"
 echo "Create file for import"
 dd if=/dev/urandom of="$imp" bs=512 count=300
 
@@ -49,7 +50,7 @@ echo "Import Export test passed"
 
 # We can make use of the export function to test downstairs clone
 echo "Test clone"
-echo "Starting downstairs"
+echo "Starting source downstairs"
 ${cds} run -d "$region_dir" -p 8810 --mode ro > ${testdir}/ds_out.txt &
 ds_pid=$!
 
@@ -69,6 +70,13 @@ ${cds} clone -d "$clone_dir" -s 127.0.0.1:12810
 echo "Verify clone using export"
 ${cds} export -d "$clone_dir" -e "$clone_exp" --count 300
 
+diff $imp $clone_exp
+
+echo "Creating new downstairs from clone directly"
+${cds} create -u $(uuidgen) -d "$create_clone_dir" --extent-size 100 --extent-count 15 --block-size 512 --clone-source 127.0.0.1:12810
+
+echo "Verify second clone using export"
+${cds} export -d "$create_clone_dir" -e "$clone_exp" --count 300
 diff $imp $clone_exp
 
 echo "Stopping downstairs"


### PR DESCRIPTION
When creating a region, add the ability to optionally populate that region from an existing and running downstairs using the clone ability.  

This makes use of the already written clone subcommand functions, but calls them directly after creating the region.

The current `clone` subcommand still exists and we can still use it directly if so desired.