### PR TITLE
Speed up `crutest fill`

### DIFF
--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -1345,8 +1345,10 @@ fn fill_vec(
     for (block_offset, chunk) in (block_index..(block_index + blocks))
         .zip(vec.spare_capacity_mut().chunks_mut(bs as usize))
     {
+        // The start of each block contains that block's index mod 255
         chunk[0].write((block_offset % 255) as u8);
 
+        // Fill the rest of the buffer with the new write count
         let seed = wl.get_seed(block_offset);
         chunk[1..].iter_mut().for_each(|b| {
             b.write(seed);


### PR DESCRIPTION
The compiler faceplants at optimizing our current `fill_vec` implementation:

<img width="1535" alt="Screenshot 2024-05-13 at 6 03 07 PM" src="https://github.com/oxidecomputer/crucible/assets/745333/76963c71-36b2-4938-bdae-7b9f240bbef9">

Writing directly into the uninitialized buffer makes filling about 30% faster.  Testing on a 128 GiB region, filling goes from 4:05 → 2:43; verification remains the same at about 2:30.

<img width="1534" alt="Screenshot 2024-05-13 at 6 04 18 PM" src="https://github.com/oxidecomputer/crucible/assets/745333/22727f84-a3bc-4819-bf84-2474d9a531e6">
