### PR TITLE
Remove `Replay` state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,6 +1252,7 @@ dependencies = [
  "scopeguard",
  "semver 1.0.23",
  "serde",
+ "serde_json",
  "slog",
  "spin 0.9.8",
  "syn 2.0.71",

--- a/cmon/src/main.rs
+++ b/cmon/src/main.rs
@@ -103,7 +103,6 @@ fn short_state(dss: DsState) -> String {
         DsState::LiveRepair => "LR".to_string(),
         DsState::Migrating => "MIG".to_string(),
         DsState::Offline => "OFF".to_string(),
-        DsState::Replay => "REP".to_string(),
         DsState::Deactivated => "DAV".to_string(),
         DsState::Disabled => "DIS".to_string(),
         DsState::Replacing => "RPC".to_string(),

--- a/openapi/crucible-control.json
+++ b/openapi/crucible-control.json
@@ -104,7 +104,6 @@
           "live_repair",
           "migrating",
           "offline",
-          "replay",
           "deactivated",
           "disabled",
           "replacing",

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -714,15 +714,15 @@ pub(crate) struct RawReadResponse {
  *              │     ▼   ▼   ▲    ▲                     ║     │
  *              │     │   │   │    │                     ║     │
  *              │     │   │   │    │                     ║     │
- *              │     │   │   ▲  ┌─┘                     ║     │
- *              │     │   │ ┌─┴──┴──┐                    ║     │
- *              │     │   │ │Replay │                    ║     │
- *              │     │   │ │       ├─►─┐                ║     │
- *              │     │   │ └─┬──┬──┘   │                ║     │
- *              │     │   ▼   ▼  ▲      │                ║     │
- *              │     │   │   │  │      │                ▲     │
- *              │     │ ┌─┴───┴──┴──┐   │   ┌────────────╨──┐  │
- *              │     │ │  Offline  │   └─►─┤   Faulted     │  │
+ *              │     │   │   │    │                     ║     │
+ *              │     │   │   │    │                     ║     │
+ *              │     │   │   │    │                     ║     │
+ *              │     │   │   │    │                     ║     │
+ *              │     │   │   │    │                     ║     │
+ *              │     │   ▼   ▲    ▲                     ║     │
+ *              │     │   │   │    │                     ▲     │
+ *              │     │ ┌─┴───┴────┴┐       ┌────────────╨──┐  │
+ *              │     │ │  Offline  │       │   Faulted     │  │
  *              │     │ │           ├─────►─┤               │  │
  *              │     │ └───────────┘       └─┬─┬───────┬─┬─┘  │
  *              │     │                       ▲ ▲       ▼ ▲    ▲
@@ -813,11 +813,6 @@ pub enum DsState {
      */
     Offline,
     /*
-     * This downstairs was offline but is now back online and we are
-     * sending it all the I/O it missed when it was unavailable.
-     */
-    Replay,
-    /*
      * A guest requested deactivation, this downstairs has completed all
      * its outstanding work and is now waiting for the upstairs to
      * transition back to initializing.
@@ -882,9 +877,6 @@ impl std::fmt::Display for DsState {
             }
             DsState::Offline => {
                 write!(f, "Offline")
-            }
-            DsState::Replay => {
-                write!(f, "Replay")
             }
             DsState::Deactivated => {
                 write!(f, "Deactivated")


### PR DESCRIPTION
We never actually dwell in the `Replay` state; we enter `Replay` then immediately enter `Active` one line later.

The actual work of replaying jobs is done elsewhere, in `Downstairs::reinitialize`.  As such, the `Replay` state doesn't need to exist, and is kinda misleading; for example, we can't actually transition from `Replay` to `Faulted` or `Deactivated`, despite the flow diagram.