### PR TITLE
Add `BlockOffset` and `BlockIndex` types

### DIFF
--- a/common/src/impacted_blocks.rs
+++ b/common/src/impacted_blocks.rs
@@ -232,7 +232,7 @@ impl ImpactedBlocks {
     }
 }
 
-/// Given an global offset and number of blocks, compute a list of individually
+/// Given a global offset and number of blocks, compute a list of individually
 /// impacted blocks:
 ///
 ///  |eid0                   |eid1

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -16,9 +16,9 @@ use tokio::time::{Duration, Instant};
 
 mod region;
 pub use region::{
-    Block, ExtentId, RegionDefinition, RegionOptions, DATABASE_READ_VERSION,
-    DATABASE_WRITE_VERSION, MAX_BLOCK_SIZE, MAX_SHIFT, MIN_BLOCK_SIZE,
-    MIN_SHIFT,
+    Block, BlockIndex, BlockOffset, ExtentId, RegionDefinition, RegionOptions,
+    DATABASE_READ_VERSION, DATABASE_WRITE_VERSION, MAX_BLOCK_SIZE, MAX_SHIFT,
+    MIN_BLOCK_SIZE, MIN_SHIFT,
 };
 
 pub mod impacted_blocks;

--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -254,9 +254,8 @@ impl RegionDefinition {
         &self,
         offset: BlockIndex,
         length: usize,
-        ddef: &RegionDefinition,
     ) -> Result<(), CrucibleError> {
-        let final_offset = offset.0 * ddef.block_size + length as u64;
+        let final_offset = offset.0 * self.block_size + length as u64;
 
         if final_offset > self.total_size() {
             return Err(CrucibleError::OffsetInvalid);
@@ -511,91 +510,91 @@ mod test {
          *   Region |---|---|---|---|
          *   IO     |---|
          */
-        assert_eq!(rd.validate_io(BlockIndex(0), 512, &rd), Ok(()));
+        assert_eq!(rd.validate_io(BlockIndex(0), 512), Ok(()));
 
         /*
          *   Region |---|---|---|---|
          *   IO         |---|
          */
-        assert_eq!(rd.validate_io(BlockIndex(1), 512, &rd), Ok(()));
+        assert_eq!(rd.validate_io(BlockIndex(1), 512), Ok(()));
 
         /*
          *   Region |---|---|---|---|
          *   IO             |---|
          */
-        assert_eq!(rd.validate_io(BlockIndex(2), 512, &rd), Ok(()));
+        assert_eq!(rd.validate_io(BlockIndex(2), 512), Ok(()));
 
         /*
          *   Region |---|---|---|---|
          *   IO                 |---|
          */
-        assert_eq!(rd.validate_io(BlockIndex(3), 512, &rd), Ok(()));
+        assert_eq!(rd.validate_io(BlockIndex(3), 512), Ok(()));
 
         /*
          *   Region |---|---|---|---|
          *   IO                     |---|
          */
-        assert!(rd.validate_io(BlockIndex(4), 512, &rd).is_err());
+        assert!(rd.validate_io(BlockIndex(4), 512).is_err());
 
         /*
          *   Region |---|---|---|---|
          *   IO     |---|---|
          */
-        assert_eq!(rd.validate_io(BlockIndex(0), 1024, &rd), Ok(()));
+        assert_eq!(rd.validate_io(BlockIndex(0), 1024), Ok(()));
 
         /*
          *   Region |---|---|---|---|
          *   IO         |---|---|
          */
-        assert_eq!(rd.validate_io(BlockIndex(1), 1024, &rd), Ok(()));
+        assert_eq!(rd.validate_io(BlockIndex(1), 1024), Ok(()));
 
         /*
          *   Region |---|---|---|---|
          *   IO             |---|---|
          */
-        assert_eq!(rd.validate_io(BlockIndex(2), 1024, &rd), Ok(()));
+        assert_eq!(rd.validate_io(BlockIndex(2), 1024), Ok(()));
 
         /*
          *   Region |---|---|---|---|
          *   IO                 |---|---|
          */
-        assert!(rd.validate_io(BlockIndex(3), 1024, &rd).is_err());
+        assert!(rd.validate_io(BlockIndex(3), 1024).is_err());
 
         /*
          *   Region |---|---|---|---|
          *   IO                     |---|---|
          */
-        assert!(rd.validate_io(BlockIndex(4), 1024, &rd).is_err());
+        assert!(rd.validate_io(BlockIndex(4), 1024).is_err());
 
         /*
          *   Region |---|---|---|---|
          *   IO     |---|---|---|
          */
-        assert_eq!(rd.validate_io(BlockIndex(0), 1536, &rd), Ok(()));
+        assert_eq!(rd.validate_io(BlockIndex(0), 1536), Ok(()));
 
         /*
          *   Region |---|---|---|---|
          *   IO         |---|---|---|
          */
-        assert_eq!(rd.validate_io(BlockIndex(1), 1536, &rd), Ok(()));
+        assert_eq!(rd.validate_io(BlockIndex(1), 1536), Ok(()));
 
         /*
          *   Region |---|---|---|---|
          *   IO             |---|---|---|
          */
-        assert!(rd.validate_io(BlockIndex(2), 1536, &rd).is_err());
+        assert!(rd.validate_io(BlockIndex(2), 1536).is_err());
 
         /*
          *   Region |---|---|---|---|
          *   IO     |---|---|---|---|
          */
-        assert_eq!(rd.validate_io(BlockIndex(0), 2048, &rd), Ok(()));
+        assert_eq!(rd.validate_io(BlockIndex(0), 2048), Ok(()));
 
         /*
          *   Region |---|---|---|---|
          *   IO         |---|---|---|---|
          */
-        assert!(rd.validate_io(BlockIndex(1), 2048, &rd).is_err());
+        assert!(rd.validate_io(BlockIndex(1), 2048).is_err());
     }
 
     fn test_rd() -> RegionDefinition {

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -535,7 +535,7 @@ fn show_extent(
             let response = region.region_read(
                 &RegionReadRequest(vec![RegionReadReq {
                     extent: cmp_extent,
-                    offset: Block::new_with_ddef(block, &region.def()),
+                    offset: BlockOffset(block),
                     count: NonZeroUsize::new(1).unwrap(),
                 }]),
                 JobId(0),
@@ -647,7 +647,7 @@ fn show_extent_block(
         let response = region.region_read(
             &RegionReadRequest(vec![RegionReadReq {
                 extent: cmp_extent,
-                offset: Block::new_with_ddef(block_in_extent, &region.def()),
+                offset: BlockOffset(block_in_extent),
                 count: NonZeroUsize::new(1).unwrap(),
             }]),
             JobId(0),

--- a/downstairs/src/dynamometer.rs
+++ b/downstairs/src/dynamometer.rs
@@ -76,10 +76,7 @@ pub fn dynamometer(
                         RegionWriteReq {
                             extent: eid,
                             write: ExtentWrite {
-                                offset: Block::new_with_ddef(
-                                    i as u64 + block_offset,
-                                    &ddef,
-                                ),
+                                offset: BlockOffset(i as u64 + block_offset),
                                 data: block_bytes.clone(),
                                 block_contexts: vec![ctx],
                             },

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -585,7 +585,7 @@ pub fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
                  * We have hit EOF.  Extend the read buffer with zeroes until
                  * it is a multiple of the block size.
                  */
-                while !Block::is_valid_byte_size(total, &rm) {
+                while !rm.is_valid_byte_size(total) {
                     buffer[total] = 0;
                     total += 1;
                 }
@@ -610,7 +610,7 @@ pub fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
          * Use the same function upstairs uses to decide where to put the
          * data based on the LBA offset.
          */
-        let nblocks = Block::from_bytes(total, &rm);
+        let nblocks = rm.bytes_to_blocks(total);
         let block_size = region.def().block_size() as usize;
         let blocks: Vec<_> = extent_from_offset(&rm, offset, nblocks)
             .blocks(&rm)
@@ -635,7 +635,7 @@ pub fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
 
         // We have no job ID, so it makes no sense for accounting.
         region.region_write(&write, JobId(0), false)?;
-        offset.0 += nblocks.value;
+        offset.0 += nblocks;
     }
 
     /*

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -15,8 +15,8 @@ use std::time::Duration;
 
 use crucible_common::{
     build_logger, impacted_blocks::extent_from_offset, integrity_hash,
-    mkdir_for_file, verbose_timeout, Block, CrucibleError, ExtentId,
-    RegionDefinition, MAX_BLOCK_SIZE,
+    mkdir_for_file, verbose_timeout, Block, BlockIndex, BlockOffset,
+    CrucibleError, ExtentId, RegionDefinition, MAX_BLOCK_SIZE,
 };
 use crucible_protocol::{
     BlockContext, CrucibleDecoder, JobId, Message, MessageWriter,
@@ -133,7 +133,7 @@ impl IOop {
 /// of `data`, so it's rarely the correct choice.
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) struct ExtentReadRequest {
-    offset: Block,
+    offset: BlockOffset,
     /// This buffer should be uninitialized; read size is set by its capacity
     data: BytesMut,
 }
@@ -142,11 +142,11 @@ pub(crate) struct ExtentReadRequest {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) struct RegionReadRequest(Vec<RegionReadReq>);
 
-/// Inner type for a single read requests
+/// Inner type for a single read request
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) struct RegionReadReq {
     extent: ExtentId,
-    offset: Block,
+    offset: BlockOffset,
     count: NonZeroUsize,
 }
 
@@ -159,8 +159,8 @@ impl RegionReadRequest {
                 // extent as the previous read request
                 Some(prev)
                     if prev.extent == req.eid
-                        && prev.offset.value + prev.count.get() as u64
-                            == req.offset.value =>
+                        && prev.offset.0 + prev.count.get() as u64
+                            == req.offset.0 =>
                 {
                     // If so, enlarge it by one block
                     prev.count = prev.count.saturating_add(1);
@@ -239,12 +239,13 @@ impl RegionReadResponse {
     /// If the size of the request is larger than our remaining buffer capacity
     fn request(
         &mut self,
-        offset: Block,
+        offset: BlockOffset,
         block_count: usize,
+        def: &RegionDefinition,
     ) -> ExtentReadRequest {
         let mut data = self
             .uninit
-            .split_off(block_count * offset.block_size_in_bytes() as usize);
+            .split_off(block_count * def.block_size() as usize);
         std::mem::swap(&mut data, &mut self.uninit);
         ExtentReadRequest { offset, data }
     }
@@ -317,7 +318,7 @@ pub(crate) struct ExtentReadResponse {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) struct ExtentWrite {
     /// Block offset, relative to the start of this extent
-    pub offset: Block,
+    pub offset: BlockOffset,
 
     /// One context per block to be written
     pub block_contexts: Vec<BlockContext>,
@@ -353,12 +354,9 @@ impl RegionWrite {
     pub fn new(
         blocks: &[crucible_protocol::WriteBlockMetadata],
         mut buf: bytes::Bytes,
+        ddef: &RegionDefinition,
     ) -> Result<Self, CrucibleError> {
-        let block_size = if let Some(b) = blocks.first() {
-            b.offset.block_size_in_bytes() as usize
-        } else {
-            return Ok(Self(vec![]));
-        };
+        let block_size = ddef.block_size() as usize;
         if buf.len() % block_size != 0 {
             return Err(CrucibleError::DataLenUnaligned);
         } else if buf.len() / block_size != blocks.len() {
@@ -388,9 +386,9 @@ impl RegionWrite {
             None => false,
             Some(prev) => {
                 prev.extent == b.eid
-                    && prev.write.offset.value
+                    && prev.write.offset.0
                         + prev.write.block_contexts.len() as u64
-                        == b.offset.value
+                        == b.offset.0
             }
         }
     }
@@ -491,10 +489,7 @@ pub fn downstairs_export<P: AsRef<Path> + std::fmt::Debug>(
                 let response = region.region_read(
                     &RegionReadRequest(vec![RegionReadReq {
                         extent: eid,
-                        offset: Block::new_with_ddef(
-                            block_offset,
-                            &region.def(),
-                        ),
+                        offset: BlockOffset(block_offset),
                         count: NonZeroUsize::new(1).unwrap(),
                     }]),
                     JobId(0),
@@ -563,7 +558,7 @@ pub fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
     const CHUNK_SIZE: usize = 32 * 1024 * 1024;
     assert_eq!(CHUNK_SIZE % MAX_BLOCK_SIZE, 0);
 
-    let mut offset = Block::new_with_ddef(0, &region.def());
+    let mut offset = BlockIndex(0);
     loop {
         let mut buffer = BytesMut::new();
         buffer.resize(CHUNK_SIZE, 0u8);
@@ -636,11 +631,11 @@ pub fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
             })
             .collect();
 
-        let write = RegionWrite::new(&blocks, buffer)?;
+        let write = RegionWrite::new(&blocks, buffer, &region.def())?;
 
         // We have no job ID, so it makes no sense for accounting.
         region.region_write(&write, JobId(0), false)?;
-        offset.advance(nblocks);
+        offset.0 += nblocks.value;
     }
 
     /*
@@ -651,8 +646,8 @@ pub fn downstairs_import<P: AsRef<Path> + std::fmt::Debug>(
     println!(
         "Populated {} extents by copying {} bytes ({} blocks)",
         extents_needed,
-        offset.byte_value(),
-        offset.value,
+        offset.0 * region.def().block_size(),
+        offset.0,
     );
 
     Ok(())
@@ -1131,7 +1126,8 @@ impl ActiveConnection {
         let r = match m {
             Message::Write { header, data } => {
                 cdt::submit__write__start!(|| header.job_id.0);
-                let writes = RegionWrite::new(&header.blocks, data)?;
+                let writes =
+                    RegionWrite::new(&header.blocks, data, &region.def())?;
 
                 let new_write = IOop::Write {
                     dependencies: header.dependencies,
@@ -1178,7 +1174,8 @@ impl ActiveConnection {
             }
             Message::WriteUnwritten { header, data } => {
                 cdt::submit__writeunwritten__start!(|| header.job_id.0);
-                let writes = RegionWrite::new(&header.blocks, data)?;
+                let writes =
+                    RegionWrite::new(&header.blocks, data, &region.def())?;
 
                 let new_write = IOop::WriteUnwritten {
                     dependencies: header.dependencies,
@@ -1661,10 +1658,7 @@ impl ActiveConnection {
                                 (0..req.count.get()).map(|i| {
                                     (
                                         req.extent,
-                                        Block {
-                                            value: req.offset.value + i as u64,
-                                            shift: req.offset.shift,
-                                        },
+                                        BlockOffset(req.offset.0 + i as u64),
                                     )
                                 })
                             })
@@ -3712,7 +3706,7 @@ mod test {
                     dependencies: deps,
                     requests: RegionReadRequest(vec![RegionReadReq {
                         extent: ExtentId(1),
-                        offset: Block::new_512(1),
+                        offset: BlockOffset(1),
                         count: NonZeroUsize::new(1).unwrap(),
                     }]),
                 }
@@ -3845,7 +3839,7 @@ mod test {
             dependencies: Vec::new(),
             requests: RegionReadRequest(vec![RegionReadReq {
                 extent: ExtentId(0),
-                offset: Block::new_512(1),
+                offset: BlockOffset(1),
                 count: NonZeroUsize::new(1).unwrap(),
             }]),
         };
@@ -3856,7 +3850,7 @@ mod test {
             dependencies: deps,
             requests: RegionReadRequest(vec![RegionReadReq {
                 extent: ExtentId(1),
-                offset: Block::new_512(1),
+                offset: BlockOffset(1),
                 count: NonZeroUsize::new(1).unwrap(),
             }]),
         };
@@ -3956,7 +3950,7 @@ mod test {
             dependencies: deps,
             requests: RegionReadRequest(vec![RegionReadReq {
                 extent: ExtentId(2),
-                offset: Block::new_512(1),
+                offset: BlockOffset(1),
                 count: NonZeroUsize::new(1).unwrap(),
             }]),
         };
@@ -4138,7 +4132,7 @@ mod test {
     // matches the hash.
     fn create_generic_test_write(eid: ExtentId) -> RegionWrite {
         let data = Bytes::from(vec![9u8; 512]);
-        let offset = Block::new_512(1);
+        let offset = BlockOffset(1);
 
         RegionWrite(vec![RegionWriteReq {
             extent: eid,
@@ -5470,7 +5464,7 @@ mod test {
                 let response = region.region_read(
                     &RegionReadRequest(vec![RegionReadReq {
                         extent: eid,
-                        offset: Block::new_512(offset),
+                        offset: BlockOffset(offset),
                         count: NonZeroUsize::new(1).unwrap(),
                     }]),
                     JobId(0),
@@ -5858,7 +5852,7 @@ mod test {
             dependencies: Vec::new(),
             requests: RegionReadRequest(vec![RegionReadReq {
                 extent: ExtentId(0),
-                offset: Block::new_512(1),
+                offset: BlockOffset(1),
                 count: NonZeroUsize::new(1).unwrap(),
             }]),
         };
@@ -5868,7 +5862,7 @@ mod test {
             dependencies: Vec::new(),
             requests: RegionReadRequest(vec![RegionReadReq {
                 extent: ExtentId(1),
-                offset: Block::new_512(2),
+                offset: BlockOffset(2),
                 count: NonZeroUsize::new(1).unwrap(),
             }]),
         };
@@ -6119,24 +6113,28 @@ mod test {
 
     #[test]
     fn decode_write() {
+        let mut def = RegionDefinition::default();
+        def.set_block_size(512);
+        def.set_extent_size(Block::new_512(10));
+
         use crucible_protocol::WriteBlockMetadata;
         let blocks = vec![WriteBlockMetadata {
             eid: ExtentId(0),
-            offset: Block::new_512(0),
+            offset: BlockOffset(0),
             block_context: BlockContext {
                 hash: 123,
                 encryption_context: None,
             },
         }];
         let data = Bytes::from(vec![1u8; 512]);
-        let w = RegionWrite::new(&blocks, data).unwrap();
+        let w = RegionWrite::new(&blocks, data, &def).unwrap();
         assert_eq!(w.0.len(), 1);
 
         // Two contiguous blocks
         let blocks = vec![
             WriteBlockMetadata {
                 eid: ExtentId(0),
-                offset: Block::new_512(0),
+                offset: BlockOffset(0),
                 block_context: BlockContext {
                     hash: 123,
                     encryption_context: None,
@@ -6144,7 +6142,7 @@ mod test {
             },
             WriteBlockMetadata {
                 eid: ExtentId(0),
-                offset: Block::new_512(1),
+                offset: BlockOffset(1),
                 block_context: BlockContext {
                     hash: 123,
                     encryption_context: None,
@@ -6152,17 +6150,17 @@ mod test {
             },
         ];
         let data = Bytes::from(vec![1u8; 512 * 2]);
-        let w = RegionWrite::new(&blocks, data).unwrap();
+        let w = RegionWrite::new(&blocks, data, &def).unwrap();
         assert_eq!(w.0.len(), 1);
         assert_eq!(w.0[0].extent, ExtentId(0));
-        assert_eq!(w.0[0].write.offset, Block::new_512(0));
+        assert_eq!(w.0[0].write.offset, BlockOffset(0));
         assert_eq!(w.0[0].write.data.len(), 512 * 2);
 
         // Two non-contiguous blocks
         let blocks = vec![
             WriteBlockMetadata {
                 eid: ExtentId(1),
-                offset: Block::new_512(0),
+                offset: BlockOffset(0),
                 block_context: BlockContext {
                     hash: 123,
                     encryption_context: None,
@@ -6170,7 +6168,7 @@ mod test {
             },
             WriteBlockMetadata {
                 eid: ExtentId(2),
-                offset: Block::new_512(1),
+                offset: BlockOffset(1),
                 block_context: BlockContext {
                     hash: 123,
                     encryption_context: None,
@@ -6178,20 +6176,20 @@ mod test {
             },
         ];
         let data = Bytes::from(vec![1u8; 512 * 2]);
-        let w = RegionWrite::new(&blocks, data).unwrap();
+        let w = RegionWrite::new(&blocks, data, &def).unwrap();
         assert_eq!(w.0.len(), 2);
         assert_eq!(w.0[0].extent, ExtentId(1));
-        assert_eq!(w.0[0].write.offset, Block::new_512(0));
+        assert_eq!(w.0[0].write.offset, BlockOffset(0));
         assert_eq!(w.0[0].write.data.len(), 512);
         assert_eq!(w.0[1].extent, ExtentId(2));
-        assert_eq!(w.0[1].write.offset, Block::new_512(1));
+        assert_eq!(w.0[1].write.offset, BlockOffset(1));
         assert_eq!(w.0[1].write.data.len(), 512);
 
         // Overlapping writes to the same block
         let blocks = vec![
             WriteBlockMetadata {
                 eid: ExtentId(1),
-                offset: Block::new_512(3),
+                offset: BlockOffset(3),
                 block_context: BlockContext {
                     hash: 123,
                     encryption_context: None,
@@ -6199,7 +6197,7 @@ mod test {
             },
             WriteBlockMetadata {
                 eid: ExtentId(1),
-                offset: Block::new_512(3),
+                offset: BlockOffset(3),
                 block_context: BlockContext {
                     hash: 123,
                     encryption_context: None,
@@ -6207,30 +6205,30 @@ mod test {
             },
         ];
         let data = Bytes::from(vec![1u8; 512 * 2]);
-        let w = RegionWrite::new(&blocks, data).unwrap();
+        let w = RegionWrite::new(&blocks, data, &def).unwrap();
         assert_eq!(w.0.len(), 2);
         assert_eq!(w.0[0].extent, ExtentId(1));
-        assert_eq!(w.0[0].write.offset, Block::new_512(3));
+        assert_eq!(w.0[0].write.offset, BlockOffset(3));
         assert_eq!(w.0[0].write.data.len(), 512);
         assert_eq!(w.0[1].extent, ExtentId(1));
-        assert_eq!(w.0[1].write.offset, Block::new_512(3));
+        assert_eq!(w.0[1].write.offset, BlockOffset(3));
         assert_eq!(w.0[1].write.data.len(), 512);
 
         // Mismatched block / data sizes
         let blocks = vec![WriteBlockMetadata {
             eid: ExtentId(1),
-            offset: Block::new_512(3),
+            offset: BlockOffset(3),
             block_context: BlockContext {
                 hash: 123,
                 encryption_context: None,
             },
         }];
         let data = Bytes::from(vec![1u8; 512 * 2]);
-        let r = RegionWrite::new(&blocks, data);
+        let r = RegionWrite::new(&blocks, data, &def);
         assert!(r.is_err());
 
         let data = Bytes::from(vec![1u8; 513]);
-        let r = RegionWrite::new(&blocks, data);
+        let r = RegionWrite::new(&blocks, data, &def);
         assert!(r.is_err());
     }
 }

--- a/upstairs/src/buffer.rs
+++ b/upstairs/src/buffer.rs
@@ -374,7 +374,7 @@ impl UninitializedBuffer {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{Block, BlockContext, ReadResponseBlockMetadata};
+    use crate::{BlockContext, BlockOffset, ReadResponseBlockMetadata};
     use crucible_common::ExtentId;
     use rand::RngCore;
 
@@ -497,7 +497,7 @@ mod test {
         let blocks = (0..10)
             .map(|i| ReadResponseBlockMetadata {
                 eid: ExtentId(0),
-                offset: Block::new_512(i),
+                offset: BlockOffset(i),
                 block_context: if f(i) {
                     Some(BlockContext {
                         hash: 123,
@@ -573,7 +573,7 @@ mod test {
         let blocks = (0..10)
             .map(|i| ReadResponseBlockMetadata {
                 eid: ExtentId(0),
-                offset: Block::new_512(i),
+                offset: BlockOffset(i),
                 block_context: Some(BlockContext {
                     hash: 123,
                     encryption_context: None,

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -1294,10 +1294,7 @@ impl DownstairsClient {
                         }
 
                         // If a read job fails, we sometimes need to panic.
-                        IOop::Read {
-                            dependencies: _,
-                            requests: _,
-                        } => {
+                        IOop::Read { .. } => {
                             // It's possible we get a read error if the
                             // downstairs disconnects. However XXX, someone
                             // should be told about this error.
@@ -1338,19 +1335,10 @@ impl DownstairsClient {
              * sure to update the last flush for this client.
              */
             match &job.work {
-                IOop::Flush {
-                    dependencies: _dependencies,
-                    flush_number: _flush_number,
-                    gen_number: _gen_number,
-                    snapshot_details: _,
-                    extent_limit: _,
-                } => {
+                IOop::Flush { .. } => {
                     self.last_flush = ds_id;
                 }
-                IOop::Read {
-                    dependencies: _dependencies,
-                    requests,
-                } => {
+                IOop::Read { requests, .. } => {
                     /*
                      * For a read, make sure the data from a previous read
                      * has the same hash

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -18,6 +18,7 @@ use crate::DsState;
 use crate::{IO_OUTSTANDING_MAX_BYTES, IO_OUTSTANDING_MAX_JOBS};
 use crucible_client_types::CrucibleOpts;
 use crucible_common::Block;
+use crucible_common::BlockOffset;
 use crucible_common::ExtentId;
 use crucible_common::RegionDefinition;
 use crucible_common::RegionOptions;
@@ -616,7 +617,7 @@ fn make_blank_read_response() -> (ReadResponseBlockMetadata, BytesMut) {
     (
         ReadResponseBlockMetadata {
             eid: ExtentId(0),
-            offset: Block::new_512(0),
+            offset: BlockOffset(0),
             block_context: Some(BlockContext {
                 hash,
                 encryption_context: None,

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -1148,16 +1148,16 @@ pub mod repair_test {
         finish_live_repair(&mut up, 1000);
 
         up.submit_dummy_write(
-            Block::new_512(0),
+            BlockIndex(0),
             BytesMut::from(vec![0xff; 512].as_slice()),
             false,
         );
 
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(1, 512));
+        up.submit_dummy_read(BlockIndex(0), Buffer::new(1, 512));
 
         // WriteUnwritten
         up.submit_dummy_write(
-            Block::new_512(0),
+            BlockIndex(0),
             BytesMut::from(vec![0xff; 512].as_slice()),
             true,
         );
@@ -1183,16 +1183,16 @@ pub mod repair_test {
         let mut up = start_up_and_repair(ClientId::new(1));
 
         up.submit_dummy_write(
-            Block::new_512(0),
+            BlockIndex(0),
             BytesMut::from(vec![0xff; 512].as_slice()),
             false,
         );
 
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(1, 512));
+        up.submit_dummy_read(BlockIndex(0), Buffer::new(1, 512));
 
         // WriteUnwritten
         up.submit_dummy_write(
-            Block::new_512(0),
+            BlockIndex(0),
             BytesMut::from(vec![0xff; 512].as_slice()),
             true,
         );
@@ -1214,16 +1214,16 @@ pub mod repair_test {
         let mut up = start_up_and_repair(ClientId::new(1));
 
         up.submit_dummy_write(
-            Block::new_512(3),
+            BlockIndex(3),
             BytesMut::from(vec![0xff; 512].as_slice()),
             false,
         );
 
-        up.submit_dummy_read(Block::new_512(3), Buffer::new(1, 512));
+        up.submit_dummy_read(BlockIndex(3), Buffer::new(1, 512));
 
         // WriteUnwritten
         up.submit_dummy_write(
-            Block::new_512(3),
+            BlockIndex(3),
             BytesMut::from(vec![0xff; 512].as_slice()),
             true,
         );
@@ -1296,16 +1296,16 @@ pub mod repair_test {
 
         // Our default extent size is 3, so 9 blocks will span 3 extents
         up.submit_dummy_write(
-            Block::new_512(0),
+            BlockIndex(0),
             BytesMut::from(vec![0xff; 512 * 9].as_slice()),
             false,
         );
 
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(9, 512));
+        up.submit_dummy_read(BlockIndex(0), Buffer::new(9, 512));
 
         // WriteUnwritten
         up.submit_dummy_write(
-            Block::new_512(0),
+            BlockIndex(0),
             BytesMut::from(vec![0xff; 512 * 9].as_slice()),
             true,
         );
@@ -1362,7 +1362,7 @@ pub mod repair_test {
         finish_live_repair(&mut up, 1000);
 
         // Our default extent size is 3, so 9 blocks will span 3 extents
-        up.submit_dummy_read(Block::new_512(0), Buffer::new(9, 512));
+        up.submit_dummy_read(BlockIndex(0), Buffer::new(9, 512));
 
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         up.show_all_work();
@@ -1423,7 +1423,7 @@ pub mod repair_test {
 
         // Our default extent size is 3, so 9 blocks will span 3 extents
         up.submit_dummy_write(
-            Block::new_512(0),
+            BlockIndex(0),
             BytesMut::from(vec![0xff; 512 * 9].as_slice()),
             false,
         );
@@ -1487,7 +1487,7 @@ pub mod repair_test {
 
         // Our default extent size is 3, so block 3 will be on extent 1
         up.submit_dummy_write(
-            Block::new_512(0),
+            BlockIndex(0),
             BytesMut::from(vec![0xff; 512 * 9].as_slice()),
             false,
         );

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -133,7 +133,6 @@ pub(crate) mod up_test {
         num_blocks: u64,
     ) -> Vec<(ExtentId, BlockOffset)> {
         let ddef = up.get_region_definition();
-        let num_blocks = Block::new_with_ddef(num_blocks, &ddef);
         extent_from_offset(&ddef, offset, num_blocks)
             .blocks(&ddef)
             .collect()

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -59,8 +59,8 @@ pub(crate) mod up_test {
         build_logger()
     }
 
-    fn extent_tuple(eid: u32, offset: u64) -> (ExtentId, Block) {
-        (ExtentId(eid), Block::new_512(offset))
+    fn extent_tuple(eid: u32, offset: u64) -> (ExtentId, BlockOffset) {
+        (ExtentId(eid), BlockOffset(offset))
     }
 
     #[test]
@@ -129,9 +129,9 @@ pub(crate) mod up_test {
      */
     fn up_efo(
         up: &Upstairs,
-        offset: Block,
+        offset: BlockIndex,
         num_blocks: u64,
-    ) -> Vec<(ExtentId, Block)> {
+    ) -> Vec<(ExtentId, BlockOffset)> {
         let ddef = up.get_region_definition();
         let num_blocks = Block::new_with_ddef(num_blocks, &ddef);
         extent_from_offset(&ddef, offset, num_blocks)
@@ -145,19 +145,19 @@ pub(crate) mod up_test {
 
         for i in 0..100 {
             let exv = vec![extent_tuple(0, i)];
-            assert_eq!(up_efo(&up, Block::new_512(i), 1), exv);
+            assert_eq!(up_efo(&up, BlockIndex(i), 1), exv);
         }
 
         for i in 0..100 {
             let exv = vec![extent_tuple(1, i)];
-            assert_eq!(up_efo(&up, Block::new_512(100 + i), 1), exv);
+            assert_eq!(up_efo(&up, BlockIndex(100 + i), 1), exv);
         }
 
         let exv = vec![extent_tuple(2, 0)];
-        assert_eq!(up_efo(&up, Block::new_512(200), 1), exv);
+        assert_eq!(up_efo(&up, BlockIndex(200), 1), exv);
 
         let exv = vec![extent_tuple(9, 99)];
-        assert_eq!(up_efo(&up, Block::new_512(999), 1), exv);
+        assert_eq!(up_efo(&up, BlockIndex(999), 1), exv);
     }
 
     #[test]
@@ -166,25 +166,25 @@ pub(crate) mod up_test {
 
         for i in 0..99 {
             let exv = vec![extent_tuple(0, i), extent_tuple(0, i + 1)];
-            assert_eq!(up_efo(&up, Block::new_512(i), 2), exv);
+            assert_eq!(up_efo(&up, BlockIndex(i), 2), exv);
         }
 
         let exv = vec![extent_tuple(0, 99), extent_tuple(1, 0)];
-        assert_eq!(up_efo(&up, Block::new_512(99), 2), exv);
+        assert_eq!(up_efo(&up, BlockIndex(99), 2), exv);
 
         for i in 0..99 {
             let exv = vec![extent_tuple(1, i)];
-            assert_eq!(up_efo(&up, Block::new_512(100 + i), 1), exv);
+            assert_eq!(up_efo(&up, BlockIndex(100 + i), 1), exv);
         }
 
         let exv = vec![extent_tuple(1, 99), extent_tuple(2, 0)];
-        assert_eq!(up_efo(&up, Block::new_512(199), 2), exv);
+        assert_eq!(up_efo(&up, BlockIndex(199), 2), exv);
 
         let exv = vec![extent_tuple(2, 0), extent_tuple(2, 1)];
-        assert_eq!(up_efo(&up, Block::new_512(200), 2), exv);
+        assert_eq!(up_efo(&up, BlockIndex(200), 2), exv);
 
         let exv = vec![extent_tuple(9, 98), extent_tuple(9, 99)];
-        assert_eq!(up_efo(&up, Block::new_512(998), 2), exv);
+        assert_eq!(up_efo(&up, BlockIndex(998), 2), exv);
     }
 
     #[test]
@@ -198,11 +198,11 @@ pub(crate) mod up_test {
          * 1024 buffer
          */
         assert_eq!(
-            up_efo(&up, Block::new_512(99), 2),
+            up_efo(&up, BlockIndex(99), 2),
             vec![extent_tuple(0, 99), extent_tuple(1, 0)],
         );
         assert_eq!(
-            up_efo(&up, Block::new_512(98), 4),
+            up_efo(&up, BlockIndex(98), 4),
             vec![
                 extent_tuple(0, 98),
                 extent_tuple(0, 99),
@@ -224,7 +224,7 @@ pub(crate) mod up_test {
                 })
                 .collect();
             assert_eq!(
-                up_efo(&up, Block::new_512(u64::from(offset)), 100),
+                up_efo(&up, BlockIndex(u64::from(offset)), 100),
                 expected
             );
         }
@@ -236,40 +236,33 @@ pub(crate) mod up_test {
     #[test]
     fn off_to_extent_length_zero() {
         let up = make_upstairs();
-        assert_eq!(up_efo(&up, Block::new_512(0), 0), vec![]);
+        assert_eq!(up_efo(&up, BlockIndex(0), 0), vec![]);
     }
 
     #[test]
     fn off_to_extent_length_almost_too_big() {
         let up = make_upstairs();
-        up_efo(&up, Block::new_512(0), 1000);
+        up_efo(&up, BlockIndex(0), 1000);
     }
 
     #[test]
     #[should_panic]
     fn off_to_extent_length_too_big() {
         let up = make_upstairs();
-        up_efo(&up, Block::new_512(0), 1001);
+        up_efo(&up, BlockIndex(0), 1001);
     }
 
     #[test]
     fn off_to_extent_length_and_offset_almost_too_big() {
         let up = make_upstairs();
-        up_efo(&up, Block::new_512(900), 100);
+        up_efo(&up, BlockIndex(900), 100);
     }
 
     #[test]
     #[should_panic]
     fn off_to_extent_length_and_offset_too_big() {
         let up = make_upstairs();
-        up_efo(&up, Block::new_512(1000), 1);
-    }
-
-    #[test]
-    #[should_panic]
-    fn not_right_block_size() {
-        let up = make_upstairs();
-        up_efo(&up, Block::new_4096(900), 1);
+        up_efo(&up, BlockIndex(1000), 1);
     }
 
     // key material made with `openssl rand -base64 32`
@@ -519,10 +512,11 @@ pub(crate) mod up_test {
         // Below limit
         let request = ReadRequest {
             eid: ExtentId(0),
-            offset: Block::new_512(7),
+            offset: BlockOffset(7),
         };
         let op = IOop::Read {
             dependencies: vec![],
+            block_size: 512,
             requests: vec![request],
         };
         assert!(op.send_io_live_repair(Some(ExtentId(2))));
@@ -530,20 +524,22 @@ pub(crate) mod up_test {
         // At limit
         let request = ReadRequest {
             eid: ExtentId(2),
-            offset: Block::new_512(7),
+            offset: BlockOffset(7),
         };
         let op = IOop::Read {
             dependencies: vec![],
+            block_size: 512,
             requests: vec![request],
         };
         assert!(op.send_io_live_repair(Some(ExtentId(2))));
 
         let request = ReadRequest {
             eid: ExtentId(3),
-            offset: Block::new_512(7),
+            offset: BlockOffset(7),
         };
         let op = IOop::Read {
             dependencies: vec![],
+            block_size: 512,
             requests: vec![request],
         };
         // We are past the extent limit, so this should return false
@@ -557,7 +553,7 @@ pub(crate) mod up_test {
     fn write_at_extent(eid: ExtentId, wu: bool) -> IOop {
         let request = crucible_protocol::WriteBlockMetadata {
             eid,
-            offset: Block::new_512(7),
+            offset: BlockOffset(7),
             block_context: BlockContext {
                 encryption_context: None,
                 hash: 0,

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -13,8 +13,8 @@ use crate::{
     extent_from_offset,
     guest::GuestBlockRes,
     stats::UpStatOuter,
-    Block, BlockOp, BlockRes, Buffer, ClientId, ClientMap, CrucibleOpts,
-    DsState, EncryptionContext, GuestIoHandle, Message, RegionDefinition,
+    BlockOp, BlockRes, Buffer, ClientId, ClientMap, CrucibleOpts, DsState,
+    EncryptionContext, GuestIoHandle, Message, RegionDefinition,
     RegionDefinitionStatus, SnapshotDetails, WQCounts,
 };
 use crucible_common::{BlockIndex, CrucibleError};
@@ -1333,7 +1333,7 @@ impl Upstairs {
         let impacted_blocks = crate::extent_from_offset(
             &ddef,
             offset,
-            Block::from_bytes(data.len(), &ddef),
+            ddef.bytes_to_blocks(data.len()),
         );
 
         /*
@@ -1460,11 +1460,8 @@ impl Upstairs {
          * byte offset that translates into. Keep in mind that an offset
          * and length may span two extents.
          */
-        let impacted_blocks = extent_from_offset(
-            &ddef,
-            offset,
-            Block::from_bytes(data.len(), &ddef),
-        );
+        let impacted_blocks =
+            extent_from_offset(&ddef, offset, ddef.bytes_to_blocks(data.len()));
 
         Some(DeferredWrite {
             ddef,
@@ -2096,7 +2093,7 @@ pub(crate) mod test {
         client::ClientStopReason,
         downstairs::test::set_all_active,
         test::{make_encrypted_upstairs, make_upstairs},
-        BlockContext, BlockOp, BlockOpWaiter, DsState, JobId,
+        Block, BlockContext, BlockOp, BlockOpWaiter, DsState, JobId,
     };
     use bytes::BytesMut;
     use crucible_common::{integrity_hash, BlockOffset, ExtentId};

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1316,7 +1316,7 @@ impl Upstairs {
         /*
          * Verify IO is in range for our region
          */
-        if let Err(e) = ddef.validate_io(offset, data.len(), &ddef) {
+        if let Err(e) = ddef.validate_io(offset, data.len()) {
             if let Some(res) = res {
                 res.send_err((data, e));
             }
@@ -1448,7 +1448,7 @@ impl Upstairs {
          * Verify IO is in range for our region
          */
         let ddef = self.ddef.get_def().unwrap();
-        if let Err(e) = ddef.validate_io(offset, data.len(), &ddef) {
+        if let Err(e) = ddef.validate_io(offset, data.len()) {
             if let Some(res) = res {
                 res.send_err(e);
             }


### PR DESCRIPTION
The `Block` type is very overloaded:

- Sometimes, its value represents an offset relative to the start of an extent
- Other times, its value represents an absolute block index
- In some cases, it represents an extent size!
- `Block` contains both a `value` and a `shift`; `shift` usually means _log2(block size)_
  - `shift` is rarely used and only sometimes checked
  - It's basically only relevant when `Block` represents an extent size
  - However, it's always present, so we have to provide it to `Block::new` even when irrelevant

This PR adds two new types to clarify the meaning of `Block`:

- `BlockIndex` is an absolute block index
- `BlockOffset` is an offset relative to the start of an extent

Both of these types are wrappers around a single `u64` and **do not** store block size.  This is good, because it simplifies the conceptual space: since the `Block` argument includes the block size, we have to handle the case where the block size is **wrong**.  If we simply don't store the block size, then we eliminate all of that logic.

The rest of this PR is using `BlockIndex` and `BlockOffset` types wherever possible, and removing superfluous functions on the original `Block` type.

⚠️ This is a change to wire format, because we're using `BlockOffset` (one `u64`) instead of `Block` (a `u64` + `u32`) in various messages.

This does **not** change the `BlockIO` API, although I'm planning to do that in a subsequent PR.

See also https://github.com/oxidecomputer/crucible/issues/923 , although I don't change `RegionDefinition` in this PR (because the existing format has been serialized to disk).