### PR TITLE
Update crutest replace test, and mismatch printing.

### DIFF
--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -71,7 +71,7 @@ for t in crucible-downstairs crucible-hammer crutest dsc crudd; do
 done
 
 mkdir -p /work/scripts
-for s in tools/test_perf.sh tools/crudd-speed-battery.sh tools/dtrace/perf-downstairs-tick.d tools/test_mem.sh; do
+for s in tools/test_perf.sh tools/crudd-speed-battery.sh tools/dtrace/perf-downstairs-tick.d tools/dtrace/upstairs_info.d tools/test_mem.sh; do
 	cp "$s" /work/scripts/
 done
 

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -121,8 +121,14 @@ else
     exit 1
 fi
 
+banner dtrace
 # Start up a dtrace script to record upstairs activity.
+ls -l $input/scripts
 pfexec dtrace -Z -s $input/scripts/upstairs-info.d > /tmp/upstairs_info.txt 2>&1 &
+
+banner why
+ps -ef | grep dtrace
+ls -l /tmp
 
 banner LR
 ptime -m "$BINDIR"/crutest replace \

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -123,12 +123,7 @@ fi
 
 banner dtrace
 # Start up a dtrace script to record upstairs activity.
-ls -l $input/scripts
-pfexec dtrace -Z -s $input/scripts/upstairs-info.d > /tmp/upstairs_info.txt 2>&1 &
-
-banner why
-ps -ef | grep dtrace
-ls -l /tmp
+pfexec dtrace -Z -s $input/scripts/upstairs_info.d > /tmp/upstairs_info.txt 2>&1 &
 
 banner LR
 ptime -m "$BINDIR"/crutest replace \

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -85,10 +85,14 @@ ls -ltr "$BINDIR" || true
 banner CreateDS
 echo $BINDIR/dsc create \
   --ds-bin "$BINDIR"/crucible-downstairs \
+  --extent-size 4000 \
+  --extent-count 200 \
   --region-count 4 \
   --cleanup
 $BINDIR/dsc create \
   --ds-bin "$BINDIR"/crucible-downstairs \
+  --extent-size 4000 \
+  --extent-count 200 \
   --region-count 4 \
   --cleanup
 
@@ -116,6 +120,9 @@ else
     cat /tmp/dsc.log || true
     exit 1
 fi
+
+# Start up a dtrace script to record upstairs activity.
+pfexec dtrace -Z -s $input/scripts/upstairs-info.d > /tmp/upstairs_info.txt 2>&1 &
 
 banner LR
 ptime -m "$BINDIR"/crutest replace \

--- a/.github/buildomat/jobs/test-live-repair.sh
+++ b/.github/buildomat/jobs/test-live-repair.sh
@@ -123,7 +123,7 @@ fi
 
 banner dtrace
 # Start up a dtrace script to record upstairs activity.
-pfexec dtrace -Z -s $input/scripts/upstairs_info.d > /tmp/upstairs_info.txt 2>&1 &
+pfexec dtrace -Z -s $input/scripts/upstairs_info.d > /tmp/upstairs-info.txt 2>&1 &
 
 banner LR
 ptime -m "$BINDIR"/crutest replace \

--- a/.github/buildomat/jobs/test-memory.sh
+++ b/.github/buildomat/jobs/test-memory.sh
@@ -4,7 +4,7 @@
 #: variety = "basic"
 #: target = "helios-2.0"
 #: output_rules = [
-#:  "/tmp/test_mem_log.txt",
+#:  "/tmp/*.txt",
 #:  "/tmp/dsc/*.txt",
 #:  "/tmp/core.*",
 #: ]
@@ -40,6 +40,10 @@ export BINDIR=/var/tmp/bins
 
 banner setup
 pfexec plimit -n 9123456 $$
+
+banner dtrace
+ls -l $input/scripts
+pfexec dtrace -Z -s $input/scripts/upstairs_info.d > /tmp/upstairs-info.txt 2>&1 &
 
 banner start
 ptime -m bash $input/scripts/test_mem.sh

--- a/.github/buildomat/jobs/test-perf.sh
+++ b/.github/buildomat/jobs/test-perf.sh
@@ -6,6 +6,7 @@
 #: output_rules = [
 #:  "=/tmp/perf*.csv",
 #:  "/tmp/perfout.txt",
+#:  "/tmp/upstairs-info.txt",
 #:  "%/tmp/debug/*.txt",
 #:  "/tmp/dsc/*.txt",
 #:  "/tmp/core.*",
