### PR TITLE
Parameterize more tests

### DIFF
--- a/tools/test_mem.sh
+++ b/tools/test_mem.sh
@@ -80,7 +80,10 @@ function show_mem_summary() {
 
 }
 
-test_mem_log="/tmp/test_mem_log.txt"
+# Location of logs and working files
+ WORK_ROOT=${WORK_ROOT:-/tmp}
+mkdir -p "$WORK_ROOT"
+test_mem_log="$WORK_ROOT/test_mem_log.txt"
 # Create a region with the given extent_size ($1) and extent_count ($2)
 # Once created, write to every block in the region, then display memory usage.
 function mem_test() {

--- a/tools/test_mem.sh
+++ b/tools/test_mem.sh
@@ -81,7 +81,7 @@ function show_mem_summary() {
 }
 
 # Location of logs and working files
- WORK_ROOT=${WORK_ROOT:-/tmp}
+WORK_ROOT=${WORK_ROOT:-/tmp}
 mkdir -p "$WORK_ROOT"
 test_mem_log="$WORK_ROOT/test_mem_log.txt"
 # Create a region with the given extent_size ($1) and extent_count ($2)

--- a/tools/test_perf.sh
+++ b/tools/test_perf.sh
@@ -31,6 +31,7 @@ count=30000
 prefill=0
 read_loops=2
 write_loops=2
+REGION_ROOT=${REGION_ROOT:-/var/tmp/test_perf}
 region_dir="/var/tmp/dsc"
 
 while getopts 'b:c:g:hfr:w:' opt; do

--- a/tools/test_replay.sh
+++ b/tools/test_replay.sh
@@ -14,7 +14,10 @@ function ctrl_c() {
     ${dsc} cmd shutdown
 }
 
-test_log=/tmp/test_replay.log
+WORK_ROOT=${WORK_ROOT:-/tmp}
+mkdir -p "$WORK_ROOT"
+
+test_log="$WORK_ROOT/test_replay.log"
 
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 export BINDIR=${BINDIR:-$ROOT/target/debug}
@@ -45,8 +48,8 @@ while getopts 'l:' opt; do
     esac
 done
 
-echo "" > ${test_log}
-echo "starting $(date)" | tee ${test_log}
+echo "" > "$test_log"
+echo "starting $(date)" | tee "$test_log"
 echo "Tail $test_log for test output"
 
 echo "Creating downstairs regions" | tee -a "$test_log"
@@ -90,11 +93,11 @@ result=$?
 duration=$SECONDS
 if [[ $result -ne 0 ]]; then
     printf "Error $result after %d:%02d\n" \
-            $((duration / 60)) $((duration % 60)) | tee -a ${test_log}
+            $((duration / 60)) $((duration % 60)) | tee -a "$test_log"
 else
     (( gen += 1 ))
     printf "Replays:%d time: %d:%02d\n" \
-      "$loops" $((duration / 60)) $((duration % 60)) | tee -a ${test_log}
+      "$loops" $((duration / 60)) $((duration % 60)) | tee -a "$test_log"
 
     echo "Do final verify" | tee -a "$test_log"
     if ! "$crucible_test" verify "${args[@]}" -q -g "$gen"\


### PR DESCRIPTION
Building on https://github.com/oxidecomputer/crucible/pull/1345
This updates more of the tests in the tools directory to honor both 
`REGION_ROOT ` and `WORK_ROOT` to help avoid conflicts and 
give tests a place to store region files.