### PR TITLE
Use uninitialized memory when doing reads

### DIFF
--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -223,7 +223,7 @@ impl ExtentInner for RawInner {
             // memory in the buffer.  This is fine; we sized the buffer
             // appropriately in advance (and will panic here if we messed up).
             let expected_bytes = n_contiguous_blocks * block_size as usize;
-            assert!(buf.capacity() >= expected_bytes);
+            assert!(buf.spare_capacity_mut().len() >= expected_bytes);
 
             let first_resp = &out.blocks[resp_run_start];
             check_input(self.extent_size, first_resp.offset, &buf)?;

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -238,7 +238,7 @@ impl ExtentInner for RawInner {
             let r = unsafe {
                 libc::pread(
                     self.file.as_raw_fd(),
-                    buf.spare_capacity_mut().as_mut_ptr().cast(),
+                    buf.spare_capacity_mut().as_mut_ptr() as *mut libc::c_void,
                     expected_bytes as libc::size_t,
                     first_req.offset.value as i64 * block_size as i64,
                 )

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -17,7 +17,7 @@ use slog::{error, Logger};
 use std::collections::{BTreeMap, HashSet};
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, Read, Seek, SeekFrom};
-use std::os::fd::AsFd;
+use std::os::fd::{AsFd, AsRawFd};
 use std::path::Path;
 
 #[derive(Debug)]
@@ -342,12 +342,37 @@ impl SqliteMoreInner {
                 (job_id.0, self.extent_number, n_contiguous_blocks as u64)
             });
 
-            nix::sys::uio::pread(
-                self.file.as_fd(),
-                &mut buf,
-                first_req.offset.value as i64 * block_size as i64,
-            )
-            .map_err(|e| CrucibleError::IoError(e.to_string()))?;
+            // SAFETY: the buffer has sufficient capacity, and this is a valid
+            // file descriptor.
+            let r = unsafe {
+                libc::pread(
+                    self.file.as_raw_fd(),
+                    buf.spare_capacity_mut().as_mut_ptr().cast(),
+                    expected_bytes as libc::size_t,
+                    first_req.offset.value as i64 * block_size as i64,
+                )
+            };
+            // Check against the expected number of bytes.  We could do more
+            // robust error handling here (e.g. retrying in a loop), but for
+            // now, simply bailing out seems wise.
+            let r = nix::errno::Errno::result(r).map(|r| r as usize);
+            let num_bytes = r.map_err(|e| {
+                CrucibleError::IoError(format!(
+                    "extent {}: read failed: {e}",
+                    self.extent_number
+                ))
+            })?;
+            if num_bytes != expected_bytes {
+                return Err(CrucibleError::IoError(format!(
+                    "extent {}: incomplete read \
+                     (expected {expected_bytes}, got {num_bytes})",
+                    self.extent_number
+                )));
+            }
+            // SAFETY: we just initialized this chunk of the buffer
+            unsafe {
+                buf.set_len(expected_bytes);
+            }
 
             cdt::extent__read__file__done!(|| {
                 (job_id.0, self.extent_number, n_contiguous_blocks as u64)
@@ -388,6 +413,7 @@ impl SqliteMoreInner {
 
             req_run_start += n_contiguous_blocks;
         }
+        out.data.unsplit(buf);
         Ok(())
     }
 

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -347,7 +347,7 @@ impl SqliteMoreInner {
             let r = unsafe {
                 libc::pread(
                     self.file.as_raw_fd(),
-                    buf.spare_capacity_mut().as_mut_ptr().cast(),
+                    buf.spare_capacity_mut().as_mut_ptr() as *mut libc::c_void,
                     expected_bytes as libc::size_t,
                     first_req.offset.value as i64 * block_size as i64,
                 )

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -328,11 +328,11 @@ impl SqliteMoreInner {
                 out.blocks.push(resp);
             }
 
-            // Calculate the number of expected bytes, then resize our buffer
-            //
-            // This should fill memory, but should not reallocate
+            // To avoid a `memset`, we're reading directly into uninitialized
+            // memory in the buffer.  This is fine; we sized the buffer
+            // appropriately in advance (and will panic here if we messed up).
             let expected_bytes = n_contiguous_blocks * block_size as usize;
-            buf.resize(expected_bytes, 1);
+            assert!(buf.capacity() >= expected_bytes);
 
             let first_resp = &out.blocks[resp_run_start];
             check_input(self.extent_size, first_resp.offset, &buf)?;

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -332,7 +332,7 @@ impl SqliteMoreInner {
             // memory in the buffer.  This is fine; we sized the buffer
             // appropriately in advance (and will panic here if we messed up).
             let expected_bytes = n_contiguous_blocks * block_size as usize;
-            assert!(buf.capacity() >= expected_bytes);
+            assert!(buf.spare_capacity_mut().len() >= expected_bytes);
 
             let first_resp = &out.blocks[resp_run_start];
             check_input(self.extent_size, first_resp.offset, &buf)?;


### PR DESCRIPTION
While fixing #1286, I noticed that 8% of on-CPU time being spend doing `memset` in `read_into`:

<img width="1918" alt="Screenshot 2024-05-01 at 4 59 46 PM" src="https://github.com/oxidecomputer/crucible/assets/745333/f75d2275-aa38-4162-8d50-f63742dc7f6a">

This is unnecessary work: the buffer has sufficient capacity, and we're about to overwrite that region of the buffer.

In this PR, we switch to using `libc::pread` into the uninitialized portion of the buffer, then manually set the length with `set_len`.  Sure enough, this removes the `memset`:

<img width="1918" alt="Screenshot 2024-05-01 at 5 06 31 PM" src="https://github.com/oxidecomputer/crucible/assets/745333/32e51a35-ea3f-4c6d-8aa8-7fa051517428">

Note that the new code is identical between `extent_inner_sqlite.rs` and `extent_inner_raw.rs`, because they have the same data format; since we're planning to remove SQLite in #1267 , I don't feel the need to refactor into helper functions.

There's also a drive-by fix revealed by the new assertion: we need to reattach the remaining `buf` to `out.data` (by calling `unsplit(..)`); otherwise, it will force a reallocation.  This will only trigger for reads which span multiple extents, so it's probably not a big deal in the wild, but let's do the correct thing instead of the wrong thing.