### PR TITLE
Add some DTrace scripts to the package.

### DIFF
--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -6,6 +6,7 @@ source.rust.release = true
 source.paths = [
   { from = "agent/smf", to = "/var/svc/manifest/site/crucible" },
   { from = "agent/downstairs_method_script.sh", to = "/opt/oxide/lib/svc/manifest/crucible/downstairs.sh" },
+  { from = "tools/dtrace/downstairs_count.d", to = "/opt/oxide/dtrace/downstairs_count.d" },
 ]
 output.type = "zone"
 
@@ -16,5 +17,10 @@ source.rust.binary_names = ["crucible-pantry"]
 source.rust.release = true
 source.paths = [
   { from = "pantry/smf/pantry.xml", to = "/var/svc/manifest/site/crucible/pantry.xml" },
+  { from = "tools/dtrace/upstairs_info.d", to = "/opt/oxide/dtrace/upstairs_info.d" },
+  { from = "tools/dtrace/upstairs_repair.d", to = "/opt/oxide/dtrace/upstairs_repair.d" },
+  { from = "tools/dtrace/upstairs_raw.d", to = "/opt/oxide/dtrace/upstairs_raw.d" },
+  { from = "tools/dtrace/get-lr-state.sh", to = "/opt/oxide/dtrace/get-lr-state.sh" },
+  { from = "tools/dtrace/get-ds-state.sh", to = "/opt/oxide/dtrace/get-ds-state.sh" },
 ]
 output.type = "zone"

--- a/tools/dtrace/upstairs_info.d
+++ b/tools/dtrace/upstairs_info.d
@@ -21,7 +21,7 @@ tick-1s
 {
     printf("%6s ", "PID");
     printf("%17s %17s %17s", "DS STATE 0", "DS STATE 1", "DS STATE 2");
-    printf("  %5s %5s %5s %5s", "UPW", "DSW", "DELTA", "BAKPR");
+    printf("  %5s %5s %9s %5s", "UPW", "DSW", "JOBID", "BAKPR");
     printf(" %10s", "WRITE_BO");
     printf("  %5s %5s %5s", "NEW0", "NEW1", "NEW2");
     printf("  %5s %5s %5s", "IP0", "IP1", "IP2");
@@ -50,17 +50,9 @@ crucible_upstairs*:::up-status
     printf(" %5s", json(copyinstr(arg1), "ok.ds_count"));
 
     /*
-     * Job ID delta and backpressure
+     * Job ID and backpressure
      */
-    current_str = json(copyinstr(arg1), "ok.next_job_id");
-    current = strtoll(current_str, 10);
-    if (last[pid] == 0)
-        delta = current;
-    else
-        delta = current - last[pid];
-
-    last[pid] = current;
-    printf(" %5d", delta);
+    printf(" %9d", json(copyinstr(arg1), "ok.next_job_id"));
     printf(" %5s", json(copyinstr(arg1), "ok.up_backpressure"));
     printf(" %10s", json(copyinstr(arg1), "ok.write_bytes_out"));
 


### PR DESCRIPTION
Added a few dtrace scripts to the pantry and downstairs packages. 
Updated the upstairs_info.d DTrace script to handle multiple volumes under the same PID.  
More work is needed there, but this at least will print correct numbers.