### PR TITLE
Make many `Region` functions synchronous

### DIFF
--- a/downstairs/src/admin.rs
+++ b/downstairs/src/admin.rs
@@ -71,7 +71,6 @@ pub async fn run_downstairs_for_region(
             run_params.flush_errors,
         )
         .build()
-        .await
         .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
 
     let handle = d.handle();

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -18,7 +18,7 @@ struct ExtInfo {
  *
  * If you don't want color, then set nc to true.
  */
-pub async fn dump_region(
+pub fn dump_region(
     region_dir: Vec<PathBuf>,
     mut cmp_extent: Option<ExtentId>,
     block: Option<u64>,
@@ -45,8 +45,7 @@ pub async fn dump_region(
     assert!(!region_dir.is_empty());
     for (index, dir) in region_dir.iter().enumerate() {
         // Open Region read only
-        let region =
-            Region::open(dir, Default::default(), false, true, &log).await?;
+        let region = Region::open(dir, Default::default(), false, true, &log)?;
 
         blocks_per_extent = region.def().extent_size().value;
         total_extents = region.def().extent_count();
@@ -95,7 +94,7 @@ pub async fn dump_region(
                 }
             }
 
-            let extent_info = e.get_meta_info().await;
+            let extent_info = e.get_meta_info();
 
             /*
              * If we have an entry already, then add this at our directory
@@ -140,8 +139,7 @@ pub async fn dump_region(
                 only_show_differences,
                 nc,
                 log,
-            )
-            .await;
+            );
         }
 
         show_extent(
@@ -152,8 +150,7 @@ pub async fn dump_region(
             only_show_differences,
             nc,
             log,
-        )
-        .await?;
+        )?;
 
         return Ok(());
     };
@@ -437,7 +434,7 @@ fn return_status_letters<'a, U: std::cmp::PartialEq>(
  * Show the metadata and a block by block diff of a single extent
  * We need at least two directories to compare, and no more than three.
  */
-async fn show_extent(
+fn show_extent(
     region_dir: Vec<PathBuf>,
     ei_hm: &HashMap<u32, ExtentMeta>,
     cmp_extent: ExtentId,
@@ -534,19 +531,16 @@ async fn show_extent(
         for (index, dir) in region_dir.iter().enumerate() {
             // Open Region read only
             let mut region =
-                Region::open(dir, Default::default(), false, true, &log)
-                    .await?;
+                Region::open(dir, Default::default(), false, true, &log)?;
 
-            let response = region
-                .region_read(
-                    &RegionReadRequest(vec![RegionReadReq {
-                        extent: cmp_extent,
-                        offset: Block::new_with_ddef(block, &region.def()),
-                        count: NonZeroUsize::new(1).unwrap(),
-                    }]),
-                    JobId(0),
-                )
-                .await?;
+            let response = region.region_read(
+                &RegionReadRequest(vec![RegionReadReq {
+                    extent: cmp_extent,
+                    offset: Block::new_with_ddef(block, &region.def()),
+                    count: NonZeroUsize::new(1).unwrap(),
+                }]),
+                JobId(0),
+            )?;
             assert_eq!(response.blocks.len(), 1);
             dvec.insert(index, response);
         }
@@ -619,7 +613,7 @@ fn is_all_same<T: PartialEq>(slice: &[T]) -> bool {
 /*
  * Show detailed comparison of different region's blocks
  */
-async fn show_extent_block(
+fn show_extent_block(
     region_dir: Vec<PathBuf>,
     cmp_extent: ExtentId,
     block: u64,
@@ -650,21 +644,16 @@ async fn show_extent_block(
     for (index, dir) in region_dir.iter().enumerate() {
         // Open Region read only
         let mut region =
-            Region::open(dir, Default::default(), false, true, &log).await?;
+            Region::open(dir, Default::default(), false, true, &log)?;
 
-        let response = region
-            .region_read(
-                &RegionReadRequest(vec![RegionReadReq {
-                    extent: cmp_extent,
-                    offset: Block::new_with_ddef(
-                        block_in_extent,
-                        &region.def(),
-                    ),
-                    count: NonZeroUsize::new(1).unwrap(),
-                }]),
-                JobId(0),
-            )
-            .await?;
+        let response = region.region_read(
+            &RegionReadRequest(vec![RegionReadReq {
+                extent: cmp_extent,
+                offset: Block::new_with_ddef(block_in_extent, &region.def()),
+                count: NonZeroUsize::new(1).unwrap(),
+            }]),
+            JobId(0),
+        )?;
         assert_eq!(response.blocks.len(), 1);
         dvec.insert(index, response);
     }

--- a/downstairs/src/dynamometer.rs
+++ b/downstairs/src/dynamometer.rs
@@ -8,7 +8,7 @@ pub enum DynoFlushConfig {
     None,
 }
 
-pub async fn dynamometer(
+pub fn dynamometer(
     mut region: Region,
     num_writes: usize,
     samples: usize,
@@ -89,7 +89,7 @@ pub async fn dynamometer(
                 let rw = RegionWrite(writes);
 
                 let io_operation_time = Instant::now();
-                region.region_write(rw, JobId(1000), false).await?;
+                region.region_write(rw, JobId(1000), false)?;
 
                 total_io_time += io_operation_time.elapsed();
                 io_operations_sent += num_writes;
@@ -141,15 +141,13 @@ pub async fn dynamometer(
                 };
 
                 if needs_flush {
-                    region
-                        .region_flush(
-                            flush_number,
-                            gen_number,
-                            &None, // snapshot_details
-                            JobId(1000),
-                            None, // extent_limit
-                        )
-                        .await?;
+                    region.region_flush(
+                        flush_number,
+                        gen_number,
+                        &None, // snapshot_details
+                        JobId(1000),
+                        None, // extent_limit
+                    )?;
 
                     flush_number += 1;
                     gen_number += 1;

--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -320,16 +320,14 @@ impl Extent {
         Ok(extent)
     }
 
-    #[allow(clippy::unused_async)] // this will be async again in the future
-    pub async fn dirty(&self) -> bool {
+    pub fn dirty(&self) -> bool {
         self.inner.dirty().unwrap()
     }
 
     /**
      * Close an extent and the metadata db files for it.
      */
-    #[allow(clippy::unused_async)] // this will be async again in the future
-    pub async fn close(self) -> Result<(u64, u64, bool), CrucibleError> {
+    pub fn close(self) -> Result<(u64, u64, bool), CrucibleError> {
         let gen = self.inner.gen_number().unwrap();
         let flush = self.inner.flush_number().unwrap();
         let dirty = self.inner.dirty().unwrap();
@@ -394,7 +392,7 @@ impl Extent {
     /// returned.  Otherwise, the value in `ExtentReadResponse::data` is
     /// guaranteed to be fully initialized and of the requested length.
     #[instrument]
-    pub async fn read(
+    pub fn read(
         &mut self,
         job_id: JobId,
         req: ExtentReadRequest,
@@ -410,7 +408,7 @@ impl Extent {
     }
 
     #[instrument]
-    pub async fn write(
+    pub fn write(
         &mut self,
         job_id: JobId,
         write: ExtentWrite,
@@ -432,7 +430,7 @@ impl Extent {
     }
 
     #[instrument]
-    pub(crate) async fn flush<I: Into<JobOrReconciliationId> + Debug>(
+    pub(crate) fn flush<I: Into<JobOrReconciliationId> + Debug>(
         &mut self,
         new_flush: u64,
         new_gen: u64,
@@ -460,8 +458,7 @@ impl Extent {
         self.inner.flush(new_flush, new_gen, job_id)
     }
 
-    #[allow(clippy::unused_async)] // this will be async again in the future
-    pub async fn get_meta_info(&self) -> ExtentMeta {
+    pub fn get_meta_info(&self) -> ExtentMeta {
         ExtentMeta {
             ext_version: 0,
             gen_number: self.inner.gen_number().unwrap(),
@@ -476,8 +473,7 @@ impl Extent {
     /// If the inner extent implementation does not support setting block
     /// contexts separately from a write operation
     #[cfg(test)]
-    #[allow(clippy::unused_async)] // this will be async again in the future
-    pub async fn set_dirty_and_block_context(
+    pub fn set_dirty_and_block_context(
         &mut self,
         block_context: &DownstairsBlockContext,
     ) -> Result<(), CrucibleError> {
@@ -490,8 +486,7 @@ impl Extent {
     /// If the inner extent implementation does not support getting block
     /// contexts separately from a read operation
     #[cfg(test)]
-    #[allow(clippy::unused_async)] // this will be async again in the future
-    pub async fn get_block_contexts(
+    pub fn get_block_contexts(
         &mut self,
         block: u64,
         count: u64,

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -298,8 +298,7 @@ async fn main() -> Result<()> {
 
             let mut ds = Downstairs::new_builder(&data, true)
                 .set_logger(log)
-                .build()
-                .await?;
+                .build()?;
             ds.clone_region(source).await?;
             Ok(())
         }
@@ -321,22 +320,20 @@ async fn main() -> Result<()> {
                 uuid,
                 encrypted,
                 log.clone(),
-            )
-            .await?;
+            )?;
 
             if let Some(ref ip) = import_path {
-                downstairs_import(&mut region, ip).await.unwrap();
+                downstairs_import(&mut region, ip).unwrap();
                 /*
                  * The region we just created should now have a flush so the
                  * new data and inital flush number is written to disk.
                  */
-                region.region_flush(1, 0, &None, JobId(0), None).await?;
+                region.region_flush(1, 0, &None, JobId(0), None)?;
             } else if let Some(ref clone_source) = clone_source {
                 info!(log, "Cloning from: {:?}", clone_source);
                 let mut ds = Downstairs::new_builder(&data, false)
                     .set_logger(log.clone())
-                    .build()
-                    .await?;
+                    .build()?;
                 ds.clone_region(*clone_source).await?;
             }
 
@@ -368,7 +365,6 @@ async fn main() -> Result<()> {
                 no_color,
                 log,
             )
-            .await
         }
         Args::Export {
             count,
@@ -383,10 +379,9 @@ async fn main() -> Result<()> {
                 true,
                 true,
                 &log,
-            )
-            .await?;
+            )?;
 
-            downstairs_export(&mut region, export_path, skip, count).await
+            downstairs_export(&mut region, export_path, skip, count)
         }
         Args::Run {
             address,
@@ -426,8 +421,7 @@ async fn main() -> Result<()> {
                 .set_lossy(lossy)
                 .set_logger(log)
                 .set_test_errors(read_errors, write_errors, flush_errors)
-                .build()
-                .await?;
+                .build()?;
 
             let downstairs = start_downstairs(
                 d,
@@ -499,8 +493,7 @@ async fn main() -> Result<()> {
                 uuid,
                 encrypted,
                 log.clone(),
-            )
-            .await?;
+            )?;
 
             let flush_config = if let Some(flush_per_iops) = flush_per_iops {
                 DynoFlushConfig::FlushPerIops(flush_per_iops)
@@ -512,7 +505,7 @@ async fn main() -> Result<()> {
                 DynoFlushConfig::None
             };
 
-            dynamometer(region, num_writes, samples, flush_config).await
+            dynamometer(region, num_writes, samples, flush_config)
         }
     }
 }

--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -47,7 +47,7 @@ fn build_api() -> ApiDescription<Arc<FileServerContext>> {
 }
 
 /// Returns Ok(listen address) if everything launched ok, Err otherwise
-pub async fn repair_main(
+pub fn repair_main(
     ds: &Downstairs,
     addr: SocketAddr,
     log: &Logger,
@@ -326,16 +326,15 @@ mod test {
         build_logger()
     }
 
-    #[tokio::test]
-    async fn extent_expected_files() -> Result<()> {
+    #[test]
+    fn extent_expected_files() -> Result<()> {
         // Verify that the list of files returned for an extent matches
         // what we expect.  This is a hack of sorts as we are hard coding
         // the expected names of files here in that test, rather than
         // determine them through some programmatic means.
         let dir = tempdir()?;
-        let mut region =
-            Region::create(&dir, new_region_options(), csl()).await?;
-        region.extend(3).await?;
+        let mut region = Region::create(&dir, new_region_options(), csl())?;
+        region.extend(3)?;
 
         // Determine the directory and name for expected extent files.
         let eid = ExtentId(1);
@@ -349,19 +348,18 @@ mod test {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn extent_expected_files_with_close() -> Result<()> {
+    #[test]
+    fn extent_expected_files_with_close() -> Result<()> {
         // Verify that the list of files returned for an extent matches
         // what we expect. In this case we expect the extent data file and
         // nothing else. We close the extent here first, and on illumos that
         // behaves a little different than elsewhere.
         let dir = tempdir()?;
-        let mut region =
-            Region::create(&dir, new_region_options(), csl()).await?;
-        region.extend(3).await?;
+        let mut region = Region::create(&dir, new_region_options(), csl())?;
+        region.extend(3)?;
 
         let eid = ExtentId(1);
-        region.close_extent(eid).await.unwrap();
+        region.close_extent(eid).unwrap();
 
         // Determine the directory and name for expected extent files.
         let extent_dir = extent_dir(&dir, eid);
@@ -375,14 +373,13 @@ mod test {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn extent_expected_files_fail() -> Result<()> {
+    #[test]
+    fn extent_expected_files_fail() -> Result<()> {
         // Verify that we get an error if the expected extent file
         // is missing.
         let dir = tempdir()?;
-        let mut region =
-            Region::create(&dir, new_region_options(), csl()).await?;
-        region.extend(3).await?;
+        let mut region = Region::create(&dir, new_region_options(), csl())?;
+        region.extend(3)?;
 
         // Determine the directory and name for expected extent files.
         let eid = ExtentId(1);

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -64,8 +64,7 @@ mod test {
                 encrypted,
                 backend,
                 csl(),
-            )
-            .await?;
+            )?;
 
             let mut downstairs =
                 Downstairs::new_builder(tempdir.path(), read_only)
@@ -73,8 +72,7 @@ mod test {
                     .set_logger(csl())
                     .set_test_errors(problematic, problematic, problematic)
                     .set_backend(backend)
-                    .build()
-                    .await?;
+                    .build()?;
 
             if let Some(ref clone_source) = clone_source {
                 downstairs.clone_region(*clone_source).await?
@@ -100,8 +98,7 @@ mod test {
         pub async fn reboot_read_only(&mut self) -> Result<()> {
             let downstairs = Downstairs::new_builder(self.tempdir.path(), true)
                 .set_logger(csl())
-                .build()
-                .await?;
+                .build()?;
 
             self.downstairs = Some(
                 start_downstairs(
@@ -131,8 +128,7 @@ mod test {
             let mut downstairs =
                 Downstairs::new_builder(self.tempdir.path(), true)
                     .set_logger(csl())
-                    .build()
-                    .await?;
+                    .build()?;
             downstairs.clone_region(source).await
         }
 


### PR DESCRIPTION
(staged on top of #1355)

For performance, we want to make these functions synchronous and use `block_in_place`.  This PR does the first half, which is purely mechanical removing of `async` and `.await`.

(Previously, we were considering per-extent IO workers, but I haven't gotten that to perform as well)