### PR TITLE
Replace a downstairs before we are active.

### DIFF
--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -1105,14 +1105,14 @@ pub async fn start_cli_server(
                         },
                         Some(cmd) => {
                             process_cli_command(
-                                    guest,
-                                    &mut fw,
-                                    cmd,
-                                    &mut ri,
-                                    &mut wc_filled,
-                                    verify_input.clone(),
-                                    verify_output.clone()
-                                ).await?;
+                                guest,
+                                &mut fw,
+                                cmd,
+                                &mut ri,
+                                &mut wc_filled,
+                                verify_input.clone(),
+                                verify_output.clone()
+                            ).await?;
                         }
                     }
                 }

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -2237,7 +2237,7 @@ async fn replace_while_reconcile(
         }
     }
 
-    info!(log, "Test replace_special has completed");
+    info!(log, "Test replace_while_reconcile has completed");
     Ok(())
 }
 

--- a/crutest/src/protocol.rs
+++ b/crutest/src/protocol.rs
@@ -18,6 +18,8 @@ use crucible_common::CrucibleError;
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub enum CliMessage {
     Activate(u64),
+    // Request an activation but don't wait for the result.
+    ActivateRequest(u64),
     ActiveIs(bool),
     // Tell the cliserver to commit the current write log
     Commit,
@@ -225,6 +227,13 @@ mod tests {
     #[test]
     fn rt_activate() -> Result<()> {
         let input = CliMessage::Activate(99);
+        assert_eq!(input, round_trip(&input)?);
+        Ok(())
+    }
+
+    #[test]
+    fn rt_activate_request() -> Result<()> {
+        let input = CliMessage::ActivateRequest(99);
         assert_eq!(input, round_trip(&input)?);
         Ok(())
     }

--- a/tools/README.md
+++ b/tools/README.md
@@ -57,6 +57,10 @@ region size of ~100G).
 A test to break, then repair a downstairs region that is out of sync with
 the other regions, in a loop
 
+## test_replace_special.sh
+A test to verify that we can replace a downstairs while reconciliation is
+underway.
+
 ## test_replay.sh
 A test that checks the replay code path, if a downstairs disconnects and
 then reconnects, we replay jobs to it.  This is a thin wrapper around the

--- a/tools/make-nightly.sh
+++ b/tools/make-nightly.sh
@@ -30,6 +30,7 @@ tar cavf out/crucible-nightly.tar.gz \
   tools/test_perf.sh \
   tools/test_replay.sh \
   tools/test_repair.sh \
+  tools/test_replace_special.sh \
   tools/test_restart_repair.sh \
   tools/test_nightly.sh \
   tools/loop-repair.sh \

--- a/tools/test_nightly.sh
+++ b/tools/test_nightly.sh
@@ -68,6 +68,17 @@ else
     echo "$(date) live_repair fail with: $res" >> "$output_file"
     (( err += 1 ))
 fi
+
+banner replace_reconcile
+echo "$(date) replace_reconcile start" >> "$output_file"
+./tools/test_replace_special.sh -l 20
+res=$?
+if [[ "$res" -eq 0 ]]; then
+    echo "$(date) replace_reconcile pass" >> "$output_file"
+else
+    echo "$(date) replace_reconcile fail with: $res" >> "$output_file"
+    (( err += 1 ))
+fi
 duration=$SECONDS
 
 banner results

--- a/tools/test_replace_special.sh
+++ b/tools/test_replace_special.sh
@@ -64,7 +64,7 @@ if ! ${dsc} create --cleanup \
   --region-dir "$REGION_ROOT" \
   --region-count 4 \
   --ds-bin "$downstairs" \
-  --extent-count 100 \
+  --extent-count 400 \
   --block-size 4096 >> "$test_log"; then
     echo "Failed to create downstairs regions"
     exit 1

--- a/tools/test_replace_special.sh
+++ b/tools/test_replace_special.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 
-# Create regions and start up four downstairs.
-# We create four and use the forth downstairs as the replacement
-# downstairs.
-# Run the crutest replace (live_repair) test using the downstairs
-# we just started.  Each test lap will do 50 replacements and we
-# verify our volume on start and record what we wrote on exit
-# so the next loop will start assuming to read the data the previous
-# loop wrote.
+# A stress test of replacing a downstairs while reconciliation is underway.
+# Using dsc, we create the regions and start up four downstairs.
+# Run the crutest special replacement tests using the downstairs we just
+# started, with the fourth being the first one to replace.
 err=0
 total=0
 pass_total=0
@@ -20,15 +16,15 @@ function ctrl_c() {
     ${dsc} cmd shutdown
 }
 
-REGION_ROOT=${REGION_ROOT:-/var/tmp/test_live_repair}
+REGION_ROOT=${REGION_ROOT:-/var/tmp/test_replace_special}
 mkdir -p "$REGION_ROOT"
 
 # Location of logs and working files
 WORK_ROOT=${WORK_ROOT:-/tmp}
 mkdir -p "$WORK_ROOT"
 
-loop_log="$WORK_ROOT"/test_live_repair_summary.log
-test_log="$WORK_ROOT"/test_live_repair.log
+loop_log="$WORK_ROOT"/test_replace_special_summary.log
+test_log="$WORK_ROOT"/test_replace_special.log
 
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 export BINDIR=${BINDIR:-$ROOT/target/debug}
@@ -68,8 +64,8 @@ if ! ${dsc} create --cleanup \
   --region-dir "$REGION_ROOT" \
   --region-count 4 \
   --ds-bin "$downstairs" \
-  --extent-size 4000 \
-  --extent-count 200 >> "$test_log"; then
+  --extent-count 100 \
+  --block-size 4096 >> "$test_log"; then
     echo "Failed to create downstairs regions"
     exit 1
 fi
@@ -98,14 +94,14 @@ if ! "$crucible_test" fill "${args[@]}" -q -g "$gen"\
 fi
 (( gen += 1 ))
 
-# Now run the crutest replace test in a loop
+# Now run the crutest replace-reconcole test in a loop
 count=1
 while [[ $count -le $loops ]]; do
     SECONDS=0
     cp "$test_log" "$test_log".last
     echo "" > "$test_log"
     echo "New loop, $count starts now $(date)" >> "$test_log"
-    "$crucible_test" replace "${args[@]}" -c 5 \
+    "$crucible_test" replace-reconcile "${args[@]}" -c 5 \
             --replacement 127.0.0.1:8840 \
             --stable -g "$gen" --verify-out alan \
             --verify-at-start \
@@ -121,17 +117,18 @@ while [[ $count -le $loops ]]; do
         break
     fi
     duration=$SECONDS
-    (( gen += 1 ))
+    # Gen should grow by at least the `-c` from crutest
+    (( gen += 10 ))
     (( pass_total += 1 ))
     (( total += duration ))
     ave=$(( total / pass_total ))
     printf "[%03d/%03d] %d:%02d  ave:%d:%02d  total:%d:%02d errors:%d \
-last_run_seconds:%d\n" \
-  "$count" "$loops" \
-  $((duration / 60)) $((duration % 60)) \
-  $((ave / 60)) $((ave % 60)) \
-  $((total / 60)) $((total % 60)) \
-  "$err" $duration | tee -a "$loop_log"
+      last_run_seconds:%d\n" \
+      "$count" "$loops" \
+    $((duration / 60)) $((duration % 60)) \
+    $((ave / 60)) $((ave % 60)) \
+    $((total / 60)) $((total % 60)) \
+    "$err" $duration | tee -a "$loop_log"
     (( count += 1 ))
 
 done

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -148,8 +148,7 @@ res=0
 gen=1
 # Keep deactivate test last, and add 15 to the generation number so
 # tests that follow will be able to activate.
-#test_list="span big dep balloon deactivate"
-test_list="span"
+test_list="span big dep balloon deactivate"
 for tt in ${test_list}; do
     # Add a blank line in the output file as all the output follows.
     echo "" >> "${log_prefix}_out.txt"

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -148,7 +148,8 @@ res=0
 gen=1
 # Keep deactivate test last, and add 15 to the generation number so
 # tests that follow will be able to activate.
-test_list="span big dep balloon deactivate"
+#test_list="span big dep balloon deactivate"
+test_list="span"
 for tt in ${test_list}; do
     # Add a blank line in the output file as all the output follows.
     echo "" >> "${log_prefix}_out.txt"
@@ -341,6 +342,7 @@ if ! "$dsc" cmd shutdown; then
 fi
 
 # Loop till dsc has stopped
+sleep 5
 while : ; do
     if ! pgrep -P $dsc_pid > /dev/null; then
         break
@@ -353,7 +355,7 @@ echo "Begin replace reconcile test" >> "${log_prefix}_out.txt"
 
 # Create a larger region size for these tests.
 echo "Creating four larger downstairs regions"
-echo "${dsc}" create "${dsc_create_args[@]}" --region-count 4 --extent-count 100 --block-size 4096 "${dsc_args[@]}" >> "$dsc_output"
+echo "${dsc}" create "${dsc_create_args[@]}" --region-count 4 --extent-count 300 --block-size 4096 "${dsc_args[@]}" >> "$dsc_output"
 "${dsc}" create "${dsc_create_args[@]}" --region-count 4 --extent-count 100 --block-size 4096 "${dsc_args[@]}" >> "$dsc_output" 2>&1
 
 echo "Starting four downstairs"

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -12,7 +12,7 @@ ROOT=$(cd "$(dirname "$0")/.." && pwd)
 BINDIR=${BINDIR:-$ROOT/target/debug}
 
 echo "$ROOT"
-cd "$ROOT"
+cd "$ROOT" || exit 1
 
 if pgrep -fl crucible-downstairs; then
     echo 'Downstairs already running?' >&2
@@ -96,7 +96,6 @@ mkdir -p ${dsc_output_dir}
 dsc_output="${test_output_dir}/dsc-out.txt"
 
 dsc_create_args+=( --cleanup )
-dsc_create_args+=( --extent-size 10 --extent-count 5 )
 dsc_args+=( --output-dir "$dsc_output_dir" )
 dsc_args+=( --ds-bin "$cds" )
 
@@ -113,8 +112,8 @@ dsc_args+=( --region-dir "$testdir" )
 echo "dsc output goes to $dsc_output"
 
 echo "Creating three downstairs regions"
-echo "${dsc}" create "${dsc_create_args[@]}" "${dsc_args[@]}" > "$dsc_output"
-"${dsc}" create "${dsc_create_args[@]}" "${dsc_args[@]}" >> "$dsc_output" 2>&1
+echo "${dsc}" create "${dsc_create_args[@]}" --extent-size 10 --extent-count 5 "${dsc_args[@]}" > "$dsc_output"
+"${dsc}" create "${dsc_create_args[@]}" --extent-size 10 --extent-count 5 "${dsc_args[@]}" >> "$dsc_output" 2>&1
 
 echo "Starting three downstairs"
 echo "${dsc}" start "${dsc_args[@]}" >> "$dsc_output"
@@ -190,10 +189,11 @@ fi
 echo "" >> "${log_prefix}_out.txt"
 echo "Run repair tests" | tee -a "${log_prefix}_out.txt"
 
-args+=( --verify-out "${testdir}/verify_file" )
-echo "$ct" fill -g "$gen" -q "${args[@]}" | tee -a "${log_prefix}_out.txt"
+new_args=( "${args[@]}" )
+new_args+=( --verify-out "${testdir}/verify_file" )
+echo "$ct" fill -g "$gen" -q "${new_args[@]}" | tee -a "${log_prefix}_out.txt"
 
-if ! "$ct" fill -g "$gen" -q "${args[@]}"; then
+if ! "$ct" fill -g "$gen" -q "${new_args[@]}"; then
     (( res += 1 ))
     echo ""
     echo "Failed setup repair test" | tee -a "${log_prefix}_out.txt"
@@ -212,9 +212,9 @@ echo "Copy the $port file" | tee -a "${log_prefix}_out.txt"
 echo cp -r "${testdir}/${port}" "${testdir}/previous"
 cp -r "${testdir}/${port}" "${testdir}/previous"
 
-args+=( --verify-in "${testdir}/verify_file" )
-echo "$ct" repair -g "$gen" -q "${args[@]}"
-if ! "$ct" repair -g "$gen" -q "${args[@]}"; then
+new_args+=( --verify-in "${testdir}/verify_file" )
+echo "$ct" repair -g "$gen" -q "${new_args[@]}"
+if ! "$ct" repair -g "$gen" -q "${new_args[@]}"; then
     (( res += 1 ))
     echo ""
     echo "Failed repair test part 1"
@@ -282,8 +282,8 @@ fi
 
 echo ""
 echo ""
-echo "$ct" "$tt" --range -g "$gen" -q "${args[@]}"
-if ! "$ct" verify --range -g "$gen" -q "${args[@]}"; then
+echo "$ct" "$tt" --range -g "$gen" -q "${new_args[@]}"
+if ! "$ct" verify --range -g "$gen" -q "${new_args[@]}"; then
     (( res += 1 ))
     echo ""
     echo "Failed repair test part 2"
@@ -332,6 +332,72 @@ fi
 
 # Tests done, shut down the downstairs.
 echo "Upstairs tests have completed, stopping all downstairs"
+if ! "$dsc" cmd shutdown; then
+    (( res += 1 ))
+    echo ""
+    echo "Failed dsc shutdown"
+    echo "Failed dsc shutdown" >> "$fail_log"
+    echo
+fi
+
+# Loop till dsc has stopped
+while : ; do
+    if ! pgrep -P $dsc_pid > /dev/null; then
+        break
+    fi
+    echo "dsc at $dsc_pid has not yet stopped, waiting"
+    sleep 5
+done
+
+echo "Begin replace reconcile test" >> "${log_prefix}_out.txt"
+
+# Create a larger region size for these tests.
+echo "Creating four larger downstairs regions"
+echo "${dsc}" create "${dsc_create_args[@]}" --region-count 4 --extent-count 100 --block-size 4096 "${dsc_args[@]}" >> "$dsc_output"
+"${dsc}" create "${dsc_create_args[@]}" --region-count 4 --extent-count 100 --block-size 4096 "${dsc_args[@]}" >> "$dsc_output" 2>&1
+
+echo "Starting four downstairs"
+echo "${dsc}" start --region-count 4 "${dsc_args[@]}" >> "$dsc_output"
+"${dsc}" start --region-count 4 "${dsc_args[@]}" >> "$dsc_output" 2>&1 &
+dsc_pid=$!
+
+sleep 5
+if ! pgrep -P $dsc_pid > /dev/null; then
+    echo "larger dsc at $dsc_pid failed to start"
+    exit 1
+fi
+echo "" >> "${log_prefix}_out.txt"
+
+echo "Now do the replace-reconcile test"
+
+echo "$ct" replace-reconcile --replacement 127.0.0.1:8840 -c 4 -g "$gen" --stable "${args[@]}" >> "${log_prefix}_out.txt"
+if ! "$ct" replace-reconcile --replacement 127.0.0.1:8840 -c 4 -g "$gen" --stable "${args[@]}" >> "${log_prefix}_out.txt" 2>&1; then
+    (( res += 1 ))
+    echo ""
+    echo "Failed crutest replace-reconcile test"
+    echo "Failed crutest replace-reconcile test" >> "${log_prefix}_out.txt"
+    echo "Failed crutest replace-reconcile test" >> "$fail_log"
+    echo ""
+else
+    echo "Completed test: replace-reconcile"
+fi
+
+((gen += 20))
+echo "Now do the replace-before-active test"
+echo "$ct" replace-before-active --replacement 127.0.0.1:8840 -c 4 -g "$gen" --stable "${args[@]}" >> "${log_prefix}_out.txt"
+if ! "$ct" replace-before-active --replacement 127.0.0.1:8840 -c 4 -g "$gen" --stable "${args[@]}" >> "${log_prefix}_out.txt" 2>&1; then
+    (( res += 1 ))
+    echo ""
+    echo "Failed crutest replace-before-active"
+    echo "Failed crutest replace-before-active" >> "${log_prefix}_out.txt"
+    echo "Failed crutest replace-before-active" >> "$fail_log"
+    echo ""
+else
+    echo "Completed test: replace-before-active"
+fi
+
+# Tests done, shut down the downstairs.
+echo "Tests have completed, stopping all downstairs"
 if ! "$dsc" cmd shutdown; then
     (( res += 1 ))
     echo ""


### PR DESCRIPTION
Allow a downstairs to be replaced if the request comes in before the upstairs is active.  
Fix for: https://github.com/oxidecomputer/crucible/issues/871
(Also fixed: https://github.com/oxidecomputer/crucible/issues/1375)
(Also fixed: https://github.com/oxidecomputer/crucible/issues/1376)

This actually was a pretty small change to the upstairs code itself as the general idea of
replacement before active fits within the overall "make all downstairs consistent before starting".

If the activate has not been requested from the guest, then we can do the replacement in
place (as we have not started negotiation yet).  If reconciliation is in progress, it will be aborted and 
then restarted.   The code already checked for any state change in a downstairs and aborted the
reconciliation.  All we had to change here was allowing the reconciliation to restart after a replacement.

Created two new crutest tests that will test replacement before active for both before reconciliation has
started and after reconciliation has started.  Added a clone of the logger for crutest itself to use.

Updated the crutest cli to allow us to send an activation without waiting for the result.  This then allows 
us to trigger a replacement from the cli.

Added a new test, test_replace_special.sh that will spin up downstairs and then call crutest and test 
the replacement of a downstairs while reconciliation is underway.

Added two tests to `test_up.sh`. One that will test replacement of a downstairs before activation and before reconciliation. A second test will test replacement before activation but during reconciliation.

Added the test_replace_special.sh to the nightly test.