### PR TITLE
Using `block_in_place` for IO operations

### DIFF
--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -352,7 +352,6 @@ impl ExtentInner for RawInner {
                 req.offset.value as i64 * block_size as i64,
             )
         };
-
         // Check against the expected number of bytes.  We could do more
         // robust error handling here (e.g. retrying in a loop), but for
         // now, simply bailing out seems wise.

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -10,8 +10,8 @@ use crate::{
     },
     integrity_hash, mkdir_for_file,
     region::JobOrReconciliationId,
-    run_blocking, Block, BlockContext, CrucibleError, ExtentReadRequest,
-    ExtentReadResponse, ExtentWrite, JobId, RegionDefinition,
+    Block, BlockContext, CrucibleError, ExtentReadRequest, ExtentReadResponse,
+    ExtentWrite, JobId, RegionDefinition,
 };
 use crucible_common::ExtentId;
 
@@ -344,14 +344,14 @@ impl ExtentInner for RawInner {
         // SAFETY: the buffer has sufficient capacity, and this is a valid
         // file descriptor.
         let expected_bytes = buf.capacity();
-        let r = run_blocking(|| unsafe {
+        let r = unsafe {
             libc::pread(
                 self.file.as_raw_fd(),
                 buf.spare_capacity_mut().as_mut_ptr() as *mut libc::c_void,
                 expected_bytes as libc::size_t,
                 req.offset.value as i64 * block_size as i64,
             )
-        });
+        };
 
         // Check against the expected number of bytes.  We could do more
         // robust error handling here (e.g. retrying in a loop), but for
@@ -889,14 +889,12 @@ impl RawInner {
                 [..count * block_size as usize];
             let start_block = write.offset.value + start as u64;
 
-            run_blocking(|| {
-                pwrite_all(
-                    self.file.as_fd(),
-                    data,
-                    (start_block * block_size) as i64,
-                )
-                .map_err(|e| CrucibleError::IoError(e.to_string()))
-            })?;
+            pwrite_all(
+                self.file.as_fd(),
+                data,
+                (start_block * block_size) as i64,
+            )
+            .map_err(|e| CrucibleError::IoError(e.to_string()))?;
         }
         Ok(())
     }

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -654,6 +654,20 @@ pub fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
     Ok(())
 }
 
+/// Run the given function in the Tokio blocking IO pool if present
+///
+/// Otherwise, the function is run locally
+pub(crate) fn run_blocking<R, F: FnOnce() -> R>(f: F) -> R {
+    if matches!(
+        tokio::runtime::Handle::try_current().map(|r| r.runtime_flavor()),
+        Ok(tokio::runtime::RuntimeFlavor::MultiThread)
+    ) {
+        tokio::task::block_in_place(f)
+    } else {
+        f()
+    }
+}
+
 /*
  * Debug function to dump the work list.
  */

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -23,7 +23,7 @@ use repair_client::Client;
 /// (i.e. 128 for the Gimlet server sleds).
 const WORKER_POOL_SIZE: usize = 8;
 
-/// Size at which reads and writes should be done in the Tokio blocking pool
+/// Size above which reads and writes should be done in the Tokio blocking pool
 ///
 /// This is chosen somewhat arbitrarily.
 const MIN_BLOCKING_SIZE: usize = 64 * 1024; // 64 KiB

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -883,7 +883,7 @@ impl Region {
         //   multiple at the same time.
         let mut results = vec![Ok(()); dirty_extents.len()];
         let log = self.log.clone();
-        let mut f = || {
+        run_blocking(|| {
             let mut slice_start = 0;
             let mut slice = self.extents.as_mut_slice();
             self.pool.scope(|s| {
@@ -903,15 +903,7 @@ impl Region {
                     });
                 }
             })
-        };
-        if matches!(
-            tokio::runtime::Handle::try_current().map(|r| r.runtime_flavor()),
-            Ok(tokio::runtime::RuntimeFlavor::MultiThread)
-        ) {
-            tokio::task::block_in_place(f)
-        } else {
-            f()
-        }
+        });
 
         cdt::os__flush__done!(|| job_id.0);
 

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -801,7 +801,7 @@ impl Region {
             let extent = self.get_opened_extent_mut(req.extent);
             let req = response.request(req.offset, req.count.get());
 
-            // Run sufficiently large reads on in the blocking pool
+            // Run sufficiently large reads in the blocking pool
             let out = if req.data.capacity() > MIN_BLOCKING_SIZE {
                 run_blocking(|| extent.read(job_id, req))
             } else {


### PR DESCRIPTION
(staged on top of #1356)

`tokio::task::block_in_place` may cause a lot of problems, but it also helps a lot of IOs get done on time, so, it;s impossible to say if its bad or not