### PR TITLE
Move Work into ConnectionState

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1874,7 +1874,7 @@ impl Downstairs {
 
     /// Adds a new connection, then sets it to `ConnectionState::Running`
     ///
-    /// This skips autonegotiation for ease of unit testing
+    /// This skips negotiation for ease of unit testing
     #[cfg(test)]
     fn add_fake_connection(
         &mut self,
@@ -2960,7 +2960,7 @@ impl Downstairs {
         id: ConnectionId,
         reply_channel_tx: mpsc::UnboundedSender<Message>,
     ) -> tokio_util::sync::CancellationToken {
-        // Prepare for the autonegotiation / IO loop
+        // Prepare for the negotiation / IO loop
         //
         // We'll create a cancellation token here, store it in a DropGuard, and
         // return a child token for `recv_task` (as the most 'upstream' task)


### PR DESCRIPTION
(stacked on top of #1339)

This moves the `struct Work` into the `struct ActiveConnection`.

It was previously in an `ActiveDownstairs`, which was stored in `active_upstairs: HashMap<Uuid, ActiveUpstairs>`.

Putting it into the `ActiveConnection` consolidates where per-connection data lives, since we don't actually want to reuse `Work` if someone reconnects with a matching `Uuid`.  This is a step towards having the `ActiveConnection` do most of the per-connection work; for example, this PR moves `is_message_valid` and `add_work` into `ActiveConnection`.

Because we only have one task accessing the `Downstairs`, we can then remove a bunch of checks against being interrupted mid-operation: we have a `&mut Downstairs`, so no one is interrupting us.  In other words, many functions become infallible once we've checked that we're operating on an active connection.