### PR TITLE
Make a DTrace package

### DIFF
--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -43,12 +43,12 @@
 #: from_output = "/out/crucible-pantry.sha256.txt"
 #:
 #: [[publish]]
-#: series = "dtrace-image"
+#: series = "image"
 #: name = "crucible-dtrace.tar.gz"
 #: from_output = "/out/crucible-dtrace.tar.gz"
 #:
 #: [[publish]]
-#: series = "dtrace-image"
+#: series = "image"
 #: name = "crucible-dtrace.sha256.txt"
 #: from_output = "/out/crucible-dtrace.sha256.txt"
 #:

--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -120,4 +120,4 @@ cd /out
 digest -a sha256 crucible.tar.gz > crucible.sha256.txt
 digest -a sha256 crucible-pantry.tar.gz > crucible-pantry.sha256.txt
 digest -a sha256 crucible-nightly.tar.gz > crucible-nightly.sha256.txt
-digest -a sha256 crucible-dtrace.tar.gz > crucible-dtrace.sha256.txt
+digest -a sha256 crucible-dtrace.tar > crucible-dtrace.sha256.txt

--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -42,6 +42,16 @@
 #: name = "crucible-pantry.sha256.txt"
 #: from_output = "/out/crucible-pantry.sha256.txt"
 #:
+#: [[publish]]
+#: series = "dtrace-image"
+#: name = "crucible-dtrace.tar.gz"
+#: from_output = "/out/crucible-dtrace.tar.gz"
+#:
+#: [[publish]]
+#: series = "dtrace-image"
+#: name = "crucible-dtrace.sha256.txt"
+#: from_output = "/out/crucible-dtrace.sha256.txt"
+#:
 
 set -o errexit
 set -o pipefail
@@ -97,8 +107,17 @@ banner nightly
 banner copy
 mv out/crucible-nightly.tar.gz /out/crucible-nightly.tar.gz
 
+# Build the dtrace archive file which should include all the dtrace scripts.
+# This needs the ./out directory created above
+banner dtrace
+./tools/make-dtrace.sh
+
+banner copy
+mv out/crucible-dtrace.tar.gz /out/crucible-dtrace.tar.gz
+
 banner checksum
 cd /out
 digest -a sha256 crucible.tar.gz > crucible.sha256.txt
 digest -a sha256 crucible-pantry.tar.gz > crucible-pantry.sha256.txt
 digest -a sha256 crucible-nightly.tar.gz > crucible-nightly.sha256.txt
+digest -a sha256 crucible-dtrace.tar.gz > crucible-dtrace.sha256.txt

--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -44,8 +44,8 @@
 #:
 #: [[publish]]
 #: series = "image"
-#: name = "crucible-dtrace.tar.gz"
-#: from_output = "/out/crucible-dtrace.tar.gz"
+#: name = "crucible-dtrace.tar"
+#: from_output = "/out/crucible-dtrace.tar"
 #:
 #: [[publish]]
 #: series = "image"
@@ -113,11 +113,11 @@ banner dtrace
 ./tools/make-dtrace.sh
 
 banner copy
-mv out/crucible-dtrace.tar.gz /out/crucible-dtrace.tar.gz
+mv out/crucible-dtrace.tar /out/crucible-dtrace.tar
 
 banner checksum
 cd /out
 digest -a sha256 crucible.tar.gz > crucible.sha256.txt
 digest -a sha256 crucible-pantry.tar.gz > crucible-pantry.sha256.txt
 digest -a sha256 crucible-nightly.tar.gz > crucible-nightly.sha256.txt
-digest -a sha256 crucible-dtrace.tar.gz > crucible-dtrace.sha256.txt
+digest -a sha256 crucible-dtrace.tar > crucible-dtrace.sha256.txt

--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -44,8 +44,8 @@
 #:
 #: [[publish]]
 #: series = "image"
-#: name = "crucible-dtrace.tar.gz"
-#: from_output = "/out/crucible-dtrace.tar.gz"
+#: name = "crucible-dtrace.tar"
+#: from_output = "/out/crucible-dtrace.tar"
 #:
 #: [[publish]]
 #: series = "image"
