### PR TITLE
replace needing no work should not be an error

### DIFF
--- a/crucible-client-types/src/lib.rs
+++ b/crucible-client-types/src/lib.rs
@@ -103,6 +103,7 @@ pub enum ReplaceResult {
     StartedAlready,
     CompletedAlready,
     Missing,
+    VcrMatches,
 }
 
 impl Debug for ReplaceResult {
@@ -120,6 +121,21 @@ impl Debug for ReplaceResult {
             ReplaceResult::Missing => {
                 write!(f, "Missing")
             }
+            ReplaceResult::VcrMatches { .. } => {
+                write!(f, "VcrMatches")
+            }
         }
     }
+}
+
+/// Result of comparing an original volume construction request to a candidate
+/// replacement one.
+pub enum ReplacementRequestCheck {
+    /// The replacement was validated, and this variant holds the old downstairs
+    /// target and the new one replacing it.
+    Valid { old: SocketAddr, new: SocketAddr },
+
+    /// The replacement is not necessary because the replacement matches the
+    /// original.
+    ReplacementMatchesOriginal,
 }

--- a/openapi/crucible-pantry.json
+++ b/openapi/crucible-pantry.json
@@ -787,7 +787,8 @@
           "started",
           "started_already",
           "completed_already",
-          "missing"
+          "missing",
+          "vcr_matches"
         ]
       },
       "ScrubResponse": {


### PR DESCRIPTION
Previously, if a caller requested a target replacement, and supplied the same construction request for the original and replacement arguments, a `ReplaceRequestInvalid` error would be returned. This isn't exactly an error, it's a state where no work needs to be done.

Return `VcrMatches` as a `ReplaceResult` if this is the case, not an error. Note `compare_vcr_for_replacement` still returns all the same errors otherwise.