### PR TITLE
Remove `Workstate::Done` (unused)

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -3329,12 +3329,6 @@ impl Work {
                 // return idempotently.
                 true
             }
-            WorkState::Done => {
-                /*
-                 * job id is not new, we can't run it.
-                 */
-                false
-            }
         }
     }
 
@@ -3361,17 +3355,12 @@ impl Work {
     }
 }
 
-/*
- * XXX We may not need Done. At the moment all we actually look at is New or
- * InProgress.
- */
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum WorkState {
     New,
     DepWait,
     InProgress,
-    Done,
 }
 
 impl fmt::Display for WorkState {
@@ -3385,9 +3374,6 @@ impl fmt::Display for WorkState {
             }
             WorkState::InProgress => {
                 write!(f, "In P")
-            }
-            WorkState::Done => {
-                write!(f, "Done")
             }
         }
     }

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -3229,8 +3229,6 @@ impl Work {
     /// `false`.
     ///
     /// If the job already is `InProgress`, return `true` (to be idempotent).
-    ///
-    /// If this job is `Done`, then just return `false`.
     fn in_progress(&mut self, ds_id: JobId) -> bool {
         let Some(job) = self.active.get_mut(&ds_id) else {
             panic!("called in_progress for invalid job");


### PR DESCRIPTION
(staged on top of #1354)

We never actually assigned anything to `WorkState::Done`, so we can remove it.