@@ -113,7 +113,7 @@ banner dtrace
 ./tools/make-dtrace.sh
 
 banner copy
-mv out/crucible-dtrace.tar.gz /out/crucible-dtrace.tar.gz
+mv out/crucible-dtrace.tar /out/crucible-dtrace.tar
 
 banner checksum
 cd /out

--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -44,8 +44,8 @@
 #:
 #: [[publish]]
 #: series = "image"
-#: name = "crucible-dtrace.tar"
-#: from_output = "/out/crucible-dtrace.tar"
+#: name = "crucible-dtrace.tar.gz"
+#: from_output = "/out/crucible-dtrace.tar.gz"
 #:
 #: [[publish]]
 #: series = "image"
@@ -113,11 +113,11 @@ banner dtrace
 ./tools/make-dtrace.sh
 
 banner copy
-mv out/crucible-dtrace.tar /out/crucible-dtrace.tar
+mv out/crucible-dtrace.tar.gz /out/crucible-dtrace.tar.gz
 
 banner checksum
 cd /out
 digest -a sha256 crucible.tar.gz > crucible.sha256.txt
 digest -a sha256 crucible-pantry.tar.gz > crucible-pantry.sha256.txt
 digest -a sha256 crucible-nightly.tar.gz > crucible-nightly.sha256.txt
-digest -a sha256 crucible-dtrace.tar > crucible-dtrace.sha256.txt
+digest -a sha256 crucible-dtrace.tar.gz > crucible-dtrace.sha256.txt

--- a/tools/README.md
+++ b/tools/README.md
@@ -12,6 +12,10 @@ that you already have downstairs running on port 88[1-3]0.
 The test will check for panic or assert in the output and stop if it
 detects them or a test exits with an error.
 
+## make-dtrace.sh
+Build and package the DTrace scripts for use in the global zone of each sled.
+The output of this script is published as an artifact by buildomat.
+
 ## make-nightly.sh
 A simple script to build and package all that is required to run the
 test_nightly.sh script.  Use this when you want to manually create and

--- a/tools/dtrace/README.md
+++ b/tools/dtrace/README.md
@@ -1,5 +1,10 @@
 # Oxide DTrace Crucible scripts
 
+Select DTrace scripts are packaged up (by ../make-dtrace.sh) and added to
+the global zone on each sled.  If you add a script here and wish to make it
+part of the scripts added to the global zone, include it in that make-dtrace
+script.
+
 ## all_downstairs.d
 A DTrace script to show IOs coming and going on all downstairs as well as the
 work task geting new work, performing the work and completing the work. Stats

--- a/tools/make-dtrace.sh
+++ b/tools/make-dtrace.sh
@@ -11,9 +11,9 @@ git log -1 >> dtrace-info.txt
 echo "git status:" >> dtrace-info.txt
 git status >> dtrace-info.txt
 
