### PR TITLE
More Pantry updates for Region replacement

### DIFF
--- a/crucible-client-types/src/lib.rs
+++ b/crucible-client-types/src/lib.rs
@@ -4,6 +4,7 @@ use base64::{engine, Engine};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::fmt::Debug;
 use std::net::SocketAddr;
 use uuid::Uuid;
 
@@ -92,5 +93,32 @@ impl std::fmt::Display for CrucibleOpts {
         write!(f, " Control: {:?}, ", self.control)?;
         write!(f, " read_only: {:?}", self.read_only)?;
         Ok(())
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub enum ReplaceResult {
+    Started,
+    StartedAlready,
+    CompletedAlready,
+    Missing,
+}
+
+impl Debug for ReplaceResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ReplaceResult::Started => {
+                write!(f, "Started")
+            }
+            ReplaceResult::StartedAlready => {
+                write!(f, "StartedAlready")
+            }
+            ReplaceResult::CompletedAlready => {
+                write!(f, "CompletedAlready")
+            }
+            ReplaceResult::Missing => {
+                write!(f, "Missing")
+            }
+        }
     }
 }

--- a/crucible-client-types/src/lib.rs
+++ b/crucible-client-types/src/lib.rs
@@ -97,6 +97,7 @@ impl std::fmt::Display for CrucibleOpts {
 }
 
 #[derive(Clone, Copy, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum ReplaceResult {
     Started,
     StartedAlready,

--- a/openapi/crucible-pantry.json
+++ b/openapi/crucible-pantry.json
@@ -988,7 +988,7 @@
         "type": "object",
         "properties": {
           "active": {
-            "description": "Is the Volume active?",
+            "description": "Is the Volume currently active?",
             "type": "boolean"
           },
           "num_job_handles": {
@@ -996,11 +996,16 @@
             "type": "integer",
             "format": "uint",
             "minimum": 0
+          },
+          "seen_active": {
+            "description": "Has the Pantry ever seen this Volume active?",
+            "type": "boolean"
           }
         },
         "required": [
           "active",
-          "num_job_handles"
+          "num_job_handles",
+          "seen_active"
         ]
       }
     },

--- a/openapi/crucible-pantry.json
+++ b/openapi/crucible-pantry.json
@@ -175,7 +175,7 @@
         }
       },
       "delete": {
-        "summary": "Flush and close a volume, removing it from the Pantry",
+        "summary": "Deactivate a volume, removing it from the Pantry",
         "operationId": "detach",
         "parameters": [
           {

--- a/openapi/crucible-pantry.json
+++ b/openapi/crucible-pantry.json
@@ -363,6 +363,50 @@
         }
       }
     },
