### PR TITLE
Update itertools to 13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,7 +846,7 @@ dependencies = [
  "http 0.2.12",
  "humantime",
  "internal-dns",
- "itertools",
+ "itertools 0.13.0",
  "libc",
  "nexus-client",
  "omicron-common",
@@ -1003,7 +1003,7 @@ dependencies = [
  "http 0.2.12",
  "hyper",
  "hyper-staticfile",
- "itertools",
+ "itertools 0.13.0",
  "libc",
  "mime_guess",
  "nix 0.29.0",
@@ -1283,7 +1283,7 @@ dependencies = [
  "crucible-workspace-hack",
  "futures",
  "futures-core",
- "itertools",
+ "itertools 0.13.0",
  "ringbuffer",
  "serde",
  "serde_json",
@@ -2461,6 +2461,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -4080,7 +4089,7 @@ dependencies = [
  "chrono",
  "crossterm",
  "fd-lock",
- "itertools",
+ "itertools 0.12.1",
  "nu-ansi-term 0.50.0",
  "serde",
  "strip-ansi-escapes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ humantime = "2.1.0"
 hyper = { version = "0.14", features = [ "full" ] }
 hyper-staticfile = "0.9.6"
 indicatif = { version = "0.17.8", features = ["rayon"] }
-itertools = "0.12.1"
+itertools = "0.13.0"
 libc = "0.2"
 mime_guess = "2.0.5"
 nbd = "0.3.1"

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -838,7 +838,7 @@ impl RawInner {
         let mut writes = 0u64;
         for (slot, group) in block_contexts
             .iter()
-            .group_by(|block_context| {
+            .chunk_by(|block_context| {
                 // We'll be writing to the inactive slot
                 !self.active_context[block_context.block as usize]
             })
@@ -911,7 +911,7 @@ impl RawInner {
         let mut out = Vec::with_capacity(count as usize);
         let mut reads = 0u64;
         for (slot, group) in (block..block + count)
-            .group_by(|block| self.active_context[*block as usize])
+            .chunk_by(|block| self.active_context[*block as usize])
             .into_iter()
         {
             let mut group = group.peekable();
@@ -943,7 +943,7 @@ impl RawInner {
         // Perform writes, which may be broken up by skipped blocks
         let block_size = self.extent_size.block_size_in_bytes() as u64;
         for (skip, mut group) in (0..write.block_contexts.len())
-            .group_by(|i| writes_to_skip.contains(i))
+            .chunk_by(|i| writes_to_skip.contains(i))
             .into_iter()
         {
             if skip {

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -527,7 +527,7 @@ impl SqliteMoreInner {
 
         // Perform writes, which may be broken up by skipped blocks
         for (skip, mut group) in (0..write.block_contexts.len())
-            .group_by(|i| writes_to_skip.contains(i))
+            .chunk_by(|i| writes_to_skip.contains(i))
             .into_iter()
         {
             if skip {

--- a/upstairs/src/buffer.rs
+++ b/upstairs/src/buffer.rs
@@ -151,7 +151,7 @@ impl Buffer {
             .blocks
             .iter()
             .enumerate()
-            .group_by(|(_i, b)| matches!(b, ReadBlockContext::Empty))
+            .chunk_by(|(_i, b)| matches!(b, ReadBlockContext::Empty))
         {
             if empty {
                 continue;


### PR DESCRIPTION
Replaced deprecated group_by() with suggested replacement chunk_by()

https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.group_by