@@ -42,6 +43,9 @@ export BINDIR=/var/tmp/bins
 
 banner setup
 pfexec plimit -n 9123456 $$
+
+banner dtrace
+pfexec dtrace -Z -s $input/scripts/upstairs_info.d > /tmp/upstairs-info.txt 2>&1 &
 
 echo "Setup self timeout"
 # This timeout is from issue 520

--- a/.github/buildomat/jobs/test-repair.sh
+++ b/.github/buildomat/jobs/test-repair.sh
@@ -45,6 +45,9 @@ done
 
 export BINDIR=/var/tmp/bins
 
+banner dtrace
+pfexec dtrace -Z -s $input/scripts/upstairs_info.d > /tmp/upstairs-info.txt 2>&1 &
+
 banner repair
 ptime -m bash "$input/scripts/test_repair.sh" "-N"
 

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -1,4 +1,5 @@
 // Copyright 2023 Oxide Computer Company
+use std::fmt;
 use std::fs::File;
 use std::io::Write;
 use std::net::{IpAddr, SocketAddr};
@@ -105,7 +106,7 @@ enum Workload {
     },
     Repair,
     /// Test the downstairs replay path.
-    /// Top a downstairs, then run some IO, then start that downstairs back
+    /// Stop a downstairs, then run some IO, then start that downstairs back
     /// up.  Verify all IO to all downstairs finishes.
     Replay {
         /// URL location of the running dsc server
@@ -124,10 +125,6 @@ enum Workload {
         /// The address:port of a running downstairs for replacement
         #[clap(long, action)]
         replacement: SocketAddr,
-
-        /// Number of IOs to do after replacement has started.
-        #[clap(long, default_value_t = 1800, action)]
-        work: usize,
     },
     Span,
     Verify,
@@ -702,26 +699,11 @@ async fn main() -> Result<()> {
         bail!("Verify requires verify_in file");
     }
 
-    // If we are running the replace workload, we need to know the
-    // current list of targets the upstairs will be started with.
-    let full_target = if let Workload::Replace {
-        fast_fill: _,
-        replacement,
-        work: _,
-    } = opt.workload
-    {
-        let mut full_target = opt.target.clone();
-        full_target.push(replacement);
-        Some(full_target)
-    } else {
-        None
-    };
-
     let up_uuid = opt.uuid.unwrap_or_else(Uuid::new_v4);
 
     let crucible_opts = CrucibleOpts {
         id: up_uuid,
-        target: opt.target,
+        target: opt.target.clone(),
         lossy: opt.lossy,
         flush_timeout: opt.flush_timeout,
         key: opt.key,
@@ -1090,8 +1072,7 @@ async fn main() -> Result<()> {
         }
         Workload::Replace {
             fast_fill,
-            replacement: _,
-            work,
+            replacement,
         } => {
             // Either we have a count, or we run until we get a signal.
             let mut wtq = {
@@ -1103,14 +1084,19 @@ async fn main() -> Result<()> {
                 }
             };
 
-            // This should already be setup for us.
-            let full_target = full_target.unwrap();
+            // Build the list of targets we use during the replace test.
+            // The first three are provided in the crucible opts, and the
+            // final one (the replacement) is a test specific arg.
+            let mut targets = Vec::with_capacity(4);
+            for t in opt.target.iter() {
+                targets.push(*t);
+            }
+            targets.push(replacement);
             replace_workload(
                 &guest,
                 &mut wtq,
                 &mut region_info,
-                &full_target,
-                work,
+                targets,
                 fast_fill,
             )
             .await?;
@@ -1378,12 +1364,46 @@ fn fill_vec(
  * expect the same value (i.e. we cut off any higher write count).
  */
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 enum ValidateStatus {
     Good,
     InRange,
     Bad,
 }
+
+// Block mismatch summary.
+// When we have a mismatch on a block, don't print a line for every single
+// byte that is wrong, collect the range and print a single summary at the
+// end of the range.
+struct BlockErr {
+    block: usize,
+    starting_offset: usize,
+    ending_offset: usize,
+    starting_volume_offset: u64,
+    ending_volume_offset: u64,
+    expected_value: u8,
+    found_value: u8,
+    status: ValidateStatus,
+    msg: String,
+}
+
+impl fmt::Display for BlockErr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}:{} bo:{}-{} Volume offset:{}-{}  Expected:{} Got:{}",
+            self.msg,
+            self.block,
+            self.starting_offset,
+            self.ending_offset,
+            self.starting_volume_offset,
+            self.ending_volume_offset,
+            self.expected_value,
+            self.found_value,
+        )
+    }
+}
+
 /*
  * Compare a vec buffer with what we expect to be written for that offset.
  * This assumes you used the fill_vec function (with get_seed) to write
@@ -1443,6 +1463,7 @@ fn validate_vec<V: AsRef<[u8]>>(
         }
 
         let seed = wl.get_seed(block_offset);
+        let mut block_err: Option<BlockErr> = None;
         for i in 1..bs {
             if data[data_offset + i] != seed {
                 // Our data is not what we expect.
@@ -1470,16 +1491,61 @@ fn validate_vec<V: AsRef<[u8]>>(
                     res = ValidateStatus::Bad;
                 }
 
-                println!(
-                    "{}:{} bo:{} Volume offset:{}  Expected:{} Got:{}",
-                    msg,
-                    block_offset,
-                    i,
-                    byte_offset + i as u64,
-                    seed,
-                    data[data_offset + i],
-                );
+                // Check to see if we have an error already
+                block_err = match block_err {
+                    None => Some(BlockErr {
+                        block: block_offset,
+                        starting_offset: i,
+                        ending_offset: i,
+                        starting_volume_offset: byte_offset,
+                        ending_volume_offset: byte_offset,
+                        expected_value: seed,
+                        found_value: data[data_offset + i],
+                        status: res.clone(),
+                        msg,
+                    }),
+                    Some(mut be) => {
+                        // We have an existing error, does this extend our
+                        // range or start a new one?
+                        if be.status == res
+                            && be.found_value == data[data_offset + i]
+                            && be.ending_offset + 1 == i
+                        {
+                            be.ending_offset = i;
+                            be.ending_volume_offset = byte_offset;
+                            Some(be)
+                        } else {
+                            // Print the current range
+                            println!("{}", be);
+                            // Start a new range.
+                            Some(BlockErr {
+                                block: block_offset,
+                                starting_offset: i,
+                                ending_offset: i,
+                                starting_volume_offset: byte_offset,
+                                ending_volume_offset: byte_offset,
+                                expected_value: seed,
+                                found_value: data[data_offset + i],
+                                status: res.clone(),
+                                msg,
+                            })
+                        }
+                    }
+                };
+            } else {
+                // This check was valid. If we have seen previous errors,
+                // print out the summary report now.
+                if let Some(be) = block_err {
+                    println!("{}", be);
+                    block_err = None;
+                }
             }
+        }
+
+        // If the last check was bad, we will exit the loop without having
+        // printed any errors yet. Print the summary now.
+        if let Some(be) = block_err {
+            println!("{}", be);
         }
         data_offset += bs;
     }
@@ -1924,77 +1990,118 @@ async fn replace_workload(
     guest: &Arc<Guest>,
     wtq: &mut WhenToQuit,
     ri: &mut RegionInfo,
-    full_targets: &[SocketAddr],
-    work: usize,
+    targets: Vec<SocketAddr>,
     fill: bool,
 ) -> Result<()> {
-    assert!(full_targets.len() == 4);
+    assert!(targets.len() == 4);
 
-    let mut preload_wtq = WhenToQuit::Count { count: 100 };
-    let mut replace_wtq = WhenToQuit::Count { count: work };
+    if fill {
+        fill_sparse_workload(guest, ri).await?;
+    }
+    // Make a copy of the stop at counter if one was provided so the
+    // IO task and the replace task don't have to share wtq
+    let stop_at = match wtq {
+        WhenToQuit::Count { count } => Some(*count),
+        _ => None,
+    };
 
-    let mut c = 1;
-    let mut old_ds = 0;
-    let mut new_ds = 3;
-    loop {
-        println!("[{c}] Replace loop starts");
-        if fill {
-            fill_sparse_workload(guest, ri).await?;
-        }
-        generic_workload(guest, &mut preload_wtq, ri, false).await?;
-
-        println!(
-            "[{c}] Replacing DS {old_ds}:{} with {new_ds}:{}",
-            full_targets[old_ds], full_targets[new_ds],
-        );
-        let res = guest
-            .replace_downstairs(
-                Uuid::new_v4(),
-                full_targets[old_ds],
-                full_targets[new_ds],
-            )
-            .await;
-
-        match res {
-            Ok(ReplaceResult::Started) => {}
-            x => {
-                bail!("[{c}] Failed replace: {:?}", x);
-            }
-        }
-        old_ds = (old_ds + 1) % 4;
-        new_ds = (new_ds + 1) % 4;
-
-        generic_workload(guest, &mut replace_wtq, ri, false).await?;
-
-        // Wait for all IO to settle down before we continue
+    // Start up a task to do the replacement workload
+    let (work_stop_tx, mut work_stop_rx) = mpsc::channel(1);
+    let (work_count_tx, mut work_count_rx) = mpsc::channel(1);
+    let guest_c = guest.clone();
+    let handle = tokio::spawn(async move {
+        let mut c: usize = 1;
+        let mut old_ds = 0;
+        let mut new_ds = 3;
         loop {
-            let wc = guest.show_work().await?;
             println!(
-                "[{c}] Replace: Up:{} ds:{} act:{}",
-                wc.up_count, wc.ds_count, wc.active_count
+                "[{c}] Replacing DS {old_ds}:{} with {new_ds}:{}",
+                targets[old_ds], targets[new_ds],
             );
-            if wc.up_count + wc.ds_count == 0 && wc.active_count == 3 {
-                println!("[{c}] Replace: All jobs finished, all DS active.");
+            match guest_c
+                .replace_downstairs(
+                    Uuid::new_v4(),
+                    targets[old_ds],
+                    targets[new_ds],
+                )
+                .await
+            {
+                Ok(ReplaceResult::Started) => {}
+                x => {
+                    bail!("[{c}] Failed replace: {:?}", x);
+                }
+            }
+            // Wait for the replacement to be reflected in the downstairs status.
+            let mut wc = guest_c.show_work().await?;
+            while wc.active_count == 3 {
+                // Wait for one of the DS to start repair
+                println!(
+                    "[{c}] Waiting for replace to start: up:{} ds:{} act:{}",
+                    wc.up_count, wc.ds_count, wc.active_count
+                );
+                tokio::time::sleep(tokio::time::Duration::from_secs(4)).await;
+                wc = guest_c.show_work().await?;
+            }
+
+            // We have started live repair, now wait for it to finish.
+            while wc.active_count != 3 {
+                println!(
+                    "[{c}] Waiting for replace to finish: up:{} ds:{} act:{}",
+                    wc.up_count, wc.ds_count, wc.active_count
+                );
+                tokio::time::sleep(tokio::time::Duration::from_secs(4)).await;
+                wc = guest_c.show_work().await?;
+            }
+            // Tell the global thread that a repair is done and what count we
+            // are at.
+            work_count_tx.send(c).await.expect("Failed to send count");
+
+            // Check if the IO task has asked us to quit.
+            if work_stop_rx.try_recv().is_ok() {
                 break;
             }
-            tokio::time::sleep(tokio::time::Duration::from_secs(4)).await;
-        }
+            // See (if provided) we have reached a requested number of loops
+            if let Some(stop_at) = stop_at {
+                if c >= stop_at {
+                    println!("[{c}] Replace task ends as count was reached");
+                    break;
+                }
+            }
 
-        c += 1;
+            // No stopping yet, lets do another loop.
+            old_ds = (old_ds + 1) % 4;
+            new_ds = (new_ds + 1) % 4;
+            c += 1;
+        }
+        println!("Replace tasks ends after {c} loops");
+        Ok(())
+    });
+
+    // The replace is started, now generate traffic through the guest
+    // in a loop, checking to see if it is time to stop.
+    loop {
+        let mut workload_wtq = WhenToQuit::Count { count: 100 };
+        generic_workload(guest, &mut workload_wtq, ri, false)
+            .await
+            .unwrap();
+
+        let io_count = work_count_rx.try_recv().unwrap_or(0);
+        println!("IO task with {io_count} replacements ");
+
         match wtq {
             WhenToQuit::Count { count } => {
-                if c > *count {
+                if io_count >= *count {
+                    println!("IO task shutting down for count");
                     break;
                 }
             }
             WhenToQuit::Signal { shutdown_rx } => {
                 match shutdown_rx.try_recv() {
                     Ok(SignalAction::Shutdown) => {
-                        println!("shutting down in response to SIGUSR1");
+                        println!("IO task shutting down from SIGUSR1");
                         break;
                     }
                     Ok(SignalAction::Verify) => {
-                        println!("Verify Volume");
                         if let Err(e) = verify_volume(guest, ri, false).await {
                             bail!("Requested volume verify failed: {:?}", e)
                         }
@@ -2005,9 +2112,31 @@ async fn replace_workload(
         }
     }
 
+    // The replace task may have already exited.
+    let _ = work_stop_tx.send(true).await;
+    if let Err(e) = handle.await.unwrap() {
+        bail!("Failed in IO workload: {:?}", e);
+    }
+
+    // Wait for all IO to settle down and all downstairs to be active
+    // before we do the next loop.
+    loop {
+        let wc = guest.show_work().await?;
+        println!(
+            "Replace test done: up:{} ds:{} act:{}",
+            wc.up_count, wc.ds_count, wc.active_count
+        );
+        if wc.up_count + wc.ds_count == 0 && wc.active_count == 3 {
+            println!("Replace: All jobs finished, all DS active.");
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_secs(4)).await;
+    }
+
     println!("Test replace has completed");
     Ok(())
 }
+
 /*
  * Do a few writes to random offsets then exit as soon as they finish.
  * We are trying to leave extents "dirty" so we want to exit before the

--- a/tools/test_live_repair.sh
+++ b/tools/test_live_repair.sh
@@ -38,7 +38,7 @@ loops=5
 
 usage () {
     echo "Usage: $0 [-l #]]" >&2
-    echo " -l loops   Number of test loops to perform (default 10)" >&2
+    echo " -l loops   Number of test loops to perform (default 5)" >&2
 }
 
 while getopts 'l:' opt; do
@@ -60,7 +60,8 @@ echo "Tail $test_log for test output"
 if ! ${dsc} create --cleanup \
   --region-count 4 \
   --ds-bin "$downstairs" \
-  --extent-count 50 >> "$test_log"; then
+  --extent-size 4000 \
+  --extent-count 200 >> "$test_log"; then
     echo "Failed to create downstairs regions"
     exit 1
 fi
@@ -91,11 +92,13 @@ fi
 count=1
 while [[ $count -le $loops ]]; do
     SECONDS=0
+    cp "$test_log" "$test_log".last
     echo "" > "$test_log"
-    echo "New loop starts now $(date)" >> "$test_log"
-    "$crucible_test" replace "${args[@]}" -c 50 \
+    echo "New loop, $count starts now $(date)" >> "$test_log"
+    "$crucible_test" replace "${args[@]}" -c 5 \
             --replacement 127.0.0.1:8840 \
             --stable -g "$gen" --verify-out alan \
+            --verify-at-start \
             --verify-in alan >> "$test_log" 2>&1
     result=$?
     if [[ $result -ne 0 ]]; then


### PR DESCRIPTION
Updated the replace test to better reflect replacing a downstairs when IO is underway.  We spawn a task to do the replacement and wait for it to finish while the main task just sends IO in a loop.

Updated the CI tests for live repair to make a little larger region so we can catch IO in progress while doing live repair. Updated the test to also collect dtrace stats.

Updated the crutest block mismatch printing code to detect a mismatch range and just print a summary at the end of the range instead of printing a line for every byte that does not match what is expected.
Here is an example mismatch where I have written one more IO to 5 blocks than the verify file expects:
(recreating an extra write, though a missing write would look similar)
```
Mismatch     Block::0 bo:1-511 Volume offset:0-0  Expected:12 Got:13
Mismatch     Block::1 bo:1-511 Volume offset:512-512  Expected:19 Got:20
Mismatch     Block::2 bo:1-511 Volume offset:1024-1024  Expected:27 Got:28
Mismatch     Block::3 bo:1-511 Volume offset:1536-1536  Expected:30 Got:31
Mismatch     Block::4 bo:1-511 Volume offset:2048-2048  Expected:31 Got:32
Error in block range 0 -> 8
```

Here is an example mismatch when I've corrupted block 2 and 3 with the
contents from block 6 and 7 (recreating a write to the wrong location)
```
Mismatch Block Index Block:2 Offset:1024 Expected:2 Got:6
Mismatch     Block::2 bo:1-511 Volume offset:1024-1024  Expected:30 Got:26
Mismatch Block Index Block:3 Offset:1536 Expected:3 Got:7
Mismatch     Block::3 bo:1-511 Volume offset:1536-1536  Expected:35 Got:20
Error in block range 0 -> 8
```