### PR TITLE
Refactor downstairs writes

### DIFF
--- a/downstairs/src/dynamometer.rs
+++ b/downstairs/src/dynamometer.rs
@@ -73,9 +73,9 @@ pub async fn dynamometer(
                                 },
                             ),
                         };
-                        (
-                            eid as u64,
-                            ExtentWrite {
+                        RegionWriteReq {
+                            extent: eid as u64,
+                            write: ExtentWrite {
                                 offset: Block::new_with_ddef(
                                     i as u64 + block_offset,
                                     &ddef,
@@ -83,7 +83,7 @@ pub async fn dynamometer(
                                 data: block_bytes.clone(),
                                 block_contexts: vec![ctx],
                             },
-                        )
+                        }
                     })
                     .collect();
                 let rw = RegionWrite(writes);

--- a/downstairs/src/dynamometer.rs
+++ b/downstairs/src/dynamometer.rs
@@ -63,14 +63,8 @@ pub async fn dynamometer(
                 let tag = tag.clone();
 
                 let writes: Vec<_> = (0..num_writes)
-                    .map(|i| crucible_protocol::Write {
-                        eid: eid as u64,
-                        offset: Block::new_with_ddef(
-                            i as u64 + block_offset,
-                            &ddef,
-                        ),
-                        data: block_bytes.clone(),
-                        block_context: BlockContext {
+                    .map(|i| {
+                        let ctx = BlockContext {
                             hash,
                             encryption_context: Some(
                                 crucible_protocol::EncryptionContext {
@@ -78,12 +72,24 @@ pub async fn dynamometer(
                                     tag: tag.as_slice().try_into().unwrap(),
                                 },
                             ),
-                        },
+                        };
+                        (
+                            eid as u64,
+                            ExtentWrite {
+                                offset: Block::new_with_ddef(
+                                    i as u64 + block_offset,
+                                    &ddef,
+                                ),
+                                data: block_bytes.clone(),
+                                block_contexts: vec![ctx],
+                            },
+                        )
                     })
                     .collect();
+                let rw = RegionWrite(writes);
 
                 let io_operation_time = Instant::now();
-                region.region_write(&writes, JobId(1000), false).await?;
+                region.region_write(rw, JobId(1000), false).await?;
 
                 total_io_time += io_operation_time.elapsed();
                 io_operations_sent += num_writes;

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -9,9 +9,9 @@ use crate::{
         pread_all, pwrite_all, OnDiskMeta, BLOCK_META_SIZE_BYTES,
     },
     integrity_hash, mkdir_for_file,
-    region::{BatchedPwritev, JobOrReconciliationId},
+    region::JobOrReconciliationId,
     Block, BlockContext, CrucibleError, ExtentReadRequest, ExtentReadResponse,
-    JobId, RegionDefinition,
+    ExtentWrite, JobId, RegionDefinition,
 };
 
 use itertools::Itertools;
@@ -134,38 +134,172 @@ impl ExtentInner for RawInner {
         Ok(self.dirty)
     }
 
+    /// Performs a single write within this extent
     fn write(
         &mut self,
         job_id: JobId,
-        writes: &[crucible_protocol::Write],
+        write: &ExtentWrite,
         only_write_unwritten: bool,
-        iov_max: usize,
+        _iov_max: usize,
     ) -> Result<(), CrucibleError> {
-        // If the same block is written multiple times in a single write, then
-        // (1) that's weird, and (2) we need to handle it specially.  To handle
-        // such cases, we split the `writes` slice into sub-slices of unique
-        // writes.
-        let mut seen = HashSet::new();
-        let mut start = 0;
-        for i in 0..=writes.len() {
-            // If this value is a duplicate or we have reached the end of
-            // the list, then write everything up to this point and adjust
-            // our starting point and `seen` array
-            if i == writes.len() || !seen.insert(writes[i].offset.value) {
-                self.write_without_overlaps(
-                    job_id,
-                    &writes[start..i],
-                    only_write_unwritten,
-                    iov_max,
-                )?;
-                // Keep going, resetting the hashmap and start position
-                if i != writes.len() {
-                    seen.clear();
-                    seen.insert(writes[i].offset.value);
-                    start = i;
+        check_input(self.extent_size, write.offset, write.data.len())?;
+        /*
+         * In order to be crash consistent, perform the following steps in
+         * order:
+         *
+         * 1) set the dirty bit
+         * 2) for each write:
+         *   a) write out encryption context and hashes first
+         *   b) write out extent data second
+         *
+         * If encryption context is written after the extent data, a crash or
+         * interruption before extent data is written would potentially leave
+         * data on the disk that cannot be decrypted.
+         *
+         * If hash is written after extent data, same thing - a crash or
+         * interruption would leave data on disk that would fail the
+         * integrity hash check.
+         *
+         * Note that writing extent data here does not assume that it is
+         * durably on disk - the only guarantee of that is returning
+         * ok from fsync. The data is only potentially on disk and
+         * this depends on operating system implementation.
+         *
+         * To minimize the performance hit of sending many transactions to the
+         * filesystem, as much as possible is written at the same time. This
+         * means multiple loops are required. The steps now look like:
+         *
+         * 1) set the dirty bit
+         * 2) gather and write all encryption contexts + hashes
+         * 3) write all extent data
+         *
+         * If "only_write_unwritten" is true, then we only issue a write for
+         * a block if that block has not been written to yet.  Note
+         * that we can have a write that is "sparse" if the range of
+         * blocks it contains has a mix of written an unwritten
+         * blocks.
+         *
+         * We define a block being written to or not has if that block has
+         * `Some(...)` with a matching checksum serialized into a context slot
+         * or not. So it is required that a written block has a checksum.
+         */
+
+        let num_blocks = write.block_contexts.len() as u64;
+        let block_size = self.extent_size.block_size_in_bytes() as u64;
+        // If `only_write_written`, we need to skip writing to blocks that
+        // already contain data. We'll first query the metadata to see which
+        // blocks have hashes
+        let mut writes_to_skip = HashSet::new();
+        if only_write_unwritten {
+            cdt::extent__write__get__hashes__start!(|| {
+                (job_id.0, self.extent_number, num_blocks)
+            });
+
+            // Query hashes for the write range.
+            let block_contexts =
+                self.get_block_contexts(write.offset.value, num_blocks)?;
+
+            for (i, block_contexts) in block_contexts.iter().enumerate() {
+                if block_contexts.is_some() {
+                    writes_to_skip.insert(i);
+                }
+            }
+
+            cdt::extent__write__get__hashes__done!(|| {
+                (job_id.0, self.extent_number, num_blocks)
+            });
+
+            if writes_to_skip.len() == write.block_contexts.len() {
+                // Nothing to do
+                return Ok(());
+            }
+        }
+
+        self.set_dirty()?;
+
+        // Write all the context data to the raw file
+        //
+        // TODO right now we're including the integrity_hash() time in the
+        // measured time.  Is it small enough to be ignored?
+        cdt::extent__write__raw__context__insert__start!(|| {
+            (job_id.0, self.extent_number, num_blocks)
+        });
+
+        // Compute block contexts, then write them to disk
+        let block_ctx: Vec<_> = write
+            .block_contexts
+            .iter()
+            .enumerate()
+            .filter(|(i, _ctx)| !writes_to_skip.contains(i))
+            .map(|(i, ctx)| {
+                // TODO it would be nice if we could profile what % of time we're
+                // spending on hashes locally vs writing to disk
+                let chunk = &write.data[i * block_size as usize..]
+                    [..block_size as usize];
+                let on_disk_hash = integrity_hash(&[chunk]);
+
+                DownstairsBlockContext {
+                    block_context: *ctx,
+                    block: write.offset.value + i as u64,
+                    on_disk_hash,
+                }
+            })
+            .collect();
+
+        self.set_block_contexts(&block_ctx)?;
+
+        cdt::extent__write__raw__context__insert__done!(|| {
+            (job_id.0, self.extent_number, num_blocks)
+        });
+
+        // PERFORMANCE TODO:
+        //
+        // Something worth considering for small writes is that, based on
+        // my memory of conversations we had with propolis folks about what
+        // OSes expect out of an NVMe driver, I believe our contract with the
+        // upstairs doesn't require us to have the writes inside the file
+        // until after a flush() returns. If that is indeed true, we could
+        // buffer a certain amount of writes, only actually writing that
+        // buffer when either a flush is issued or the buffer exceeds some
+        // set size (based on our memory constraints). This would have
+        // benefits on any workload that frequently writes to the same block
+        // between flushes, would have benefits for small contiguous writes
+        // issued over multiple write commands by letting us batch them into
+        // a larger write, and (speculation) may benefit non-contiguous writes
+        // by cutting down the number of metadata writes. But, it introduces
+        // complexity. The time spent implementing that would probably better be
+        // spent switching to aio or something like that.
+        cdt::extent__write__file__start!(|| {
+            (job_id.0, self.extent_number, num_blocks)
+        });
+
+        let r = self.write_inner(write, &writes_to_skip);
+
+        if r.is_err() {
+            for i in 0..write.block_contexts.len() {
+                if !writes_to_skip.contains(&i) {
+                    // Try to recompute the context slot from the file.  If this
+                    // fails, then we _really_ can't recover, so bail out
+                    // unceremoniously.
+                    let block = write.offset.value + i as u64;
+                    self.recompute_slot_from_file(block).unwrap();
+                }
+            }
+        } else {
+            // Now that writes have gone through, update active context slots
+            for i in 0..write.block_contexts.len() {
+                if !writes_to_skip.contains(&i) {
+                    // We always write to the inactive slot, so just swap it
+                    let block = write.offset.value as usize + i;
+                    self.active_context[block] = !self.active_context[block];
                 }
             }
         }
+
+        cdt::extent__write__file__done!(|| {
+            (job_id.0, self.extent_number, num_blocks)
+        });
+
         Ok(())
     }
 
@@ -774,27 +908,32 @@ impl RawInner {
 
     fn write_inner(
         &self,
-        writes: &[crucible_protocol::Write],
-        writes_to_skip: &HashSet<u64>,
-        iov_max: usize,
+        write: &ExtentWrite,
+        writes_to_skip: &HashSet<usize>,
     ) -> Result<(), CrucibleError> {
-        // Now, batch writes into iovecs and use pwritev to write them all out.
-        let mut batched_pwritev = BatchedPwritev::new(
-            self.file.as_fd(),
-            writes.len(),
-            self.extent_size.block_size_in_bytes().into(),
-            iov_max,
-        );
-
-        for write in writes {
-            if !writes_to_skip.contains(&write.offset.value) {
-                batched_pwritev.add_write(write)?;
+        // Perform writes, which may be broken up by skipped blocks
+        let block_size = self.extent_size.block_size_in_bytes() as u64;
+        for (skip, mut group) in (0..write.block_contexts.len())
+            .group_by(|i| writes_to_skip.contains(i))
+            .into_iter()
+        {
+            if skip {
+                continue;
             }
+            let start = group.next().unwrap();
+            let count = group.count() + 1;
+
+            let data = &write.data[start * block_size as usize..]
+                [..count * block_size as usize];
+            let start_block = write.offset.value + start as u64;
+
+            pwrite_all(
+                self.file.as_fd(),
+                data,
+                (start_block * block_size) as i64,
+            )
+            .map_err(|e| CrucibleError::IoError(e.to_string()))?;
         }
-
-        // Write any remaining data
-        batched_pwritev.perform_writes()?;
-
         Ok(())
     }
 
@@ -932,196 +1071,6 @@ impl RawInner {
             // for the file.
         }
         r.map(|_| ())
-    }
-
-    /// Implementation details for `ExtentInner::write`
-    ///
-    /// This function requires that `writes` not have any overlapping writes,
-    /// i.e. blocks that are written multiple times.  We write the contexts
-    /// first, then block data; if a single block is written multiple times,
-    /// then we'd write multiple contexts, then multiple block data, and it
-    /// would be possible for them to get out of sync.
-    fn write_without_overlaps(
-        &mut self,
-        job_id: JobId,
-        writes: &[crucible_protocol::Write],
-        only_write_unwritten: bool,
-        iov_max: usize,
-    ) -> Result<(), CrucibleError> {
-        /*
-         * In order to be crash consistent, perform the following steps in
-         * order:
-         *
-         * 1) set the dirty bit
-         * 2) for each write:
-         *   a) write out encryption context and hashes first
-         *   b) write out extent data second
-         *
-         * If encryption context is written after the extent data, a crash or
-         * interruption before extent data is written would potentially leave
-         * data on the disk that cannot be decrypted.
-         *
-         * If hash is written after extent data, same thing - a crash or
-         * interruption would leave data on disk that would fail the
-         * integrity hash check.
-         *
-         * Note that writing extent data here does not assume that it is
-         * durably on disk - the only guarantee of that is returning
-         * ok from fsync. The data is only potentially on disk and
-         * this depends on operating system implementation.
-         *
-         * To minimize the performance hit of sending many transactions to the
-         * filesystem, as much as possible is written at the same time. This
-         * means multiple loops are required. The steps now look like:
-         *
-         * 1) set the dirty bit
-         * 2) gather and write all encryption contexts + hashes
-         * 3) write all extent data
-         *
-         * If "only_write_unwritten" is true, then we only issue a write for
-         * a block if that block has not been written to yet.  Note
-         * that we can have a write that is "sparse" if the range of
-         * blocks it contains has a mix of written an unwritten
-         * blocks.
-         *
-         * We define a block being written to or not has if that block has
-         * `Some(...)` with a matching checksum serialized into a context slot
-         * or not. So it is required that a written block has a checksum.
-         */
-
-        // If `only_write_written`, we need to skip writing to blocks that
-        // already contain data. We'll first query the metadata to see which
-        // blocks have hashes
-        let mut writes_to_skip = HashSet::new();
-        if only_write_unwritten {
-            cdt::extent__write__get__hashes__start!(|| {
-                (job_id.0, self.extent_number, writes.len() as u64)
-            });
-            let mut write_run_start = 0;
-            while write_run_start < writes.len() {
-                let first_write = &writes[write_run_start];
-
-                // Starting from the first write in the potential run, we scan
-                // forward until we find a write with a block that isn't
-                // contiguous with the request before it. Since we're counting
-                // pairs, and the number of pairs is one less than the number of
-                // writes, we need to add 1 to get our actual run length.
-                let n_contiguous_writes = writes[write_run_start..]
-                    .windows(2)
-                    .take_while(|wr_pair| {
-                        wr_pair[0].offset.value + 1 == wr_pair[1].offset.value
-                    })
-                    .count()
-                    + 1;
-
-                // Query hashes for the write range.
-                let block_contexts = self.get_block_contexts(
-                    first_write.offset.value,
-                    n_contiguous_writes as u64,
-                )?;
-
-                for (i, block_contexts) in block_contexts.iter().enumerate() {
-                    if block_contexts.is_some() {
-                        let _ = writes_to_skip
-                            .insert(i as u64 + first_write.offset.value);
-                    }
-                }
-
-                write_run_start += n_contiguous_writes;
-            }
-            cdt::extent__write__get__hashes__done!(|| {
-                (job_id.0, self.extent_number, writes.len() as u64)
-            });
-
-            if writes_to_skip.len() == writes.len() {
-                // Nothing to do
-                return Ok(());
-            }
-        }
-
-        self.set_dirty()?;
-
-        // Write all the context data to the raw file
-        //
-        // TODO right now we're including the integrity_hash() time in the
-        // measured time.  Is it small enough to be ignored?
-        cdt::extent__write__raw__context__insert__start!(|| {
-            (job_id.0, self.extent_number, writes.len() as u64)
-        });
-
-        // Compute block contexts, then write them to disk
-        let block_ctx: Vec<_> = writes
-            .iter()
-            .filter(|write| !writes_to_skip.contains(&write.offset.value))
-            .map(|write| {
-                // TODO it would be nice if we could profile what % of time we're
-                // spending on hashes locally vs writing to disk
-                let on_disk_hash = integrity_hash(&[&write.data[..]]);
-
-                DownstairsBlockContext {
-                    block_context: write.block_context,
-                    block: write.offset.value,
-                    on_disk_hash,
-                }
-            })
-            .collect();
-
-        self.set_block_contexts(&block_ctx)?;
-
-        cdt::extent__write__raw__context__insert__done!(|| {
-            (job_id.0, self.extent_number, writes.len() as u64)
-        });
-
-        // PERFORMANCE TODO:
-        //
-        // Something worth considering for small writes is that, based on
-        // my memory of conversations we had with propolis folks about what
-        // OSes expect out of an NVMe driver, I believe our contract with the
-        // upstairs doesn't require us to have the writes inside the file
-        // until after a flush() returns. If that is indeed true, we could
-        // buffer a certain amount of writes, only actually writing that
-        // buffer when either a flush is issued or the buffer exceeds some
-        // set size (based on our memory constraints). This would have
-        // benefits on any workload that frequently writes to the same block
-        // between flushes, would have benefits for small contiguous writes
-        // issued over multiple write commands by letting us batch them into
-        // a larger write, and (speculation) may benefit non-contiguous writes
-        // by cutting down the number of metadata writes. But, it introduces
-        // complexity. The time spent implementing that would probably better be
-        // spent switching to aio or something like that.
-        cdt::extent__write__file__start!(|| {
-            (job_id.0, self.extent_number, writes.len() as u64)
-        });
-
-        let r = self.write_inner(writes, &writes_to_skip, iov_max);
-
-        if r.is_err() {
-            for write in writes.iter() {
-                let block = write.offset.value;
-                if !writes_to_skip.contains(&block) {
-                    // Try to recompute the context slot from the file.  If this
-                    // fails, then we _really_ can't recover, so bail out
-                    // unceremoniously.
-                    self.recompute_slot_from_file(block).unwrap();
-                }
-            }
-        } else {
-            // Now that writes have gone through, update active context slots
-            for write in writes.iter() {
-                let block = write.offset.value;
-                if !writes_to_skip.contains(&block) {
-                    // We always write to the inactive slot, so just swap it
-                    self.active_context[block as usize] =
-                        !self.active_context[block as usize];
-                }
-            }
-        }
-
-        cdt::extent__write__file__done!(|| {
-            (job_id.0, self.extent_number, writes.len() as u64)
-        });
-
-        Ok(())
     }
 }
 
@@ -1586,16 +1535,15 @@ mod test {
         // Write a block, but don't flush.
         let data = Bytes::from(vec![0x55; 512]);
         let hash = integrity_hash(&[&data[..]]);
-        let write = crucible_protocol::Write {
-            eid: 0,
+        let write = ExtentWrite {
             offset: Block::new_512(0),
             data,
-            block_context: BlockContext {
+            block_contexts: vec![BlockContext {
                 encryption_context: None,
                 hash,
-            },
+            }],
         };
-        inner.write(JobId(10), &[write], false, IOV_MAX_TEST)?;
+        inner.write(JobId(10), &write, false, IOV_MAX_TEST)?;
 
         // The context should be in place, though we haven't flushed yet
 
@@ -1608,13 +1556,12 @@ mod test {
                 encryption_context: None,
                 hash,
             };
-            let write = crucible_protocol::Write {
-                eid: 0,
+            let write = ExtentWrite {
                 offset: Block::new_512(0),
                 data: data.clone(),
-                block_context,
+                block_contexts: vec![block_context],
             };
-            inner.write(JobId(20), &[write], true, IOV_MAX_TEST)?;
+            inner.write(JobId(20), &write, true, IOV_MAX_TEST)?;
 
             let read = ExtentReadRequest {
                 offset: Block::new_512(0),
@@ -1635,13 +1582,12 @@ mod test {
                 encryption_context: None,
                 hash,
             };
-            let write = crucible_protocol::Write {
-                eid: 0,
+            let write = ExtentWrite {
                 offset: Block::new_512(1),
                 data: data.clone(),
-                block_context,
+                block_contexts: vec![block_context],
             };
-            inner.write(JobId(30), &[write], true, IOV_MAX_TEST)?;
+            inner.write(JobId(30), &write, true, IOV_MAX_TEST)?;
 
             let read = ExtentReadRequest {
                 offset: Block::new_512(1),
@@ -1667,44 +1613,43 @@ mod test {
         // Write a block, but don't flush.
         let data = Bytes::from(vec![0x55; 512]);
         let hash = integrity_hash(&[&data[..]]);
-        let write = crucible_protocol::Write {
-            eid: 0,
+        let write = ExtentWrite {
             offset: Block::new_512(0),
             data,
-            block_context: BlockContext {
+            block_contexts: vec![BlockContext {
                 encryption_context: None,
                 hash,
-            },
+            }],
         };
 
         // Write block 1, so that we can notice when a sync happens.  The write
         // should go to slot B.
-        let write1 = crucible_protocol::Write {
+        let write1 = ExtentWrite {
             offset: Block::new_512(1),
             ..write.clone()
         };
-        inner.write(JobId(10), &[write1], false, IOV_MAX_TEST)?;
+        inner.write(JobId(10), &write1, false, IOV_MAX_TEST)?;
         assert_eq!(inner.context_slot_dirty[0], 0b00);
         assert_eq!(inner.active_context[0], ContextSlot::A);
         assert_eq!(inner.context_slot_dirty[1], 0b10);
         assert_eq!(inner.active_context[1], ContextSlot::B);
 
         // The context should be written to block 0, slot B
-        inner.write(JobId(10), &[write.clone()], false, IOV_MAX_TEST)?;
+        inner.write(JobId(10), &write, false, IOV_MAX_TEST)?;
         assert_eq!(inner.context_slot_dirty[0], 0b10);
         assert_eq!(inner.active_context[0], ContextSlot::B);
         assert_eq!(inner.context_slot_dirty[1], 0b10); // unchanged
         assert_eq!(inner.active_context[1], ContextSlot::B); // unchanged
 
         // The context should be written to block 0, slot A
-        inner.write(JobId(11), &[write.clone()], false, IOV_MAX_TEST)?;
+        inner.write(JobId(11), &write, false, IOV_MAX_TEST)?;
         assert_eq!(inner.context_slot_dirty[0], 0b11);
         assert_eq!(inner.active_context[0], ContextSlot::A);
         assert_eq!(inner.context_slot_dirty[1], 0b10); // unchanged
         assert_eq!(inner.active_context[1], ContextSlot::B); // unchanged
 
         // The context should be written to slot B, forcing a sync
-        inner.write(JobId(12), &[write], false, IOV_MAX_TEST)?;
+        inner.write(JobId(12), &write, false, IOV_MAX_TEST)?;
         assert_eq!(inner.context_slot_dirty[0], 0b10);
         assert_eq!(inner.active_context[0], ContextSlot::B);
         assert_eq!(inner.context_slot_dirty[1], 0b00);
@@ -1723,17 +1668,16 @@ mod test {
         // Write a block, but don't flush.
         let data = Bytes::from(vec![0x55; 512]);
         let hash = integrity_hash(&[&data[..]]);
-        let write = crucible_protocol::Write {
-            eid: 0,
+        let write = ExtentWrite {
             offset: Block::new_512(0),
             data,
-            block_context: BlockContext {
+            block_contexts: vec![BlockContext {
                 encryption_context: None,
                 hash,
-            },
+            }],
         };
         // The context should be written to slot B
-        inner.write(JobId(10), &[write.clone()], false, IOV_MAX_TEST)?;
+        inner.write(JobId(10), &write, false, IOV_MAX_TEST)?;
         assert_eq!(inner.active_context[0], ContextSlot::B);
         assert_eq!(inner.context_slot_dirty[0], 0b10);
 
@@ -1743,17 +1687,17 @@ mod test {
         assert_eq!(inner.context_slot_dirty[0], 0b00);
 
         // The context should be written to slot A
-        inner.write(JobId(11), &[write.clone()], false, IOV_MAX_TEST)?;
+        inner.write(JobId(11), &write, false, IOV_MAX_TEST)?;
         assert_eq!(inner.active_context[0], ContextSlot::A);
         assert_eq!(inner.context_slot_dirty[0], 0b01);
 
         // The context should be written to slot B
-        inner.write(JobId(12), &[write.clone()], false, IOV_MAX_TEST)?;
+        inner.write(JobId(12), &write, false, IOV_MAX_TEST)?;
         assert_eq!(inner.active_context[0], ContextSlot::B);
         assert_eq!(inner.context_slot_dirty[0], 0b11);
 
         // The context should be written to slot A, forcing a sync
-        inner.write(JobId(12), &[write.clone()], false, IOV_MAX_TEST)?;
+        inner.write(JobId(12), &write, false, IOV_MAX_TEST)?;
         assert_eq!(inner.active_context[0], ContextSlot::A);
         assert_eq!(inner.context_slot_dirty[0], 0b01);
 
@@ -1770,22 +1714,21 @@ mod test {
         // Write a block, but don't flush.
         let data = Bytes::from(vec![0x55; 512]);
         let hash = integrity_hash(&[&data[..]]);
-        let write = crucible_protocol::Write {
-            eid: 0,
+        let write = ExtentWrite {
             offset: Block::new_512(0),
             data,
-            block_context: BlockContext {
+            block_contexts: vec![BlockContext {
                 encryption_context: None,
                 hash,
-            },
+            }],
         };
         // The context should be written to slot B
-        inner.write(JobId(10), &[write.clone()], false, IOV_MAX_TEST)?;
+        inner.write(JobId(10), &write, false, IOV_MAX_TEST)?;
         assert_eq!(inner.active_context[0], ContextSlot::B);
         assert_eq!(inner.context_slot_dirty[0], 0b10);
 
         // The context should be written to slot A
-        inner.write(JobId(11), &[write.clone()], false, IOV_MAX_TEST)?;
+        inner.write(JobId(11), &write, false, IOV_MAX_TEST)?;
         assert_eq!(inner.active_context[0], ContextSlot::A);
         assert_eq!(inner.context_slot_dirty[0], 0b11);
 
@@ -1795,17 +1738,17 @@ mod test {
         assert_eq!(inner.context_slot_dirty[0], 0b00);
 
         // The context should be written to slot B
-        inner.write(JobId(12), &[write.clone()], false, IOV_MAX_TEST)?;
+        inner.write(JobId(12), &write, false, IOV_MAX_TEST)?;
         assert_eq!(inner.active_context[0], ContextSlot::B);
         assert_eq!(inner.context_slot_dirty[0], 0b10);
 
         // The context should be written to slot A
-        inner.write(JobId(12), &[write.clone()], false, IOV_MAX_TEST)?;
+        inner.write(JobId(12), &write, false, IOV_MAX_TEST)?;
         assert_eq!(inner.active_context[0], ContextSlot::A);
         assert_eq!(inner.context_slot_dirty[0], 0b11);
 
         // The context should be written to slot B, forcing a sync
-        inner.write(JobId(11), &[write.clone()], false, IOV_MAX_TEST)?;
+        inner.write(JobId(11), &write, false, IOV_MAX_TEST)?;
         assert_eq!(inner.active_context[0], ContextSlot::B);
         assert_eq!(inner.context_slot_dirty[0], 0b10);
 
@@ -1851,13 +1794,12 @@ mod test {
                 encryption_context: None,
                 hash,
             };
-            let write = crucible_protocol::Write {
-                eid: 0,
+            let write = ExtentWrite {
                 offset: Block::new_512(0),
                 data: data.clone(),
-                block_context,
+                block_contexts: vec![block_context],
             };
-            inner.write(JobId(30), &[write], true, IOV_MAX_TEST)?;
+            inner.write(JobId(30), &write, true, IOV_MAX_TEST)?;
 
             let read = ExtentReadRequest {
                 offset: Block::new_512(0),
@@ -1884,16 +1826,15 @@ mod test {
         let data = Bytes::from(vec![0x55; 512]);
         let hash = integrity_hash(&[&data[..]]);
         for i in 0..5 {
-            let write = crucible_protocol::Write {
-                eid: 0,
+            let write = ExtentWrite {
                 offset: Block::new_512(i * 2),
                 data: data.clone(),
-                block_context: BlockContext {
+                block_contexts: vec![BlockContext {
                     encryption_context: None,
                     hash,
-                },
+                }],
             };
-            inner.write(JobId(30), &[write], false, IOV_MAX_TEST)?;
+            inner.write(JobId(30), &write, false, IOV_MAX_TEST)?;
         }
 
         for i in 0..10 {
@@ -1925,23 +1866,22 @@ mod test {
 
         // Now, do one big write, which will be forced to bounce between the
         // context slots.
-        let mut writes = vec![];
-        let data = Bytes::from(vec![0x33; 512]);
-        let hash = integrity_hash(&[&data[..]]);
-        for i in 0..10 {
-            let write = crucible_protocol::Write {
-                eid: 0,
-                offset: Block::new_512(i),
-                data: data.clone(),
-                block_context: BlockContext {
-                    encryption_context: None,
-                    hash,
-                },
-            };
-            writes.push(write);
-        }
+        let data = Bytes::from(vec![0x33; 512 * 10]);
+        let block_contexts = data
+            .chunks(512)
+            .map(|chunk| BlockContext {
+                encryption_context: None,
+                hash: integrity_hash(&[chunk]),
+            })
+            .collect();
+        let write = ExtentWrite {
+            offset: Block::new_512(0),
+            data,
+            block_contexts,
+        };
+        inner.write(JobId(30), &write, false, IOV_MAX_TEST)?;
+
         // This write has toggled every single context slot
-        inner.write(JobId(30), &writes, false, IOV_MAX_TEST)?;
         for i in 0..10 {
             assert_eq!(
                 inner.active_context[i],
@@ -1984,16 +1924,15 @@ mod test {
         let hash = integrity_hash(&[&data[..]]);
 
         for i in 0..3 {
-            let write = crucible_protocol::Write {
-                eid: 0,
+            let write = ExtentWrite {
                 offset: Block::new_512(i * 2),
                 data: data.clone(),
-                block_context: BlockContext {
+                block_contexts: vec![BlockContext {
                     encryption_context: None,
                     hash,
-                },
+                }],
             };
-            inner.write(JobId(30), &[write], false, IOV_MAX_TEST)?;
+            inner.write(JobId(30), &write, false, IOV_MAX_TEST)?;
         }
         // 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
         // --|---|---|---|---|---|---|---|---|---
@@ -2027,26 +1966,24 @@ mod test {
 
         // Now, do one big write, which will be forced to bounce between the
         // context slots.
-        let mut writes = vec![];
-        let data = Bytes::from(vec![0x33; 512]);
-        let hash = integrity_hash(&[&data[..]]);
-        for i in 0..10 {
-            let write = crucible_protocol::Write {
-                eid: 0,
-                offset: Block::new_512(i),
-                data: data.clone(),
-                block_context: BlockContext {
-                    encryption_context: None,
-                    hash,
-                },
-            };
-            writes.push(write);
-        }
+        let data = Bytes::from(vec![0x33; 512 * 10]);
+        let block_contexts = data
+            .chunks(512)
+            .map(|chunk| BlockContext {
+                encryption_context: None,
+                hash: integrity_hash(&[chunk]),
+            })
+            .collect();
+        let write = ExtentWrite {
+            offset: Block::new_512(0),
+            data,
+            block_contexts,
+        };
         // This write should toggled every single context slot:
         // 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
         // --|---|---|---|---|---|---|---|---|---
         // A | B | A | B | A | B | B | B | B | B
-        inner.write(JobId(30), &writes, false, IOV_MAX_TEST)?;
+        inner.write(JobId(30), &write, false, IOV_MAX_TEST)?;
         for i in 0..10 {
             assert_eq!(
                 inner.active_context[i],
@@ -2091,16 +2028,15 @@ mod test {
         let hash = integrity_hash(&[&data[..]]);
 
         for i in 0..3 {
-            let write = crucible_protocol::Write {
-                eid: 0,
+            let write = ExtentWrite {
                 offset: Block::new_512(i * 2),
                 data: data.clone(),
-                block_context: BlockContext {
+                block_contexts: vec![BlockContext {
                     encryption_context: None,
                     hash,
-                },
+                }],
             };
-            inner.write(JobId(30), &[write], false, IOV_MAX_TEST)?;
+            inner.write(JobId(30), &write, false, IOV_MAX_TEST)?;
         }
         // 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
         // --|---|---|---|---|---|---|---|---|---
@@ -2134,23 +2070,21 @@ mod test {
 
         // Now, do two big writes, which will be forced to bounce between the
         // context slots.
-        let mut writes = vec![];
-        let data = Bytes::from(vec![0x33; 512]);
-        let hash = integrity_hash(&[&data[..]]);
-        for i in 0..10 {
-            let write = crucible_protocol::Write {
-                eid: 0,
-                offset: Block::new_512(i),
-                data: data.clone(),
-                block_context: BlockContext {
-                    encryption_context: None,
-                    hash,
-                },
-            };
-            writes.push(write);
-        }
-        inner.write(JobId(30), &writes, false, IOV_MAX_TEST)?;
-        inner.write(JobId(30), &writes, false, IOV_MAX_TEST)?;
+        let data = Bytes::from(vec![0x33; 512 * 10]);
+        let block_contexts = data
+            .chunks(512)
+            .map(|chunk| BlockContext {
+                encryption_context: None,
+                hash: integrity_hash(&[chunk]),
+            })
+            .collect();
+        let write = ExtentWrite {
+            offset: Block::new_512(0),
+            data,
+            block_contexts,
+        };
+        inner.write(JobId(30), &write, false, IOV_MAX_TEST)?;
+        inner.write(JobId(30), &write, false, IOV_MAX_TEST)?;
         // This write should toggled every single context slot:
         // 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
         // --|---|---|---|---|---|---|---|---|---
@@ -2199,16 +2133,15 @@ mod test {
         let hash = integrity_hash(&[&data[..]]);
 
         for i in 0..2 {
-            let write = crucible_protocol::Write {
-                eid: 0,
+            let write = ExtentWrite {
                 offset: Block::new_512(i * 2),
                 data: data.clone(),
-                block_context: BlockContext {
+                block_contexts: vec![BlockContext {
                     encryption_context: None,
                     hash,
-                },
+                }],
             };
-            inner.write(JobId(30), &[write], false, IOV_MAX_TEST)?;
+            inner.write(JobId(30), &write, false, IOV_MAX_TEST)?;
         }
         // 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
         // --|---|---|---|---|---|---|---|---|---
@@ -2242,23 +2175,21 @@ mod test {
 
         // Now, do two big writes, which will be forced to bounce between the
         // context slots.
-        let mut writes = vec![];
-        let data = Bytes::from(vec![0x33; 512]);
-        let hash = integrity_hash(&[&data[..]]);
-        for i in 0..10 {
-            let write = crucible_protocol::Write {
-                eid: 0,
-                offset: Block::new_512(i),
-                data: data.clone(),
-                block_context: BlockContext {
-                    encryption_context: None,
-                    hash,
-                },
-            };
-            writes.push(write);
-        }
-        inner.write(JobId(30), &writes, false, IOV_MAX_TEST)?;
-        inner.write(JobId(30), &writes, false, IOV_MAX_TEST)?;
+        let data = Bytes::from(vec![0x33; 512 * 10]);
+        let block_contexts = data
+            .chunks(512)
+            .map(|chunk| BlockContext {
+                encryption_context: None,
+                hash: integrity_hash(&[chunk]),
+            })
+            .collect();
+        let write = ExtentWrite {
+            offset: Block::new_512(0),
+            data,
+            block_contexts,
+        };
+        inner.write(JobId(30), &write, false, IOV_MAX_TEST)?;
+        inner.write(JobId(30), &write, false, IOV_MAX_TEST)?;
         // This write should toggled every single context slot:
         // 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
         // --|---|---|---|---|---|---|---|---|---
@@ -2311,60 +2242,5 @@ mod test {
         };
         let mut ctx_buf = [0u8; BLOCK_CONTEXT_SLOT_SIZE_BYTES as usize];
         bincode::serialize_into(ctx_buf.as_mut_slice(), &Some(c)).unwrap();
-    }
-
-    /// Test that multiple writes to the same location work
-    #[test]
-    fn test_multiple_writes_to_same_location_raw() -> Result<()> {
-        let dir = tempdir()?;
-        let mut inner =
-            RawInner::create(dir.as_ref(), &new_region_definition(), 0)
-                .unwrap();
-
-        // Write the same block four times in the same write command.
-
-        let writes: Vec<_> = (0..4)
-            .map(|i| {
-                let data = Bytes::from(vec![i as u8; 512]);
-                let hash = integrity_hash(&[&data[..]]);
-
-                crucible_protocol::Write {
-                    eid: 0,
-                    offset: Block::new_512(0),
-                    data,
-                    block_context: BlockContext {
-                        encryption_context: None,
-                        hash,
-                    },
-                }
-            })
-            .collect();
-
-        assert_eq!(inner.context_slot_dirty[0], 0b00);
-        inner.write(JobId(30), &writes, false, IOV_MAX_TEST)?;
-
-        // The write should be split into four separate calls to
-        // `write_without_overlaps`, triggering one bonus fsync.
-        assert_eq!(inner.context_slot_dirty[0], 0b11);
-
-        // Block 0 should be 0x03 repeated.
-        let read = ExtentReadRequest {
-            offset: Block::new_512(0),
-            data: BytesMut::with_capacity(512),
-        };
-        let resp = inner.read(JobId(31), read, IOV_MAX_TEST)?;
-
-        let data = Bytes::from(vec![0x03; 512]);
-        let hash = integrity_hash(&[&data[..]]);
-        let block_context = BlockContext {
-            encryption_context: None,
-            hash,
-        };
-
-        // Only the most recent block context should be returned
-        assert_eq!(resp.blocks, vec![vec![block_context],]);
-        assert_eq!(resp.data, BytesMut::from(data.as_ref()));
-
-        Ok(())
     }
 }

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -313,8 +313,17 @@ pub(crate) struct ExtentReadResponse {
 /// reduce memory copies.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) struct ExtentWrite {
+    /// Block offset, relative to the start of this extent
     pub offset: Block,
+
+    /// One context per block to be written
     pub block_contexts: Vec<BlockContext>,
+
+    /// Raw block data to be written
+    ///
+    /// This must be compatible with `block_contexts`, i.e.
+    /// `block_contexts.len() == data.len() / block_size` for this extent's
+    /// chosen block size.
     pub data: bytes::Bytes,
 }
 

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -26,7 +26,7 @@ use crucible_protocol::{
 use repair_client::Client;
 
 use anyhow::{bail, Result};
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use futures::StreamExt;
 use rand::prelude::*;
 use slog::{debug, error, info, o, warn, Logger};
@@ -61,11 +61,11 @@ pub use stats::{DsCountStat, DsStatOuter};
 enum IOop {
     Write {
         dependencies: Vec<JobId>, // Jobs that must finish before this
-        writes: Vec<crucible_protocol::Write>,
+        writes: RegionWrite,
     },
     WriteUnwritten {
         dependencies: Vec<JobId>, // Jobs that must finish before this
-        writes: Vec<crucible_protocol::Write>,
+        writes: RegionWrite,
     },
     Read {
         dependencies: Vec<JobId>, // Jobs that must finish before this
@@ -307,6 +307,122 @@ pub(crate) struct ExtentReadResponse {
     data: BytesMut,
 }
 
+/// Deserialized write operation, contiguous to a single extent
+///
+/// `data` should be a borrowed section of the received `Message::Write`, to
+/// reduce memory copies.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct ExtentWrite {
+    pub offset: Block,
+    pub block_contexts: Vec<BlockContext>,
+    pub data: bytes::Bytes,
+}
+
+/// A `RegionWrite` is an ordered list of extent writes
+///
+/// Each element is a tuple of `(extent id, write)`. The same extent may appear
+/// multiple times in the output list, if the source write has multiple
+/// non-contiguous writes to that extent.
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub(crate) struct RegionWrite(Vec<(u64, ExtentWrite)>);
+
+impl RegionWrite {
+    /// Destructures into a list of contiguous writes, borrowing the buffer
+    ///
+    /// Returns an error if `buf.len()` is not an even multiple of
+    /// `header.blocks.len()`.
+    pub fn new(
+        blocks: &[crucible_protocol::WriteBlockMetadata],
+        mut buf: bytes::Bytes,
+    ) -> Result<Self, CrucibleError> {
+        let block_size = if let Some(b) = blocks.first() {
+            b.offset.block_size_in_bytes() as usize
+        } else {
+            return Ok(Self(vec![]));
+        };
+        if buf.len() % block_size != 0 {
+            return Err(CrucibleError::DataLenUnaligned);
+        } else if buf.len() / block_size != blocks.len() {
+            return Err(CrucibleError::InvalidNumberOfBlocks(format!(
+                "got {} contexts but {} blocks",
+                blocks.len(),
+                buf.len() / block_size
+            )));
+        }
+        let mut out = Self(vec![]);
+        for b in blocks {
+            let append = out.can_append(b);
+            if append {
+                out.append_block_context(b.block_context);
+            } else {
+                out.set_last_data(block_size, &mut buf);
+                out.begin_write(*b);
+            }
+        }
+        out.set_last_data(block_size, &mut buf);
+        assert!(buf.is_empty());
+        Ok(out)
+    }
+
+    /// Checks whether the next write can be appended to our existing write
+    fn can_append(&self, b: &crucible_protocol::WriteBlockMetadata) -> bool {
+        match self.0.last() {
+            None => false,
+            Some((prev_extent, prev_write)) => {
+                *prev_extent == b.eid
+                    && prev_write.offset.value
+                        + prev_write.block_contexts.len() as u64
+                        == b.offset.value
+            }
+        }
+    }
+
+    /// Sets the data member of the last write as part of construction
+    ///
+    /// # Panics
+    /// If the last write already has data
+    fn set_last_data(&mut self, block_size: usize, buf: &mut Bytes) {
+        if let Some((_, prev)) = self.0.last_mut() {
+            assert!(prev.data.is_empty());
+            let data = buf.split_to(prev.block_contexts.len() * block_size);
+            prev.data = data;
+        }
+    }
+
+    /// Appends the given block context to an existing write
+    ///
+    /// # Panics
+    /// If there is no write
+    fn append_block_context(&mut self, ctx: BlockContext) {
+        self.0.last_mut().unwrap().1.block_contexts.push(ctx);
+    }
+
+    /// Begins a new write, guided by the given metadata
+    fn begin_write(&mut self, b: crucible_protocol::WriteBlockMetadata) {
+        self.0.push((
+            b.eid,
+            ExtentWrite {
+                offset: b.offset,
+                block_contexts: vec![b.block_context],
+                data: bytes::Bytes::default(),
+            },
+        ));
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &(u64, ExtentWrite)> {
+        self.0.iter()
+    }
+}
+
+impl IntoIterator for RegionWrite {
+    type Item = (u64, ExtentWrite);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 /*
  * Export the contents or partial contents of a Downstairs Region to
  * the file indicated.
@@ -432,7 +548,8 @@ pub async fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
 
     let mut offset = Block::new_with_ddef(0, &region.def());
     loop {
-        let mut buffer = vec![0; CHUNK_SIZE];
+        let mut buffer = BytesMut::new();
+        buffer.resize(CHUNK_SIZE, 0u8);
 
         /*
          * Read data into the buffer until it is full, or we hit EOF.
@@ -473,40 +590,39 @@ pub async fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
             break;
         }
 
+        // Crop the buffer to exactly our write size
+        buffer.resize(total, 0u8);
+        let buffer = buffer.freeze();
+
         /*
          * Use the same function upstairs uses to decide where to put the
          * data based on the LBA offset.
          */
         let nblocks = Block::from_bytes(total, &rm);
-        let mut pos = Block::from_bytes(0, &rm);
-        let mut writes = vec![];
-        for (eid, offset) in
-            extent_from_offset(&rm, offset, nblocks).blocks(&rm)
-        {
-            let len = Block::new_with_ddef(1, &region.def());
-            let data = &buffer[pos.bytes()..(pos.bytes() + len.bytes())];
-            let mut buffer = BytesMut::with_capacity(data.len());
-            buffer.resize(data.len(), 0);
-            buffer.copy_from_slice(data);
+        let block_size = region.def().block_size() as usize;
+        let blocks: Vec<_> = extent_from_offset(&rm, offset, nblocks)
+            .blocks(&rm)
+            .zip(
+                buffer
+                    .chunks(block_size)
+                    .map(|chunk| integrity_hash(&[chunk])),
+            )
+            .map(|((eid, offset), hash)| {
+                crucible_protocol::WriteBlockMetadata {
+                    eid,
+                    offset,
+                    block_context: BlockContext {
+                        hash,
+                        encryption_context: None,
+                    },
+                }
+            })
+            .collect();
 
-            writes.push(crucible_protocol::Write {
-                eid,
-                offset,
-                data: buffer.freeze(),
-                block_context: BlockContext {
-                    hash: integrity_hash(&[data]),
-                    encryption_context: None,
-                },
-            });
-
-            pos.advance(len);
-        }
+        let write = RegionWrite::new(&blocks, buffer)?;
 
         // We have no job ID, so it makes no sense for accounting.
-        region.region_write(&writes, JobId(0), false).await?;
-
-        assert_eq!(nblocks, pos);
-        assert_eq!(total, pos.bytes());
+        region.region_write(write, JobId(0), false).await?;
         offset.advance(nblocks);
     }
 
@@ -1898,11 +2014,14 @@ impl Downstairs {
                     data,
                 }))
             }
-            IOop::WriteUnwritten { writes, .. } => {
+            IOop::WriteUnwritten { .. } => {
                 /*
                  * Any error from an IO should be intercepted here and passed
                  * back to the upstairs.
                  */
+                let IOop::WriteUnwritten { writes, .. } = job.work else {
+                    unreachable!();
+                };
                 let result = if self.write_errors && random() && random() {
                     warn!(self.log, "returning error on writeunwritten!");
                     Err(CrucibleError::GenericError("test error".to_string()))
@@ -1922,10 +2041,14 @@ impl Downstairs {
                     result,
                 }))
             }
-            IOop::Write {
-                dependencies,
-                writes,
-            } => {
+            IOop::Write { .. } => {
+                let IOop::Write {
+                    writes,
+                    dependencies,
+                } = job.work
+                else {
+                    unreachable!();
+                };
                 let result = if self.write_errors && random() && random() {
                     warn!(self.log, "returning error on write!");
                     Err(CrucibleError::GenericError("test error".to_string()))
@@ -2612,7 +2735,7 @@ impl Downstairs {
         let r = match m {
             Message::Write { header, data } => {
                 cdt::submit__write__start!(|| header.job_id.0);
-                let writes = header.get_writes(data);
+                let writes = RegionWrite::new(&header.blocks, data)?;
 
                 let new_write = IOop::Write {
                     dependencies: header.dependencies,
@@ -2648,7 +2771,7 @@ impl Downstairs {
             }
             Message::WriteUnwritten { header, data } => {
                 cdt::submit__writeunwritten__start!(|| header.job_id.0);
-                let writes = header.get_writes(data);
+                let writes = RegionWrite::new(&header.blocks, data)?;
 
                 let new_write = IOop::WriteUnwritten {
                     dependencies: header.dependencies,
@@ -3651,7 +3774,7 @@ mod test {
                 ds_id,
                 work: IOop::WriteUnwritten {
                     dependencies: deps,
-                    writes: Vec::with_capacity(1),
+                    writes: RegionWrite(vec![]),
                 },
                 state: WorkState::New,
             },
@@ -4102,27 +4225,29 @@ mod test {
     // A test function that will return a generic crucible write command
     // for use when building the IOop::Write structure.  The data (of 9's)
     // matches the hash.
-    fn create_generic_test_write(eid: u64) -> Vec<crucible_protocol::Write> {
-        let data = BytesMut::from(&[9u8; 512][..]);
+    fn create_generic_test_write(eid: u64) -> RegionWrite {
+        let data = Bytes::from(vec![9u8; 512]);
         let offset = Block::new_512(1);
 
-        vec![crucible_protocol::Write {
+        RegionWrite(vec![(
             eid,
-            offset,
-            data: data.freeze(),
-            block_context: BlockContext {
-                encryption_context: Some(
-                    crucible_protocol::EncryptionContext {
-                        nonce: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-                        tag: [
-                            4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-                            18, 19,
-                        ],
-                    },
-                ),
-                hash: 14137680576404864188, // Hash for all 9s
+            ExtentWrite {
+                offset,
+                data,
+                block_contexts: vec![BlockContext {
+                    encryption_context: Some(
+                        crucible_protocol::EncryptionContext {
+                            nonce: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                            tag: [
+                                4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+                                17, 18, 19,
+                            ],
+                        },
+                    ),
+                    hash: 14137680576404864188, // Hash for all 9s
+                }],
             },
-        }]
+        )])
     }
 
     #[tokio::test]
@@ -6584,5 +6709,122 @@ mod test {
             }
         }
         Ok(())
+    }
+
+    #[test]
+    fn decode_write() {
+        use crucible_protocol::WriteBlockMetadata;
+        let blocks = vec![WriteBlockMetadata {
+            eid: 0,
+            offset: Block::new_512(0),
+            block_context: BlockContext {
+                hash: 123,
+                encryption_context: None,
+            },
+        }];
+        let data = Bytes::from(vec![1u8; 512]);
+        let w = RegionWrite::new(&blocks, data).unwrap();
+        assert_eq!(w.0.len(), 1);
+
+        // Two contiguous blocks
+        let blocks = vec![
+            WriteBlockMetadata {
+                eid: 0,
+                offset: Block::new_512(0),
+                block_context: BlockContext {
+                    hash: 123,
+                    encryption_context: None,
+                },
+            },
+            WriteBlockMetadata {
+                eid: 0,
+                offset: Block::new_512(1),
+                block_context: BlockContext {
+                    hash: 123,
+                    encryption_context: None,
+                },
+            },
+        ];
+        let data = Bytes::from(vec![1u8; 512 * 2]);
+        let w = RegionWrite::new(&blocks, data).unwrap();
+        assert_eq!(w.0.len(), 1);
+        assert_eq!(w.0[0].0, 0);
+        assert_eq!(w.0[0].1.offset, Block::new_512(0));
+        assert_eq!(w.0[0].1.data.len(), 512 * 2);
+
+        // Two non-contiguous blocks
+        let blocks = vec![
+            WriteBlockMetadata {
+                eid: 1,
+                offset: Block::new_512(0),
+                block_context: BlockContext {
+                    hash: 123,
+                    encryption_context: None,
+                },
+            },
+            WriteBlockMetadata {
+                eid: 2,
+                offset: Block::new_512(1),
+                block_context: BlockContext {
+                    hash: 123,
+                    encryption_context: None,
+                },
+            },
+        ];
+        let data = Bytes::from(vec![1u8; 512 * 2]);
+        let w = RegionWrite::new(&blocks, data).unwrap();
+        assert_eq!(w.0.len(), 2);
+        assert_eq!(w.0[0].0, 1);
+        assert_eq!(w.0[0].1.offset, Block::new_512(0));
+        assert_eq!(w.0[0].1.data.len(), 512);
+        assert_eq!(w.0[1].0, 2);
+        assert_eq!(w.0[1].1.offset, Block::new_512(1));
+        assert_eq!(w.0[1].1.data.len(), 512);
+
+        // Overlapping writes to the same block
+        let blocks = vec![
+            WriteBlockMetadata {
+                eid: 1,
+                offset: Block::new_512(3),
+                block_context: BlockContext {
+                    hash: 123,
+                    encryption_context: None,
+                },
+            },
+            WriteBlockMetadata {
+                eid: 1,
+                offset: Block::new_512(3),
+                block_context: BlockContext {
+                    hash: 123,
+                    encryption_context: None,
+                },
+            },
+        ];
+        let data = Bytes::from(vec![1u8; 512 * 2]);
+        let w = RegionWrite::new(&blocks, data).unwrap();
+        assert_eq!(w.0.len(), 2);
+        assert_eq!(w.0[0].0, 1);
+        assert_eq!(w.0[0].1.offset, Block::new_512(3));
+        assert_eq!(w.0[0].1.data.len(), 512);
+        assert_eq!(w.0[1].0, 1);
+        assert_eq!(w.0[1].1.offset, Block::new_512(3));
+        assert_eq!(w.0[1].1.data.len(), 512);
+
+        // Mismatched block / data sizes
+        let blocks = vec![WriteBlockMetadata {
+            eid: 1,
+            offset: Block::new_512(3),
+            block_context: BlockContext {
+                hash: 123,
+                encryption_context: None,
+            },
+        }];
+        let data = Bytes::from(vec![1u8; 512 * 2]);
+        let r = RegionWrite::new(&blocks, data);
+        assert!(r.is_err());
+
+        let data = Bytes::from(vec![1u8; 513]);
+        let r = RegionWrite::new(&blocks, data);
+        assert!(r.is_err());
     }
 }

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -367,8 +367,7 @@ impl RegionWrite {
         }
         let mut out = Self(vec![]);
         for b in blocks {
-            let append = out.can_append(b);
-            if append {
+            if out.can_append(b) {
                 out.append_block_context(b.block_context);
             } else {
                 out.set_last_data(block_size, &mut buf);

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -820,13 +820,13 @@ impl Region {
             cdt::os__write__start!(|| job_id.0);
         }
         for req in writes {
+            // Mark any extents we sent a write-command to as potentially dirty
+            self.dirty_extents.insert(req.extent as usize);
+
             let extent = self.get_opened_extent_mut(req.extent as usize);
             extent
                 .write(job_id, req.write, only_write_unwritten)
                 .await?;
-
-            // Mark any extents we sent a write-command to as potentially dirty
-            self.dirty_extents.insert(req.extent as usize);
         }
 
         if only_write_unwritten {

--- a/upstairs/src/deferred.rs
+++ b/upstairs/src/deferred.rs
@@ -4,11 +4,11 @@ use std::sync::Arc;
 
 use crate::{
     client::ConnectionId, upstairs::UpstairsConfig, BlockContext, BlockOp,
-    BlockRes, ClientId, ImpactedBlocks, Message,
+    BlockRes, ClientId, ImpactedBlocks, Message, RawWrite,
 };
 use bytes::BytesMut;
 use crucible_common::{integrity_hash, CrucibleError, RegionDefinition};
-use crucible_protocol::{RawWrite, WriteBlockMetadata};
+use crucible_protocol::WriteBlockMetadata;
 use futures::{
     future::{ready, Either, Ready},
     stream::FuturesOrdered,

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -16,11 +16,11 @@ use crate::{
     AckStatus, ActiveJobs, AllocRingBuffer, ClientData, ClientIOStateCount,
     ClientId, ClientMap, CrucibleError, DownstairsIO, DownstairsMend, DsState,
     ExtentFix, ExtentRepairIDs, GuestWorkId, IOState, IOStateCount, IOop,
-    ImpactedBlocks, JobId, Message, RawReadResponse, ReadRequest, ReconcileIO,
-    ReconciliationId, RegionDefinition, ReplaceResult, SnapshotDetails,
-    WorkSummary,
+    ImpactedBlocks, JobId, Message, RawReadResponse, RawWrite, ReadRequest,
+    ReconcileIO, ReconciliationId, RegionDefinition, ReplaceResult,
+    SnapshotDetails, WorkSummary,
 };
-use crucible_protocol::{RawWrite, WriteHeader};
+use crucible_protocol::WriteHeader;
 
 use rand::prelude::*;
 use ringbuffer::RingBuffer;

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -587,6 +587,27 @@ impl EncryptionContext {
     }
 }
 
+/// Write data, containing data from all blocks
+#[derive(Debug)]
+pub struct RawWrite {
+    /// Per-block metadata
+    pub blocks: Vec<WriteBlockMetadata>,
+    /// Raw data
+    pub data: bytes::BytesMut,
+}
+
+impl RawWrite {
+    /// Builds a new empty `RawWrite` with the given capacity
+    pub fn with_capacity(block_count: usize, block_size: u64) -> Self {
+        Self {
+            blocks: Vec::with_capacity(block_count),
+            data: bytes::BytesMut::with_capacity(
+                block_count * block_size as usize,
+            ),
+        }
+    }
+}
+
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Copy, Clone, JsonSchema, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
https://github.com/oxidecomputer/crucible/pull/1206 reorganized the `Message::Write` variant so that the bulk data was all packed at the end, and could be sent in a single write (instead of incurring the cost of serialization).

The `Downstairs` then took that data and split it into a `Vec<crucible_protocol::Write>` objects, which each look like this:
```rust
pub struct Write {
    pub eid: u64,
    pub offset: Block,
    pub data: Bytes,

    pub block_context: BlockContext,
}
```

Note that this `Write` does not do an extra copy; the `data: Bytes` is borrowed from the received data (this is good).

However, it's still an awkward API: a single contiguous `Bytes` object arrives on the wire, then we split it into a bunch of smaller (block-sized) chunks, then we write those chunks to contiguous blocks with `pwritev`.

Put a different way, it's awkward to have `ExtentInner::write` take a `&[crucible_protocol::Write]`: the extent implementation has to jump through hoops to reassemble contiguous writes from the incoming slice of writes.  As a smaller papercut, it's also awkward that this struct contains an `eid`: what should happen if someone calls `ExtentInner::write` with an `eid` that doesn't match?

This PR reorganizes our writes into two new types in the `crucible-downstairs` crate:
```rust
/// Deserialized write operation, contiguous to a single extent
///
/// `data` should be a borrowed section of the received `Message::Write`, to
/// reduce memory copies.
#[derive(Debug, Clone, Eq, PartialEq)]
pub(crate) struct ExtentWrite {
    pub offset: Block, // starting position
    pub block_contexts: Vec<BlockContext>, // one per block
    pub data: bytes::Bytes, // num blocks * block size
}

/// `ExtentWrite` plus an extent tag
#[derive(Debug, Clone, Eq, PartialEq)]
pub(crate) struct Write {
    extent: u64,
    write: ExtentWrite,
}
```

The `ExtentWrite` is represents a set of contiguous writes, because it simply doesn't store one offset per block; it just has a starting offset.  Note that it does not contain an extent tag, so `ExtentInner::write` no longer needs to think about what happens if there's a mismatch.  The target extent lives in a new `crucible_downstairs::Write` object, where it's used for dispatch at the `Region` level (but not passed to the `Extent`).

The process of splitting the write into contiguous, separated-by-extent subwrites still has to happen, but it's now a conversion from `Message::Write → Vec<Write>` that happens when messages are received.

This means that the extent implementations can use `pwrite` instead of `pwritev`, and no longer need to consider whether the incoming writes are contiguous.

There should be no change to on-disk formats; this is purely a change to how we wrangle data from the wire into the extent data file.

Performance benchmarking to come, but this feels like the correct architecture to me.