### PR TITLE
Update `BlockIO` trait to use `BlockIndex` type

### DIFF
--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -223,10 +223,10 @@ async fn cli_read(
     /*
      * Convert offset to its byte value.
      */
-    let offset = Block::new(block_index as u64, ri.block_size.trailing_zeros());
+    let offset = BlockIndex(block_index as u64);
     let mut data = crucible::Buffer::repeat(255, size, ri.block_size as usize);
 
-    println!("Read  at block {:5}, len:{:7}", offset.value, data.len());
+    println!("Read  at block {:5}, len:{:7}", offset.0, data.len());
     guest.read(offset, &mut data).await?;
 
     let mut dl = data.into_bytes();
@@ -290,7 +290,7 @@ async fn cli_write(
     /*
      * Convert offset and length to their byte values.
      */
-    let offset = Block::new(block_index as u64, ri.block_size.trailing_zeros());
+    let offset = BlockIndex(block_index as u64);
 
     /*
      * Update the write count for the block we plan to write to.
@@ -310,7 +310,7 @@ async fn cli_write(
         fill_vec(block_index, size, &ri.write_log, ri.block_size)
     };
 
-    println!("Write at block {:5}, len:{:7}", offset.value, data.len());
+    println!("Write at block {:5}, len:{:7}", offset.0, data.len());
 
     guest.write(offset, data).await?;
 
@@ -333,7 +333,7 @@ async fn cli_write_unwritten(
     /*
      * Convert offset to its byte value.
      */
-    let offset = Block::new(block_index as u64, ri.block_size.trailing_zeros());
+    let offset = BlockIndex(block_index as u64);
 
     // To determine what we put into our write buffer, look to see if
     // we believe we have written to this block or not.
@@ -355,7 +355,7 @@ async fn cli_write_unwritten(
 
     println!(
         "WriteUnwritten at block {:5}, len:{:7}",
-        offset.value,
+        offset.0,
         data.len(),
     );
 

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -1232,8 +1232,7 @@ async fn verify_volume(
             let mut result = Ok(());
             let mut data = crucible::Buffer::new(0, block_size as usize);
             while block_index < total_blocks {
-                let offset =
-                    Block::new(block_index as u64, block_size.trailing_zeros());
+                let offset = BlockIndex(block_index as u64);
 
                 let next_io_blocks = (total_blocks - block_index).min(IO_SIZE);
                 data.reset(next_io_blocks, block_size as usize);
@@ -1566,8 +1565,7 @@ async fn balloon_workload(guest: &Guest, ri: &mut RegionInfo) -> Result<()> {
             /*
              * Convert block_index to its byte value.
              */
-            let offset =
-                Block::new(block_index as u64, ri.block_size.trailing_zeros());
+            let offset = BlockIndex(block_index as u64);
 
             println!("IO at block:{}  size in blocks:{}", block_index, size);
             guest.write(offset, data).await?;
@@ -1631,8 +1629,7 @@ async fn fill_workload(
         let pb = pb.clone();
         tasks.push(tokio::task::spawn(async move {
             while block_index < total_blocks {
-                let offset =
-                    Block::new(block_index as u64, block_size.trailing_zeros());
+                let offset = BlockIndex(block_index as u64);
 
                 let next_io_blocks = (total_blocks - block_index).min(IO_SIZE);
 
@@ -1707,8 +1704,7 @@ async fn fill_sparse_workload(
         let random_offset: usize = rng.gen_range(0..extent_size);
         block_index += random_offset;
 
-        let offset =
-            Block::new(block_index as u64, ri.block_size.trailing_zeros());
+        let offset = BlockIndex(block_index as u64);
 
         ri.write_log.update_wc(block_index);
 
@@ -1779,8 +1775,7 @@ async fn generic_workload(
             let block_index = rng.gen_range(0..block_max);
 
             // Convert offset and length to their byte values.
-            let offset =
-                Block::new(block_index as u64, ri.block_size.trailing_zeros());
+            let offset = BlockIndex(block_index as u64);
 
             if op <= 4 {
                 // Write
@@ -1812,7 +1807,7 @@ async fn generic_workload(
                 if !quiet {
                     print!(
                         " Write block {:>bw$}  len {:>sw$}  data:",
-                        offset.value,
+                        offset.0,
                         data.len(),
                         bw = block_width,
                         sw = size_width,
@@ -1846,7 +1841,7 @@ async fn generic_workload(
                     }
                     println!(
                         " Read  block {:>bw$}  len {:>sw$}",
-                        offset.value,
+                        offset.0,
                         data.len(),
                         bw = block_width,
                         sw = size_width,
@@ -2157,8 +2152,7 @@ async fn dirty_workload(
         /*
          * Convert offset and length to their byte values.
          */
-        let offset =
-            Block::new(block_index as u64, ri.block_size.trailing_zeros());
+        let offset = BlockIndex(block_index as u64);
 
         /*
          * Update the write count for the block we plan to write to.
@@ -2171,7 +2165,7 @@ async fn dirty_workload(
             "[{:>0width$}/{:>0width$}] Write at block {}, len:{}",
             c,
             count,
-            offset.value,
+            offset.0,
             data.len(),
             width = count_width,
         );
@@ -2579,15 +2573,11 @@ async fn rand_read_write_workload(
                     buf.resize(cfg.blocks_per_io * block_size, 0u8);
                     let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
                     rng.fill_bytes(&mut buf);
-                    let block_shift = block_size.trailing_zeros();
                     while !stop.load(Ordering::Acquire) {
                         let offset =
                             rng.gen_range(0..=total_blocks - cfg.blocks_per_io);
                         guest
-                            .write(
-                                Block::new(offset as u64, block_shift),
-                                buf.clone(),
-                            )
+                            .write(BlockIndex(offset as u64), buf.clone())
                             .await
                             .unwrap();
                         byte_count.fetch_add(buf.len(), Ordering::Relaxed);
@@ -2596,15 +2586,11 @@ async fn rand_read_write_workload(
                 RandReadWriteMode::Read => {
                     let mut buf = Buffer::new(cfg.blocks_per_io, block_size);
                     let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
-                    let block_shift = block_size.trailing_zeros();
                     while !stop.load(Ordering::Acquire) {
                         let offset =
                             rng.gen_range(0..=total_blocks - cfg.blocks_per_io);
                         guest
-                            .read(
-                                Block::new(offset as u64, block_shift),
-                                &mut buf,
-                            )
+                            .read(BlockIndex(offset as u64), &mut buf)
                             .await
                             .unwrap();
                         byte_count.fetch_add(buf.len(), Ordering::Relaxed);
@@ -2727,7 +2713,7 @@ async fn one_workload(guest: &Guest, ri: &mut RegionInfo) -> Result<()> {
     /*
      * Convert offset and length to their byte values.
      */
-    let offset = Block::new(block_index as u64, ri.block_size.trailing_zeros());
+    let offset = BlockIndex(block_index as u64);
 
     /*
      * Update the write count for the block we plan to write to.
@@ -2736,13 +2722,13 @@ async fn one_workload(guest: &Guest, ri: &mut RegionInfo) -> Result<()> {
 
     let data = fill_vec(block_index, size, &ri.write_log, ri.block_size);
 
-    println!("Write at block {:5}, len:{:7}", offset.value, data.len());
+    println!("Write at block {:5}, len:{:7}", offset.0, data.len());
 
     guest.write(offset, data).await?;
 
     let mut data = crucible::Buffer::repeat(255, size, ri.block_size as usize);
 
-    println!("Read  at block {:5}, len:{:7}", offset.value, data.len());
+    println!("Read  at block {:5}, len:{:7}", offset.0, data.len());
     guest.read(offset, &mut data).await?;
 
     let dl = data.into_bytes();
@@ -2868,8 +2854,7 @@ async fn write_flush_read_workload(
         /*
          * Convert offset and length to their byte values.
          */
-        let offset =
-            Block::new(block_index as u64, ri.block_size.trailing_zeros());
+        let offset = BlockIndex(block_index as u64);
 
         /*
          * Update the write count for all blocks we plan to write to.
@@ -2884,7 +2869,7 @@ async fn write_flush_read_workload(
             "{:>0width$}/{:>0width$} IO at block {:5}, len:{:7}",
             c,
             count,
-            offset.value,
+            offset.0,
             data.len(),
             width = count_width,
         );
@@ -3018,8 +3003,7 @@ async fn repair_workload(
             let block_index = rng.gen_range(0..block_max);
 
             // Convert offset and length to their byte values.
-            let offset =
-                Block::new(block_index as u64, ri.block_size.trailing_zeros());
+            let offset = BlockIndex(block_index as u64);
 
             if !one_write || op <= 4 {
                 // Write
@@ -3037,7 +3021,7 @@ async fn repair_workload(
                     block {:>bw$}  len {:>sw$}  data:",
                     c,
                     count,
-                    offset.value,
+                    offset.0,
                     data.len(),
                     width = count_width,
                     bw = block_width,
@@ -3059,7 +3043,7 @@ async fn repair_workload(
                     block {:>bw$}  len {:>sw$}",
                     c,
                     count,
-                    offset.value,
+                    offset.0,
                     data.len(),
                     width = count_width,
                     bw = block_width,
@@ -3116,8 +3100,7 @@ async fn demo_workload(
             let block_index = rng.gen_range(0..block_max);
 
             // Convert offset and length to their byte values.
-            let offset =
-                Block::new(block_index as u64, ri.block_size.trailing_zeros());
+            let offset = BlockIndex(block_index as u64);
 
             if op <= 4 {
                 // Write
@@ -3197,7 +3180,7 @@ async fn span_workload(guest: &Guest, ri: &mut RegionInfo) -> Result<()> {
     ri.write_log.update_wc(block_index);
     ri.write_log.update_wc(block_index + 1);
 
-    let offset = Block::new(block_index as u64, ri.block_size.trailing_zeros());
+    let offset = BlockIndex(block_index as u64);
     let data = fill_vec(block_index, 2, &ri.write_log, ri.block_size);
 
     println!("Sending a write spanning two extents");
@@ -3237,8 +3220,7 @@ async fn big_workload(guest: &Guest, ri: &mut RegionInfo) -> Result<()> {
         /*
          * Convert block_index to its byte value.
          */
-        let offset =
-            Block::new(block_index as u64, ri.block_size.trailing_zeros());
+        let offset = BlockIndex(block_index as u64);
 
         guest.write(offset, data).await?;
 
@@ -3296,8 +3278,7 @@ async fn biggest_io_workload(guest: &Guest, ri: &mut RegionInfo) -> Result<()> {
     );
     let mut block_index = 0;
     while block_index < ri.total_blocks {
-        let offset =
-            Block::new(block_index as u64, ri.block_size.trailing_zeros());
+        let offset = BlockIndex(block_index as u64);
 
         let next_io_blocks =
             if block_index + biggest_io_in_blocks > ri.total_blocks {

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -420,25 +420,21 @@ mod test {
 
         // Verify contents are zero on init
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x00_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         // Write data in
         volume
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
         // Read parent, verify contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
@@ -477,9 +473,7 @@ mod test {
         // Verify contents are zero on init
         let mut buffer = Buffer::new(NUM_BLOCKS, BLOCK_SIZE);
         for i in 0..10 {
-            volume
-                .read(Block::new(i, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-                .await?;
+            volume.read(BlockIndex(i), &mut buffer).await?;
             assert_eq!(vec![0x00_u8; BLOCK_SIZE * NUM_BLOCKS], &buffer[..]);
         }
 
@@ -487,28 +481,18 @@ mod test {
             let mut data = vec![0; BLOCK_SIZE * NUM_BLOCKS];
             rand::thread_rng().fill(&mut data[..]);
             volume
-                .write(
-                    Block::new(i, BLOCK_SIZE.trailing_zeros()),
-                    BytesMut::from(data.as_slice()),
-                )
+                .write(BlockIndex(i), BytesMut::from(data.as_slice()))
                 .await?;
 
             // Read parent, verify contents
             let mut buffer = Buffer::new(NUM_BLOCKS, BLOCK_SIZE);
-            volume
-                .read(Block::new(i, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-                .await?;
+            volume.read(BlockIndex(i), &mut buffer).await?;
             assert_eq!(&data, &buffer[..]);
 
             // Do a shifted read, to detect any block shuffling that's
             // consistent between reads and writes (which would be weird!)
             let mut buffer = Buffer::new(NUM_BLOCKS - 1, BLOCK_SIZE);
-            volume
-                .read(
-                    Block::new(i + 1, BLOCK_SIZE.trailing_zeros()),
-                    &mut buffer,
-                )
-                .await?;
+            volume.read(BlockIndex(i + 1), &mut buffer).await?;
             assert_eq!(&data[BLOCK_SIZE..], &buffer[..]);
         }
 
@@ -541,16 +525,11 @@ mod test {
 
         // A read of zero length does not error.
         let mut buffer = Buffer::new(0, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         // A write of zero length does not return error.
         volume
-            .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                BytesMut::from(vec![0x55; 0].as_slice()),
-            )
+            .write(BlockIndex(0), BytesMut::from(vec![0x55; 0].as_slice()))
             .await?;
 
         Ok(())
@@ -585,15 +564,13 @@ mod test {
 
         in_memory_data
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![11; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        in_memory_data
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        in_memory_data.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
@@ -616,9 +593,7 @@ mod test {
 
         // Verify contents are 11 on init
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
@@ -626,14 +601,14 @@ mod test {
         if is_write_unwritten {
             volume
                 .write_unwritten(
-                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                    BlockIndex(0),
                     BytesMut::from(vec![55; BLOCK_SIZE * 10].as_slice()),
                 )
                 .await?;
         } else {
             volume
                 .write(
-                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                    BlockIndex(0),
                     BytesMut::from(vec![55; BLOCK_SIZE * 10].as_slice()),
                 )
                 .await?;
@@ -641,17 +616,13 @@ mod test {
 
         // Verify parent wasn't written to
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        in_memory_data
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        in_memory_data.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
         // Read and verify contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![55; BLOCK_SIZE * 10], &buffer[..]);
 
@@ -674,15 +645,13 @@ mod test {
 
         in_memory_data
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![11; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        in_memory_data
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        in_memory_data.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
@@ -715,33 +684,27 @@ mod test {
 
         // Verify contents are 11 on init
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
         // Write data in
         volume
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
         // Verify parent wasn't written to
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        in_memory_data
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        in_memory_data.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
         // Read and verify contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![55; BLOCK_SIZE * 10], &buffer[..]);
 
@@ -799,25 +762,21 @@ mod test {
 
         // Read one block: should be all 0xff
         let mut buffer = Buffer::new(1, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0xff; BLOCK_SIZE], &buffer[..]);
 
         // Write one block full of 0x01
         volume
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x01; BLOCK_SIZE].as_slice()),
             )
             .await?;
 
         // Read one block: should be all 0x01
         let mut buffer = Buffer::new(1, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x01; BLOCK_SIZE], &buffer[..]);
         Ok(())
@@ -851,9 +810,7 @@ mod test {
 
         // Read one block: should be all 0x00
         let mut buffer = Buffer::new(1, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x00; BLOCK_SIZE], &buffer[..]);
 
@@ -899,32 +856,28 @@ mod test {
         // Write data in
         volume
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
         // Read volume, verify contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         // Write_unwritten data in, should not change anything
         volume
             .write_unwritten(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x22; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
         // Read volume, verify original contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
@@ -969,32 +922,28 @@ mod test {
         // Write data in
         volume
             .write_unwritten(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
         // Read parent, verify contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         // A second Write_unwritten data, should not change anything
         volume
             .write_unwritten(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x22; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
         // Read volume, verify original contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
@@ -1041,7 +990,7 @@ mod test {
         // Write data at block 0
         volume
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x33; BLOCK_SIZE].as_slice()),
             )
             .await?;
@@ -1049,16 +998,14 @@ mod test {
         // A second Write_unwritten that overlaps the original write.
         volume
             .write_unwritten(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
         // Read and verify
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         // Verify data in the first block is from the first write
         assert_eq!(vec![0x33_u8; BLOCK_SIZE], &buffer[0..BLOCK_SIZE]);
@@ -1124,32 +1071,28 @@ mod test {
         // Write data in
         volume
             .write_unwritten(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x55; full_volume_size].as_slice()),
             )
             .await?;
 
         // Read parent, verify contents
         let mut buffer = Buffer::new(full_volume_blocks, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x55_u8; full_volume_size], &buffer[..]);
 
         // A second Write_unwritten data, should not change anything
         volume
             .write_unwritten(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x22; full_volume_size].as_slice()),
             )
             .await?;
 
         // Read volume, verify original contents
         let mut buffer = Buffer::new(full_volume_blocks, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x55_u8; full_volume_size], &buffer[..]);
 
@@ -1211,16 +1154,14 @@ mod test {
         // second vol.
         volume
             .write_unwritten(
-                Block::new(9, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(9),
                 BytesMut::from(vec![0x55; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
 
         // Read parent, verify contents
         let mut buffer = Buffer::new(2, BLOCK_SIZE);
-        volume
-            .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(9), &mut buffer).await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 2], &buffer[..]);
 
@@ -1229,7 +1170,7 @@ mod test {
         // were not written yet.
         volume
             .write_unwritten(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x22; full_volume_size].as_slice()),
             )
             .await?;
@@ -1237,9 +1178,7 @@ mod test {
         // Read full volume, verify first write_unwritten still valid, but the
         // other blocks of the 2nd write_unwritten are updated.
         let mut buffer = Buffer::new(full_volume_blocks, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         // Verify data in blocks 0-9 is the second write_unwritten
         assert_eq!(vec![0x22_u8; BLOCK_SIZE * 9], &buffer[0..(BLOCK_SIZE * 9)]);
@@ -1316,7 +1255,7 @@ mod test {
         // second vol.
         volume
             .write_unwritten(
-                Block::new(9, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(9),
                 BytesMut::from(vec![0x55; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
@@ -1326,7 +1265,7 @@ mod test {
         // were not written yet.
         volume
             .write_unwritten(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x22; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
@@ -1334,16 +1273,14 @@ mod test {
         // A write
         volume
             .write(
-                Block::new(7, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(7),
                 BytesMut::from(vec![0x11; BLOCK_SIZE * 13].as_slice()),
             )
             .await?;
 
         // Read full volume
         let mut buffer = Buffer::new(full_volume_blocks, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         // Verify data in blocks 0-7 is the second write_unwritten
         assert_eq!(vec![0x22_u8; BLOCK_SIZE * 7], &buffer[0..(BLOCK_SIZE * 7)]);
@@ -1390,16 +1327,14 @@ mod test {
         // Fill the in_memory block_io with 1s
         in_memory_data
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![11; BLOCK_SIZE * 5].as_slice()),
             )
             .await?;
 
         // Read back in_memory, verify 1s
         let mut buffer = Buffer::new(5, BLOCK_SIZE);
-        in_memory_data
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        in_memory_data.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 5], &buffer[..]);
 
@@ -1422,16 +1357,14 @@ mod test {
 
         // Verify parent contents in one read
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         let mut expected = vec![11; BLOCK_SIZE * 5];
         expected.extend(vec![0x00; BLOCK_SIZE * 5]);
         assert_eq!(expected, &buffer[..]);
 
         // One big write!
-        let write_offset = Block::new(0, BLOCK_SIZE.trailing_zeros());
+        let write_offset = BlockIndex(0);
         let write_data = BytesMut::from(vec![55; BLOCK_SIZE * 10].as_slice());
         if is_write_unwritten {
             volume.write(write_offset, write_data).await?;
@@ -1441,9 +1374,7 @@ mod test {
 
         // Verify volume contents in one read
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![55; BLOCK_SIZE * 10], &buffer[..]);
 
@@ -1478,7 +1409,7 @@ mod test {
         // Fill in_memory (which will become RO parent)
         in_memory_data
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![11; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
@@ -1502,9 +1433,7 @@ mod test {
 
         // Verify contents are 11 at startup
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
@@ -1516,16 +1445,14 @@ mod test {
         // data as the scrubber has finished.
         volume
             .write_unwritten(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
         // Read and verify contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
@@ -1561,7 +1488,7 @@ mod test {
         // Fill in_memory (which will become RO parent)
         in_memory_data
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![11; BLOCK_SIZE * 5].as_slice()),
             )
             .await?;
@@ -1585,17 +1512,13 @@ mod test {
 
         // Verify contents of RO parent are 1s at startup
         let mut buffer = Buffer::new(5, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 5], &buffer[..]);
 
         // Verify contents of blocks 5-10 are zero.
         let mut buffer = Buffer::new(5, BLOCK_SIZE);
-        volume
-            .read(Block::new(5, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(5), &mut buffer).await?;
 
         assert_eq!(vec![00; BLOCK_SIZE * 5], &buffer[..]);
 
@@ -1607,16 +1530,14 @@ mod test {
         // unwritten data as the scrubber has finished.
         volume
             .write_unwritten(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
         // Read and verify contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         // Verify data in the first half is from the RO parent
         assert_eq!(vec![11; BLOCK_SIZE * 5], &buffer[0..BLOCK_SIZE * 5]);
@@ -1662,7 +1583,7 @@ mod test {
         // Fill in_memory (which will become RO parent)
         in_memory_data
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![11; BLOCK_SIZE * 5].as_slice()),
             )
             .await?;
@@ -1687,7 +1608,7 @@ mod test {
         // SV: |--2-------|
         volume
             .write(
-                Block::new(2, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(2),
                 BytesMut::from(vec![22; BLOCK_SIZE].as_slice()),
             )
             .await?;
@@ -1695,7 +1616,7 @@ mod test {
         // SV: |-------3--|
         volume
             .write(
-                Block::new(7, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(7),
                 BytesMut::from(vec![33; BLOCK_SIZE].as_slice()),
             )
             .await?;
@@ -1707,9 +1628,7 @@ mod test {
 
         // Read and verify contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         // First blocks are 1s   |11--------|
         let mut expected = vec![11; BLOCK_SIZE * 2];
@@ -1757,7 +1676,7 @@ mod test {
         // Fill in_memory (which will become RO parent)
         in_memory_data
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![11; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
@@ -1781,16 +1700,14 @@ mod test {
 
         // Verify contents are 11 at startup
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![11; BLOCK_SIZE * 10], &buffer[..]);
 
         // Write to the whole volume
         volume
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
@@ -1800,9 +1717,7 @@ mod test {
 
         // Read and verify contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![55; BLOCK_SIZE * 10], &buffer[..]);
 
@@ -1840,7 +1755,7 @@ mod test {
 
         in_memory_data
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![11; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
@@ -1889,23 +1804,21 @@ mod test {
         // second vol.
         volume
             .write(
-                Block::new(9, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(9),
                 BytesMut::from(vec![22; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
 
         // Read and verify contents
         let mut buffer = Buffer::new(2, BLOCK_SIZE);
-        volume
-            .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(9), &mut buffer).await?;
 
         assert_eq!(vec![22; BLOCK_SIZE * 2], &buffer[..]);
 
         // A second write
         volume
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![33; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
@@ -1915,9 +1828,7 @@ mod test {
 
         // Read full volume
         let mut buffer = Buffer::new(20, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         // Build the expected vec to compare our read with.
         // First two blocks are 3s     |33--------||----------|
@@ -1965,7 +1876,7 @@ mod test {
 
         in_memory_data
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![11; BLOCK_SIZE * 15].as_slice()),
             )
             .await?;
@@ -2015,16 +1926,14 @@ mod test {
         //     |---------2||2---------|
         volume
             .write(
-                Block::new(9, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(9),
                 BytesMut::from(vec![22; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
 
         // Read and verify contents
         let mut buffer = Buffer::new(2, BLOCK_SIZE);
-        volume
-            .read(Block::new(9, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(9), &mut buffer).await?;
 
         assert_eq!(vec![22; BLOCK_SIZE * 2], &buffer[..]);
 
@@ -2032,7 +1941,7 @@ mod test {
         //     |33--------||----------|
         volume
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![33; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
@@ -2041,7 +1950,7 @@ mod test {
         //     |----------||----44----|
         volume
             .write(
-                Block::new(14, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(14),
                 BytesMut::from(vec![44; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
@@ -2051,9 +1960,7 @@ mod test {
 
         // Read full volume
         let mut buffer = Buffer::new(20, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         // Build the expected vec to compare our read with.
         // First two blocks are 3s     |33--------||----------|
@@ -2123,16 +2030,12 @@ mod test {
 
         // Read one block: should be all 0x00
         let mut buffer = Buffer::new(1, BLOCK_SIZE);
-        volume1
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume1.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x00; BLOCK_SIZE], &buffer[..]);
 
         let mut buffer = Buffer::new(1, BLOCK_SIZE);
-        volume2
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume2.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x00; BLOCK_SIZE], &buffer[..]);
 
@@ -2176,16 +2079,14 @@ mod test {
 
         // Verify contents are 00 at startup
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0; BLOCK_SIZE * 10], &buffer[..]);
 
         // Write to half volume
         volume
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![55; BLOCK_SIZE * 5].as_slice()),
             )
             .await?;
@@ -2195,9 +2096,7 @@ mod test {
 
         // Read and verify contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         // Build the expected vec to compare our read with.
         // First 5 blocks are 5s              |55555-----|
@@ -2244,10 +2143,7 @@ mod test {
         };
 
         volume
-            .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                BytesMut::from(random_buffer.as_slice()),
-            )
+            .write(BlockIndex(0), BytesMut::from(random_buffer.as_slice()))
             .await?;
 
         volume.deactivate().await?;
@@ -2278,15 +2174,13 @@ mod test {
             let volume_size = volume.total_size().await? as usize;
             assert_eq!(volume_size % BLOCK_SIZE, 0);
             let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
-            volume
-                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-                .await?;
+            volume.read(BlockIndex(0), &mut buffer).await?;
 
             assert_eq!(&buffer[..], random_buffer);
 
             assert!(volume
                 .write(
-                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                    BlockIndex(0),
                     BytesMut::from(vec![0u8; BLOCK_SIZE].as_slice()),
                 )
                 .await
@@ -2336,9 +2230,7 @@ mod test {
             let volume_size = volume.total_size().await? as usize;
             assert_eq!(volume_size % BLOCK_SIZE, 0);
             let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
-            volume
-                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-                .await?;
+            volume.read(BlockIndex(0), &mut buffer).await?;
 
             assert_eq!(&buffer[..], random_buffer);
         }
@@ -2349,7 +2241,7 @@ mod test {
         // Write one block of 0x00 in, validate with a read
         volume
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0u8; BLOCK_SIZE].as_slice()),
             )
             .await?;
@@ -2358,9 +2250,7 @@ mod test {
             let volume_size = volume.total_size().await? as usize;
             assert_eq!(volume_size % BLOCK_SIZE, 0);
             let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
-            volume
-                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-                .await?;
+            volume.read(BlockIndex(0), &mut buffer).await?;
 
             assert_eq!(&buffer[..BLOCK_SIZE], vec![0u8; BLOCK_SIZE]);
             assert_eq!(&buffer[BLOCK_SIZE..], &random_buffer[BLOCK_SIZE..]);
@@ -2415,10 +2305,7 @@ mod test {
         };
 
         volume
-            .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                BytesMut::from(random_buffer.as_slice()),
-            )
+            .write(BlockIndex(0), BytesMut::from(random_buffer.as_slice()))
             .await?;
 
         volume.deactivate().await?;
@@ -2457,15 +2344,13 @@ mod test {
             let volume_size = volume.total_size().await? as usize;
             assert_eq!(volume_size % BLOCK_SIZE, 0);
             let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
-            volume
-                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-                .await?;
+            volume.read(BlockIndex(0), &mut buffer).await?;
 
             assert_eq!(&buffer[..], random_buffer);
 
             assert!(volume
                 .write(
-                    Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                    BlockIndex(0),
                     BytesMut::from(vec![0u8; BLOCK_SIZE].as_slice()),
                 )
                 .await
@@ -2523,9 +2408,7 @@ mod test {
             let volume_size = volume.total_size().await? as usize;
             assert_eq!(volume_size % BLOCK_SIZE, 0);
             let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
-            volume
-                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-                .await?;
+            volume.read(BlockIndex(0), &mut buffer).await?;
 
             assert_eq!(&buffer[..], random_buffer);
         }
@@ -2536,7 +2419,7 @@ mod test {
         // Write one block of 0x00 in, validate with a read
         volume
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0u8; BLOCK_SIZE].as_slice()),
             )
             .await?;
@@ -2545,9 +2428,7 @@ mod test {
             let volume_size = volume.total_size().await? as usize;
             assert_eq!(volume_size % BLOCK_SIZE, 0);
             let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
-            volume
-                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-                .await?;
+            volume.read(BlockIndex(0), &mut buffer).await?;
 
             assert_eq!(&buffer[..BLOCK_SIZE], vec![0u8; BLOCK_SIZE]);
             assert_eq!(&buffer[BLOCK_SIZE..], &random_buffer[BLOCK_SIZE..]);
@@ -2599,10 +2480,7 @@ mod test {
         };
 
         volume
-            .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                BytesMut::from(random_buffer.as_slice()),
-            )
+            .write(BlockIndex(0), BytesMut::from(random_buffer.as_slice()))
             .await?;
 
         volume.deactivate().await?;
@@ -2645,9 +2523,7 @@ mod test {
         let volume_size = volume.total_size().await? as usize;
         assert_eq!(volume_size % BLOCK_SIZE, 0);
         let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(&buffer[..], random_buffer);
 
@@ -2696,10 +2572,7 @@ mod test {
         };
 
         volume
-            .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                BytesMut::from(random_buffer.as_slice()),
-            )
+            .write(BlockIndex(0), BytesMut::from(random_buffer.as_slice()))
             .await?;
 
         volume.deactivate().await.unwrap();
@@ -2754,9 +2627,7 @@ mod test {
         // Verify our volume still has the random data we wrote.
         let volume_size = volume.total_size().await? as usize;
         let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(&buffer[BLOCK_SIZE..], &random_buffer[BLOCK_SIZE..]);
 
@@ -2803,9 +2674,7 @@ mod test {
         // Verify our volume still has the random data we wrote.
         let volume_size = volume.total_size().await? as usize;
         let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(&buffer[BLOCK_SIZE..], &random_buffer[BLOCK_SIZE..]);
 
@@ -2860,10 +2729,7 @@ mod test {
         };
 
         volume
-            .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                BytesMut::from(random_buffer.as_slice()),
-            )
+            .write(BlockIndex(0), BytesMut::from(random_buffer.as_slice()))
             .await?;
 
         volume.deactivate().await.unwrap();
@@ -2919,9 +2785,7 @@ mod test {
         // Verify our volume still has the random data we wrote.
         let volume_size = volume.total_size().await? as usize;
         let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(&buffer[BLOCK_SIZE..], &random_buffer[BLOCK_SIZE..]);
 
@@ -3180,10 +3044,7 @@ mod test {
         };
 
         volume
-            .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                BytesMut::from(random_buffer.as_slice()),
-            )
+            .write(BlockIndex(0), BytesMut::from(random_buffer.as_slice()))
             .await?;
 
         // Create a new downstairs, then replace one of our current
@@ -3231,9 +3092,7 @@ mod test {
         let volume_size = volume.total_size().await? as usize;
         assert_eq!(volume_size % BLOCK_SIZE, 0);
         let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(&buffer[BLOCK_SIZE..], &random_buffer[BLOCK_SIZE..]);
 
@@ -3275,10 +3134,7 @@ mod test {
         };
 
         volume
-            .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                BytesMut::from(random_buffer.as_slice()),
-            )
+            .write(BlockIndex(0), BytesMut::from(random_buffer.as_slice()))
             .await?;
 
         volume.deactivate().await.unwrap();
@@ -3367,9 +3223,7 @@ mod test {
         let volume_size = volume.total_size().await? as usize;
         assert_eq!(volume_size % BLOCK_SIZE, 0);
         let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(&buffer[BLOCK_SIZE..], &random_buffer[BLOCK_SIZE..]);
 
@@ -3599,10 +3453,7 @@ mod test {
         };
 
         volume
-            .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
-                BytesMut::from(random_buffer.as_slice()),
-            )
+            .write(BlockIndex(0), BytesMut::from(random_buffer.as_slice()))
             .await?;
 
         volume.flush(None).await?;
@@ -3677,9 +3528,7 @@ mod test {
         let volume_size = volume.total_size().await? as usize;
         assert_eq!(volume_size % BLOCK_SIZE, 0);
         let mut buffer = Buffer::new(volume_size / BLOCK_SIZE, BLOCK_SIZE);
-        new_volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        new_volume.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(&buffer[BLOCK_SIZE..], &random_buffer[BLOCK_SIZE..]);
 
@@ -3732,7 +3581,7 @@ mod test {
             for (i, random_buffer) in chunks.iter() {
                 volume
                     .write(
-                        Block::new(*i as u64, BLOCK_SIZE.trailing_zeros()),
+                        BlockIndex(*i as u64),
                         BytesMut::from(random_buffer.as_slice()),
                     )
                     .await?;
@@ -3742,12 +3591,7 @@ mod test {
                 assert_eq!(CHUNK_SIZE % BLOCK_SIZE, 0);
                 let mut buffer =
                     Buffer::new(CHUNK_SIZE / BLOCK_SIZE, BLOCK_SIZE);
-                volume
-                    .read(
-                        Block::new(i as u64, BLOCK_SIZE.trailing_zeros()),
-                        &mut buffer,
-                    )
-                    .await?;
+                volume.read(BlockIndex(i as u64), &mut buffer).await?;
 
                 assert_eq!(random_buffer, &buffer[..]);
             }
@@ -3781,25 +3625,21 @@ mod test {
 
         // Verify contents are zero on init
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        guest.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x00_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         // Write data in
         guest
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
         // Read parent, verify contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        guest.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
@@ -3842,25 +3682,21 @@ mod test {
 
         // Verify contents are zero on init
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        guest.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x00_u8; BLOCK_SIZE * 10], buffer.to_vec());
 
         // Write data in
         guest
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
         // Read parent, verify contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        guest.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], buffer.to_vec());
         drop(guest);
@@ -3888,14 +3724,10 @@ mod test {
 
         // Read of length 0
         let mut buffer = Buffer::new(0, BLOCK_SIZE);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        guest.read(BlockIndex(0), &mut buffer).await?;
 
         // Write of length 0
-        guest
-            .write(Block::new(0, BLOCK_SIZE.trailing_zeros()), BytesMut::new())
-            .await?;
+        guest.write(BlockIndex(0), BytesMut::new()).await?;
 
         Ok(())
     }
@@ -3919,7 +3751,7 @@ mod test {
         // Write data in
         guest
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
@@ -3967,9 +3799,7 @@ mod test {
 
         // Read back our block post replacement, verify contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        guest.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
@@ -3994,7 +3824,7 @@ mod test {
         // Expect an error attempting to write.
         let write_result = guest
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await;
@@ -4073,32 +3903,28 @@ mod test {
         // Write_unwritten data in
         guest
             .write_unwritten(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
         // Read parent, verify contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        guest.read(BlockIndex(0), &mut buffer).await?;
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
         // Write_unwritten again with different data
         guest
             .write_unwritten(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x99; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
         // Read back the same blocks.
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        guest.read(BlockIndex(0), &mut buffer).await?;
 
         // Verify data is still the original contents.
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
@@ -4106,16 +3932,14 @@ mod test {
         // Now, just write.  This should update our data.
         guest
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x89; BLOCK_SIZE * 10].as_slice()),
             )
             .await?;
 
         // Read back the same blocks.
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        guest.read(BlockIndex(0), &mut buffer).await?;
 
         // Verify data is now from the new write.
         assert_eq!(vec![0x89_u8; BLOCK_SIZE * 10], &buffer[..]);
@@ -4145,7 +3969,7 @@ mod test {
         // Write_unwritten data in the first block
         guest
             .write_unwritten(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x55; BLOCK_SIZE].as_slice()),
             )
             .await?;
@@ -4154,25 +3978,21 @@ mod test {
         // range, but write to blocks 2 and 3 this time as well.
         guest
             .write_unwritten(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x99; BLOCK_SIZE * 3].as_slice()),
             )
             .await?;
 
         // Read back the first block.
         let mut buffer = Buffer::new(1, BLOCK_SIZE);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        guest.read(BlockIndex(0), &mut buffer).await?;
 
         // Verify data is still the original contents.
         assert_eq!(vec![0x55_u8; BLOCK_SIZE], &buffer[..]);
 
         // Read back the next two blocks.
         let mut buffer = Buffer::new(2, BLOCK_SIZE);
-        guest
-            .read(Block::new(1, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        guest.read(BlockIndex(1), &mut buffer).await?;
 
         // Verify data is still the original contents.
         assert_eq!(vec![0x99_u8; BLOCK_SIZE * 2], &buffer[..]);
@@ -4202,7 +4022,7 @@ mod test {
         // Write_unwritten data in the second block
         guest
             .write_unwritten(
-                Block::new(1, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(1),
                 BytesMut::from(vec![0x55; BLOCK_SIZE].as_slice()),
             )
             .await?;
@@ -4211,16 +4031,14 @@ mod test {
         // to blocks 0, 1, and 2.
         guest
             .write_unwritten(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x99; BLOCK_SIZE * 3].as_slice()),
             )
             .await?;
 
         // Read back the all three blocks.
         let mut buffer = Buffer::new(3, BLOCK_SIZE);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        guest.read(BlockIndex(0), &mut buffer).await?;
 
         // Verify data in the first block is from the second write_unwritten
         assert_eq!(vec![0x99_u8; BLOCK_SIZE], &buffer[0..BLOCK_SIZE]);
@@ -4260,7 +4078,7 @@ mod test {
         // Write_unwritten data in the third block
         guest
             .write_unwritten(
-                Block::new(2, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(2),
                 BytesMut::from(vec![0x55; BLOCK_SIZE].as_slice()),
             )
             .await?;
@@ -4269,16 +4087,14 @@ mod test {
         // to blocks 0, 1, and 2.
         guest
             .write_unwritten(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x99; BLOCK_SIZE * 3].as_slice()),
             )
             .await?;
 
         // Read back the all three blocks.
         let mut buffer = Buffer::new(3, BLOCK_SIZE);
-        guest
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        guest.read(BlockIndex(0), &mut buffer).await?;
 
         // Verify data in the first two blocks is the data from the
         // second write_unwritten
@@ -4313,7 +4129,7 @@ mod test {
         // Write_unwritten data in last block of the extent
         guest
             .write_unwritten(
-                Block::new(4, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(4),
                 BytesMut::from(vec![0x55; BLOCK_SIZE].as_slice()),
             )
             .await?;
@@ -4322,16 +4138,14 @@ mod test {
         // write size to include the first block in the 2nd extent.
         guest
             .write_unwritten(
-                Block::new(4, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(4),
                 BytesMut::from(vec![0x99; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
 
         // Read back both blocks
         let mut buffer = Buffer::new(2, BLOCK_SIZE);
-        guest
-            .read(Block::new(4, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        guest.read(BlockIndex(4), &mut buffer).await?;
 
         // Verify data in the first block is the data from the first write.
         assert_eq!(vec![0x55_u8; BLOCK_SIZE], &buffer[0..BLOCK_SIZE]);
@@ -4366,7 +4180,7 @@ mod test {
         // Write_unwritten data in last block of the extent
         guest
             .write_unwritten(
-                Block::new(4, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(4),
                 BytesMut::from(vec![0x55; BLOCK_SIZE].as_slice()),
             )
             .await?;
@@ -4375,16 +4189,14 @@ mod test {
         // write size to include the first block in the 2nd extent.
         guest
             .write_unwritten(
-                Block::new(4, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(4),
                 BytesMut::from(vec![0x99; BLOCK_SIZE * 2].as_slice()),
             )
             .await?;
 
         // Read back both blocks
         let mut buffer = Buffer::new(2, BLOCK_SIZE);
-        guest
-            .read(Block::new(4, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await?;
+        guest.read(BlockIndex(4), &mut buffer).await?;
 
         // Verify data in the first block is the data from the first write.
         assert_eq!(vec![0x55_u8; BLOCK_SIZE], &buffer[0..BLOCK_SIZE]);
@@ -4416,7 +4228,7 @@ mod test {
         // Write a block past the end of the extent
         let res = guest
             .write(
-                Block::new(11, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(11),
                 BytesMut::from(vec![0x55; BLOCK_SIZE].as_slice()),
             )
             .await;
@@ -4425,9 +4237,7 @@ mod test {
 
         // Read a block past the end of the extent
         let mut buffer = Buffer::new(1, BLOCK_SIZE);
-        let res = guest
-            .read(Block::new(11, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await;
+        let res = guest.read(BlockIndex(11), &mut buffer).await;
 
         assert!(res.is_err());
     }
@@ -4451,7 +4261,7 @@ mod test {
         // Write a block with a buffer that extends past the end of the region
         let res = guest
             .write(
-                Block::new(10, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(10),
                 BytesMut::from(vec![0x55; BLOCK_SIZE * 2].as_slice()),
             )
             .await;
@@ -4460,9 +4270,7 @@ mod test {
 
         // Read a block with buffer that extends past the end of the region
         let mut buffer = Buffer::new(2, BLOCK_SIZE);
-        let res = guest
-            .read(Block::new(10, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await;
+        let res = guest.read(BlockIndex(10), &mut buffer).await;
 
         assert!(res.is_err());
     }
@@ -4611,10 +4419,7 @@ mod test {
 
         assert_eq!(bytes.len() % BLOCK_SIZE, 0);
         let mut buffer = Buffer::new(bytes.len() / BLOCK_SIZE, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await
-            .unwrap();
+        volume.read(BlockIndex(0), &mut buffer).await.unwrap();
 
         assert!(bytes.len() % BLOCK_SIZE == 0);
 
@@ -4718,10 +4523,7 @@ mod test {
             volume.activate().await.unwrap();
 
             let mut buffer = Buffer::new(10, BLOCK_SIZE);
-            volume
-                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-                .await
-                .unwrap();
+            volume.read(BlockIndex(0), &mut buffer).await.unwrap();
 
             assert_eq!(vec![0x00; 5120], &buffer[..]);
 
@@ -4769,10 +4571,7 @@ mod test {
         volume.activate().await.unwrap();
 
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await
-            .unwrap();
+        volume.read(BlockIndex(0), &mut buffer).await.unwrap();
 
         assert_eq!(vec![0x55; 5120], &buffer[..]);
     }
@@ -4846,10 +4645,7 @@ mod test {
         volume.activate().await.unwrap();
 
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await
-            .unwrap();
+        volume.read(BlockIndex(0), &mut buffer).await.unwrap();
 
         let buffer_data = &&buffer[..];
 
@@ -4911,10 +4707,7 @@ mod test {
         assert_eq!(PantryEntry::MAX_CHUNK_SIZE % BLOCK_SIZE, 0);
         let mut buffer =
             Buffer::new(PantryEntry::MAX_CHUNK_SIZE / BLOCK_SIZE, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await
-            .unwrap();
+        volume.read(BlockIndex(0), &mut buffer).await.unwrap();
 
         assert_eq!(vec![0x99; PantryEntry::MAX_CHUNK_SIZE], &buffer[..]);
     }
@@ -5045,10 +4838,7 @@ mod test {
 
             assert_eq!(data.len() % BLOCK_SIZE, 0);
             let mut buffer = Buffer::new(data.len() / BLOCK_SIZE, BLOCK_SIZE);
-            volume
-                .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-                .await
-                .unwrap();
+            volume.read(BlockIndex(0), &mut buffer).await.unwrap();
 
             assert_eq!(data, &buffer[..]);
 
@@ -5139,10 +4929,7 @@ mod test {
 
         assert_eq!(data.len() % BLOCK_SIZE, 0);
         let mut buffer = Buffer::new(data.len() / BLOCK_SIZE, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await
-            .unwrap();
+        volume.read(BlockIndex(0), &mut buffer).await.unwrap();
 
         assert_eq!(data, &buffer[..]);
     }
@@ -5621,7 +5408,7 @@ mod test {
         // Write data in
         volume
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await
@@ -5629,10 +5416,7 @@ mod test {
 
         // Read parent, verify contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await
-            .unwrap();
+        volume.read(BlockIndex(0), &mut buffer).await.unwrap();
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
 
@@ -5664,10 +5448,7 @@ mod test {
         volume.target_replace(original, replacement).await.unwrap();
         info!(log, "send read now");
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await
-            .unwrap();
+        volume.read(BlockIndex(0), &mut buffer).await.unwrap();
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
     }
@@ -5705,7 +5486,7 @@ mod test {
         // Write data in
         volume
             .write(
-                Block::new(0, BLOCK_SIZE.trailing_zeros()),
+                BlockIndex(0),
                 BytesMut::from(vec![0x55; BLOCK_SIZE * 10].as_slice()),
             )
             .await
@@ -5713,10 +5494,7 @@ mod test {
 
         // Read parent, verify contents
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await
-            .unwrap();
+        volume.read(BlockIndex(0), &mut buffer).await.unwrap();
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
         volume.deactivate().await.unwrap();
@@ -5791,10 +5569,7 @@ mod test {
         assert!(rop_replace.is_ok());
         info!(log, "send read now");
         let mut buffer = Buffer::new(10, BLOCK_SIZE);
-        volume
-            .read(Block::new(0, BLOCK_SIZE.trailing_zeros()), &mut buffer)
-            .await
-            .unwrap();
+        volume.read(BlockIndex(0), &mut buffer).await.unwrap();
 
         assert_eq!(vec![0x55_u8; BLOCK_SIZE * 10], &buffer[..]);
     }

--- a/upstairs/src/block_io.rs
+++ b/upstairs/src/block_io.rs
@@ -62,11 +62,11 @@ impl BlockIO for FileBlockIO {
 
     async fn read(
         &self,
-        offset: Block,
+        offset: BlockIndex,
         data: &mut Buffer,
     ) -> Result<(), CrucibleError> {
         self.check_data_size(data.len()).await?;
-        let start: usize = (offset.value * self.block_size) as usize;
+        let start: usize = (offset.0 * self.block_size) as usize;
 
         let mut file = self.file.lock().await;
         file.seek(SeekFrom::Start(start as u64))?;
@@ -80,11 +80,11 @@ impl BlockIO for FileBlockIO {
 
     async fn write(
         &self,
-        offset: Block,
+        offset: BlockIndex,
         data: BytesMut,
     ) -> Result<(), CrucibleError> {
         self.check_data_size(data.len()).await?;
-        let start = offset.value * self.block_size;
+        let start = offset.0 * self.block_size;
 
         let mut file = self.file.lock().await;
         file.seek(SeekFrom::Start(start))?;
@@ -95,7 +95,7 @@ impl BlockIO for FileBlockIO {
 
     async fn write_unwritten(
         &self,
-        _offset: Block,
+        _offset: BlockIndex,
         _data: BytesMut,
     ) -> Result<(), CrucibleError> {
         crucible_bail!(
@@ -206,14 +206,14 @@ impl BlockIO for ReqwestBlockIO {
 
     async fn read(
         &self,
-        offset: Block,
+        offset: BlockIndex,
         data: &mut Buffer,
     ) -> Result<(), CrucibleError> {
         self.check_data_size(data.len()).await?;
         let cc = self.next_count();
         cdt::reqwest__read__start!(|| (cc, self.uuid));
 
-        let start = offset.value * self.block_size;
+        let start = offset.0 * self.block_size;
 
         let response = self
             .client
@@ -261,7 +261,7 @@ impl BlockIO for ReqwestBlockIO {
 
     async fn write(
         &self,
-        _offset: Block,
+        _offset: BlockIndex,
         _data: BytesMut,
     ) -> Result<(), CrucibleError> {
         crucible_bail!(Unsupported, "write unsupported for ReqwestBlockIO")
@@ -269,7 +269,7 @@ impl BlockIO for ReqwestBlockIO {
 
     async fn write_unwritten(
         &self,
-        _offset: Block,
+        _offset: BlockIndex,
         _data: BytesMut,
     ) -> Result<(), CrucibleError> {
         crucible_bail!(

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -123,19 +123,19 @@ pub trait BlockIO: Sync {
 
     async fn read(
         &self,
-        offset: Block,
+        offset: BlockIndex,
         data: &mut Buffer,
     ) -> Result<(), CrucibleError>;
 
     async fn write(
         &self,
-        offset: Block,
+        offset: BlockIndex,
         data: BytesMut,
     ) -> Result<(), CrucibleError>;
 
     async fn write_unwritten(
         &self,
-        offset: Block,
+        offset: BlockIndex,
         data: BytesMut,
     ) -> Result<(), CrucibleError>;
 
@@ -166,14 +166,14 @@ pub trait BlockIO: Sync {
     async fn byte_offset_to_block(
         &self,
         offset: u64,
-    ) -> Result<Block, CrucibleError> {
+    ) -> Result<BlockIndex, CrucibleError> {
         let bs = self.get_block_size().await?;
 
         if (offset % bs) != 0 {
             crucible_bail!(OffsetUnaligned);
         }
 
-        Ok(Block::new(offset / bs, bs.trailing_zeros()))
+        Ok(BlockIndex(offset / bs))
     }
 
     /*

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -73,13 +73,7 @@ impl IOSpan {
         block_io: &T,
     ) -> Result<(), CrucibleError> {
         block_io
-            .read(
-                Block::new(
-                    self.affected_block_numbers[0],
-                    self.block_size.trailing_zeros(),
-                ),
-                &mut self.buffer,
-            )
+            .read(BlockIndex(self.affected_block_numbers[0]), &mut self.buffer)
             .await?;
 
         Ok(())
@@ -92,10 +86,7 @@ impl IOSpan {
     ) -> Result<(), CrucibleError> {
         block_io
             .write(
-                Block::new(
-                    self.affected_block_numbers[0],
-                    self.block_size.trailing_zeros(),
-                ),
+                BlockIndex(self.affected_block_numbers[0]),
                 self.buffer.into_bytes_mut(),
             )
             .await
@@ -371,10 +362,7 @@ impl<T: BlockIO> CruciblePseudoFile<T> {
         } else {
             let _guard = self.rmw_lock.read().await;
 
-            let offset = Block::new(
-                self.offset / self.block_size,
-                self.block_size.trailing_zeros(),
-            );
+            let offset = BlockIndex(self.offset / self.block_size);
             let bytes = BytesMut::from(buf);
             self.block_io.write(offset, bytes).await?;
         }


### PR DESCRIPTION
This PR updates `trait BlockIO` to use `BlockIndex` arguments (instead of `Block`).

`BlockIndex` was introduced in #1379 and has the specific meaning of "an absolute block index".  Unlike `Block`, it does not carry a size, because it's weird for all of our operations to have the semantics of

> Do a write at this absolute block, and also here's the block size, so maybe you should check to make sure it's still valid?

By passing _only_ an absolute block index, we obviate any questions about checking and handling the `Block::size` member.

⚠️ This will require minor changes in Propolis, which I can do once this is merged.