### PR TITLE
Update oximeter dependency

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.80.0"
 profile = "default"


### PR DESCRIPTION
- Also updates other omicron deps that come along for the ride
- Updates the pinned toolchain, which is required for the version of `parse-display` that is used here.