### PR TITLE
Move 'do work for one job' into a helper function

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1420,9 +1420,15 @@ impl ActiveConnection {
     /// Do work for the given IO job
     ///
     /// This function will either complete the work (adding it to the completed
-    /// list), fail to complete the work (re-adding it to the active list and
-    /// returning the `JobId`), or fail to communicate when replying to the
-    /// Upstairs (which returns an error).
+    /// list and returning `None`), fail to complete the work (re-adding it to
+    /// the active list, sending an `ErrorPort`, and returning the `JobId`), or
+    /// fail to communicate when replying to the Upstairs (which returns an
+    /// error).
+    ///
+    /// There's one exception: failure to perform a live-repair task will -- in
+    /// addition to sending an `ErrorReport` to the upstairs -- **also** return
+    /// an error, because the connection is permanently tainted and we should
+    /// restart communication.
     async fn do_work(
         &mut self,
         job: DownstairsWork,


### PR DESCRIPTION
(staged on top of #1361)

Renames `do_work` → `do_work_inner`, and make `do_work` the canonical function to handle a `DownstairsWork`.  This is a building block for processing work immediately when it arrives, instead of having to put it into the `active` map then immediately pull it back out.