### PR TITLE
Improve deferred write encryption

### DIFF
--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -279,7 +279,7 @@ pub(crate) mod up_test {
 
         let orig_block = block;
 
-        let (nonce, tag, _) = context.encrypt_in_place(&mut block[..])?;
+        let (nonce, tag, _) = context.encrypt_in_place(&mut block[..]);
         assert_ne!(block, orig_block);
 
         context.decrypt_in_place(&mut block[..], &nonce, &tag)?;
@@ -302,7 +302,7 @@ pub(crate) mod up_test {
 
         let orig_block = block;
 
-        let (_, tag, _) = context.encrypt_in_place(&mut block[..])?;
+        let (_, tag, _) = context.encrypt_in_place(&mut block[..]);
         assert_ne!(block, orig_block);
 
         let nonce = context.get_random_nonce();
@@ -336,7 +336,7 @@ pub(crate) mod up_test {
 
         let orig_block = block;
 
-        let (nonce, mut tag, _) = context.encrypt_in_place(&mut block[..])?;
+        let (nonce, mut tag, _) = context.encrypt_in_place(&mut block[..]);
         assert_ne!(block, orig_block);
 
         tag[2] = tag[2].wrapping_add(1);
@@ -373,7 +373,7 @@ pub(crate) mod up_test {
 
         let original_data = data.clone();
 
-        let (nonce, tag, _) = context.encrypt_in_place(&mut data[..])?;
+        let (nonce, tag, _) = context.encrypt_in_place(&mut data[..]);
 
         assert_ne!(original_data, data);
 
@@ -424,7 +424,7 @@ pub(crate) mod up_test {
 
         let original_data = data.clone();
 
-        let (nonce, tag, _) = context.encrypt_in_place(&mut data[..])?;
+        let (nonce, tag, _) = context.encrypt_in_place(&mut data[..]);
 
         assert_ne!(original_data, data);
 

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -46,8 +46,8 @@ const MIN_DEFER_SIZE_BYTES: u64 = 8192;
 /// `WorkerThread::wait_until_cold` looks like a reasonable fraction of CPU
 /// time.  Rayon's default is "number of CPU threads", which is dramatic
 /// overkill on a 128-thread system; in such a system, we see a ton of CPU time
-/// being spent spinning in `WorkerThread::wait_until_cold`.
-const WORKER_POOL_SIZE: usize = 16;
+/// being spent spinning in `wait_until_cold`.
+const WORKER_POOL_SIZE: usize = 8;
 
 /// High-level upstairs state, from the perspective of the guest
 #[derive(Debug)]

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1539,9 +1539,10 @@ impl Upstairs {
                 // decryption, or there are other deferred messages in the queue
                 // (to preserve order).  Otherwise, handle it immediately.
                 if let Message::ReadResponse { header, .. } = &m {
-                    // Any read larger than this constant should be deferred to
-                    // the worker pool; smaller reads can be processed in-thread
-                    // (since the overhead isn't worth it)
+                    // Any read larger than `MIN_DEFER_SIZE_BYTES` constant
+                    // should be deferred to the worker pool; smaller reads can
+                    // be processed in-thread (since the overhead isn't worth
+                    // it)
                     let should_defer = !self.deferred_msgs.is_empty()
                         || match &header.blocks {
                             Ok(rs) => {


### PR DESCRIPTION
- Uses a per-volume pool, instead of a global pool (#1285)
- Make encryption infallible; because the only failure conditions are for sizes that we can't hit (and this makes the next step easier)
- Don't defer encryption for small writes, using the same logic as reads