### PR TITLE
Don't allow replacement before the upstairs is active

### DIFF
--- a/crucible-client-types/src/lib.rs
+++ b/crucible-client-types/src/lib.rs
@@ -104,6 +104,7 @@ pub enum ReplaceResult {
     CompletedAlready,
     Missing,
     VcrMatches,
+    NotActive,
 }
 
 impl Debug for ReplaceResult {
@@ -123,6 +124,9 @@ impl Debug for ReplaceResult {
             }
             ReplaceResult::VcrMatches { .. } => {
                 write!(f, "VcrMatches")
+            }
+            ReplaceResult::NotActive => {
+                write!(f, "NotActive")
             }
         }
     }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -3454,16 +3454,15 @@ mod test {
         let new_downstairs = test_downstairs_set.new_downstairs().await?;
 
         // Replace a downstairs.
-        let res = volume
+        assert!(volume
             .replace_downstairs(
                 test_downstairs_set.opts().id,
                 test_downstairs_set.downstairs1_address().await,
                 new_downstairs.address().await,
             )
             .await
-            .unwrap();
+            .is_err());
 
-        assert_eq!(res, ReplaceResult::Started);
         Ok(())
     }
 

--- a/openapi/crucible-pantry.json
+++ b/openapi/crucible-pantry.json
@@ -788,7 +788,8 @@
           "started_already",
           "completed_already",
           "missing",
-          "vcr_matches"
+          "vcr_matches",
+          "not_active"
         ]
       },
       "ScrubResponse": {

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -2625,10 +2625,19 @@ impl Downstairs {
         new: SocketAddr,
         up_state: &UpstairsState,
     ) -> Result<ReplaceResult, CrucibleError> {
-        warn!(
-            self.log,
-            "{id} request to replace downstairs {old} with {new}"
-        );
+        match up_state {
+            UpstairsState::Active => {
+                warn!(
+                    self.log,
+                    "{id} request to replace downstairs {old} with {new}"
+                );
+            }
+            _ => {
+                return Err(CrucibleError::ReplaceRequestInvalid(
+                    "Can't replace while Upstairs is not Active".to_string(),
+                ));
+            }
+        }
 
         // We check all targets first to not only find our current target,
         // but to be sure our new target is not an already active target


### PR DESCRIPTION
Return an error if a downstairs replacement arrives before the upstairs is active.