### PR TITLE
Do work immediately upon receipt of a job, if possible

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1246,6 +1246,7 @@ impl ActiveConnection {
                 cdt::submit__el__noop__start!(|| job_id.0);
                 let new_noop = IOop::ExtentLiveNoOp { dependencies };
                 let dsw = DownstairsWork::new(job_id, new_noop);
+                debug!(self.log, "Received NoOP {}", job_id);
                 self.do_work_if_ready(dsw, flags, reqwest_client, dss, region)
                     .await?
             }


### PR DESCRIPTION
(staged on top of #1365)

If a job is ready when it arrives, handle it immediately (instead of putting it into the hashmap).