### PR TITLE
Remove invalid DTrace probes.

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -847,10 +847,8 @@ pub mod cdt {
     ) {
     }
     fn submit__el__close__done(_: u64) {}
-    fn submit__el__flush__close__done(_: u64) {}
     fn submit__el__repair__done(_: u64) {}
-    fn submit__el__reopen__done(_: u64) {}
-    fn submit__el__noop__done(_: u64) {}
+    fn submit__el__done(_: u64) {}
     fn work__done(_: u64) {}
 }
 
@@ -1930,20 +1928,14 @@ impl Downstairs {
                 cdt::submit__read__done!(|| ds_id.0);
                 self.dss.add_read();
             }
-            Message::ExtentLiveClose { .. } => {
+            Message::ExtentLiveCloseAck { .. } => {
                 cdt::submit__el__close__done!(|| ds_id.0);
             }
-            Message::ExtentLiveFlushClose { .. } => {
-                cdt::submit__el__flush__close__done!(|| ds_id.0);
-            }
-            Message::ExtentLiveRepair { .. } => {
+            Message::ExtentLiveRepairAckId { .. } => {
                 cdt::submit__el__repair__done!(|| ds_id.0);
             }
-            Message::ExtentLiveReopen { .. } => {
-                cdt::submit__el__reopen__done!(|| ds_id.0);
-            }
-            Message::ExtentLiveNoOp { .. } => {
-                cdt::submit__el__noop__done!(|| ds_id.0);
+            Message::ExtentLiveAckId { .. } => {
+                cdt::submit__el__done!(|| ds_id.0);
             }
             _ => (),
         }


### PR DESCRIPTION
Some repair IO commands use common ACK messages when they finish.  

There existed specific probes for messages that would never happen and these probes have been removed.