### PR TITLE
Reorganize dummy downstairs tests

### DIFF
--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -2337,6 +2337,10 @@ pub(crate) enum ClientStopReason {
 
     /// The upstairs has requested that we deactivate
     Deactivated,
+
+    /// The test suite has requested a fault
+    #[cfg(test)]
+    RequestedFault,
 }
 
 /// Response received from the I/O task

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -2142,9 +2142,6 @@ async fn test_deactivate_slow() {
 
     // At this point, the upstairs sends YouAreNoLongerActive, but then
     // drops the sender end, so we can't actually see it.
-    //
-    // TODO is this correct?  Shouldn't values in the mpsc queue be read out,
-    // even if the sender has been dropped?
     assert!(harness.ds1().recv().await.is_none());
 
     // Reconnect ds1, since the Downstairs always tries to reconnect

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -1499,7 +1499,7 @@ async fn test_byte_fault_condition() {
     );
 }
 
-/// Test that we will mark a Downstairs as failed if we hit the byte limit
+/// Test that we will mark a Downstairs as failed if we hit the job limit
 #[tokio::test]
 async fn test_job_fault_condition() {
     let mut harness = TestHarness::new().await;

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -1425,7 +1425,6 @@ async fn test_byte_fault_condition() {
     const WRITE_SIZE: usize = 50 * 1024; // 50 KiB
     let write_buf = BytesMut::from(vec![1; WRITE_SIZE].as_slice()); // 50 KiB
     let num_jobs = IO_OUTSTANDING_MAX_BYTES as usize / write_buf.len() + 10;
-    let mut job_ids = Vec::with_capacity(num_jobs);
     assert!(num_jobs < IO_OUTSTANDING_MAX_JOBS);
 
     for i in 0..num_jobs {
@@ -1437,7 +1436,6 @@ async fn test_byte_fault_condition() {
         });
 
         let job_id = harness.ds2.ack_write().await;
-        job_ids.push(job_id);
         harness.ds3.ack_write().await;
 
         // With 2x responses, we can now await the write job (which ensures that
@@ -1495,7 +1493,6 @@ async fn test_job_fault_condition() {
     // IO_OUTSTANDING_MAX_JOBS jobs, the Upstairs will set ds1 to faulted,
     // and send it no more work.
     const NUM_JOBS: usize = IO_OUTSTANDING_MAX_JOBS + 200;
-    let mut job_ids = Vec::with_capacity(NUM_JOBS);
 
     for i in 0..NUM_JOBS {
         // We must `spawn` here because `write` will wait for the response to
@@ -1507,7 +1504,6 @@ async fn test_job_fault_condition() {
 
         // Respond with read responses for downstairs 2 and 3
         let job_id = harness.ds2.ack_read().await;
-        job_ids.push(job_id);
         harness.ds3.ack_read().await;
 
         // With 1x responses, we can now await the read job (which ensures that

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -1435,7 +1435,7 @@ async fn test_byte_fault_condition() {
             guest.write(Block::new_512(0), write_buf).await.unwrap();
         });
 
-        let job_id = harness.ds2.ack_write().await;
+        harness.ds2.ack_write().await;
         harness.ds3.ack_write().await;
 
         // With 2x responses, we can now await the write job (which ensures that
@@ -1503,7 +1503,7 @@ async fn test_job_fault_condition() {
         });
 
         // Respond with read responses for downstairs 2 and 3
-        let job_id = harness.ds2.ack_read().await;
+        harness.ds2.ack_read().await;
         harness.ds3.ack_read().await;
 
         // With 1x responses, we can now await the read job (which ensures that

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -751,7 +751,7 @@ async fn test_successful_live_repair() {
             Err(e) => {
                 info!(
                     harness.log,
-                    "could not send read response for job {}: {}",
+                    "ds1 can't reply to job {}, because it's disconnected: {}",
                     job_ids[0],
                     e
                 );
@@ -1608,7 +1608,7 @@ async fn test_error_during_live_repair_no_halt() {
         jh.await.unwrap();
     }
 
-    // Try to reply from DS1, to confirm that we've been kicked out
+    // Confirm that DS1 has been disconnected (and cannot reply to jobs)
     {
         let (block, data) = make_blank_read_response();
         let session_id = harness.ds1().upstairs_session_id.unwrap();
@@ -1626,7 +1626,7 @@ async fn test_error_during_live_repair_no_halt() {
             Err(e) => {
                 info!(
                     harness.log,
-                    "could not send read response for job {}: {}",
+                    "ds1 can't reply to job {}, because it's disconnected: {}",
                     job_ids[0],
                     e
                 );
@@ -2045,7 +2045,7 @@ async fn test_no_read_only_live_repair() {
         jh.await.unwrap();
     }
 
-    // Send ds1 responses for the jobs it saw
+    // Confirm that DS1 has been disconnected (and cannot reply to jobs)
     {
         let (block, data) = make_blank_read_response();
         let session_id = harness.ds1().upstairs_session_id.unwrap();
@@ -2063,7 +2063,7 @@ async fn test_no_read_only_live_repair() {
             Err(e) => {
                 info!(
                     harness.log,
-                    "could not send read response for job {}: {}",
+                    "ds1 can't reply to job {}, because it's disconnected: {}",
                     job_ids[0],
                     e
                 );

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -1524,7 +1524,7 @@ async fn test_job_fault_condition() {
         job_ids.push(job_id);
         harness.ds3.ack_read().await;
 
-        // With 1x responses, we can now await the write job (which ensures that
+        // With 1x responses, we can now await the read job (which ensures that
         // the Upstairs has finished updating its state).
         h.await.unwrap();
 

--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -470,6 +470,18 @@ impl Guest {
         self.send_and_wait(|done| BlockOp::GetDownstairsState { done })
             .await
     }
+
+    /// Mark a particular downstairs as faulted
+    ///
+    /// This is used in tests to trigger live-repair
+    #[cfg(test)]
+    pub async fn fault_downstairs(
+        &self,
+        client_id: crate::ClientId,
+    ) -> Result<(), CrucibleError> {
+        self.send_and_wait(|done| BlockOp::FaultDownstairs { client_id, done })
+            .await
+    }
 }
 
 #[async_trait]

--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -462,6 +462,14 @@ impl Guest {
             drop(_guard);
         }
     }
+
+    #[cfg(test)]
+    pub async fn downstairs_state(
+        &self,
+    ) -> Result<crate::ClientData<crate::DsState>, CrucibleError> {
+        self.send_and_wait(|done| BlockOp::GetDownstairsState { done })
+            .await
+    }
 }
 
 #[async_trait]

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1515,6 +1515,11 @@ pub(crate) enum BlockOp {
     ShowWork {
         done: BlockRes<WQCounts>,
     },
+
+    #[cfg(test)]
+    GetDownstairsState {
+        done: BlockRes<ClientData<DsState>>,
+    },
 }
 
 macro_rules! ceiling_div {

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1520,6 +1520,12 @@ pub(crate) enum BlockOp {
     GetDownstairsState {
         done: BlockRes<ClientData<DsState>>,
     },
+
+    #[cfg(test)]
+    FaultDownstairs {
+        client_id: ClientId,
+        done: BlockRes<()>,
+    },
 }
 
 macro_rules! ceiling_div {

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1098,6 +1098,16 @@ impl Upstairs {
                 }
                 done.send_ok(out);
             }
+
+            #[cfg(test)]
+            BlockOp::FaultDownstairs { client_id, done } => {
+                self.downstairs.skip_all_jobs(client_id);
+                self.downstairs.clients[client_id].fault(
+                    &self.state,
+                    crate::client::ClientStopReason::RequestedFault,
+                );
+                done.send_ok(());
+            }
         }
     }
 

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1089,6 +1089,15 @@ impl Upstairs {
                 let r = self.downstairs.replace(id, old, new, &self.state);
                 done.send_result(r);
             }
+
+            #[cfg(test)]
+            BlockOp::GetDownstairsState { done } => {
+                let mut out = crate::ClientData::new(DsState::New);
+                for i in ClientId::iter() {
+                    out[i] = self.downstairs.clients[i].state();
+                }
+                done.send_ok(out);
+            }
         }
     }
 


### PR DESCRIPTION
This is more prep for addressing #1252 

Previously, our live-repair tests were checking two different things in a single test:

- Sending 57K jobs caused a Downstairs to be marked as faulted
- Once faulted, various live-repair operations occurred

There's also a separate test, `test_byte_fault_condition` (#1192), to confirm that sending > 1 GiB caused a Downstairs to be marked as faulted.

This PR splits those two checks into separate unit tests, adding new (test-only) APIs to (1) check Downstairs state and (2) manually fault a Downstairs.  We want these checks to be separate because – once we make the changes for #1252 – sending 57K jobs will _no longer_ cause an active downstairs to be marked as faulted.

In addition, common `TestHarness` code is consolidated into helper functions:

- Clone the `Guest` and `tokio::spawn` → `TestHarness::spawn`
- Expect a particular message type and reply to it →`DownstairsHandle::ack_read`, `ack_write`, `ack_flush`