### PR TITLE
Move cancellation into Downstairs, using a token to kill IO tasks

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1061,7 +1061,9 @@ async fn proc_task(
     let (log, cancel_io) = {
         let mut ds = ads.lock().await;
         (
-            ds.log.new(o!("task" => "proc_task".to_string())),
+            ds.log.new(
+                o!("task" => "proc_task".to_string(), "id" => id.0.to_string()),
+            ),
             ds.new_connection(id, reply_channel_tx),
         )
     };


### PR DESCRIPTION
(staged on top of #1328)

The IO tasks are now cancelled by a `tokio_util::sync::CancellationToken`, instead of a oneshot channel.

The token is wrapped in a `tokio_util::sync::DropGuard` and held in the `ConnectionState`, meaning the IO tasks are cancelled automatically when we drop the `ConnectionState` – no more accidentally forgetting to stop them!

Downstairs connection replacement is now handled in the `Downstairs` itself, rather than in the IO task.  Previously, the downstairs replacement process was as follows:

- `Downstairs::promote_to_active` notices that replacement is necessary
- Downstairs signals to the old IO task on the `oneshot`
- IO task receives this signal in its loop
- IO task locks the `Downstairs` and calls `Downstairs::on_new_connection_replacing`, then exits

Now, it looks like the following:

- `Downstairs::promote_to_active` notices that replacement is necessary
- `Downstairs` calls `on_new_connection_replacing` directly
  - The previous `ConnectionState` is removed and dropped
  - This automatically cancels the IO task

This puts tricky replacement logic in just one place, and makes the IO task simpler: from its perspective, it just gets cancelled.