-tar cavf out/crucible-dtrace.tar.gz \
+tar cvf out/crucible-dtrace.tar \
   tools/dtrace/* \
   dtrace-info.txt
 
-ls -l out/crucible-dtrace.tar.gz
+ls -l out/crucible-dtrace.tar
 rm dtrace-info.txt

--- a/tools/make-dtrace.sh
+++ b/tools/make-dtrace.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 #
-# Build a tar.gz archive with selected DTrace scripts.
+# Build a tar archive with selected DTrace scripts.
 # This archive is used to install DTrace scripts on the global zone of each
 # sled.  As such, the scripts here should match the probes that exist for
 # any consumer of the upstairs, like propolis, the pantry, or crucible agent.
 set -eux
 
-rm -f out/crucible-dtrace.tar.gz 2> /dev/null
+rm -f out/crucible-dtrace.tar 2> /dev/null
 
 mkdir -p out
 
@@ -18,7 +18,7 @@ git status >> dtrace-info.txt
 mv dtrace-info.txt tools/dtrace
 
 pushd tools/dtrace
-tar cavf ../../out/crucible-dtrace.tar.gz \
+tar cvf ../../out/crucible-dtrace.tar \
     dtrace-info.txt \
     README.md \
     all_downstairs.d \
@@ -48,4 +48,4 @@ tar cavf ../../out/crucible-dtrace.tar.gz \
 
 rm dtrace-info.txt
 popd
-ls -l out/crucible-dtrace.tar.gz
+ls -l out/crucible-dtrace.tar

--- a/tools/make-dtrace.sh
+++ b/tools/make-dtrace.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+# Build a tar.gz archive with selected DTrace scripts.
+# This archive is used to install DTrace scripts on the global zone of each
+# sled.  As such, the scripts here should match the probes that exist for
+# any consumer of the upstairs, like propolis, the pantry, or crucible agent.
 set -eux
 
 rm -f out/crucible-dtrace.tar.gz 2> /dev/null
@@ -13,7 +18,33 @@ git status >> dtrace-info.txt
 mv dtrace-info.txt tools/dtrace
 
 pushd tools/dtrace
-tar cavf ../../out/crucible-dtrace.tar.gz *
+tar cavf ../../out/crucible-dtrace.tar.gz \
+    dtrace-info.txt \
+    README.md \
+    all_downstairs.d \
+    downstairs_count.d \
+    get-ds-state.sh \
+    get-lr-state.sh \
+    perf-downstairs-os.d \
+    perf-downstairs-three.d \
+    perf-downstairs-tick.d \
+    perf-downstairs.d \
+    perf-ds-client.d \
+    perf-ds-net.d \
+    perf-online-repair.d \
+    perf-reqwest.d \
+    perf-upstairs-wf.d \
+    perf-vol.d \
+    perfgw.d \
+    single_up_info.d \
+    sled_upstairs_info.d \
+    trace-vol.d \
+    tracegw.d \
+    upstairs_action.d \
+    upstairs_count.d \
+    upstairs_info.d \
+    upstairs_raw.d \
+    upstairs_repair.d
 
 rm dtrace-info.txt
 popd

--- a/tools/make-dtrace.sh
+++ b/tools/make-dtrace.sh
@@ -13,9 +13,8 @@ git status >> dtrace-info.txt
 mv dtrace-info.txt tools/dtrace
 
 pushd tools/dtrace
-tar cvf ../../out/crucible-dtrace.tar \
-  *
+tar cavf ../../out/crucible-dtrace.tar.gz *
 
 rm dtrace-info.txt
 popd
-ls -l out/crucible-dtrace.tar
+ls -l out/crucible-dtrace.tar.gz

--- a/tools/make-dtrace.sh
+++ b/tools/make-dtrace.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -eux
+
+rm -f out/crucible-dtrace.tar.gz 2> /dev/null
+
+mkdir -p out
+
+echo "$(date) Create DTrace archive on $(hostname)" > /tmp/dtrace-info.txt
+echo "git log -1:" >> dtrace-info.txt
+git log -1 >> dtrace-info.txt
+echo "git status:" >> dtrace-info.txt
+git status >> dtrace-info.txt
+
+tar cavf out/crucible-dtrace.tar.gz \
+  tools/dtrace/* \
+  dtrace-info.txt
+
+ls -l out/crucible-dtrace.tar.gz
+rm dtrace-info.txt

--- a/tools/make-dtrace.sh
+++ b/tools/make-dtrace.sh
@@ -10,10 +10,12 @@ echo "git log -1:" >> dtrace-info.txt
 git log -1 >> dtrace-info.txt
 echo "git status:" >> dtrace-info.txt
 git status >> dtrace-info.txt
+mv dtrace-info.txt tools/dtrace
 
-tar cvf out/crucible-dtrace.tar \
-  tools/dtrace/* \
-  dtrace-info.txt
+pushd tools/dtrace
+tar cvf ../../out/crucible-dtrace.tar \
+  *
 
-ls -l out/crucible-dtrace.tar
 rm dtrace-info.txt
+popd
+ls -l out/crucible-dtrace.tar


### PR DESCRIPTION
Make a package of DTrace scripts for buildomat to publish.

This package will be used to install the selected set of DTrace scripts
into a sled or host.

The downstairs zones and the pantry zones already have some DTrace scripts
installed as part of their zones, this enables adding DTrace scripts to the global
zone (with a PR in Omicron after this lands)