### PR TITLE
Make read and write messages contiguous

### DIFF
--- a/common/src/impacted_blocks.rs
+++ b/common/src/impacted_blocks.rs
@@ -129,6 +129,14 @@ impl ImpactedBlocks {
         ImpactedBlocks::Empty
     }
 
+    /// Returns the first impacted address
+    pub fn start(&self) -> Option<ImpactedAddr> {
+        match self {
+            ImpactedBlocks::InclusiveRange(a, _) => Some(*a),
+            ImpactedBlocks::Empty => None,
+        }
+    }
+
     /// Create a new ImpactedBlocks range starting at a given offset, and
     /// stretching n_blocks further into the extent. Panics an error if
     /// `extent_size` is 0. Returns ImpactedBlocks::Empty if n_blocks is 0.

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1641,13 +1641,9 @@ impl ActiveConnection {
                     response.is_ok(),
                 );
 
-                // We've got one or more block contexts per block returned, but
-                // the response format need to be in the form of
-                // `ReadResponseBlockMetadata` (which also contains extent and
-                // offset); we inject that extra information in this terrible
-                // match statement.
+                // Unpack into context blocks and stored data
                 let (blocks, data) = match response {
-                    Ok(r) => (Ok(r.blocks.clone()), r.data),
+                    Ok(r) => (Ok(r.blocks), r.data),
                     Err(e) => (Err(e), Default::default()),
                 };
 

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -2126,8 +2126,7 @@ pub(crate) mod test {
         region.extend(3, backend).unwrap();
 
         let ddef = region.def();
-        let num_blocks: usize =
-            ddef.extent_size().value as usize * ddef.extent_count() as usize;
+        let num_blocks = ddef.extent_size().value * ddef.extent_count() as u64;
 
         // use region_write_all to fill the entire region
         let buffer = region_write_all(&mut region, &ddef, false);
@@ -2139,18 +2138,7 @@ pub(crate) mod test {
         assert_eq!(buffer, read_from_files);
 
         // read all using region_read
-
-        let mut requests: Vec<crucible_protocol::ReadRequest> =
-            Vec::with_capacity(num_blocks);
-
-        for i in 0..num_blocks {
-            let eid = ExtentId((i as u64 / ddef.extent_size().value) as u32);
-            let offset = BlockOffset((i as u64) % ddef.extent_size().value);
-
-            requests.push(crucible_protocol::ReadRequest { eid, offset });
-        }
-
-        let req = RegionReadRequest::new(&requests);
+        let req = RegionReadRequest::new(BlockIndex(0), num_blocks, &ddef);
         let responses = region.region_read(&req, JobId(0)).unwrap();
 
         assert_eq!(buffer.len(), responses.data.len());
@@ -2193,17 +2181,8 @@ pub(crate) mod test {
         }
 
         // read all using region_read
-        let mut requests: Vec<crucible_protocol::ReadRequest> =
-            Vec::with_capacity(num_blocks);
-
-        for i in 0..num_blocks {
-            let eid = ExtentId((i as u64 / ddef.extent_size().value) as u32);
-            let offset = BlockOffset((i as u64) % ddef.extent_size().value);
-
-            requests.push(crucible_protocol::ReadRequest { eid, offset });
-        }
-
-        let req = RegionReadRequest::new(&requests);
+        let req =
+            RegionReadRequest::new(BlockIndex(0), num_blocks as u64, &ddef);
         let read_from_region = region.region_read(&req, JobId(0))?.data;
 
         assert_eq!(buffer.len(), read_from_region.len());
@@ -2604,8 +2583,7 @@ pub(crate) mod test {
         region.extend(3, backend).unwrap();
 
         let ddef = region.def();
-        let num_blocks: usize =
-            ddef.extent_size().value as usize * ddef.extent_count() as usize;
+        let num_blocks = ddef.extent_size().value * ddef.extent_count() as u64;
 
         // use region_write_all to fill region with write_unwritten = true
         let buffer = region_write_all(&mut region, &ddef, true);
@@ -2617,17 +2595,7 @@ pub(crate) mod test {
         assert_eq!(buffer, read_from_files);
 
         // read all using region_read
-        let mut requests: Vec<crucible_protocol::ReadRequest> =
-            Vec::with_capacity(num_blocks);
-
-        for i in 0..num_blocks {
-            let eid = ExtentId((i as u64 / ddef.extent_size().value) as u32);
-            let offset = BlockOffset((i as u64) % ddef.extent_size().value);
-
-            requests.push(crucible_protocol::ReadRequest { eid, offset });
-        }
-
-        let req = RegionReadRequest::new(&requests);
+        let req = RegionReadRequest::new(BlockIndex(0), num_blocks, &ddef);
         let responses = region.region_read(&req, JobId(0)).unwrap();
 
         assert_eq!(buffer, responses.data);
@@ -2645,8 +2613,7 @@ pub(crate) mod test {
         let ddef = region.def();
         let total_size: usize = ddef.total_size() as usize;
         println!("Total size: {}", total_size);
-        let num_blocks: usize =
-            ddef.extent_size().value as usize * ddef.extent_count() as usize;
+        let num_blocks = ddef.extent_size().value * ddef.extent_count() as u64;
 
         // Fill a buffer with "9"'s
         let data = Bytes::from(vec![9u8; 512]);
@@ -2697,17 +2664,7 @@ pub(crate) mod test {
         assert_eq!(buffer, read_from_files);
 
         // read all using region_read
-        let mut requests: Vec<crucible_protocol::ReadRequest> =
-            Vec::with_capacity(num_blocks);
-
-        for i in 0..num_blocks {
-            let eid = ExtentId((i as u64 / ddef.extent_size().value) as u32);
-            let offset = BlockOffset((i as u64) % ddef.extent_size().value);
-
-            requests.push(crucible_protocol::ReadRequest { eid, offset });
-        }
-
-        let req = RegionReadRequest::new(&requests);
+        let req = RegionReadRequest::new(BlockIndex(0), num_blocks, &ddef);
         let responses = region.region_read(&req, JobId(0)).unwrap();
 
         assert_eq!(buffer, responses.data);
@@ -2724,8 +2681,7 @@ pub(crate) mod test {
         region.extend(3, backend).unwrap();
 
         let ddef = region.def();
-        let num_blocks: usize =
-            ddef.extent_size().value as usize * ddef.extent_count() as usize;
+        let num_blocks = ddef.extent_size().value * ddef.extent_count() as u64;
 
         // Fill a buffer with "9"'s
         let data = Bytes::from(vec![9u8; 512]);
@@ -2776,17 +2732,7 @@ pub(crate) mod test {
         assert_eq!(buffer, read_from_files);
 
         // read all using region_read
-        let mut requests: Vec<crucible_protocol::ReadRequest> =
-            Vec::with_capacity(num_blocks);
-
-        for i in 0..num_blocks {
-            let eid = ExtentId((i as u64 / ddef.extent_size().value) as u32);
-            let offset = BlockOffset((i as u64) % ddef.extent_size().value);
-
-            requests.push(crucible_protocol::ReadRequest { eid, offset });
-        }
-
-        let req = RegionReadRequest::new(&requests);
+        let req = RegionReadRequest::new(BlockIndex(0), num_blocks, &ddef);
         let responses = region.region_read(&req, JobId(0)).unwrap();
 
         assert_eq!(buffer, responses.data);
@@ -2807,8 +2753,8 @@ pub(crate) mod test {
         let ddef = region.def();
         // A bunch of things expect a 512, so let's make it explicit.
         assert_eq!(ddef.block_size(), 512);
-        let num_blocks: usize = 4;
-        let total_size: usize = ddef.block_size() as usize * num_blocks;
+        let num_blocks = 4;
+        let total_size = ddef.block_size() as usize * num_blocks as usize;
 
         // Fill a buffer with "9"'s
         let data = Bytes::from(vec![9u8; 512]);
@@ -2850,23 +2796,24 @@ pub(crate) mod test {
         println!("buffer size:{}", buffer.len());
         rng.fill_bytes(&mut buffer);
 
-        let block_contexts = buffer
+        let block_contexts: Vec<_> = buffer
             .chunks(512)
             .map(|chunk| BlockContext {
                 hash: integrity_hash(&[chunk]),
                 encryption_context: None,
             })
             .collect();
-        let write = ExtentWrite {
-            offset: BlockOffset(0),
-            data: Bytes::from(buffer.as_slice().to_vec()),
-            block_contexts,
-        };
 
         // send only_write_unwritten command.
         region
             .region_write(
-                &RegionWrite(vec![RegionWriteReq { extent: eid, write }]),
+                &RegionWrite::new(
+                    BlockIndex(0),
+                    &block_contexts,
+                    Bytes::from(buffer.as_slice().to_vec()),
+                    &ddef,
+                )
+                .unwrap(),
                 JobId(0),
                 true,
             )
@@ -2880,18 +2827,7 @@ pub(crate) mod test {
         }
 
         // read all using region_read
-        let mut requests: Vec<crucible_protocol::ReadRequest> =
-            Vec::with_capacity(num_blocks);
-
-        for i in 0..num_blocks {
-            let eid = ExtentId((i as u64 / ddef.extent_size().value) as u32);
-            let offset = BlockOffset((i as u64) % ddef.extent_size().value);
-
-            println!("Read eid: {}, {} offset: {:?}", eid, i, offset);
-            requests.push(crucible_protocol::ReadRequest { eid, offset });
-        }
-
-        let req = RegionReadRequest::new(&requests);
+        let req = RegionReadRequest::new(BlockIndex(0), num_blocks, &ddef);
         let responses = region.region_read(&req, JobId(0)).unwrap();
 
         assert_eq!(buffer, responses.data);
@@ -2908,8 +2844,7 @@ pub(crate) mod test {
         let ddef = region.def();
         let total_size: usize = ddef.total_size() as usize;
         println!("Total size: {}", total_size);
-        let num_blocks: usize =
-            ddef.extent_size().value as usize * ddef.extent_count() as usize;
+        let num_blocks = ddef.extent_size().value * ddef.extent_count() as u64;
 
         // Fill a buffer with "9"s
         let blocks_to_write = [1, 3, 7, 8, 11, 12, 13];
@@ -2961,17 +2896,7 @@ pub(crate) mod test {
         }
 
         // read all using region_read
-        let mut requests: Vec<crucible_protocol::ReadRequest> =
-            Vec::with_capacity(num_blocks);
-
-        for i in 0..num_blocks {
-            let eid = ExtentId((i as u64 / ddef.extent_size().value) as u32);
-            let offset = BlockOffset((i as u64) % ddef.extent_size().value);
-
-            requests.push(crucible_protocol::ReadRequest { eid, offset });
-        }
-
-        let req = RegionReadRequest::new(&requests);
+        let req = RegionReadRequest::new(BlockIndex(0), num_blocks, &ddef);
         let responses = region.region_read(&req, JobId(0)).unwrap();
 
         assert_eq!(buffer, responses.data);
@@ -3527,14 +3452,7 @@ pub(crate) mod test {
         let (_dir, mut region, data) = prepare_random_region(backend);
 
         // Call region_read with a single large contiguous range
-        let requests: Vec<crucible_protocol::ReadRequest> = (1..8)
-            .map(|i| crucible_protocol::ReadRequest {
-                eid: ExtentId(0),
-                offset: BlockOffset(i),
-            })
-            .collect();
-
-        let req = RegionReadRequest::new(&requests);
+        let req = RegionReadRequest::new(BlockIndex(1), 7, &region.def());
         let responses = region.region_read(&req, JobId(0)).unwrap();
 
         // Validate returned data
@@ -3546,100 +3464,11 @@ pub(crate) mod test {
 
         // Call region_read with a single large contiguous range that spans
         // multiple extents
-        let requests: Vec<crucible_protocol::ReadRequest> = (9..28)
-            .map(|i| crucible_protocol::ReadRequest {
-                eid: ExtentId(i / 10),
-                offset: BlockOffset(i as u64 % 10),
-            })
-            .collect();
-
-        let req = RegionReadRequest::new(&requests);
+        let req = RegionReadRequest::new(BlockIndex(9), 19, &region.def());
         let responses = region.region_read(&req, JobId(0)).unwrap();
 
         // Validate returned data
         assert_eq!(&responses.data, &data[(9 * 512)..(28 * 512)],);
-    }
-
-    fn test_read_multiple_disjoint_large_contiguous(backend: Backend) {
-        let (_dir, mut region, data) = prepare_random_region(backend);
-
-        // Call region_read with a multiple disjoint large contiguous ranges
-        let requests: Vec<crucible_protocol::ReadRequest> = vec![
-            (1..4)
-                .map(|i| crucible_protocol::ReadRequest {
-                    eid: ExtentId(i / 10),
-                    offset: BlockOffset(i as u64 % 10),
-                })
-                .collect::<Vec<crucible_protocol::ReadRequest>>(),
-            (15..24)
-                .map(|i| crucible_protocol::ReadRequest {
-                    eid: ExtentId(i / 10),
-                    offset: BlockOffset(i as u64 % 10),
-                })
-                .collect::<Vec<crucible_protocol::ReadRequest>>(),
-            (27..28)
-                .map(|i| crucible_protocol::ReadRequest {
-                    eid: ExtentId(i / 10),
-                    offset: BlockOffset(i as u64 % 10),
-                })
-                .collect::<Vec<crucible_protocol::ReadRequest>>(),
-        ]
-        .into_iter()
-        .flatten()
-        .collect();
-
-        let req = RegionReadRequest::new(&requests);
-        let responses = region.region_read(&req, JobId(0)).unwrap();
-
-        // Validate returned data
-        assert_eq!(
-            &responses.data,
-            &[
-                &data[512..(4 * 512)],
-                &data[(15 * 512)..(24 * 512)],
-                &data[(27 * 512)..(28 * 512)],
-            ]
-            .concat(),
-        );
-    }
-
-    fn test_read_multiple_disjoint_none_contiguous(backend: Backend) {
-        let (_dir, mut region, data) = prepare_random_region(backend);
-
-        // Call region_read with a multiple disjoint non-contiguous ranges
-        let requests: Vec<crucible_protocol::ReadRequest> = vec![
-            crucible_protocol::ReadRequest {
-                eid: ExtentId(0),
-                offset: BlockOffset(0),
-            },
-            crucible_protocol::ReadRequest {
-                eid: ExtentId(1),
-                offset: BlockOffset(4),
-            },
-            crucible_protocol::ReadRequest {
-                eid: ExtentId(1),
-                offset: BlockOffset(9),
-            },
-            crucible_protocol::ReadRequest {
-                eid: ExtentId(2),
-                offset: BlockOffset(4),
-            },
-        ];
-
-        let req = RegionReadRequest::new(&requests);
-        let responses = region.region_read(&req, JobId(0)).unwrap();
-
-        // Validate returned data
-        assert_eq!(
-            &responses.data,
-            &[
-                &data[0..512],
-                &data[(14 * 512)..(15 * 512)],
-                &data[(19 * 512)..(20 * 512)],
-                &data[(24 * 512)..(25 * 512)],
-            ]
-            .concat(),
-        );
     }
 
     fn prepare_writes(
@@ -3689,14 +3518,8 @@ pub(crate) mod test {
         let num_blocks = region.def().extent_size().value
             * region.def().extent_count() as u64;
 
-        let requests: Vec<crucible_protocol::ReadRequest> = (0..num_blocks)
-            .map(|i| crucible_protocol::ReadRequest {
-                eid: ExtentId((i / 10) as u32),
-                offset: BlockOffset(i % 10),
-            })
-            .collect();
-
-        let req = RegionReadRequest::new(&requests);
+        let req =
+            RegionReadRequest::new(BlockIndex(0), num_blocks, &region.def());
         let responses = region.region_read(&req, JobId(1)).unwrap();
 
         assert_eq!(&responses.data, &data,);
@@ -3721,47 +3544,6 @@ pub(crate) mod test {
         // Call region_write with a single large contiguous range that spans
         // multiple extents
         let writes = RegionWrite(prepare_writes(9..28, &mut data));
-
-        region.region_write(&writes, JobId(0), false).unwrap();
-
-        // Validate written data by reading everything back and comparing with
-        // data buffer
-        validate_whole_region(&mut region, &data);
-    }
-
-    fn test_write_multiple_disjoint_large_contiguous(backend: Backend) {
-        let (_dir, mut region, mut data) = prepare_random_region(backend);
-
-        // Call region_write with a multiple disjoint large contiguous ranges
-        let writes = RegionWrite(
-            [
-                prepare_writes(1..4, &mut data),
-                prepare_writes(15..24, &mut data),
-                prepare_writes(27..28, &mut data),
-            ]
-            .concat(),
-        );
-
-        region.region_write(&writes, JobId(0), false).unwrap();
-
-        // Validate written data by reading everything back and comparing with
-        // data buffer
-        validate_whole_region(&mut region, &data);
-    }
-
-    fn test_write_multiple_disjoint_none_contiguous(backend: Backend) {
-        let (_dir, mut region, mut data) = prepare_random_region(backend);
-
-        // Call region_write with a multiple disjoint non-contiguous ranges
-        let writes = RegionWrite(
-            [
-                prepare_writes(0..1, &mut data),
-                prepare_writes(14..15, &mut data),
-                prepare_writes(19..20, &mut data),
-                prepare_writes(24..25, &mut data),
-            ]
-            .concat(),
-        );
 
         region.region_write(&writes, JobId(0), false).unwrap();
 
@@ -3819,71 +3601,6 @@ pub(crate) mod test {
         validate_whole_region(&mut region, &data);
     }
 
-    fn test_write_unwritten_multiple_disjoint_large_contiguous(
-        backend: Backend,
-    ) {
-        // Create a blank region
-        let dir = tempdir().unwrap();
-        let mut region =
-            Region::create(&dir, new_region_options(), csl()).unwrap();
-
-        // Create 3 extents, each size 10 blocks
-        assert_eq!(region.def().extent_size().value, 10);
-        region.extend(3, backend).unwrap();
-
-        let mut data: Vec<u8> = vec![0; region.def().total_size() as usize];
-
-        // Call region_write with a multiple disjoint large contiguous ranges
-        let writes = RegionWrite(
-            [
-                prepare_writes(1..4, &mut data),
-                prepare_writes(15..24, &mut data),
-                prepare_writes(27..28, &mut data),
-            ]
-            .concat(),
-        );
-
-        // write_unwritten = true
-        region.region_write(&writes, JobId(0), true).unwrap();
-
-        // Validate written data by reading everything back and comparing with
-        // data buffer
-        validate_whole_region(&mut region, &data);
-    }
-
-    fn test_write_unwritten_multiple_disjoint_none_contiguous(
-        backend: Backend,
-    ) {
-        // Create a blank region
-        let dir = tempdir().unwrap();
-        let mut region =
-            Region::create(&dir, new_region_options(), csl()).unwrap();
-
-        // Create 3 extents, each size 10 blocks
-        assert_eq!(region.def().extent_size().value, 10);
-        region.extend(3, backend).unwrap();
-
-        let mut data: Vec<u8> = vec![0; region.def().total_size() as usize];
-
-        // Call region_write with a multiple disjoint non-contiguous ranges
-        let writes = RegionWrite(
-            [
-                prepare_writes(0..1, &mut data),
-                prepare_writes(14..15, &mut data),
-                prepare_writes(19..20, &mut data),
-                prepare_writes(24..25, &mut data),
-            ]
-            .concat(),
-        );
-
-        // write_unwritten = true
-        region.region_write(&writes, JobId(0), true).unwrap();
-
-        // Validate written data by reading everything back and comparing with
-        // data buffer
-        validate_whole_region(&mut region, &data);
-    }
-
     /// Macro defining the full region test suite
     ///
     /// Functions in the test suite should take a `b: Backend` parameter and
@@ -3931,17 +3648,11 @@ pub(crate) mod test {
                 test_bad_hash_bad,
                 test_blank_block_read_ok,
                 test_read_single_large_contiguous,
-                test_read_multiple_disjoint_large_contiguous,
-                test_read_multiple_disjoint_none_contiguous,
                 test_write_single_large_contiguous,
                 test_write_single_large_contiguous_span_extents,
-                test_write_multiple_disjoint_large_contiguous,
-                test_write_multiple_disjoint_none_contiguous,
                 test_write_unwritten_single_large_contiguous,
                 test_write_unwritten_single_large_contiguous_span_extents,
-                test_write_unwritten_multiple_disjoint_large_contiguous,
-                test_read_single_large_contiguous_span_extents,
-                test_write_unwritten_multiple_disjoint_none_contiguous
+                test_read_single_large_contiguous_span_extents
             );
         };
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -901,7 +901,7 @@ impl CrucibleEncoder {
                     job_id: JobId(1),
                     dependencies: vec![JobId(1)],
                     start: BlockIndex(0),
-                    contexts: vec![ctx; n],
+                    contexts: vec![ctx; mid],
                 },
                 data: vec![0; mid * bs].into(),
             };

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 const MAX_FRM_LEN: usize = 100 * 1024 * 1024; // 100M
 
-use crucible_common::{BlockOffset, CrucibleError, ExtentId, RegionDefinition};
+use crucible_common::{BlockIndex, CrucibleError, ExtentId, RegionDefinition};
 
 /// Wrapper type for a job ID
 ///
@@ -115,13 +115,6 @@ impl std::fmt::Display for ClientId {
     }
 }
 
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-pub struct ReadRequest {
-    pub eid: ExtentId,
-    pub offset: BlockOffset,
-}
-
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BlockContext {
     /// If this is a non-encrypted write, then the integrity hasher has the
@@ -169,6 +162,9 @@ pub struct SnapshotDetails {
 #[repr(u32)]
 #[derive(IntoPrimitive)]
 pub enum MessageVersion {
+    /// Reorganize messages to be start + length, instead of random-access
+    V10 = 10,
+
     /// Use `BlockOffset` instead of `Block` in many places
     V9 = 9,
 
@@ -208,7 +204,7 @@ pub enum MessageVersion {
 }
 impl MessageVersion {
     pub const fn current() -> Self {
-        Self::V9
+        Self::V10
     }
 }
 
@@ -217,7 +213,7 @@ impl MessageVersion {
  * This, along with the MessageVersion enum above should be updated whenever
  * changes are made to the Message enum below.
  */
-pub const CRUCIBLE_MESSAGE_VERSION: u32 = 9;
+pub const CRUCIBLE_MESSAGE_VERSION: u32 = 10;
 
 /*
  * If you add or change the Message enum, you must also increment the
@@ -513,7 +509,10 @@ pub enum Message {
         session_id: Uuid,
         job_id: JobId,
         dependencies: Vec<JobId>,
-        requests: Vec<ReadRequest>,
+        /// Read position, as an **absolute** block position
+        start: BlockIndex,
+        /// Number of blocks to read
+        count: u64,
     },
     ReadResponse {
         header: ReadResponseHeader,
@@ -555,14 +554,20 @@ pub struct WriteHeader {
     pub session_id: Uuid,
     pub job_id: JobId,
     pub dependencies: Vec<JobId>,
-    pub blocks: Vec<WriteBlockMetadata>,
-}
 
-#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
-pub struct WriteBlockMetadata {
-    pub eid: ExtentId,
-    pub offset: BlockOffset,
-    pub block_context: BlockContext,
+    /// Starting block, as an **absolute** block position
+    pub start: BlockIndex,
+
+    /// Block contexts to write (one per block)
+    ///
+    /// The write size is implicitly set by `contexts.len()`, which **must**
+    /// be compatible with the size of `data` in the container
+    /// `Message::Write/WriteUnwritten`, i.e.
+    ///
+    /// ```text
+    /// contexts.len() == data.len() / block_size
+    /// ```
+    pub contexts: Vec<BlockContext>,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -570,33 +575,7 @@ pub struct ReadResponseHeader {
     pub upstairs_id: Uuid,
     pub session_id: Uuid,
     pub job_id: JobId,
-    pub blocks: Result<Vec<ReadResponseBlockMetadata>, CrucibleError>,
-}
-
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-pub struct ReadResponseBlockMetadata {
-    pub eid: ExtentId,
-    pub offset: BlockOffset,
-    pub block_context: Option<BlockContext>,
-}
-
-impl ReadResponseBlockMetadata {
-    // TODO this is dumb
-    pub fn hashes(&self) -> Vec<u64> {
-        self.block_context.iter().map(|x| x.hash).collect()
-    }
-
-    pub fn first_hash(&self) -> Option<u64> {
-        self.block_context.map(|ctx| ctx.hash)
-    }
-
-    // TODO this is dumb
-    pub fn encryption_contexts(&self) -> Vec<Option<&EncryptionContext>> {
-        self.block_context
-            .iter()
-            .map(|x| x.encryption_context.as_ref())
-            .collect()
-    }
+    pub blocks: Result<Vec<Option<BlockContext>>, CrucibleError>,
 }
 
 impl Message {
@@ -666,7 +645,8 @@ impl std::fmt::Display for Message {
                         session_id,
                         job_id,
                         dependencies,
-                        blocks,
+                        start,
+                        ..
                     },
                 data: _,
             } => f
@@ -675,7 +655,7 @@ impl std::fmt::Display for Message {
                 .field("session_id", &session_id)
                 .field("job_id", &job_id)
                 .field("dependencies", &dependencies)
-                .field("blocks", &blocks)
+                .field("start", &start)
                 .field("writes", &"..")
                 .finish(),
             Message::WriteUnwritten {
@@ -685,7 +665,8 @@ impl std::fmt::Display for Message {
                         session_id,
                         job_id,
                         dependencies,
-                        blocks,
+                        start,
+                        ..
                     },
                 data: _,
             } => f
@@ -694,7 +675,7 @@ impl std::fmt::Display for Message {
                 .field("session_id", &session_id)
                 .field("job_id", &job_id)
                 .field("dependencies", &dependencies)
-                .field("blocks", &blocks)
+                .field("start", &start)
                 .field("writes", &"..")
                 .finish(),
             Message::ReadResponse {
@@ -831,20 +812,6 @@ impl CrucibleEncoder {
         Ok(len)
     }
 
-    fn a_write() -> WriteBlockMetadata {
-        WriteBlockMetadata {
-            eid: ExtentId(1),
-            offset: BlockOffset(1),
-            block_context: BlockContext {
-                hash: 0,
-                encryption_context: Some(EncryptionContext {
-                    nonce: [0; 12],
-                    tag: [0; 16],
-                }),
-            },
-        }
-    }
-
     /*
      * Binary search to find the maximum number of blocks we can send.
      *
@@ -854,9 +821,14 @@ impl CrucibleEncoder {
      * given our constant MAX_FRM_LEN.
      */
     pub fn max_io_blocks(bs: usize) -> Result<usize, anyhow::Error> {
-        let block_meta = CrucibleEncoder::a_write();
-        let size_of_write_message =
-            CrucibleEncoder::serialized_size(CrucibleEncoder::a_write())? + bs;
+        let ctx = BlockContext {
+            hash: 0,
+            encryption_context: Some(EncryptionContext {
+                nonce: [0; 12],
+                tag: [0; 16],
+            }),
+        };
+        let size_of_write_message = CrucibleEncoder::serialized_size(ctx)? + bs;
 
         // Maximum frame length divided by a write of one block is the lower
         // bound.
@@ -867,7 +839,8 @@ impl CrucibleEncoder {
                 session_id: Uuid::new_v4(),
                 job_id: JobId(1),
                 dependencies: vec![JobId(1)],
-                blocks: vec![block_meta; n],
+                start: BlockIndex(0),
+                contexts: vec![ctx; n],
             },
             data: vec![0; n * bs].into(),
         };
@@ -886,7 +859,8 @@ impl CrucibleEncoder {
                 session_id: Uuid::new_v4(),
                 job_id: JobId(1),
                 dependencies: vec![JobId(1)],
-                blocks: vec![block_meta; n],
+                start: BlockIndex(0),
+                contexts: vec![ctx; n],
             },
             data: vec![0; n * bs].into(),
         };
@@ -900,14 +874,14 @@ impl CrucibleEncoder {
         // given MAX_FRM_LEN.
 
         let mut lower = match lower_size_write_message {
-            Message::Write { header, .. } => header.blocks.len(),
+            Message::Write { header, .. } => header.contexts.len(),
             _ => {
                 bail!("wat");
             }
         };
 
         let mut upper = match upper_size_write_message {
-            Message::Write { header, .. } => header.blocks.len(),
+            Message::Write { header, .. } => header.contexts.len(),
             _ => {
                 bail!("wat");
             }
@@ -926,7 +900,8 @@ impl CrucibleEncoder {
                     session_id: Uuid::new_v4(),
                     job_id: JobId(1),
                     dependencies: vec![JobId(1)],
-                    blocks: vec![block_meta; mid],
+                    start: BlockIndex(0),
+                    contexts: vec![ctx; n],
                 },
                 data: vec![0; mid * bs].into(),
             };
@@ -1257,13 +1232,10 @@ mod tests {
                 session_id: Uuid::new_v4(),
                 job_id: JobId(1),
                 dependencies: vec![],
-                blocks: vec![WriteBlockMetadata {
-                    eid: ExtentId(0),
-                    offset: BlockOffset(0),
-                    block_context: BlockContext {
-                        hash,
-                        encryption_context: None,
-                    },
+                start: BlockIndex(0),
+                contexts: vec![BlockContext {
+                    hash,
+                    encryption_context: None,
                 }],
             },
             data,

--- a/upstairs/src/buffer.rs
+++ b/upstairs/src/buffer.rs
@@ -150,7 +150,7 @@ impl Buffer {
             .blocks
             .iter()
             .enumerate()
-            .group_by(|(_i, b)| b.block_context.is_none())
+            .group_by(|(_i, b)| b.is_none())
         {
             if empty {
                 continue;
@@ -374,8 +374,7 @@ impl UninitializedBuffer {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{BlockContext, BlockOffset, ReadResponseBlockMetadata};
-    use crucible_common::ExtentId;
+    use crate::BlockContext;
     use rand::RngCore;
 
     #[test]
@@ -495,17 +494,15 @@ mod test {
         rng.fill_bytes(&mut data);
 
         let blocks = (0..10)
-            .map(|i| ReadResponseBlockMetadata {
-                eid: ExtentId(0),
-                offset: BlockOffset(i),
-                block_context: if f(i) {
+            .map(|i| {
+                if f(i) {
                     Some(BlockContext {
                         hash: 123,
                         encryption_context: None,
                     })
                 } else {
                     None
-                },
+                }
             })
             .collect();
 
@@ -571,13 +568,11 @@ mod test {
         rng.fill_bytes(&mut data);
 
         let blocks = (0..10)
-            .map(|i| ReadResponseBlockMetadata {
-                eid: ExtentId(0),
-                offset: BlockOffset(i),
-                block_context: Some(BlockContext {
+            .map(|_| {
+                Some(BlockContext {
                     hash: 123,
                     encryption_context: None,
-                }),
+                })
             })
             .collect();
 

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -1350,7 +1350,11 @@ impl DownstairsClient {
                 IOop::Flush { .. } => {
                     self.last_flush = ds_id;
                 }
-                IOop::Read { requests, .. } => {
+                IOop::Read {
+                    start_eid,
+                    start_offset,
+                    ..
+                } => {
                     /*
                      * For a read, make sure the data from a previous read
                      * has the same hash
@@ -1365,14 +1369,15 @@ impl DownstairsClient {
                             "[{}] read hash mismatch on id {}\n\
                             Expected {:x?}\n\
                             Computed {:x?}\n\
-                            guest_id:{} request:{:?}\n\
+                            guest_id:{} start eid:{:?} start offset:{:?}\n\
                             job state:{:?}",
                             self.client_id,
                             ds_id,
                             job.read_validations,
                             read_validations,
                             job.guest_id,
-                            requests,
+                            start_eid,
+                            start_offset,
                             job.state,
                         );
                         if job.replay {

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -19,7 +19,6 @@ use crate::{IO_OUTSTANDING_MAX_BYTES, IO_OUTSTANDING_MAX_JOBS};
 use crucible_client_types::CrucibleOpts;
 use crucible_common::Block;
 use crucible_common::BlockIndex;
-use crucible_common::BlockOffset;
 use crucible_common::ExtentId;
 use crucible_common::RegionDefinition;
 use crucible_common::RegionOptions;
@@ -28,7 +27,6 @@ use crucible_protocol::CrucibleDecoder;
 use crucible_protocol::CrucibleEncoder;
 use crucible_protocol::JobId;
 use crucible_protocol::Message;
-use crucible_protocol::ReadResponseBlockMetadata;
 use crucible_protocol::ReadResponseHeader;
 use crucible_protocol::WriteHeader;
 
@@ -331,7 +329,7 @@ impl DownstairsHandle {
                 upstairs_id,
                 session_id: self.upstairs_session_id.unwrap(),
                 job_id,
-                blocks: Ok(vec![block.clone()]),
+                blocks: Ok(vec![block]),
             },
             data: data.clone(),
         })
@@ -611,19 +609,15 @@ impl TestHarness {
     }
 }
 
-fn make_blank_read_response() -> (ReadResponseBlockMetadata, BytesMut) {
+fn make_blank_read_response() -> (Option<BlockContext>, BytesMut) {
     let data = vec![0u8; 512];
     let hash = crucible_common::integrity_hash(&[&data]);
 
     (
-        ReadResponseBlockMetadata {
-            eid: ExtentId(0),
-            offset: BlockOffset(0),
-            block_context: Some(BlockContext {
-                hash,
-                encryption_context: None,
-            }),
-        },
+        Some(BlockContext {
+            hash,
+            encryption_context: None,
+        }),
         BytesMut::from(&data[..]),
     )
 }
@@ -770,7 +764,7 @@ async fn run_live_repair(mut harness: TestHarness) {
                 upstairs_id,
                 session_id,
                 job_id,
-                blocks: Ok(vec![block.clone()]),
+                blocks: Ok(vec![block]),
             },
             data: data.clone(),
         }) {
@@ -905,7 +899,7 @@ async fn run_live_repair(mut harness: TestHarness) {
                                 upstairs_id: *upstairs_id,
                                 session_id: *session_id,
                                 job_id: *job_id,
-                                blocks: Ok(vec![block.clone()]),
+                                blocks: Ok(vec![block]),
                             },
                             data,
                         });
@@ -951,7 +945,7 @@ async fn run_live_repair(mut harness: TestHarness) {
                             upstairs_id: *upstairs_id,
                             session_id: *session_id,
                             job_id: *job_id,
-                            blocks: Ok(vec![block.clone()]),
+                            blocks: Ok(vec![block]),
                         },
                         data,
                     });
@@ -978,7 +972,7 @@ async fn run_live_repair(mut harness: TestHarness) {
                             upstairs_id: *upstairs_id,
                             session_id: *session_id,
                             job_id: *job_id,
-                            blocks: Ok(vec![block.clone()]),
+                            blocks: Ok(vec![block]),
                         },
                         data,
                     });
@@ -2021,7 +2015,7 @@ async fn test_error_during_live_repair_no_halt() {
                 upstairs_id,
                 session_id,
                 job_id: job_ids[0],
-                blocks: Ok(vec![block.clone()]),
+                blocks: Ok(vec![block]),
             },
             data: data.clone(),
         }) {
@@ -2464,7 +2458,7 @@ async fn test_no_read_only_live_repair() {
                 upstairs_id,
                 session_id,
                 job_id: job_ids[0],
-                blocks: Ok(vec![block.clone()]),
+                blocks: Ok(vec![block]),
             },
             data: data.clone(),
         }) {

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -509,37 +509,31 @@ pub(crate) mod up_test {
         // at extent limit, and above extent limit.
 
         // Below limit
-        let request = ReadRequest {
-            eid: ExtentId(0),
-            offset: BlockOffset(7),
-        };
         let op = IOop::Read {
             dependencies: vec![],
+            start_eid: ExtentId(0),
+            start_offset: BlockOffset(7),
+            count: 1,
             block_size: 512,
-            requests: vec![request],
         };
         assert!(op.send_io_live_repair(Some(ExtentId(2))));
 
         // At limit
-        let request = ReadRequest {
-            eid: ExtentId(2),
-            offset: BlockOffset(7),
-        };
         let op = IOop::Read {
             dependencies: vec![],
+            start_eid: ExtentId(2),
+            start_offset: BlockOffset(7),
+            count: 1,
             block_size: 512,
-            requests: vec![request],
         };
         assert!(op.send_io_live_repair(Some(ExtentId(2))));
 
-        let request = ReadRequest {
-            eid: ExtentId(3),
-            offset: BlockOffset(7),
-        };
         let op = IOop::Read {
             dependencies: vec![],
+            start_eid: ExtentId(3),
+            start_offset: BlockOffset(7),
+            count: 1,
             block_size: 512,
-            requests: vec![request],
         };
         // We are past the extent limit, so this should return false
         assert!(!op.send_io_live_repair(Some(ExtentId(2))));
@@ -550,13 +544,9 @@ pub(crate) mod up_test {
 
     // Construct an IOop::Write or IOop::WriteUnwritten at the given extent
     fn write_at_extent(eid: ExtentId, wu: bool) -> IOop {
-        let request = crucible_protocol::WriteBlockMetadata {
-            eid,
-            offset: BlockOffset(7),
-            block_context: BlockContext {
-                encryption_context: None,
-                hash: 0,
-            },
+        let request = BlockContext {
+            encryption_context: None,
+            hash: 0,
         };
         let data = BytesMut::from(vec![1].as_slice());
         let blocks = vec![request];
@@ -565,12 +555,16 @@ pub(crate) mod up_test {
             IOop::WriteUnwritten {
                 dependencies: vec![],
                 blocks,
+                start_eid: eid,
+                start_offset: BlockOffset(7),
                 data: data.freeze(),
             }
         } else {
             IOop::Write {
                 dependencies: vec![],
                 blocks,
+                start_eid: eid,
+                start_offset: BlockOffset(7),
                 data: data.freeze(),
             }
         }


### PR DESCRIPTION
The `BlockIO` trait only allows us to access contiguous sets of blocks for reading and writing.

However, our internal `Message` type converts these contiguous spans into random-access block lists.  This adds complexity: we have to support the possibility for disjoint operations everywhere, even though they should never actually happen.

This PR changes the `Message` types to accept a starting index + block count (for reads), or a starting index + block and context data (for writes).  In addition, the `ReadResponse` is simplified to not include per-block indexes, because they're implied by the start index + position in the list.

Various tests for disjoint reads and writes are removed.