### PR TITLE
Refactor downstairs reads

### DIFF
--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -539,11 +539,11 @@ async fn show_extent(
 
             let response = region
                 .region_read(
-                    &RegionReadRequest(vec![(
-                        cmp_extent as u64,
-                        Block::new_with_ddef(block, &region.def()),
-                        NonZeroUsize::new(1).unwrap(),
-                    )]),
+                    &RegionReadRequest(vec![RegionReadReq {
+                        extent: cmp_extent as u64,
+                        offset: Block::new_with_ddef(block, &region.def()),
+                        count: NonZeroUsize::new(1).unwrap(),
+                    }]),
                     JobId(0),
                 )
                 .await?;
@@ -654,11 +654,14 @@ async fn show_extent_block(
 
         let response = region
             .region_read(
-                &RegionReadRequest(vec![(
-                    cmp_extent as u64,
-                    Block::new_with_ddef(block_in_extent, &region.def()),
-                    NonZeroUsize::new(1).unwrap(),
-                )]),
+                &RegionReadRequest(vec![RegionReadReq {
+                    extent: cmp_extent as u64,
+                    offset: Block::new_with_ddef(
+                        block_in_extent,
+                        &region.def(),
+                    ),
+                    count: NonZeroUsize::new(1).unwrap(),
+                }]),
                 JobId(0),
             )
             .await?;

--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -12,7 +12,6 @@ use tracing::instrument;
 
 use crate::region::JobOrReconciliationId;
 use crucible_common::*;
-use crucible_protocol::RawReadResponse;
 use repair_client::types::FileType;
 
 use super::*;
@@ -42,30 +41,12 @@ pub(crate) trait ExtentInner: Send + Sync + Debug {
         job_id: JobOrReconciliationId,
     ) -> Result<(), CrucibleError>;
 
-    fn read_into(
-        &mut self,
-        job_id: JobId,
-        requests: &[crucible_protocol::ReadRequest],
-        out: &mut RawReadResponse,
-        iov_max: usize,
-    ) -> Result<(), CrucibleError>;
-
-    /// Performs a read then destructures into a `Vec<ReadResponse>`
-    #[cfg(test)]
     fn read(
         &mut self,
         job_id: JobId,
-        requests: &[crucible_protocol::ReadRequest],
+        req: ExtentReadRequest,
         iov_max: usize,
-    ) -> Result<RawReadResponse, CrucibleError> {
-        let block_size = requests[0].offset.block_size_in_bytes();
-        let mut out =
-            RawReadResponse::with_capacity(requests.len(), block_size as u64);
-        if !requests.is_empty() {
-            self.read_into(job_id, requests, &mut out, iov_max)?;
-        }
-        Ok(out)
-    }
+    ) -> Result<ExtentReadResponse, CrucibleError>;
 
     fn write(
         &mut self,
@@ -553,22 +534,19 @@ impl Extent {
     /// an error occurs while processing any of the requests, the state of
     /// `responses` is undefined.
     #[instrument]
-    pub async fn read_into(
+    pub async fn read(
         &mut self,
         job_id: JobId,
-        requests: &[crucible_protocol::ReadRequest],
-        out: &mut RawReadResponse,
-    ) -> Result<(), CrucibleError> {
-        cdt::extent__read__start!(|| {
-            (job_id.0, self.number, requests.len() as u64)
-        });
+        req: ExtentReadRequest,
+    ) -> Result<ExtentReadResponse, CrucibleError> {
+        let num_blocks =
+            (req.data.len() / req.offset.block_size_in_bytes() as usize) as u64;
+        cdt::extent__read__start!(|| { (job_id.0, self.number, num_blocks,) });
 
-        self.inner.read_into(job_id, requests, out, self.iov_max)?;
-        cdt::extent__read__done!(|| {
-            (job_id.0, self.number, requests.len() as u64)
-        });
+        let out = self.inner.read(job_id, req, self.iov_max)?;
+        cdt::extent__read__done!(|| { (job_id.0, self.number, num_blocks) });
 
-        Ok(())
+        Ok(out)
     }
 
     #[instrument]
@@ -848,13 +826,13 @@ pub fn sync_path<P: AsRef<Path> + std::fmt::Debug>(
 pub(crate) fn check_input(
     extent_size: Block,
     offset: Block,
-    data: &[u8],
+    data_len: usize,
 ) -> Result<(), CrucibleError> {
     let block_size = extent_size.block_size_in_bytes() as u64;
     /*
      * Only accept block-aligned operations
      */
-    if data.len() % block_size as usize != 0 {
+    if data_len % block_size as usize != 0 {
         crucible_bail!(DataLenUnaligned);
     }
 
@@ -869,7 +847,7 @@ pub(crate) fn check_input(
     let total_size = block_size * extent_size.value;
     let byte_offset = offset.value * block_size;
 
-    if (byte_offset + data.len() as u64) > total_size {
+    if (byte_offset + data_len as u64) > total_size {
         crucible_bail!(OffsetInvalid);
     }
 
@@ -887,8 +865,8 @@ mod test {
         let mut data = BytesMut::with_capacity(512);
         data.put(&[1; 512][..]);
 
-        check_input(extent_size, Block::new_512(0), &data).unwrap();
-        check_input(extent_size, Block::new_512(99), &data).unwrap();
+        check_input(extent_size, Block::new_512(0), data.len()).unwrap();
+        check_input(extent_size, Block::new_512(99), data.len()).unwrap();
     }
 
     #[test]
@@ -898,7 +876,7 @@ mod test {
         let mut data = BytesMut::with_capacity(513);
         data.put(&[1; 513][..]);
 
-        check_input(extent_size, Block::new_512(0), &data).unwrap();
+        check_input(extent_size, Block::new_512(0), data.len()).unwrap();
     }
 
     #[test]
@@ -908,7 +886,7 @@ mod test {
         let mut data = BytesMut::with_capacity(511);
         data.put(&[1; 511][..]);
 
-        check_input(extent_size, Block::new_512(0), &data).unwrap();
+        check_input(extent_size, Block::new_512(0), data.len()).unwrap();
     }
 
     #[test]
@@ -918,7 +896,7 @@ mod test {
         let mut data = BytesMut::with_capacity(512);
         data.put(&[1; 512][..]);
 
-        check_input(extent_size, Block::new_512(100), &data).unwrap();
+        check_input(extent_size, Block::new_512(100), data.len()).unwrap();
     }
 
     #[test]
@@ -928,7 +906,7 @@ mod test {
         let mut data = BytesMut::with_capacity(1024);
         data.put(&[1; 1024][..]);
 
-        check_input(extent_size, Block::new_512(99), &data).unwrap();
+        check_input(extent_size, Block::new_512(99), data.len()).unwrap();
     }
 
     #[test]
@@ -938,7 +916,7 @@ mod test {
         let mut data = BytesMut::with_capacity(512 * 100);
         data.put(&[1; 512 * 100][..]);
 
-        check_input(extent_size, Block::new_512(1), &data).unwrap();
+        check_input(extent_size, Block::new_512(1), data.len()).unwrap();
     }
 
     #[test]

--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -530,9 +530,14 @@ impl Extent {
         self.number
     }
 
-    /// Read the real data off underlying storage, and get block metadata. If
-    /// an error occurs while processing any of the requests, the state of
-    /// `responses` is undefined.
+    /// Read the data and metadata off underlying storage
+    ///
+    /// The size of the read is determined by the `capacity` of the (allocated
+    /// but uninitialized) buffer in `req`.
+    ///
+    /// If an error occurs while processing any of the requests, an error is
+    /// returned.  Otherwise, the value in `ExtentReadResponse::data` is
+    /// guaranteed to be fully initialized and of the requested length.
     #[instrument]
     pub async fn read(
         &mut self,

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -10,10 +10,10 @@ use crate::{
     },
     integrity_hash, mkdir_for_file,
     region::{BatchedPwritev, JobOrReconciliationId},
-    Block, BlockContext, CrucibleError, JobId, RegionDefinition,
+    Block, BlockContext, CrucibleError, ExtentReadRequest, ExtentReadResponse,
+    JobId, RegionDefinition,
 };
 
-use crucible_protocol::{RawReadResponse, ReadResponseBlockMetadata};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use slog::{error, Logger};
@@ -169,144 +169,81 @@ impl ExtentInner for RawInner {
         Ok(())
     }
 
-    fn read_into(
+    fn read(
         &mut self,
         job_id: JobId,
-        requests: &[crucible_protocol::ReadRequest],
-        out: &mut RawReadResponse,
-        _iov_max: usize, // unused by raw file backend
-    ) -> Result<(), CrucibleError> {
-        // This code batches up operations for contiguous regions of
-        // ReadRequests, so we can perform larger read syscalls queries. This
-        // significantly improves read throughput.
+        req: ExtentReadRequest,
+        _iov_max: usize, // unused by SQLite backend
+    ) -> Result<ExtentReadResponse, CrucibleError> {
+        let mut buf = req.data;
+        let block_size = self.extent_size.block_size_in_bytes() as u64;
+        let num_blocks = buf.capacity() as u64 / block_size;
+        check_input(self.extent_size, req.offset, buf.capacity())?;
 
-        // Keep track of the index of the first request in any contiguous run
-        // of requests. Of course, a "contiguous run" might just be a single
-        // request.
-        let mut req_run_start = 0;
-        let block_size = self.extent_size.block_size_in_bytes();
+        // Query the block metadata
+        cdt::extent__read__get__contexts__start!(|| {
+            (job_id.0, self.extent_number, num_blocks)
+        });
+        let block_contexts =
+            self.get_block_contexts(req.offset.value, num_blocks)?;
+        cdt::extent__read__get__contexts__done!(|| {
+            (job_id.0, self.extent_number, num_blocks)
+        });
 
-        let mut buf = out.data.split_off(out.data.len());
-        while req_run_start < requests.len() {
-            let first_req = &requests[req_run_start];
+        // Convert from DownstairsBlockContext -> BlockContext
+        let blocks = block_contexts
+            .into_iter()
+            .map(|bs| bs.into_iter().map(|b| b.block_context).collect())
+            .collect();
 
-            // Starting from the first request in the potential run, we scan
-            // forward until we find a request with a block that isn't
-            // contiguous with the request before it. Since we're counting
-            // pairs, and the number of pairs is one less than the number of
-            // requests, we need to add 1 to get our actual run length.
-            let mut n_contiguous_blocks = 1;
+        // To avoid a `memset`, we're reading directly into uninitialized
+        // memory in the buffer.  This is fine; we sized the buffer
+        // appropriately in advance (and will panic here if we messed up).
+        assert!(buf.is_empty());
 
-            for request_window in requests[req_run_start..].windows(2) {
-                if request_window[0].offset.value + 1
-                    == request_window[1].offset.value
-                {
-                    n_contiguous_blocks += 1;
-                } else {
-                    break;
-                }
-            }
+        // Finally we get to read the actual data. That's why we're here
+        cdt::extent__read__file__start!(|| {
+            (job_id.0, self.extent_number, num_blocks)
+        });
 
-            // Create our responses and push them into the output. While we're
-            // at it, check for overflows.
-            let resp_run_start = out.blocks.len();
-            for req in requests[req_run_start..][..n_contiguous_blocks].iter() {
-                let resp = ReadResponseBlockMetadata {
-                    eid: req.eid,
-                    offset: req.offset,
-                    block_contexts: Vec::with_capacity(1),
-                };
-                out.blocks.push(resp);
-            }
-
-            // To avoid a `memset`, we're reading directly into uninitialized
-            // memory in the buffer.  This is fine; we sized the buffer
-            // appropriately in advance (and will panic here if we messed up).
-            let expected_bytes = n_contiguous_blocks * block_size as usize;
-            assert!(buf.spare_capacity_mut().len() >= expected_bytes);
-
-            let first_resp = &out.blocks[resp_run_start];
-            check_input(self.extent_size, first_resp.offset, &buf)?;
-
-            // Finally we get to read the actual data. That's why we're here
-            cdt::extent__read__file__start!(|| {
-                (job_id.0, self.extent_number, n_contiguous_blocks as u64)
-            });
-
-            // SAFETY: the buffer has sufficient capacity, and this is a valid
-            // file descriptor.
-            let r = unsafe {
-                libc::pread(
-                    self.file.as_raw_fd(),
-                    buf.spare_capacity_mut().as_mut_ptr() as *mut libc::c_void,
-                    expected_bytes as libc::size_t,
-                    first_req.offset.value as i64 * block_size as i64,
-                )
-            };
-            // Check against the expected number of bytes.  We could do more
-            // robust error handling here (e.g. retrying in a loop), but for
-            // now, simply bailing out seems wise.
-            let r = nix::errno::Errno::result(r).map(|r| r as usize);
-            let num_bytes = r.map_err(|e| {
-                CrucibleError::IoError(format!(
-                    "extent {}: read failed: {e}",
-                    self.extent_number
-                ))
-            })?;
-            if num_bytes != expected_bytes {
-                return Err(CrucibleError::IoError(format!(
-                    "extent {}: incomplete read \
-                     (expected {expected_bytes}, got {num_bytes})",
-                    self.extent_number
-                )));
-            }
-            // SAFETY: we just initialized this chunk of the buffer
-            unsafe {
-                buf.set_len(expected_bytes);
-            }
-
-            cdt::extent__read__file__done!(|| {
-                (job_id.0, self.extent_number, n_contiguous_blocks as u64)
-            });
-
-            // Reattach this chunk to the main `BytesMut` array
-            //
-            // This should be O(1), because we allocated enough space to not
-            // reallocate anywhere in the process.
-            let chunk = buf.split_to(expected_bytes);
-            out.data.unsplit(chunk);
-
-            // Query the block metadata
-            cdt::extent__read__get__contexts__start!(|| {
-                (job_id.0, self.extent_number, n_contiguous_blocks as u64)
-            });
-            let block_contexts = self.get_block_contexts(
-                first_req.offset.value,
-                n_contiguous_blocks as u64,
-            )?;
-            cdt::extent__read__get__contexts__done!(|| {
-                (job_id.0, self.extent_number, n_contiguous_blocks as u64)
-            });
-
-            // Now it's time to put block contexts into the responses.
-            // We use into_iter here to move values out of enc_ctxts/hashes,
-            // avoiding a clone(). For code consistency, we use iters for the
-            // response and data chunks too. These iters will be the same length
-            // (equal to n_contiguous_blocks) so zipping is fine
-            let resp_iter =
-                out.blocks[resp_run_start..][..n_contiguous_blocks].iter_mut();
-            let ctx_iter = block_contexts.into_iter();
-
-            for (resp, r_ctx) in resp_iter.zip(ctx_iter) {
-                assert!(resp.block_contexts.is_empty());
-                resp.block_contexts
-                    .extend(r_ctx.into_iter().map(|x| x.block_context));
-            }
-
-            req_run_start += n_contiguous_blocks;
+        // SAFETY: the buffer has sufficient capacity, and this is a valid
+        // file descriptor.
+        let expected_bytes = buf.capacity();
+        let r = unsafe {
+            libc::pread(
+                self.file.as_raw_fd(),
+                buf.spare_capacity_mut().as_mut_ptr() as *mut libc::c_void,
+                expected_bytes as libc::size_t,
+                req.offset.value as i64 * block_size as i64,
+            )
+        };
+        // Check against the expected number of bytes.  We could do more
+        // robust error handling here (e.g. retrying in a loop), but for
+        // now, simply bailing out seems wise.
+        let r = nix::errno::Errno::result(r).map(|r| r as usize);
+        let num_bytes = r.map_err(|e| {
+            CrucibleError::IoError(format!(
+                "extent {}: read failed: {e}",
+                self.extent_number
+            ))
+        })?;
+        if num_bytes != expected_bytes {
+            return Err(CrucibleError::IoError(format!(
+                "extent {}: incomplete read \
+                      (expected {expected_bytes}, got {num_bytes})",
+                self.extent_number
+            )));
         }
-        out.data.unsplit(buf);
-        Ok(())
+        // SAFETY: we just initialized this chunk of the buffer
+        unsafe {
+            buf.set_len(expected_bytes);
+        }
+
+        cdt::extent__read__file__done!(|| {
+            (job_id.0, self.extent_number, num_blocks)
+        });
+
+        Ok(ExtentReadResponse { data: buf, blocks })
     }
 
     fn flush(
@@ -1428,7 +1365,6 @@ mod test {
     use anyhow::Result;
     use bytes::{Bytes, BytesMut};
     use crucible_protocol::EncryptionContext;
-    use crucible_protocol::ReadRequest;
     use rand::Rng;
     use tempfile::tempdir;
 
@@ -1680,21 +1616,14 @@ mod test {
             };
             inner.write(JobId(20), &[write], true, IOV_MAX_TEST)?;
 
-            let read = ReadRequest {
-                eid: 0,
+            let read = ExtentReadRequest {
                 offset: Block::new_512(0),
+                data: BytesMut::with_capacity(512),
             };
-            let resp = inner.read(JobId(21), &[read], IOV_MAX_TEST)?;
+            let resp = inner.read(JobId(21), read, IOV_MAX_TEST)?;
 
             // We should not get back our data, because block 0 was written.
-            assert_ne!(
-                resp.blocks,
-                vec![ReadResponseBlockMetadata {
-                    eid: 0,
-                    offset: Block::new_512(0),
-                    block_contexts: vec![block_context]
-                }]
-            );
+            assert_ne!(resp.blocks, vec![vec![block_context]]);
             assert_ne!(resp.data, BytesMut::from(data.as_ref()));
         }
 
@@ -1714,21 +1643,14 @@ mod test {
             };
             inner.write(JobId(30), &[write], true, IOV_MAX_TEST)?;
 
-            let read = ReadRequest {
-                eid: 0,
+            let read = ExtentReadRequest {
                 offset: Block::new_512(1),
+                data: BytesMut::with_capacity(512),
             };
-            let resp = inner.read(JobId(31), &[read], IOV_MAX_TEST)?;
+            let resp = inner.read(JobId(31), read, IOV_MAX_TEST)?;
 
             // We should get back our data! Block 1 was never written.
-            assert_eq!(
-                resp.blocks,
-                vec![ReadResponseBlockMetadata {
-                    eid: 0,
-                    offset: Block::new_512(1),
-                    block_contexts: vec![block_context]
-                }]
-            );
+            assert_eq!(resp.blocks, vec![vec![block_context]]);
             assert_eq!(resp.data, BytesMut::from(data.as_ref()));
         }
 
@@ -1937,21 +1859,14 @@ mod test {
             };
             inner.write(JobId(30), &[write], true, IOV_MAX_TEST)?;
 
-            let read = ReadRequest {
-                eid: 0,
+            let read = ExtentReadRequest {
                 offset: Block::new_512(0),
+                data: BytesMut::with_capacity(512),
             };
-            let resp = inner.read(JobId(31), &[read], IOV_MAX_TEST)?;
+            let resp = inner.read(JobId(31), read, IOV_MAX_TEST)?;
 
             // We should get back our data! Block 1 was never written.
-            assert_eq!(
-                resp.blocks,
-                vec![ReadResponseBlockMetadata {
-                    eid: 0,
-                    offset: Block::new_512(0),
-                    block_contexts: vec![block_context]
-                }]
-            );
+            assert_eq!(resp.blocks, vec![vec![block_context]]);
             assert_eq!(resp.data, BytesMut::from(data.as_ref()));
         }
 
@@ -2433,11 +2348,11 @@ mod test {
         assert_eq!(inner.context_slot_dirty[0], 0b11);
 
         // Block 0 should be 0x03 repeated.
-        let read = ReadRequest {
-            eid: 0,
+        let read = ExtentReadRequest {
             offset: Block::new_512(0),
+            data: BytesMut::with_capacity(512),
         };
-        let resp = inner.read(JobId(31), &[read], IOV_MAX_TEST)?;
+        let resp = inner.read(JobId(31), read, IOV_MAX_TEST)?;
 
         let data = Bytes::from(vec![0x03; 512]);
         let hash = integrity_hash(&[&data[..]]);
@@ -2446,15 +2361,8 @@ mod test {
             hash,
         };
 
-        assert_eq!(
-            resp.blocks,
-            vec![ReadResponseBlockMetadata {
-                eid: 0,
-                offset: Block::new_512(0),
-                // Only the most recent block context should be returned
-                block_contexts: vec![block_context],
-            }]
-        );
+        // Only the most recent block context should be returned
+        assert_eq!(resp.blocks, vec![vec![block_context],]);
         assert_eq!(resp.data, BytesMut::from(data.as_ref()));
 
         Ok(())

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -173,7 +173,7 @@ impl ExtentInner for RawInner {
         &mut self,
         job_id: JobId,
         req: ExtentReadRequest,
-        _iov_max: usize, // unused by SQLite backend
+        _iov_max: usize, // unused by raw backend
     ) -> Result<ExtentReadResponse, CrucibleError> {
         let mut buf = req.data;
         let block_size = self.extent_size.block_size_in_bytes() as u64;

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -230,7 +230,7 @@ impl ExtentInner for RawInner {
         if num_bytes != expected_bytes {
             return Err(CrucibleError::IoError(format!(
                 "extent {}: incomplete read \
-                      (expected {expected_bytes}, got {num_bytes})",
+                 (expected {expected_bytes}, got {num_bytes})",
                 self.extent_number
             )));
         }

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -4,11 +4,10 @@ use crate::{
     extent::{check_input, extent_path, DownstairsBlockContext, ExtentInner},
     integrity_hash,
     region::{BatchedPwritev, JobOrReconciliationId},
-    Block, BlockContext, CrucibleError, JobId, RegionDefinition,
+    Block, BlockContext, CrucibleError, ExtentReadRequest, ExtentReadResponse,
+    JobId, RegionDefinition,
 };
-use crucible_protocol::{
-    EncryptionContext, RawReadResponse, ReadResponseBlockMetadata,
-};
+use crucible_protocol::EncryptionContext;
 
 use anyhow::{bail, Result};
 use rusqlite::{params, Connection, Transaction};
@@ -43,14 +42,13 @@ impl ExtentInner for SqliteInner {
         self.0.lock().unwrap().flush(new_flush, new_gen, job_id)
     }
 
-    fn read_into(
+    fn read(
         &mut self,
         job_id: JobId,
-        requests: &[crucible_protocol::ReadRequest],
-        out: &mut RawReadResponse,
+        req: ExtentReadRequest,
         _iov_max: usize, // unused by SQLite backend
-    ) -> Result<(), CrucibleError> {
-        self.0.lock().unwrap().read_into(job_id, requests, out)
+    ) -> Result<ExtentReadResponse, CrucibleError> {
+        self.0.lock().unwrap().read(job_id, req)
     }
 
     fn write(
@@ -280,141 +278,80 @@ impl SqliteMoreInner {
         Ok(())
     }
 
-    fn read_into(
+    fn read(
         &mut self,
         job_id: JobId,
-        requests: &[crucible_protocol::ReadRequest],
-        out: &mut RawReadResponse,
-    ) -> Result<(), CrucibleError> {
-        // This code batches up operations for contiguous regions of
-        // ReadRequests, so we can perform larger read syscalls and sqlite
-        // queries. This significantly improves read throughput.
+        req: ExtentReadRequest,
+    ) -> Result<ExtentReadResponse, CrucibleError> {
+        let mut buf = req.data;
 
-        // Keep track of the index of the first request in any contiguous run
-        // of requests. Of course, a "contiguous run" might just be a single
-        // request.
-        let mut req_run_start = 0;
-        let mut buf = out.data.split_off(out.data.len());
-        while req_run_start < requests.len() {
-            let first_req = &requests[req_run_start];
+        let block_size = self.extent_size.block_size_in_bytes() as u64;
+        let num_blocks = buf.capacity() as u64 / block_size;
+        check_input(self.extent_size, req.offset, buf.capacity())?;
 
-            // Starting from the first request in the potential run, we scan
-            // forward until we find a request with a block that isn't
-            // contiguous with the request before it. Since we're counting
-            // pairs, and the number of pairs is one less than the number of
-            // requests, we need to add 1 to get our actual run length.
-            let mut n_contiguous_blocks = 1;
+        // Query the block metadata
+        cdt::extent__read__get__contexts__start!(|| {
+            (job_id.0, self.extent_number, num_blocks)
+        });
+        let block_contexts =
+            self.get_block_contexts(req.offset.value, num_blocks)?;
+        cdt::extent__read__get__contexts__done!(|| {
+            (job_id.0, self.extent_number, num_blocks)
+        });
+        // Convert from DownstairsBlockContext -> BlockContext
+        let blocks = block_contexts
+            .into_iter()
+            .map(|bs| bs.into_iter().map(|b| b.block_context).collect())
+            .collect();
 
-            for request_window in requests[req_run_start..].windows(2) {
-                if request_window[0].offset.value + 1
-                    == request_window[1].offset.value
-                {
-                    n_contiguous_blocks += 1;
-                } else {
-                    break;
-                }
-            }
+        // To avoid a `memset`, we're reading directly into uninitialized
+        // memory in the buffer.  This is fine; we sized the buffer
+        // appropriately in advance (and will panic here if we messed up).
+        assert!(buf.is_empty());
 
-            // Create our responses and push them into the output. While we're
-            // at it, check for overflows.
-            let resp_run_start = out.blocks.len();
-            let block_size = self.extent_size.block_size_in_bytes() as u64;
-            for req in requests[req_run_start..][..n_contiguous_blocks].iter() {
-                let resp = ReadResponseBlockMetadata {
-                    eid: req.eid,
-                    offset: req.offset,
-                    block_contexts: Vec::with_capacity(1),
-                };
-                out.blocks.push(resp);
-            }
+        // Finally we get to read the actual data. That's why we're here
+        cdt::extent__read__file__start!(|| {
+            (job_id.0, self.extent_number, num_blocks)
+        });
 
-            // To avoid a `memset`, we're reading directly into uninitialized
-            // memory in the buffer.  This is fine; we sized the buffer
-            // appropriately in advance (and will panic here if we messed up).
-            let expected_bytes = n_contiguous_blocks * block_size as usize;
-            assert!(buf.spare_capacity_mut().len() >= expected_bytes);
-
-            let first_resp = &out.blocks[resp_run_start];
-            check_input(self.extent_size, first_resp.offset, &buf)?;
-
-            // Finally we get to read the actual data. That's why we're here
-            cdt::extent__read__file__start!(|| {
-                (job_id.0, self.extent_number, n_contiguous_blocks as u64)
-            });
-
-            // SAFETY: the buffer has sufficient capacity, and this is a valid
-            // file descriptor.
-            let r = unsafe {
-                libc::pread(
-                    self.file.as_raw_fd(),
-                    buf.spare_capacity_mut().as_mut_ptr() as *mut libc::c_void,
-                    expected_bytes as libc::size_t,
-                    first_req.offset.value as i64 * block_size as i64,
-                )
-            };
-            // Check against the expected number of bytes.  We could do more
-            // robust error handling here (e.g. retrying in a loop), but for
-            // now, simply bailing out seems wise.
-            let r = nix::errno::Errno::result(r).map(|r| r as usize);
-            let num_bytes = r.map_err(|e| {
-                CrucibleError::IoError(format!(
-                    "extent {}: read failed: {e}",
-                    self.extent_number
-                ))
-            })?;
-            if num_bytes != expected_bytes {
-                return Err(CrucibleError::IoError(format!(
-                    "extent {}: incomplete read \
-                     (expected {expected_bytes}, got {num_bytes})",
-                    self.extent_number
-                )));
-            }
-            // SAFETY: we just initialized this chunk of the buffer
-            unsafe {
-                buf.set_len(expected_bytes);
-            }
-
-            cdt::extent__read__file__done!(|| {
-                (job_id.0, self.extent_number, n_contiguous_blocks as u64)
-            });
-
-            // Reattach this chunk to the main `BytesMut` array
-            //
-            // This should be O(1), because we allocated enough space to not
-            // reallocate anywhere in the process.
-            let chunk = buf.split_to(expected_bytes);
-            out.data.unsplit(chunk);
-
-            // Query the block metadata
-            cdt::extent__read__get__contexts__start!(|| {
-                (job_id.0, self.extent_number, n_contiguous_blocks as u64)
-            });
-            let block_contexts = self.get_block_contexts(
-                first_req.offset.value,
-                n_contiguous_blocks as u64,
-            )?;
-            cdt::extent__read__get__contexts__done!(|| {
-                (job_id.0, self.extent_number, n_contiguous_blocks as u64)
-            });
-
-            // Now it's time to put block contexts into the responses.
-            // We use into_iter here to move values out of enc_ctxts/hashes,
-            // avoiding a clone(). For code consistency, we use iters for the
-            // response and data chunks too. These iters will be the same length
-            // (equal to n_contiguous_requests) so zipping is fine
-            let resp_iter =
-                out.blocks[resp_run_start..][..n_contiguous_blocks].iter_mut();
-            let ctx_iter = block_contexts.into_iter();
-
-            for (resp, r_ctx) in resp_iter.zip(ctx_iter) {
-                resp.block_contexts =
-                    r_ctx.into_iter().map(|x| x.block_context).collect();
-            }
-
-            req_run_start += n_contiguous_blocks;
+        // SAFETY: the buffer has sufficient capacity, and this is a valid
+        // file descriptor.
+        let expected_bytes = buf.capacity();
+        let r = unsafe {
+            libc::pread(
+                self.file.as_raw_fd(),
+                buf.spare_capacity_mut().as_mut_ptr() as *mut libc::c_void,
+                expected_bytes as libc::size_t,
+                req.offset.value as i64 * block_size as i64,
+            )
+        };
+        // Check against the expected number of bytes.  We could do more
+        // robust error handling here (e.g. retrying in a loop), but for
+        // now, simply bailing out seems wise.
+        let r = nix::errno::Errno::result(r).map(|r| r as usize);
+        let num_bytes = r.map_err(|e| {
+            CrucibleError::IoError(format!(
+                "extent {}: read failed: {e}",
+                self.extent_number
+            ))
+        })?;
+        if num_bytes != expected_bytes {
+            return Err(CrucibleError::IoError(format!(
+                "extent {}: incomplete read \
+                      (expected {expected_bytes}, got {num_bytes})",
+                self.extent_number
+            )));
         }
-        out.data.unsplit(buf);
-        Ok(())
+        // SAFETY: we just initialized this chunk of the buffer
+        unsafe {
+            buf.set_len(expected_bytes);
+        }
+
+        cdt::extent__read__file__done!(|| {
+            (job_id.0, self.extent_number, num_blocks)
+        });
+
+        Ok(ExtentReadResponse { data: buf, blocks })
     }
 
     fn write(
@@ -425,7 +362,7 @@ impl SqliteMoreInner {
         iov_max: usize,
     ) -> Result<(), CrucibleError> {
         for write in writes {
-            check_input(self.extent_size, write.offset, &write.data)?;
+            check_input(self.extent_size, write.offset, write.data.len())?;
         }
 
         /*
@@ -1253,7 +1190,6 @@ fn open_sqlite_connection<P: AsRef<Path>>(path: &P) -> Result<Connection> {
 mod test {
     use super::*;
     use bytes::{Bytes, BytesMut};
-    use crucible_protocol::ReadRequest;
     use rand::Rng;
     use tempfile::tempdir;
 
@@ -1686,21 +1622,14 @@ mod test {
             };
             inner.write(JobId(20), &[write], true, IOV_MAX_TEST)?;
 
-            let read = ReadRequest {
-                eid: 0,
+            let read = ExtentReadRequest {
                 offset: Block::new_512(0),
+                data: BytesMut::with_capacity(512),
             };
-            let resp = inner.read(JobId(21), &[read], IOV_MAX_TEST)?;
+            let resp = inner.read(JobId(21), read, IOV_MAX_TEST)?;
 
             // We should not get back our data, because block 0 was written.
-            assert_ne!(
-                resp.blocks,
-                vec![ReadResponseBlockMetadata {
-                    eid: 0,
-                    offset: Block::new_512(0),
-                    block_contexts: vec![block_context]
-                }]
-            );
+            assert_ne!(resp.blocks, vec![vec![block_context]]);
             assert_ne!(resp.data, BytesMut::from(data.as_ref()));
         }
 
@@ -1720,21 +1649,14 @@ mod test {
             };
             inner.write(JobId(30), &[write], true, IOV_MAX_TEST)?;
 
-            let read = ReadRequest {
-                eid: 0,
+            let read = ExtentReadRequest {
                 offset: Block::new_512(1),
+                data: BytesMut::with_capacity(512),
             };
-            let resp = inner.read(JobId(31), &[read], IOV_MAX_TEST)?;
+            let resp = inner.read(JobId(31), read, IOV_MAX_TEST)?;
 
             // We should get back our data! Block 1 was never written.
-            assert_eq!(
-                resp.blocks,
-                vec![ReadResponseBlockMetadata {
-                    eid: 0,
-                    offset: Block::new_512(1),
-                    block_contexts: vec![block_context]
-                }]
-            );
+            assert_eq!(resp.blocks, vec![vec![block_context]]);
             assert_eq!(resp.data, BytesMut::from(data.as_ref()));
         }
 
@@ -1786,21 +1708,14 @@ mod test {
             };
             inner.write(JobId(30), &[write], true, IOV_MAX_TEST)?;
 
-            let read = ReadRequest {
-                eid: 0,
+            let read = ExtentReadRequest {
                 offset: Block::new_512(0),
+                data: BytesMut::with_capacity(512),
             };
-            let resp = inner.read(JobId(31), &[read], IOV_MAX_TEST)?;
+            let resp = inner.read(JobId(31), read, IOV_MAX_TEST)?;
 
             // We should get back our data! Block 1 was never written.
-            assert_eq!(
-                resp.blocks,
-                vec![ReadResponseBlockMetadata {
-                    eid: 0,
-                    offset: Block::new_512(0),
-                    block_contexts: vec![block_context]
-                }]
-            );
+            assert_eq!(resp.blocks, vec![vec![block_context]]);
             assert_eq!(resp.data, BytesMut::from(data.as_ref()));
         }
 

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -338,7 +338,7 @@ impl SqliteMoreInner {
         if num_bytes != expected_bytes {
             return Err(CrucibleError::IoError(format!(
                 "extent {}: incomplete read \
-                      (expected {expected_bytes}, got {num_bytes})",
+                 (expected {expected_bytes}, got {num_bytes})",
                 self.extent_number
             )));
         }

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -9,6 +9,7 @@ use std::fmt;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::net::{IpAddr, SocketAddr};
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -19,7 +20,7 @@ use crucible_common::{
     verbose_timeout, Block, CrucibleError, RegionDefinition, MAX_BLOCK_SIZE,
 };
 use crucible_protocol::{
-    BlockContext, CrucibleDecoder, JobId, Message, MessageWriter, ReadRequest,
+    BlockContext, CrucibleDecoder, JobId, Message, MessageWriter,
     ReconciliationId, SnapshotDetails, CRUCIBLE_MESSAGE_VERSION,
 };
 use repair_client::Client;
@@ -68,7 +69,7 @@ enum IOop {
     },
     Read {
         dependencies: Vec<JobId>, // Jobs that must finish before this
-        requests: Vec<ReadRequest>,
+        requests: RegionReadRequest,
     },
     Flush {
         dependencies: Vec<JobId>, // Jobs that must finish before this
@@ -120,6 +121,184 @@ impl IOop {
     }
 }
 
+/// Read request for a particular extent
+///
+/// `data` should be an uninitializezd borrowed section of the outgoing buffer
+/// (i.e. from a [`RegionReadResponse`]), to reduce memory copies.
+///
+/// Do not derive `Clone` on this type; cloning the object will break the borrow
+/// of `data`, so it's rarely the correct choice.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct ExtentReadRequest {
+    offset: Block,
+    /// This buffer should be uninitialized; read size is set by its capacity
+    data: BytesMut,
+}
+
+/// Ordered list of read requests, as `(extent, block, count)` tuples
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct RegionReadRequest(Vec<(u64, Block, NonZeroUsize)>);
+
+impl RegionReadRequest {
+    fn new(reqs: &[crucible_protocol::ReadRequest]) -> Self {
+        let mut out = Self(vec![]);
+        for req in reqs {
+            match out.0.last_mut() {
+                // Check whether this read request is contiguous and in the same
+                // extent as the previous read request
+                Some((eid, offset, size))
+                    if *eid == req.eid
+                        && offset.value + size.get() as u64
+                            == req.offset.value =>
+                {
+                    // If so, enlarge it by one block
+                    *size = size.saturating_add(1);
+                }
+                _ => {
+                    // Otherwise, begin a new request
+                    out.0.push((
+                        req.eid,
+                        req.offset,
+                        NonZeroUsize::new(1).unwrap(),
+                    ));
+                }
+            }
+        }
+        out
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &(u64, Block, NonZeroUsize)> {
+        self.0.iter()
+    }
+}
+
+impl IntoIterator for RegionReadRequest {
+    type Item = (u64, Block, NonZeroUsize);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+/// Read response data, designed to prevent copies and reallocations
+///
+/// We initialize a read response before performing any reads, then chop up its
+/// (allocated but uninitialized) buffer space into a set of
+/// `ExtentReadRequest`.  Each `ExtentReadRequest` is transformed into an
+/// `ExtentReadResponse` (reusing that chunk of buffer), which are then
+/// reassembled into the original `RegionReadResponse`.
+///
+/// Do not derive `Clone` on this type; it will be expensive and tempting to
+/// call by accident!
+pub(crate) struct RegionReadResponse {
+    blocks: Vec<Vec<BlockContext>>,
+    data: BytesMut,
+    uninit: BytesMut,
+}
+
+impl RegionReadResponse {
+    /// Builds a new empty `ReadResponse` with the given capacity
+    fn with_capacity(block_count: usize, block_size: u64) -> Self {
+        Self {
+            blocks: vec![],
+            data: BytesMut::new(),
+            uninit: BytesMut::with_capacity(block_size as usize * block_count),
+        }
+    }
+
+    /// Borrow the head of this `ReadResponse`, turning it into a read request
+    ///
+    /// ## Before
+    /// ```text
+    /// self.uninit = [ ----------------------------------- ]
+    /// ```
+    ///
+    /// ## After
+    /// ```text
+    /// self.uninit =             [ ----------------------- ]
+    /// req         = [ -------- ]
+    /// ```
+    ///
+    /// Note that the `BytesMut` objects remain uninitialized throughout this
+    /// whole procedure (to avoid `memset` calls).  We'll read directly into the
+    /// uninitialized request buffer, then call `unsplit` to build it back up.
+    ///
+    /// # Panics
+    /// If the size of the request is larger than our remaining buffer capacity
+    fn request(
+        &mut self,
+        offset: Block,
+        block_count: usize,
+    ) -> ExtentReadRequest {
+        let mut data = self
+            .uninit
+            .split_off(block_count * offset.block_size_in_bytes() as usize);
+        std::mem::swap(&mut data, &mut self.uninit);
+        ExtentReadRequest { offset, data }
+    }
+
+    /// Merge the given `ExtentReadResponse` into the tail of this response
+    ///
+    /// ## Before
+    /// ```text
+    /// self.data = [ -------- ]
+    /// r.data    =             [ ----------------------- ]
+    /// ```
+    ///
+    /// ## After
+    /// ```text
+    /// self.data = [ ----------------------------------- ]
+    /// ```
+    ///
+    /// # Panics
+    /// If the buffers cannot be unsplit without a reallocation; this indicates
+    /// a logic error in our code.
+    fn unsplit(&mut self, r: ExtentReadResponse) {
+        // The most common case is for a read to only touch one extent, so we
+        // have a fast path for just moving the blocks Vec.
+        if self.blocks.is_empty() {
+            self.blocks = r.blocks;
+        } else {
+            self.blocks.extend(r.blocks);
+        }
+        let prev_ptr = self.data.as_ptr();
+        let was_empty = self.data.is_empty();
+        self.data.unsplit(r.data);
+        assert!(was_empty || prev_ptr == self.data.as_ptr());
+    }
+
+    /// Returns hashes for the given response
+    ///
+    /// This is expensive and should only be used for debugging
+    pub fn hashes(&self, i: usize) -> Vec<u64> {
+        self.blocks[i].iter().map(|ctx| ctx.hash).collect()
+    }
+
+    /// Returns encryption contexts for the given response
+    ///
+    /// This is expensive and should only be used for debugging
+    pub fn encryption_contexts(
+        &self,
+        i: usize,
+    ) -> Vec<Option<&crucible_protocol::EncryptionContext>> {
+        self.blocks[i]
+            .iter()
+            .map(|ctx| ctx.encryption_context.as_ref())
+            .collect()
+    }
+}
+
+/// Read response from a single extent
+///
+/// Do not derive `Clone` on this type; it will be expensive and tempting to
+/// call by accident!
+pub(crate) struct ExtentReadResponse {
+    blocks: Vec<Vec<BlockContext>>,
+    /// At this point, the buffer must be fully initialized
+    data: BytesMut,
+}
+
 /*
  * Export the contents or partial contents of a Downstairs Region to
  * the file indicated.
@@ -168,13 +347,11 @@ pub async fn downstairs_export<P: AsRef<Path> + std::fmt::Debug>(
 
                 let response = region
                     .region_read(
-                        &[ReadRequest {
-                            eid: eid as u64,
-                            offset: Block::new_with_ddef(
-                                block_offset,
-                                &region.def(),
-                            ),
-                        }],
+                        &RegionReadRequest(vec![(
+                            eid as u64,
+                            Block::new_with_ddef(block_offset, &region.def()),
+                            NonZeroUsize::new(1).unwrap(),
+                        )]),
                         JobId(0),
                     )
                     .await?;
@@ -1644,13 +1821,15 @@ impl Downstairs {
                  * Any error from an IO should be intercepted here and passed
                  * back to the upstairs.
                  */
-                let responses = if self.read_errors && random() && random() {
+                let response = if self.read_errors && random() && random() {
                     warn!(self.log, "returning error on read!");
                     Err(CrucibleError::GenericError("test error".to_string()))
                 } else if !self.is_active(job.upstairs_connection) {
                     error!(self.log, "Upstairs inactive error");
                     Err(CrucibleError::UpstairsInactive)
                 } else {
+                    // This clone shouldn't be too expensive, since it's only
+                    // 32 bytes per extent (and should usually only be 1 extent)
                     self.region.region_read(requests, job_id).await
                 };
                 debug!(
@@ -1658,13 +1837,46 @@ impl Downstairs {
                     "Read      :{} deps:{:?} res:{}",
                     job_id,
                     dependencies,
-                    responses.is_ok(),
+                    response.is_ok(),
                 );
 
-                let (blocks, data) = match responses {
-                    Ok(r) => (Ok(r.blocks), r.data),
+                // We've got one or more block contexts per block returned, but
+                // the response format need to be in the form of
+                // `ReadResponseBlockMetadata` (which also contains extent and
+                // offset); we inject that extra information in this terrible
+                // match statement.
+                let (blocks, data) = match response {
+                    Ok(r) => (
+                        Ok(requests
+                            .iter()
+                            .flat_map(|(eid, offset, size)| {
+                                // Iterate over blocks within this extent.  By
+                                // construction, each `ReadRequest` will never
+                                // overstep the bounds of the extent.
+                                (0..size.get()).map(|i| {
+                                    (
+                                        *eid,
+                                        Block {
+                                            value: offset.value + i as u64,
+                                            shift: offset.shift,
+                                        },
+                                    )
+                                })
+                            })
+                            .zip(r.blocks)
+                            .map(|((eid, offset), block_contexts)| {
+                                crucible_protocol::ReadResponseBlockMetadata {
+                                    eid,
+                                    offset,
+                                    block_contexts,
+                                }
+                            })
+                            .collect()),
+                        r.data,
+                    ),
                     Err(e) => (Err(e), Default::default()),
                 };
+
                 Ok(Some(Message::ReadResponse {
                     header: crucible_protocol::ReadResponseHeader {
                         upstairs_id: job.upstairs_connection.upstairs_id,
@@ -2446,7 +2658,7 @@ impl Downstairs {
 
                 let new_read = IOop::Read {
                     dependencies,
-                    requests,
+                    requests: RegionReadRequest::new(&requests),
                 };
 
                 let mut d = ad.lock().await;
@@ -3403,10 +3615,11 @@ mod test {
                 } else {
                     IOop::Read {
                         dependencies: deps,
-                        requests: vec![ReadRequest {
-                            eid: 1,
-                            offset: Block::new_512(1),
-                        }],
+                        requests: RegionReadRequest(vec![(
+                            1,
+                            Block::new_512(1),
+                            NonZeroUsize::new(1).unwrap(),
+                        )]),
                     }
                 },
                 state: WorkState::New,
@@ -3572,20 +3785,22 @@ mod test {
 
         let rio = IOop::Read {
             dependencies: Vec::new(),
-            requests: vec![ReadRequest {
-                eid: 0,
-                offset: Block::new_512(1),
-            }],
+            requests: RegionReadRequest(vec![(
+                0,
+                Block::new_512(1),
+                NonZeroUsize::new(1).unwrap(),
+            )]),
         };
         ds.add_work(upstairs_connection, JobId(1000), rio)?;
 
         let deps = vec![JobId(1000)];
         let rio = IOop::Read {
             dependencies: deps,
-            requests: vec![ReadRequest {
-                eid: 1,
-                offset: Block::new_512(1),
-            }],
+            requests: RegionReadRequest(vec![(
+                1,
+                Block::new_512(1),
+                NonZeroUsize::new(1).unwrap(),
+            )]),
         };
         ds.add_work(upstairs_connection, JobId(1001), rio)?;
 
@@ -3686,10 +3901,11 @@ mod test {
         let deps = vec![JobId(1000), JobId(1001)];
         let rio = IOop::Read {
             dependencies: deps,
-            requests: vec![ReadRequest {
-                eid: 2,
-                offset: Block::new_512(1),
-            }],
+            requests: RegionReadRequest(vec![(
+                2,
+                Block::new_512(1),
+                NonZeroUsize::new(1).unwrap(),
+            )]),
         };
         ds.add_work(upstairs_connection, JobId(1002), rio)?;
 
@@ -5429,22 +5645,20 @@ mod test {
             for offset in 0..region.def().extent_size().value {
                 let response = region
                     .region_read(
-                        &[crucible_protocol::ReadRequest {
-                            eid: eid.into(),
-                            offset: Block::new_512(offset),
-                        }],
+                        &RegionReadRequest(vec![(
+                            eid.into(),
+                            Block::new_512(offset),
+                            NonZeroUsize::new(1).unwrap(),
+                        )]),
                         JobId(0),
                     )
                     .await?;
 
                 assert_eq!(response.blocks.len(), 1);
 
-                let r = &response.blocks[0];
-                assert_eq!(r.hashes().len(), 1);
-                assert_eq!(
-                    integrity_hash(&[&response.data[..]]),
-                    r.hashes()[0],
-                );
+                let hashes = response.hashes(0);
+                assert_eq!(hashes.len(), 1);
+                assert_eq!(integrity_hash(&[&response.data[..]]), hashes[0],);
 
                 read_data.extend_from_slice(&response.data[..]);
             }
@@ -5818,19 +6032,21 @@ mod test {
 
         let read_1 = IOop::Read {
             dependencies: Vec::new(),
-            requests: vec![ReadRequest {
-                eid: 0,
-                offset: Block::new_512(1),
-            }],
+            requests: RegionReadRequest(vec![(
+                0,
+                Block::new_512(1),
+                NonZeroUsize::new(1).unwrap(),
+            )]),
         };
         ds.add_work(upstairs_connection_1, JobId(1000), read_1.clone())?;
 
         let read_2 = IOop::Read {
             dependencies: Vec::new(),
-            requests: vec![ReadRequest {
-                eid: 1,
-                offset: Block::new_512(2),
-            }],
+            requests: RegionReadRequest(vec![(
+                1,
+                Block::new_512(2),
+                NonZeroUsize::new(1).unwrap(),
+            )]),
         };
         ds.add_work(upstairs_connection_2, JobId(1000), read_2.clone())?;
 
@@ -5902,10 +6118,11 @@ mod test {
         // Add one job, id 1000
         let rio = IOop::Read {
             dependencies: Vec::new(),
-            requests: vec![ReadRequest {
-                eid: 0,
-                offset: Block::new_512(1),
-            }],
+            requests: RegionReadRequest(vec![(
+                0,
+                Block::new_512(1),
+                NonZeroUsize::new(1).unwrap(),
+            )]),
         };
         ds.add_work(upstairs_connection_1, JobId(1000), rio)?;
 
@@ -5992,10 +6209,11 @@ mod test {
         // Add one job, id 1000
         let rio = IOop::Read {
             dependencies: Vec::new(),
-            requests: vec![ReadRequest {
-                eid: 0,
-                offset: Block::new_512(1),
-            }],
+            requests: RegionReadRequest(vec![(
+                0,
+                Block::new_512(1),
+                NonZeroUsize::new(1).unwrap(),
+            )]),
         };
         ds.add_work(upstairs_connection_1, JobId(1000), rio)?;
 
@@ -6082,10 +6300,11 @@ mod test {
         // Add one job, id 1000
         let rio = IOop::Read {
             dependencies: Vec::new(),
-            requests: vec![ReadRequest {
-                eid: 0,
-                offset: Block::new_512(1),
-            }],
+            requests: RegionReadRequest(vec![(
+                0,
+                Block::new_512(1),
+                NonZeroUsize::new(1).unwrap(),
+            )]),
         };
         ds.add_work(upstairs_connection_1, JobId(1000), rio)?;
 

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -12,7 +12,7 @@ use futures::TryStreamExt;
 use tracing::instrument;
 
 use crucible_common::*;
-use crucible_protocol::{RawReadResponse, SnapshotDetails};
+use crucible_protocol::SnapshotDetails;
 use repair_client::Client;
 
 use super::*;
@@ -842,52 +842,20 @@ impl Region {
     #[instrument]
     pub async fn region_read(
         &mut self,
-        requests: &[crucible_protocol::ReadRequest],
+        req: &RegionReadRequest,
         job_id: JobId,
-    ) -> Result<RawReadResponse, CrucibleError> {
-        let mut response = RawReadResponse::with_capacity(
-            requests.len(),
+    ) -> Result<RegionReadResponse, CrucibleError> {
+        let mut response = RegionReadResponse::with_capacity(
+            req.iter().map(|(_eid, _offset, size)| size.get()).sum(),
             self.def.block_size(),
         );
 
-        /*
-         * Batch reads so they can all be sent to the appropriate extent
-         * together.
-         *
-         * Note: Have to maintain order with reads! The Upstairs expects read
-         * responses to be in the same order as read requests, so we can't
-         * use a hashmap in the same way that batching writes can.
-         */
-        let mut eid: Option<u64> = None;
-        let mut batched_reads = Vec::with_capacity(requests.len());
-
         cdt::os__read__start!(|| job_id.0);
-        for request in requests {
-            if let Some(_eid) = eid {
-                if request.eid == _eid {
-                    batched_reads.push(request.clone());
-                } else {
-                    let extent = self.get_opened_extent_mut(_eid as usize);
-                    extent
-                        .read_into(job_id, &batched_reads[..], &mut response)
-                        .await?;
-
-                    eid = Some(request.eid);
-                    batched_reads.clear();
-                    batched_reads.push(request.clone());
-                }
-            } else {
-                eid = Some(request.eid);
-                batched_reads.clear();
-                batched_reads.push(request.clone());
-            }
-        }
-
-        if let Some(_eid) = eid {
-            let extent = self.get_opened_extent_mut(_eid as usize);
-            extent
-                .read_into(job_id, &batched_reads[..], &mut response)
-                .await?;
+        for &(eid, offset, size) in req.iter() {
+            let extent = self.get_opened_extent_mut(eid as usize);
+            let req = response.request(offset, size.get());
+            let out = extent.read(job_id, req).await?;
+            response.unsplit(out);
         }
         cdt::os__read__done!(|| job_id.0);
 
@@ -1884,16 +1852,10 @@ pub(crate) mod test {
             Region::open(&dir, new_region_options(), true, false, &log).await?;
         let out = region
             .region_read(
-                &[
-                    ReadRequest {
-                        eid: 1,
-                        offset: Block::new_512(0),
-                    },
-                    ReadRequest {
-                        eid: 2,
-                        offset: Block::new_512(0),
-                    },
-                ],
+                &RegionReadRequest(vec![
+                    (1, Block::new_512(0), NonZeroUsize::new(1).unwrap()),
+                    (2, Block::new_512(0), NonZeroUsize::new(1).unwrap()),
+                ]),
                 JobId(0),
             )
             .await?;
@@ -1985,16 +1947,10 @@ pub(crate) mod test {
             Region::open(&dir, new_region_options(), true, false, &log).await?;
         let out = region
             .region_read(
-                &[
-                    ReadRequest {
-                        eid: 1,
-                        offset: Block::new_512(0),
-                    },
-                    ReadRequest {
-                        eid: 2,
-                        offset: Block::new_512(0),
-                    },
-                ],
+                &RegionReadRequest(vec![
+                    (1, Block::new_512(0), NonZeroUsize::new(1).unwrap()),
+                    (2, Block::new_512(0), NonZeroUsize::new(1).unwrap()),
+                ]),
                 JobId(0),
             )
             .await?;
@@ -2421,7 +2377,8 @@ pub(crate) mod test {
             requests.push(crucible_protocol::ReadRequest { eid, offset });
         }
 
-        let responses = region.region_read(&requests, JobId(0)).await.unwrap();
+        let req = RegionReadRequest::new(&requests);
+        let responses = region.region_read(&req, JobId(0)).await.unwrap();
 
         assert_eq!(buffer.len(), responses.data.len());
         assert_eq!(buffer, responses.data);
@@ -2509,8 +2466,8 @@ pub(crate) mod test {
             requests.push(crucible_protocol::ReadRequest { eid, offset });
         }
 
-        let read_from_region =
-            region.region_read(&requests, JobId(0)).await?.data;
+        let req = RegionReadRequest::new(&requests);
+        let read_from_region = region.region_read(&req, JobId(0)).await?.data;
 
         assert_eq!(buffer.len(), read_from_region.len());
         assert_eq!(buffer, read_from_region);
@@ -2529,8 +2486,7 @@ pub(crate) mod test {
                 .join(extent_file_name(i, ExtentType::Db))
                 .exists());
         }
-        let read_from_region =
-            region.region_read(&requests, JobId(0)).await?.data;
+        let read_from_region = region.region_read(&req, JobId(0)).await?.data;
 
         assert_eq!(buffer.len(), read_from_region.len());
         assert_eq!(buffer, read_from_region);
@@ -2615,10 +2571,11 @@ pub(crate) mod test {
 
         let responses = region
             .region_read(
-                &[crucible_protocol::ReadRequest {
-                    eid: 0,
-                    offset: Block::new_512(0),
-                }],
+                &RegionReadRequest(vec![(
+                    0,
+                    Block::new_512(0),
+                    NonZeroUsize::new(1).unwrap(),
+                )]),
                 JobId(125),
             )
             .await
@@ -2710,14 +2667,18 @@ pub(crate) mod test {
         // Now read back that block, make sure it is updated.
         let responses = region
             .region_read(
-                &[crucible_protocol::ReadRequest { eid, offset }],
+                &RegionReadRequest(vec![(
+                    eid,
+                    offset,
+                    NonZeroUsize::new(1).unwrap(),
+                )]),
                 JobId(0),
             )
             .await
             .unwrap();
 
         assert_eq!(responses.blocks.len(), 1);
-        assert_eq!(responses.blocks[0].hashes().len(), 1);
+        assert_eq!(responses.hashes(0).len(), 1);
         assert_eq!(responses.data[..], [9u8; 512][..]);
     }
 
@@ -2788,7 +2749,11 @@ pub(crate) mod test {
         // Now read back that block, make sure it has the first write
         let responses = region
             .region_read(
-                &[crucible_protocol::ReadRequest { eid, offset }],
+                &RegionReadRequest(vec![(
+                    eid,
+                    offset,
+                    NonZeroUsize::new(1).unwrap(),
+                )]),
                 JobId(2),
             )
             .await
@@ -2797,7 +2762,7 @@ pub(crate) mod test {
         // We should still have one response.
         assert_eq!(responses.blocks.len(), 1);
         // Hash should be just 1
-        assert_eq!(responses.blocks[0].hashes().len(), 1);
+        assert_eq!(responses.hashes(0).len(), 1);
         // Data should match first write
         assert_eq!(responses.data[..], [9u8; 512][..]);
     }
@@ -2886,7 +2851,11 @@ pub(crate) mod test {
         // Read back our block, make sure it has the first write data
         let responses = region
             .region_read(
-                &[crucible_protocol::ReadRequest { eid, offset }],
+                &RegionReadRequest(vec![(
+                    eid,
+                    offset,
+                    NonZeroUsize::new(1).unwrap(),
+                )]),
                 JobId(2),
             )
             .await
@@ -2895,7 +2864,7 @@ pub(crate) mod test {
         // We should still have one response.
         assert_eq!(responses.blocks.len(), 1);
         // Hash should be just 1
-        assert_eq!(responses.blocks[0].hashes().len(), 1);
+        assert_eq!(responses.hashes(0).len(), 1);
         // Data should match first write
         assert_eq!(responses.data[..], [9u8; 512][..]);
     }
@@ -2968,7 +2937,8 @@ pub(crate) mod test {
             requests.push(crucible_protocol::ReadRequest { eid, offset });
         }
 
-        let responses = region.region_read(&requests, JobId(0)).await.unwrap();
+        let req = RegionReadRequest::new(&requests);
+        let responses = region.region_read(&req, JobId(0)).await.unwrap();
 
         assert_eq!(buffer, responses.data);
     }
@@ -3077,7 +3047,8 @@ pub(crate) mod test {
             requests.push(crucible_protocol::ReadRequest { eid, offset });
         }
 
-        let responses = region.region_read(&requests, JobId(0)).await.unwrap();
+        let req = RegionReadRequest::new(&requests);
+        let responses = region.region_read(&req, JobId(0)).await.unwrap();
 
         assert_eq!(buffer, responses.data);
     }
@@ -3187,7 +3158,8 @@ pub(crate) mod test {
             requests.push(crucible_protocol::ReadRequest { eid, offset });
         }
 
-        let responses = region.region_read(&requests, JobId(0)).await.unwrap();
+        let req = RegionReadRequest::new(&requests);
+        let responses = region.region_read(&req, JobId(0)).await.unwrap();
 
         assert_eq!(buffer, responses.data);
     }
@@ -3296,7 +3268,8 @@ pub(crate) mod test {
             requests.push(crucible_protocol::ReadRequest { eid, offset });
         }
 
-        let responses = region.region_read(&requests, JobId(0)).await.unwrap();
+        let req = RegionReadRequest::new(&requests);
+        let responses = region.region_read(&req, JobId(0)).await.unwrap();
 
         assert_eq!(buffer, responses.data);
     }
@@ -3406,7 +3379,8 @@ pub(crate) mod test {
             requests.push(crucible_protocol::ReadRequest { eid, offset });
         }
 
-        let responses = region.region_read(&requests, JobId(0)).await.unwrap();
+        let req = RegionReadRequest::new(&requests);
+        let responses = region.region_read(&req, JobId(0)).await.unwrap();
 
         assert_eq!(buffer, responses.data);
     }
@@ -3802,34 +3776,20 @@ pub(crate) mod test {
         let ext = region.get_opened_extent_mut(0);
 
         for (i, range) in ranges.iter().enumerate() {
-            // Get the contexts for the range
-            let mut resp = RawReadResponse::with_capacity(
-                (range.end - range.start) as usize,
-                512,
-            );
-            let reqs = range
-                .clone()
-                .map(|i| ReadRequest {
-                    eid: 0,
-                    offset: Block::new_512(i),
-                })
-                .collect::<Vec<_>>();
-            ext.read_into(JobId(i as u64), &reqs, &mut resp)
-                .await
-                .unwrap();
+            let req = ExtentReadRequest {
+                offset: Block::new_512(range.start),
+                data: BytesMut::with_capacity(
+                    512 * (range.end - range.start) as usize,
+                ),
+            };
+            let resp = ext.read(JobId(i as u64), req).await.unwrap();
 
-            // Every block should have at most 1 block
-            assert_eq!(
-                resp.blocks.iter().map(|b| b.block_contexts.len()).max(),
-                Some(1)
-            );
+            // Every block should have at most 1 block context
+            assert_eq!(resp.blocks.iter().map(|b| b.len()).max(), Some(1));
 
             // Now that we've checked that, flatten out for an easier eq
-            let actual_ctxts: Vec<_> = resp
-                .blocks
-                .iter()
-                .flat_map(|b| b.block_contexts.iter())
-                .collect();
+            let actual_ctxts: Vec<_> =
+                resp.blocks.iter().flat_map(|b| b.iter()).collect();
 
             // What we expect is the hashes for the last write we did
             let expected_ctxts: Vec<_> = last_writes[i]
@@ -3898,27 +3858,18 @@ pub(crate) mod test {
         let ext = region.get_opened_extent_mut(0);
 
         // Get the contexts for the range
-        let reqs = (0..EXTENT_SIZE)
-            .map(|i| ReadRequest {
-                eid: 0,
-                offset: Block::new_512(i),
-            })
-            .collect::<Vec<_>>();
-        let mut out = RawReadResponse::with_capacity(EXTENT_SIZE as usize, 512);
-        ext.read_into(JobId(0), &reqs, &mut out).await.unwrap();
+        let req = ExtentReadRequest {
+            offset: Block::new_512(0),
+            data: BytesMut::with_capacity(512 * EXTENT_SIZE as usize),
+        };
+        let out = ext.read(JobId(0), req).await.unwrap();
 
         // Every block should have at most 1 block
-        assert_eq!(
-            out.blocks.iter().map(|b| b.block_contexts.len()).max(),
-            Some(1)
-        );
+        assert_eq!(out.blocks.iter().map(|b| b.len()).max(), Some(1));
 
         // Now that we've checked that, flatten out for an easier eq
-        let actual_ctxts: Vec<_> = out
-            .blocks
-            .iter()
-            .flat_map(|b| b.block_contexts.iter())
-            .collect();
+        let actual_ctxts: Vec<_> =
+            out.blocks.iter().flat_map(|b| b.iter()).collect();
 
         // What we expect is the hashes for the last write we did
         let expected_ctxts: Vec<_> = last_writes
@@ -3991,17 +3942,18 @@ pub(crate) mod test {
 
         let responses = region
             .region_read(
-                &[crucible_protocol::ReadRequest {
-                    eid: 0,
-                    offset: Block::new_512(0),
-                }],
+                &RegionReadRequest(vec![(
+                    0,
+                    Block::new_512(0),
+                    NonZeroUsize::new(1).unwrap(),
+                )]),
                 JobId(0),
             )
             .await
             .unwrap();
 
         assert_eq!(responses.blocks.len(), 1);
-        assert_eq!(responses.blocks[0].hashes().len(), 0);
+        assert_eq!(responses.hashes(0).len(), 0);
         assert_eq!(responses.data[..], [0u8; 512][..]);
     }
 
@@ -4071,7 +4023,8 @@ pub(crate) mod test {
             })
             .collect();
 
-        let responses = region.region_read(&requests, JobId(0)).await.unwrap();
+        let req = RegionReadRequest::new(&requests);
+        let responses = region.region_read(&req, JobId(0)).await.unwrap();
 
         // Validate returned data
         assert_eq!(responses.data, &data[512..(8 * 512)],);
@@ -4089,7 +4042,8 @@ pub(crate) mod test {
             })
             .collect();
 
-        let responses = region.region_read(&requests, JobId(0)).await.unwrap();
+        let req = RegionReadRequest::new(&requests);
+        let responses = region.region_read(&req, JobId(0)).await.unwrap();
 
         // Validate returned data
         assert_eq!(&responses.data, &data[(9 * 512)..(28 * 512)],);
@@ -4123,7 +4077,8 @@ pub(crate) mod test {
         .flatten()
         .collect();
 
-        let responses = region.region_read(&requests, JobId(0)).await.unwrap();
+        let req = RegionReadRequest::new(&requests);
+        let responses = region.region_read(&req, JobId(0)).await.unwrap();
 
         // Validate returned data
         assert_eq!(
@@ -4160,7 +4115,8 @@ pub(crate) mod test {
             },
         ];
 
-        let responses = region.region_read(&requests, JobId(0)).await.unwrap();
+        let req = RegionReadRequest::new(&requests);
+        let responses = region.region_read(&req, JobId(0)).await.unwrap();
 
         // Validate returned data
         assert_eq!(
@@ -4219,7 +4175,8 @@ pub(crate) mod test {
             })
             .collect();
 
-        let responses = region.region_read(&requests, JobId(1)).await.unwrap();
+        let req = RegionReadRequest::new(&requests);
+        let responses = region.region_read(&req, JobId(1)).await.unwrap();
 
         assert_eq!(&responses.data, &data,);
     }

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -855,6 +855,11 @@ impl Region {
             let extent = self.get_opened_extent_mut(eid as usize);
             let req = response.request(offset, size.get());
             let out = extent.read(job_id, req).await?;
+
+            // Note that we only call `unsplit` here if `Extent::read` returned
+            // `Ok(..)` (indicating that the data is fully populated); this
+            // means that the preconditions for `RegionReadResponse::unsplit`
+            // are met and it will not panic.
             response.unsplit(out);
         }
         cdt::os__read__done!(|| job_id.0);

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -157,45 +157,6 @@ pub struct ReadRequest {
     pub offset: Block,
 }
 
-/// Read response data, containing data from all blocks
-///
-/// Do not derive `Clone` on this type; it will be expensive and tempting to
-/// call by accident!
-#[derive(Debug, Default)]
-pub struct RawReadResponse {
-    /// Per-block metadata
-    pub blocks: Vec<ReadResponseBlockMetadata>,
-    /// Raw data
-    pub data: bytes::BytesMut,
-}
-
-impl RawReadResponse {
-    /// Builds a new empty `RawReadResponse` with the given capacity
-    pub fn with_capacity(block_count: usize, block_size: u64) -> Self {
-        Self {
-            blocks: Vec::with_capacity(block_count),
-            data: bytes::BytesMut::with_capacity(
-                block_count * block_size as usize,
-            ),
-        }
-    }
-
-    pub fn hashes(&self, i: usize) -> Vec<u64> {
-        self.blocks[i].hashes()
-    }
-
-    pub fn first_hash(&self, i: usize) -> Option<u64> {
-        self.blocks[i].first_hash()
-    }
-
-    pub fn encryption_contexts(
-        &self,
-        i: usize,
-    ) -> Vec<Option<&EncryptionContext>> {
-        self.blocks[i].encryption_contexts()
-    }
-}
-
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BlockContext {

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -3,12 +3,12 @@ use crate::{
     cdt, integrity_hash, live_repair::ExtentInfo, upstairs::UpstairsConfig,
     upstairs::UpstairsState, ClientIOStateCount, ClientId, CrucibleDecoder,
     CrucibleError, DownstairsIO, DsState, EncryptionContext, IOState, IOop,
-    JobId, Message, ReconcileIO, RegionDefinitionStatus, RegionMetadata,
+    JobId, Message, RawReadResponse, ReconcileIO, RegionDefinitionStatus,
+    RegionMetadata,
 };
 use crucible_common::{deadline_secs, verbose_timeout, x509::TLSContext};
 use crucible_protocol::{
-    BlockContext, MessageWriter, RawReadResponse, ReconciliationId,
-    CRUCIBLE_MESSAGE_VERSION,
+    BlockContext, MessageWriter, ReconciliationId, CRUCIBLE_MESSAGE_VERSION,
 };
 
 use std::{

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -16,10 +16,11 @@ use crate::{
     AckStatus, ActiveJobs, AllocRingBuffer, ClientData, ClientIOStateCount,
     ClientId, ClientMap, CrucibleError, DownstairsIO, DownstairsMend, DsState,
     ExtentFix, ExtentRepairIDs, GuestWorkId, IOState, IOStateCount, IOop,
-    ImpactedBlocks, JobId, Message, ReadRequest, ReconcileIO, ReconciliationId,
-    RegionDefinition, ReplaceResult, SnapshotDetails, WorkSummary,
+    ImpactedBlocks, JobId, Message, RawReadResponse, ReadRequest, ReconcileIO,
+    ReconciliationId, RegionDefinition, ReplaceResult, SnapshotDetails,
+    WorkSummary,
 };
-use crucible_protocol::{RawReadResponse, RawWrite, WriteHeader};
+use crucible_protocol::{RawWrite, WriteHeader};
 
 use rand::prelude::*;
 use ringbuffer::RingBuffer;
@@ -4486,14 +4487,13 @@ pub(crate) mod test {
         live_repair::ExtentInfo,
         upstairs::UpstairsState,
         ClientId, CrucibleError, DownstairsIO, DsState, ExtentFix, GuestWorkId,
-        IOState, IOop, ImpactedAddr, ImpactedBlocks, JobId, ReconcileIO,
-        ReconciliationId, SnapshotDetails,
+        IOState, IOop, ImpactedAddr, ImpactedBlocks, JobId, RawReadResponse,
+        ReconcileIO, ReconciliationId, SnapshotDetails,
     };
 
     use bytes::BytesMut;
     use crucible_protocol::{
-        BlockContext, Message, RawReadResponse, ReadRequest,
-        ReadResponseBlockMetadata,
+        BlockContext, Message, ReadRequest, ReadResponseBlockMetadata,
     };
     use ringbuffer::RingBuffer;
 

--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -10,11 +10,12 @@ use std::{
 };
 
 use crate::{
-    BlockIO, BlockOp, BlockOpWaiter, BlockRes, Buffer, JobId, ReplaceResult,
-    UpstairsAction, IO_OUTSTANDING_MAX_BYTES, IO_OUTSTANDING_MAX_JOBS,
+    BlockIO, BlockOp, BlockOpWaiter, BlockRes, Buffer, JobId, RawReadResponse,
+    ReplaceResult, UpstairsAction, IO_OUTSTANDING_MAX_BYTES,
+    IO_OUTSTANDING_MAX_JOBS,
 };
 use crucible_common::{build_logger, crucible_bail, Block, CrucibleError};
-use crucible_protocol::{RawReadResponse, SnapshotDetails};
+use crucible_protocol::SnapshotDetails;
 
 use async_trait::async_trait;
 use bytes::BytesMut;

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -641,6 +641,18 @@ impl RegionDefinitionStatus {
     }
 }
 
+/// Read response data, containing data from all blocks
+///
+/// Do not derive `Clone` on this type; it will be expensive and tempting to
+/// call by accident!
+#[derive(Debug, Default)]
+pub(crate) struct RawReadResponse {
+    /// Per-block metadata
+    pub blocks: Vec<ReadResponseBlockMetadata>,
+    /// Raw data
+    pub data: bytes::BytesMut,
+}
+
 /*
  * States of a downstairs
  *


### PR DESCRIPTION
This is analogous to #1272 , but for reads instead of writes.

By the time we send a read to an extent, we want it to be contiguous and tightly packed; this makes extent code simpler and lets us do bulk reads.

The new data flow is `Message::ReadRequest` → `RegionReadRequest` → `ExtentReadRequest` → `ReadResponse` → `Message::ReadResponse`.  Allocation is minimized: we build a single `BytesMut` then use `split()` and `unsplit()` to pass it to each extent.

More generally, these two PRs are a stepping stone towards non-blocking Downstairs IO, i.e. having IOs to multiple extents pending simultaneously.