### PR TITLE
Remove `Arc<Mutex<Downstairs>>`

### DIFF
--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -296,11 +296,11 @@ async fn main() -> Result<()> {
                     .expect("Error init tracing subscriber");
             }
 
-            let d = Downstairs::new_builder(&data, true)
+            let mut ds = Downstairs::new_builder(&data, true)
                 .set_logger(log)
                 .build()
                 .await?;
-            d.lock().await.clone_region(source).await?;
+            ds.clone_region(source).await?;
             Ok(())
         }
         Args::Create {
@@ -333,11 +333,11 @@ async fn main() -> Result<()> {
                 region.region_flush(1, 0, &None, JobId(0), None).await?;
             } else if let Some(ref clone_source) = clone_source {
                 info!(log, "Cloning from: {:?}", clone_source);
-                let d = Downstairs::new_builder(&data, false)
+                let mut ds = Downstairs::new_builder(&data, false)
                     .set_logger(log.clone())
                     .build()
                     .await?;
-                d.lock().await.clone_region(*clone_source).await?;
+                ds.clone_region(*clone_source).await?;
             }
 
             info!(log, "UUID: {:?}", region.def().uuid());
@@ -429,7 +429,7 @@ async fn main() -> Result<()> {
                 .build()
                 .await?;
 
-            let downstairs_join_handle = start_downstairs(
+            let downstairs = start_downstairs(
                 d,
                 address,
                 oximeter,
@@ -442,7 +442,7 @@ async fn main() -> Result<()> {
             )
             .await?;
 
-            downstairs_join_handle.await?
+            downstairs.join_handle.await?
         }
         Args::RepairAPI => repair::write_openapi(&mut std::io::stdout()),
         Args::Serve {

--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -48,7 +48,7 @@ fn build_api() -> ApiDescription<Arc<FileServerContext>> {
 
 /// Returns Ok(listen address) if everything launched ok, Err otherwise
 pub async fn repair_main(
-    downstairs: Arc<Mutex<Downstairs>>,
+    ds: &Downstairs,
     addr: SocketAddr,
     log: &Logger,
 ) -> Result<SocketAddr, String> {
@@ -70,12 +70,10 @@ pub async fn repair_main(
      * Record the region directory where all the extents and metadata
      * files live.
      */
-    let ds = downstairs.lock().await;
     let region_dir = ds.region.dir.clone();
     let read_only = ds.flags.read_only;
     let region_definition = ds.region.def();
     let handle = ds.handle();
-    drop(ds);
 
     info!(log, "Repair listens on {} for path:{:?}", addr, region_dir);
     let context = FileServerContext {


### PR DESCRIPTION
We're finally here: the `Downstairs` can be owned by a single task, with everyone else communicating through message-passing.

This PR removes `Arc<Mutex<Downstairs>>` everywhere in favor of a owned `Downstairs`.  During normal operation, the `Downstairs` is moved into a task by `Downstairs::spawn_runner`.

Most of the changes by LOC are to test suites, removing `let ds = ads.lock().await;` everywhere.