### PR TITLE
Move remaining local state into a `struct ConnectionState`

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -919,7 +919,7 @@ enum NegotiationState {
     Ready,
 }
 
-struct NegotiationData {
+struct ConnectionState {
     /// State machine progress
     negotiated: NegotiationState,
 
@@ -936,6 +936,9 @@ struct NegotiationData {
     /// `NegotiationState::ConnectedToUpstairs` and
     /// `NegotiationState::PromotedToActive`
     another_upstairs_active_tx: Option<oneshot::Sender<UpstairsConnection>>,
+
+    /// IO channel to the reply task
+    reply_channel_tx: mpsc::UnboundedSender<Message>,
 }
 
 /// Handle all of the work for this Upstairs connection
@@ -1040,7 +1043,7 @@ where
 async fn proc_task(
     ads: Arc<Mutex<Downstairs>>,
     mut msg_channel_rx: mpsc::UnboundedReceiver<Message>,
-    mut reply_channel_tx: mpsc::UnboundedSender<Message>,
+    reply_channel_tx: mpsc::UnboundedSender<Message>,
 ) -> Result<()> {
     // In this function, repair address should exist, and shouldn't change. Grab
     // it here.
@@ -1053,13 +1056,14 @@ async fn proc_task(
     let (another_upstairs_active_tx, mut another_upstairs_active_rx) =
         oneshot::channel::<UpstairsConnection>();
 
-    let mut state = NegotiationData {
+    let mut state = ConnectionState {
         repair_addr,
         upstairs_connection: None,
         // Put the oneshot tx side into an Option so we can move it out at the
         // appropriate point in negotiation.
         another_upstairs_active_tx: Some(another_upstairs_active_tx),
         negotiated: NegotiationState::Start,
+        reply_channel_tx,
     };
 
     let log = log.new(o!("task" => "proc".to_string()));
@@ -1112,7 +1116,7 @@ async fn proc_task(
                             new_upstairs_connection, state.upstairs_connection
                         );
 
-                        if let Err(e) = reply_channel_tx.send(
+                        if let Err(e) = state.reply_channel_tx.send(
                             Message::YouAreNoLongerActive {
                                 new_upstairs_id:
                                     new_upstairs_connection.upstairs_id,
@@ -1156,7 +1160,7 @@ async fn proc_task(
                                 &ads,
                                 state.upstairs_connection.unwrap(),
                                 m,
-                                &reply_channel_tx,
+                                &state.reply_channel_tx,
                             )
                             .await
                             {
@@ -1166,7 +1170,7 @@ async fn proc_task(
                                     Downstairs::do_work_for(
                                         &ads,
                                         state.upstairs_connection.unwrap(),
-                                        &reply_channel_tx,
+                                        &state.reply_channel_tx,
                                     )
                                     .await?;
                                 }
@@ -1181,7 +1185,6 @@ async fn proc_task(
                             ds.on_negotiation_step(
                                 m,
                                 &mut state,
-                                &mut reply_channel_tx
                             ).await?;
                         }
                     }
@@ -2952,12 +2955,11 @@ impl Downstairs {
     async fn on_negotiation_step(
         &mut self,
         m: Message,
-        state: &mut NegotiationData,
-        reply_channel_tx: &mut mpsc::UnboundedSender<Message>,
+        state: &mut ConnectionState,
     ) -> Result<()> {
         match m {
             Message::Ruok => {
-                if let Err(e) = reply_channel_tx.send(Message::Imok) {
+                if let Err(e) = state.reply_channel_tx.send(Message::Imok) {
                     bail!("Failed to answer ping: {}", e);
                 }
             }
@@ -3002,7 +3004,7 @@ impl Downstairs {
                         let m = Message::VersionMismatch {
                             version: CRUCIBLE_MESSAGE_VERSION,
                         };
-                        if let Err(e) = reply_channel_tx.send(m) {
+                        if let Err(e) = state.reply_channel_tx.send(m) {
                             warn!(
                                 self.log,
                                 "Failed to send VersionMismatch: {}", e
@@ -3022,11 +3024,11 @@ impl Downstairs {
                 // Upstairs will not be able to successfully negotiate.
                 {
                     if self.flags.read_only != read_only {
-                        if let Err(e) =
-                            reply_channel_tx.send(Message::ReadOnlyMismatch {
+                        if let Err(e) = state.reply_channel_tx.send(
+                            Message::ReadOnlyMismatch {
                                 expected: self.flags.read_only,
-                            })
-                        {
+                            },
+                        ) {
                             warn!(
                                 self.log,
                                 "Failed to send ReadOnlyMismatch: {}", e
@@ -3037,11 +3039,11 @@ impl Downstairs {
                     }
 
                     if self.flags.encrypted != encrypted {
-                        if let Err(e) =
-                            reply_channel_tx.send(Message::EncryptedMismatch {
+                        if let Err(e) = state.reply_channel_tx.send(
+                            Message::EncryptedMismatch {
                                 expected: self.flags.encrypted,
-                            })
-                        {
+                            },
+                        ) {
                             warn!(
                                 self.log,
                                 "Failed to send EncryptedMismatch: {}", e
@@ -3065,7 +3067,7 @@ impl Downstairs {
                     CRUCIBLE_MESSAGE_VERSION
                 );
 
-                if let Err(e) = reply_channel_tx.send(Message::YesItsMe {
+                if let Err(e) = state.reply_channel_tx.send(Message::YesItsMe {
                     version: CRUCIBLE_MESSAGE_VERSION,
                     repair_addr: state.repair_addr,
                 }) {
@@ -3093,7 +3095,7 @@ impl Downstairs {
 
                 if !matches_self {
                     if let Err(e) =
-                        reply_channel_tx.send(Message::UuidMismatch {
+                        state.reply_channel_tx.send(Message::UuidMismatch {
                             expected_id: upstairs_connection.upstairs_id,
                         })
                     {
@@ -3132,7 +3134,7 @@ impl Downstairs {
                     state.negotiated = NegotiationState::PromotedToActive;
 
                     if let Err(e) =
-                        reply_channel_tx.send(Message::YouAreNowActive {
+                        state.reply_channel_tx.send(Message::YouAreNowActive {
                             upstairs_id,
                             session_id,
                             gen,
@@ -3152,8 +3154,9 @@ impl Downstairs {
                 state.negotiated = NegotiationState::SentRegionInfo;
                 let region_def = { self.region.def() };
 
-                if let Err(e) =
-                    reply_channel_tx.send(Message::RegionInfo { region_def })
+                if let Err(e) = state
+                    .reply_channel_tx
+                    .send(Message::RegionInfo { region_def })
                 {
                     bail!("Failed sending RegionInfo: {}", e);
                 }
@@ -3171,7 +3174,8 @@ impl Downstairs {
                 work.last_flush = last_flush_number;
                 info!(self.log, "Set last flush {}", last_flush_number);
 
-                if let Err(e) = reply_channel_tx
+                if let Err(e) = state
+                    .reply_channel_tx
                     .send(Message::LastFlushAck { last_flush_number })
                 {
                     bail!("Failed sending LastFlushAck: {}", e);
@@ -3212,11 +3216,13 @@ impl Downstairs {
                     );
                 }
 
-                if let Err(e) = reply_channel_tx.send(Message::ExtentVersions {
-                    gen_numbers,
-                    flush_numbers,
-                    dirty_bits,
-                }) {
+                if let Err(e) =
+                    state.reply_channel_tx.send(Message::ExtentVersions {
+                        gen_numbers,
+                        flush_numbers,
+                        dirty_bits,
+                    })
+                {
                     bail!("Failed sending ExtentVersions: {}", e);
                 }
 


### PR DESCRIPTION
(stacked on top of #1322)

- Renames `NegotiationData` → `ConnectionState`
- Puts the `reply_channel_tx` into it, instead of passing it as a separate argument