### PR TITLE
Simplify block context for reads

### DIFF
--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -699,8 +699,10 @@ fn show_extent_block(
         for (dir_index, r) in dvec.iter().enumerate() {
             print!("{:^24} ", dir_index);
 
-            max_nonce_depth =
-                std::cmp::max(max_nonce_depth, r.encryption_contexts(0).len());
+            max_nonce_depth = std::cmp::max(
+                max_nonce_depth,
+                r.encryption_contexts(0).is_some() as usize,
+            );
         }
         if !only_show_differences {
             print!(" {:<5}", "DIFF");
@@ -722,17 +724,14 @@ fn show_extent_block(
             let mut all_same_len = true;
             let mut nonces = Vec::with_capacity(dir_count);
             for r in dvec.iter() {
-                let ctxs = r.encryption_contexts(0);
+                // TODO this can only be 0 or 1
+                let ctxs =
+                    r.encryption_contexts(0).into_iter().collect::<Vec<_>>();
                 print!(
                     "{:^24} ",
                     if depth < ctxs.len() {
-                        if let Some(ec) = ctxs[depth] {
-                            nonces.push(&ec.nonce);
-                            hex::encode(ec.nonce)
-                        } else {
-                            all_same_len = false;
-                            "".to_string()
-                        }
+                        nonces.push(ctxs[depth].nonce);
+                        hex::encode(ctxs[depth].nonce)
                     } else {
                         all_same_len = false;
                         "".to_string()
@@ -756,8 +755,10 @@ fn show_extent_block(
         for (dir_index, r) in dvec.iter().enumerate() {
             print!("{:^32} ", dir_index);
 
-            max_tag_depth =
-                std::cmp::max(max_tag_depth, r.encryption_contexts(0).len());
+            max_tag_depth = std::cmp::max(
+                max_tag_depth,
+                r.encryption_contexts(0).is_some() as usize,
+            );
         }
         if !only_show_differences {
             print!(" {:<5}", "DIFF");
@@ -779,17 +780,13 @@ fn show_extent_block(
             let mut all_same_len = true;
             let mut tags = Vec::with_capacity(dir_count);
             for r in dvec.iter() {
-                let ctxs = r.encryption_contexts(0);
+                let ctxs =
+                    r.encryption_contexts(0).into_iter().collect::<Vec<_>>();
                 print!(
                     "{:^32} ",
                     if depth < ctxs.len() {
-                        if let Some(ec) = ctxs[depth] {
-                            tags.push(&ec.tag);
-                            hex::encode(ec.tag)
-                        } else {
-                            all_same_len = false;
-                            "".to_string()
-                        }
+                        tags.push(ctxs[depth].tag);
+                        hex::encode(ctxs[depth].tag)
                     } else {
                         all_same_len = false;
                         "".to_string()
@@ -820,7 +817,8 @@ fn show_extent_block(
         for (dir_index, r) in dvec.iter().enumerate() {
             print!("{:^16} ", dir_index);
 
-            max_hash_depth = std::cmp::max(max_hash_depth, r.hashes(0).len());
+            max_hash_depth =
+                std::cmp::max(max_hash_depth, r.hashes(0).is_some() as usize);
         }
         if !only_show_differences {
             print!(" {:<5}", "DIFF");
@@ -842,7 +840,7 @@ fn show_extent_block(
             let mut all_same_len = true;
             let mut hashes = Vec::with_capacity(dir_count);
             for r in dvec.iter() {
-                let block_hashes = r.hashes(0);
+                let block_hashes = r.hashes(0).into_iter().collect::<Vec<_>>();
                 print!(
                     "{:^16} ",
                     if depth < block_hashes.len() {

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -2956,12 +2956,14 @@ pub(crate) fn validate_encrypted_read_response(
         }
     };
 
-    // We'll start with decryption, ignoring the hash; we're using authenticated
-    // encryption, so the check is just as strong as the hash check.
+    // We're using authenticated encryption, so if it decrypts correctly, we can
+    // be confident that it wasn't corrupted.  Corruption either on-disk
+    // (unlikely due to ZFS) or in-transit (unlikely-ish due to TCP checksums)
+    // will both result in decryption failure; we can't tell these cases apart.
     //
-    // Note: decrypt_in_place does not overwrite the buffer if
-    // it fails, otherwise we would need to copy here. There's a
-    // unit test to validate this behaviour.
+    // Note: decrypt_in_place does not overwrite the buffer if it fails,
+    // otherwise we would need to copy here. There's a unit test to validate
+    // this behaviour.
     use aes_gcm_siv::{Nonce, Tag};
     let decryption_result = encryption_context.decrypt_in_place(
         data,

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -10,7 +10,7 @@ use crucible_common::{
     deadline_secs, verbose_timeout, x509::TLSContext, ExtentId,
 };
 use crucible_protocol::{
-    BlockContext, MessageWriter, ReconciliationId, CRUCIBLE_MESSAGE_VERSION,
+    MessageWriter, ReconciliationId, CRUCIBLE_MESSAGE_VERSION,
 };
 
 use std::{
@@ -2923,7 +2923,7 @@ fn update_net_done_probes(m: &Message, cid: ClientId) {
 /// The return value of this will be stored with the job, and compared
 /// between each read.
 pub(crate) fn validate_encrypted_read_response(
-    block_context: Option<BlockContext>,
+    block_context: Option<crucible_protocol::EncryptionContext>,
     data: &mut [u8],
     encryption_context: &EncryptionContext,
     log: &Logger,
@@ -2937,7 +2937,7 @@ pub(crate) fn validate_encrypted_read_response(
     // check that this read response contains block contexts that contain
     // a matching encryption context.
 
-    let Some(context) = block_context else {
+    let Some(ctx) = block_context else {
         // No block context(s) in the response!
         //
         // Either this is a read of an unwritten block, or an attacker
@@ -2956,11 +2956,6 @@ pub(crate) fn validate_encrypted_read_response(
         }
     };
 
-    let Some(block_encryption_ctx) = &context.encryption_context else {
-        // this block context is missing an encryption context!
-        return Err(CrucibleError::DecryptionError);
-    };
-
     // We'll start with decryption, ignoring the hash; we're using authenticated
     // encryption, so the check is just as strong as the hash check.
     //
@@ -2970,35 +2965,14 @@ pub(crate) fn validate_encrypted_read_response(
     use aes_gcm_siv::{Nonce, Tag};
     let decryption_result = encryption_context.decrypt_in_place(
         data,
-        Nonce::from_slice(&block_encryption_ctx.nonce[..]),
-        Tag::from_slice(&block_encryption_ctx.tag[..]),
+        Nonce::from_slice(&ctx.nonce[..]),
+        Tag::from_slice(&ctx.tag[..]),
     );
     if decryption_result.is_ok() {
-        Ok(Validation::Encrypted(*block_encryption_ctx))
+        Ok(Validation::Encrypted(ctx))
     } else {
-        // Validate integrity hash before decryption
-        let computed_hash = integrity_hash(&[
-            &block_encryption_ctx.nonce[..],
-            &block_encryption_ctx.tag[..],
-            data,
-        ]);
-
-        if computed_hash == context.hash {
-            // No encryption context combination decrypted this block, but
-            // one valid hash was found. This can occur if the decryption
-            // key doesn't match the key that the data was encrypted with.
-            error!(log, "Decryption failed with correct hash");
-            Err(CrucibleError::DecryptionError)
-        } else {
-            error!(
-                log,
-                "No match for integrity hash\n\
-             Expected: 0x{:x} != Computed: 0x{:x}",
-                context.hash,
-                computed_hash
-            );
-            Err(CrucibleError::HashMismatch)
-        }
+        error!(log, "Decryption failed!");
+        Err(CrucibleError::DecryptionError)
     }
 }
 
@@ -3008,20 +2982,20 @@ pub(crate) fn validate_encrypted_read_response(
 ///   block is all 0
 /// - Err otherwise
 pub(crate) fn validate_unencrypted_read_response(
-    block_context: Option<BlockContext>,
+    block_hash: Option<u64>,
     data: &mut [u8],
     log: &Logger,
 ) -> Result<Validation, CrucibleError> {
-    if let Some(context) = block_context {
+    if let Some(hash) = block_hash {
         // check integrity hashes - make sure it is correct
         let computed_hash = integrity_hash(&[data]);
 
-        if computed_hash == context.hash {
+        if computed_hash == hash {
             Ok(Validation::Unencrypted(computed_hash))
         } else {
             // No integrity hash was correct for this response
             error!(log, "No match computed hash:0x{:x}", computed_hash,);
-            error!(log, "No match          hash:0x{:x}", context.hash);
+            error!(log, "No match          hash:0x{:x}", hash);
             error!(log, "Data from hash:");
             for (i, d) in data[..6].iter().enumerate() {
                 error!(log, "[{i}]:{d}");

--- a/upstairs/src/deferred.rs
+++ b/upstairs/src/deferred.rs
@@ -7,7 +7,7 @@ use crate::{
     BlockRes, ClientId, ImpactedBlocks, Message, RawWrite, Validation,
 };
 use bytes::BytesMut;
-use crucible_common::{integrity_hash, RegionDefinition};
+use crucible_common::{integrity_hash, CrucibleError, RegionDefinition};
 use crucible_protocol::ReadBlockContext;
 use futures::{
     future::{ready, Either, Ready},
@@ -234,42 +234,48 @@ impl DeferredRead {
             let block_size = data.len() / rs.len();
             for (i, r) in rs.iter_mut().enumerate() {
                 let v = if let Some(ctx) = &self.cfg.encryption_context {
-                    let r = match r {
-                        ReadBlockContext::Empty => None,
+                    match r {
+                        ReadBlockContext::Empty => Ok(None),
+                        ReadBlockContext::Encrypted { ctx } => Ok(Some(*ctx)),
                         ReadBlockContext::Unencrypted { .. } => {
                             error!(
                                 self.log,
                                 "expected encrypted but got unencrypted \
                                  block context"
                             );
-                            None
+                            Err(CrucibleError::MissingBlockContext)
                         }
-                        ReadBlockContext::Encrypted { ctx } => Some(*ctx),
-                    };
-                    validate_encrypted_read_response(
-                        r,
-                        &mut data[i * block_size..][..block_size],
-                        ctx,
-                        &self.log,
-                    )
+                    }
+                    .and_then(|r| {
+                        validate_encrypted_read_response(
+                            r,
+                            &mut data[i * block_size..][..block_size],
+                            ctx,
+                            &self.log,
+                        )
+                    })
                 } else {
-                    let r = match r {
-                        ReadBlockContext::Empty => None,
+                    match r {
+                        ReadBlockContext::Empty => Ok(None),
+                        ReadBlockContext::Unencrypted { hash } => {
+                            Ok(Some(*hash))
+                        }
                         ReadBlockContext::Encrypted { .. } => {
                             error!(
                                 self.log,
                                 "expected unencrypted but got encrypted \
                                  block context"
                             );
-                            None
+                            Err(CrucibleError::MissingBlockContext)
                         }
-                        ReadBlockContext::Unencrypted { hash } => Some(*hash),
-                    };
-                    validate_unencrypted_read_response(
-                        r,
-                        &mut data[i * block_size..][..block_size],
-                        &self.log,
-                    )
+                    }
+                    .and_then(|r| {
+                        validate_unencrypted_read_response(
+                            r,
+                            &mut data[i * block_size..][..block_size],
+                            &self.log,
+                        )
+                    })
                 };
                 match v {
                     Ok(hash) => hashes.push(hash),

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -4514,7 +4514,7 @@ pub(crate) mod test {
 
     use bytes::BytesMut;
     use crucible_common::{BlockOffset, ExtentId};
-    use crucible_protocol::{BlockContext, Message};
+    use crucible_protocol::{Message, ReadBlockContext};
     use ringbuffer::RingBuffer;
 
     use std::{
@@ -4528,10 +4528,9 @@ pub(crate) mod test {
     pub fn build_read_response(data: &[u8]) -> RawReadResponse {
         RawReadResponse {
             data: BytesMut::from(data),
-            blocks: vec![Some(BlockContext {
+            blocks: vec![ReadBlockContext::Unencrypted {
                 hash: crucible_common::integrity_hash(&[data]),
-                encryption_context: None,
-            })],
+            }],
         }
     }
 

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -10,7 +10,6 @@ use std::time::Duration;
 use crate::client::CLIENT_TIMEOUT_SECS;
 use crate::guest::Guest;
 use crate::up_main;
-use crate::BlockContext;
 use crate::BlockIO;
 use crate::Buffer;
 use crate::CrucibleError;
@@ -27,6 +26,7 @@ use crucible_protocol::CrucibleDecoder;
 use crucible_protocol::CrucibleEncoder;
 use crucible_protocol::JobId;
 use crucible_protocol::Message;
+use crucible_protocol::ReadBlockContext;
 use crucible_protocol::ReadResponseHeader;
 use crucible_protocol::WriteHeader;
 
@@ -609,15 +609,12 @@ impl TestHarness {
     }
 }
 
-fn make_blank_read_response() -> (Option<BlockContext>, BytesMut) {
+fn make_blank_read_response() -> (ReadBlockContext, BytesMut) {
     let data = vec![0u8; 512];
     let hash = crucible_common::integrity_hash(&[&data]);
 
     (
-        Some(BlockContext {
-            hash,
-            encryption_context: None,
-        }),
+        ReadBlockContext::Unencrypted { hash },
         BytesMut::from(&data[..]),
     )
 }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -668,7 +668,7 @@ impl RegionDefinitionStatus {
 #[derive(Debug, Default)]
 pub(crate) struct RawReadResponse {
     /// Per-block metadata
-    pub blocks: Vec<Option<BlockContext>>,
+    pub blocks: Vec<ReadBlockContext>,
     /// Raw data
     pub data: bytes::BytesMut,
 }

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -377,29 +377,21 @@ pub(crate) mod up_test {
 
         assert_ne!(original_data, data);
 
-        let read_response_hash = integrity_hash(&[&nonce, &tag, &data[..]]);
-
-        // Create the read response
-        let block_context = BlockContext {
-            hash: read_response_hash,
-            encryption_context: Some(crucible_protocol::EncryptionContext {
-                nonce: nonce.into(),
-                tag: tag.into(),
-            }),
+        // Create the read response context
+        let ctx = crucible_protocol::EncryptionContext {
+            nonce: nonce.into(),
+            tag: tag.into(),
         };
 
         // Validate it
         let successful_hash = validate_encrypted_read_response(
-            Some(block_context),
+            Some(ctx),
             &mut data,
             &Arc::new(context),
             &csl(),
         )?;
 
-        assert_eq!(
-            successful_hash,
-            Validation::Encrypted(block_context.encryption_context.unwrap())
-        );
+        assert_eq!(successful_hash, Validation::Encrypted(ctx));
 
         // `validate_encrypted_read_response` will mutate the read
         // response's data value, make sure it decrypted
@@ -463,15 +455,9 @@ pub(crate) mod up_test {
         let read_response_hash = integrity_hash(&[&data[..]]);
         let original_data = data.clone();
 
-        // Create the read response
-        let block_context = BlockContext {
-            hash: read_response_hash,
-            encryption_context: None,
-        };
-
         // Validate it
         let successful_hash = validate_unencrypted_read_response(
-            Some(block_context),
+            Some(read_response_hash),
             &mut data,
             &csl(),
         )?;


### PR DESCRIPTION
Right now, the `ReadResponse` sends back a `Vec<Option<BlockContext>>`, i.e. an `Option<BlockContext>` for each block.  The `BlockContext` in turn contains

```rust
pub struct BlockContext {
    pub hash: u64,
    pub encryption_context: Option<EncryptionContext>,
}
```

If `encryption_context` is populated, then sending `hash` to the Upstairs is unnecessary: we are using authenticated encryption, so we know whether the block data + context is valid based on whether it decrypted successfully.

This PR removes `hash` from the `ReadResponse` message in favor of a new `enum`:
```rust
#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
pub enum ReadBlockContext {
    Empty,
    Encrypted { ctx: EncryptionContext },
    Unencrypted { hash: u64 },
}
```

This does not change the on-disk format or write message format, which both continue to use hashes:

- When  **sending** data to the Downstairs, the hash (in `BlockContext`) lets us detect corruption in transit.  We can't use the encryption context here, because the Downstairs isn't allowed to have encryption keys
- When recovering from a bad write, `on_disk_hash` is used to figure out which context slot is valid.  `on_disk_hash` is never sent over the network¹

This PR is a step towards [RFD 490 § Metadata reduction](https://rfd.shared.oxide.computer/rfd/490#_metadata_reduction), which proposes to **not** store block hashes for encrypted data on disk.  If in the future we don't store block hashes for encrypted data, we would not be able to send them over the network; this PR removes that future hurdle.

However, the PR stands alone as a small optimization (39 → 32 bytes per block) that simplifies program behavior (no need to think about what happens if encryption fails but the hash matches, or vice versa).

¹ `on_disk_hash` is also _technically_ superfluous if we already have `hash` (see https://github.com/oxidecomputer/crucible/issues/1161), but this PR doesn't change it