### PR TITLE
Remember that a replaced downstairs is replaced

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,6 +1252,7 @@ dependencies = [
  "scopeguard",
  "semver 1.0.23",
  "serde",
+ "serde_json",
  "slog",
  "spin 0.9.8",
  "syn 2.0.71",

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -527,8 +527,7 @@ impl DownstairsClient {
 
             DsState::Faulted
             | DsState::LiveRepair
-            | DsState::LiveRepairReady
-            | DsState::Replaced => DsState::Faulted,
+            | DsState::LiveRepairReady => DsState::Faulted,
 
             DsState::New
             | DsState::Deactivated
@@ -541,7 +540,8 @@ impl DownstairsClient {
             | DsState::WaitActive
             | DsState::Disabled => DsState::Disconnected,
 
-            DsState::Replacing => DsState::Replaced,
+            // If we have replaced a downstairs, don't forget that.
+            DsState::Replacing | DsState::Replaced => DsState::Replaced,
 
             DsState::Migrating => panic!(),
         };


### PR DESCRIPTION
Leave a downstairs in state Replaced after a replacement request until we connect to the new downstairs and either validate it is correct or determine it is bad.

This fixes a bug where a replaced downstairs would go to failed, then cause problems when we eventually connect to that downstairs.

Fix for: https://github.com/oxidecomputer/crucible/issues/1425