### PR TITLE
Clean up dependency checking, fixing space leak

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -3254,8 +3254,12 @@ impl DownstairsHandle {
  */
 #[derive(Debug)]
 pub struct Work {
-    /// Jobs whose dependencies are not yet complete
     dep_wait: HashMap<JobId, IOop>,
+
+    /// Map of jobs with outstanding (unmet) dependencies
+    ///
+    /// The value stored in this map is the number of unmet dependencies for the
+    /// given job.
     outstanding_deps: HashMap<JobId, usize>,
 
     /*
@@ -3381,6 +3385,7 @@ impl Work {
         };
 
         if self.check_ready(ds_id, &mut work) {
+            let _ = self.outstanding_deps.remove(&ds_id);
             Some(work)
         } else {
             // Return the work to the map


### PR DESCRIPTION
(staged on top of #1371)

We only ever use the **count** of outstanding dependencies, so we don't need to actually accumulate the specific jobs.  This PR changes `deps_outstanding: Vec<JobId>` into `num_jobs_outstanding: usize`.  It also fixes a space leak in the `outstanding_deps` map; previously, jobs were added (if they were ever skipped due to missing deps) and never removed.