+    "/crucible/pantry/0/volume/{id}/replace": {
+      "post": {
+        "summary": "Call a volume's target_replace function",
+        "operationId": "replace",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReplaceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReplaceResult"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/crucible/pantry/0/volume/{id}/scrub": {
       "post": {
         "summary": "Scrub the volume (copy blocks from read-only parent to subvolumes)",
@@ -714,15 +758,36 @@
             "minimum": 0
           },
           "volumes": {
-            "description": "How many Volumes?",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
+            "description": "Which volumes does this Pantry know about? Note this may include volumes that are no longer active, and haven't been garbage collected yet.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
           "num_job_handles",
           "volumes"
+        ]
+      },
+      "ReplaceRequest": {
+        "type": "object",
+        "properties": {
+          "volume_construction_request": {
+            "$ref": "#/components/schemas/VolumeConstructionRequest"
+          }
+        },
+        "required": [
+          "volume_construction_request"
+        ]
+      },
+      "ReplaceResult": {
+        "type": "string",
+        "enum": [
+          "started",
+          "started_already",
+          "completed_already",
+          "missing"
         ]
       },
       "ScrubResponse": {

--- a/openapi/crucible-pantry.json
+++ b/openapi/crucible-pantry.json
@@ -5,6 +5,30 @@
     "version": "0.0.0"
   },
   "paths": {
+    "/crucible/pantry/0": {
+      "get": {
+        "summary": "Get the Pantry's status",
+        "operationId": "pantry_status",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PantryStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/crucible/pantry/0/job/{id}/is-finished": {
       "get": {
         "summary": "Poll to see if a Pantry background job is done",
@@ -75,6 +99,38 @@
       }
     },
     "/crucible/pantry/0/volume/{id}": {
+      "get": {
+        "summary": "Get a current Volume's status",
+        "operationId": "volume_status",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VolumeStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
       "post": {
         "summary": "Construct a volume from a VolumeConstructionRequest, storing the result in",
         "description": "the Pantry.",
@@ -134,6 +190,44 @@
         "responses": {
           "204": {
             "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/crucible/pantry/0/volume/{id}/background": {
+      "post": {
+        "summary": "Construct a volume from a VolumeConstructionRequest, storing the result in",
+        "description": "the Pantry. Activate in a separate job so as not to block the request.",
+        "operationId": "attach_activate_background",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttachBackgroundRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
           },
           "4XX": {
             "$ref": "#/components/responses/Error"
@@ -387,6 +481,21 @@
   },
   "components": {
     "schemas": {
+      "AttachBackgroundRequest": {
+        "type": "object",
+        "properties": {
+          "job_id": {
+            "type": "string"
+          },
+          "volume_construction_request": {
+            "$ref": "#/components/schemas/VolumeConstructionRequest"
+          }
+        },
+        "required": [
+          "job_id",
+          "volume_construction_request"
+        ]
+      },
       "AttachRequest": {
         "type": "object",
         "properties": {
@@ -595,6 +704,27 @@
           "job_result_ok"
         ]
       },
+      "PantryStatus": {
+        "type": "object",
+        "properties": {
+          "num_job_handles": {
+            "description": "How many job handles?",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "volumes": {
+            "description": "How many Volumes?",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "num_job_handles",
+          "volumes"
+        ]
+      },
       "ScrubResponse": {
         "type": "object",
         "properties": {
@@ -787,6 +917,25 @@
               "type"
             ]
           }
+        ]
+      },
+      "VolumeStatus": {
+        "type": "object",
+        "properties": {
+          "active": {
+            "description": "Is the Volume active?",
+            "type": "boolean"
+          },
+          "num_job_handles": {
+            "description": "How many job handles are there for this Volume?",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "active",
+          "num_job_handles"
         ]
       }
     },

--- a/pantry/src/pantry.rs
+++ b/pantry/src/pantry.rs
@@ -396,7 +396,6 @@ impl PantryEntry {
     }
 
     pub async fn detach(&self) -> Result<(), CrucibleError> {
-        self.volume.flush(None).await?;
         self.volume.deactivate().await?;
         Ok(())
     }

--- a/pantry/src/server.rs
+++ b/pantry/src/server.rs
@@ -55,8 +55,11 @@ struct VolumePath {
 
 #[derive(Serialize, JsonSchema)]
 pub struct VolumeStatus {
-    /// Is the Volume active?
+    /// Is the Volume currently active?
     pub active: bool,
+
+    /// Has the Pantry ever seen this Volume active?
+    pub seen_active: bool,
 
     /// How many job handles are there for this Volume?
     pub num_job_handles: usize,

--- a/pantry/src/server.rs
+++ b/pantry/src/server.rs
@@ -412,7 +412,7 @@ async fn validate(
     Ok(HttpResponseOk(ValidateResponse { job_id }))
 }
 
-/// Flush and close a volume, removing it from the Pantry
+/// Deactivate a volume, removing it from the Pantry
 #[endpoint {
     method = DELETE,
     path = "/crucible/pantry/0/volume/{id}",

--- a/pantry/src/server.rs
+++ b/pantry/src/server.rs
@@ -20,11 +20,63 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slog::{info, o, Logger};
 
+use crucible::ReplaceResult;
 use crucible::VolumeConstructionRequest;
+
+#[derive(Serialize, JsonSchema)]
+pub struct PantryStatus {
+    /// Which volumes does this Pantry know about? Note this may include volumes
+    /// that are no longer active, and haven't been garbage collected yet.
+    pub volumes: Vec<String>,
+
+    /// How many job handles?
+    pub num_job_handles: usize,
+}
+
+/// Get the Pantry's status
+#[endpoint {
+    method = GET,
+    path = "/crucible/pantry/0",
+}]
+async fn pantry_status(
+    rc: RequestContext<Arc<Pantry>>,
+) -> Result<HttpResponseOk<PantryStatus>, HttpError> {
+    let pantry = rc.context();
+
+    let status = pantry.status().await?;
+
+    Ok(HttpResponseOk(status))
+}
 
 #[derive(Deserialize, JsonSchema)]
 struct VolumePath {
     pub id: String,
+}
+
+#[derive(Serialize, JsonSchema)]
+pub struct VolumeStatus {
+    /// Is the Volume active?
+    pub active: bool,
+
+    /// How many job handles are there for this Volume?
+    pub num_job_handles: usize,
+}
+
+/// Get a current Volume's status
+#[endpoint {
+    method = GET,
+    path = "/crucible/pantry/0/volume/{id}",
+}]
+async fn volume_status(
+    rc: RequestContext<Arc<Pantry>>,
+    path: TypedPath<VolumePath>,
+) -> Result<HttpResponseOk<VolumeStatus>, HttpError> {
+    let path = path.into_inner();
+    let pantry = rc.context();
+
+    let status = pantry.volume_status(path.id.clone()).await?;
+
+    Ok(HttpResponseOk(status))
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -57,6 +109,64 @@ async fn attach(
         .await?;
 
     Ok(HttpResponseOk(AttachResult { id: path.id }))
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct AttachBackgroundRequest {
+    pub volume_construction_request: VolumeConstructionRequest,
+    pub job_id: String,
+}
+
+/// Construct a volume from a VolumeConstructionRequest, storing the result in
+/// the Pantry. Activate in a separate job so as not to block the request.
+#[endpoint {
+    method = POST,
+    path = "/crucible/pantry/0/volume/{id}/background",
+}]
+async fn attach_activate_background(
+    rc: RequestContext<Arc<Pantry>>,
+    path: TypedPath<VolumePath>,
+    body: TypedBody<AttachBackgroundRequest>,
+) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+    let path = path.into_inner();
+    let body = body.into_inner();
+    let pantry = rc.context();
+
+    pantry
+        .attach_activate_background(
+            path.id.clone(),
+            body.job_id,
+            body.volume_construction_request,
+        )
+        .await?;
+
+    Ok(HttpResponseUpdatedNoContent())
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct ReplaceRequest {
+    pub volume_construction_request: VolumeConstructionRequest,
+}
+
+/// Call a volume's target_replace function
+#[endpoint {
+    method = POST,
+    path = "/crucible/pantry/0/volume/{id}/replace",
+}]
+async fn replace(
+    rc: RequestContext<Arc<Pantry>>,
+    path: TypedPath<VolumePath>,
+    body: TypedBody<ReplaceRequest>,
+) -> Result<HttpResponseOk<ReplaceResult>, HttpError> {
+    let path = path.into_inner();
+    let body = body.into_inner();
+    let pantry = rc.context();
+
+    let result = pantry
+        .replace(path.id.clone(), body.volume_construction_request)
+        .await?;
+
+    Ok(HttpResponseOk(result))
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -322,7 +432,11 @@ async fn detach(
 pub fn make_api() -> Result<dropshot::ApiDescription<Arc<Pantry>>, String> {
     let mut api = dropshot::ApiDescription::new();
 
+    api.register(pantry_status)?;
+    api.register(volume_status)?;
     api.register(attach)?;
+    api.register(attach_activate_background)?;
+    api.register(replace)?;
     api.register(is_job_finished)?;
     api.register(job_result_ok)?;
     api.register(import_from_url)?;

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -13,7 +13,9 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
-pub use crucible_client_types::{CrucibleOpts, VolumeConstructionRequest};
+pub use crucible_client_types::{
+    CrucibleOpts, ReplaceResult, VolumeConstructionRequest,
+};
 pub use crucible_common::*;
 pub use crucible_protocol::*;
 
@@ -234,32 +236,6 @@ pub type CrucibleBlockIOFuture<'a> = Pin<
             + 'a,
     >,
 >;
-
-#[derive(Clone, Copy, PartialEq, Serialize, Deserialize)]
-pub enum ReplaceResult {
-    Started,
-    StartedAlready,
-    CompletedAlready,
-    Missing,
-}
-impl Debug for ReplaceResult {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ReplaceResult::Started => {
-                write!(f, "Started")
-            }
-            ReplaceResult::StartedAlready => {
-                write!(f, "StartedAlready")
-            }
-            ReplaceResult::CompletedAlready => {
-                write!(f, "CompletedAlready")
-            }
-            ReplaceResult::Missing => {
-                write!(f, "Missing")
-            }
-        }
-    }
-}
 
 /// DTrace probes in the upstairs
 ///


### PR DESCRIPTION
Add some status endpoints so that Nexus can ask the Pantry some questions:

- how many volumes and job handles are you currently holding on to?

- for a given volume, is it active, and how many job handles refer to it?

Also:

- add an `attach_activate_background` endpoint to the Pantry, so activation can occur in a job instead of blocking the activate endpoint. this will be used by Nexus when it knows that a volume needs reconcilation.

- add a `replace` endoint to the Pantry, so that Nexus can call `target_replace` for volumes attached to the antry

Additionally, move `ReplacementResult` to crucible-client-types, and have `target_replace` return that instead of (). This will be returned by Propolis so that Nexus can tell what the status of a requested replacement is.