### PR TITLE
clippy lints for rust 1.80.0

### DIFF
--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -335,7 +335,7 @@ impl DataFile {
         /*
          * Look for an existing running snapshot.
          */
-        if inner.running_snapshots.get(&request.id).is_none() {
+        if !inner.running_snapshots.contains_key(&request.id) {
             bail!("no running snapshots for region {}", request.id.0);
         }
 

--- a/agent/src/smf_interface.rs
+++ b/agent/src/smf_interface.rs
@@ -93,6 +93,7 @@ pub trait SmfInstance {
     >;
     fn disable(&self, temporary: bool) -> Result<(), crucible_smf::ScfError>;
     fn enable(&self, temporary: bool) -> Result<(), crucible_smf::ScfError>;
+    #[cfg(test)]
     fn enabled(&self) -> bool;
 
     fn get_pg(
@@ -146,6 +147,7 @@ impl<'a> SmfInstance for RealSmfInstance<'a> {
         self.inst.enable(temporary)
     }
 
+    #[cfg(test)]
     fn enabled(&self) -> bool {
         unimplemented!();
     }
@@ -355,6 +357,7 @@ impl<'a> SmfTransaction for RealSmfTransaction<'a> {
 }
 
 #[derive(Debug)]
+#[cfg(test)]
 pub struct MockSmf {
     scope: String,
 
@@ -362,8 +365,8 @@ pub struct MockSmf {
     config: Mutex<HashMap<String, MockSmfInstance>>,
 }
 
+#[cfg(test)]
 impl MockSmf {
-    #[cfg(test)]
     pub fn new(scope: String) -> MockSmf {
         MockSmf {
             scope,
@@ -371,12 +374,12 @@ impl MockSmf {
         }
     }
 
-    #[cfg(test)]
     pub fn config_is_empty(&self) -> bool {
         self.config.lock().unwrap().is_empty()
     }
 }
 
+#[cfg(test)]
 impl PartialEq for MockSmf {
     fn eq(&self, other: &Self) -> bool {
         let lhs = self.config.lock().unwrap();
@@ -386,6 +389,7 @@ impl PartialEq for MockSmf {
     }
 }
 
+#[cfg(test)]
 impl SmfInterface for MockSmf {
     fn instances(
         &self,
@@ -435,7 +439,6 @@ impl SmfInterface for MockSmf {
     /// datafile, disabled stuff remains in the current SMF interface and will
     /// cause PartialEq comparison to fail. Prune that here so that comparison
     /// can be done.
-    #[cfg(test)]
     fn prune(&self) {
         let mut config = self.config.lock().unwrap();
         let pairs: Vec<(String, MockSmfInstance)> = config.drain().collect();
@@ -542,6 +545,7 @@ impl SmfInstance for MockSmfInstance {
         Ok(())
     }
 
+    #[cfg(test)]
     fn enabled(&self) -> bool {
         self.inner.lock().unwrap().enabled
     }

--- a/agent/src/snapshot_interface.rs
+++ b/agent/src/snapshot_interface.rs
@@ -3,8 +3,10 @@
 use super::model::*;
 use anyhow::{bail, Result};
 use slog::{error, info, Logger};
+#[cfg(test)]
 use std::collections::HashSet;
 use std::process::Command;
+#[cfg(test)]
 use std::sync::Mutex;
 
 use chrono::{TimeZone, Utc};
@@ -201,13 +203,14 @@ impl SnapshotInterface for ZfsSnapshotInterface {
     }
 }
 
+#[cfg(test)]
 pub struct TestSnapshotInterface {
     log: Logger,
     snapshots: Mutex<HashSet<String>>,
 }
 
+#[cfg(test)]
 impl TestSnapshotInterface {
-    #[cfg(test)]
     pub fn new(log: Logger) -> TestSnapshotInterface {
         TestSnapshotInterface {
             log,
@@ -216,6 +219,7 @@ impl TestSnapshotInterface {
     }
 }
 
+#[cfg(test)]
 impl SnapshotInterface for TestSnapshotInterface {
     fn get_snapshots_for_dataset(
         &self,

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -529,6 +529,7 @@ impl RawInner {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(true)
             .open(&path)?;
 
         // All 0s are fine for everything except extent version in the metadata

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -718,6 +718,7 @@ impl SqliteMoreInner {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(true)
             .open(&path)?;
 
         file.set_len(size)?;
@@ -1002,8 +1003,7 @@ impl SqliteMoreInner {
     /// unadorned variant should be called instead.
     fn truncate_encryption_contexts_and_hashes_with_tx(
         &self,
-        extent_block_indexes_and_hashes: impl Iterator<Item = (usize, u64)>
-            + ExactSizeIterator,
+        extent_block_indexes_and_hashes: impl ExactSizeIterator<Item = (usize, u64)>,
         tx: &Transaction,
     ) -> Result<()> {
         let n_blocks = extent_block_indexes_and_hashes.len();

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1,6 +1,4 @@
 // Copyright 2023 Oxide Computer Company
-#![cfg_attr(usdt_need_asm, feature(asm))]
-#![cfg_attr(all(target_os = "macos", usdt_need_asm_sym), feature(asm_sym))]
 
 use futures::lock::Mutex;
 use std::cmp::Ordering;
@@ -2438,7 +2436,7 @@ impl Downstairs {
                         .unwrap();
 
                     let active_upstairs_connection = self.connection_state
-                        [&active_id]
+                        [active_id]
                         .upstairs_connection()
                         .expect("bad ConnectionId for active connection");
                     warn!(
@@ -2539,7 +2537,7 @@ impl Downstairs {
     fn is_active(&self, connection: UpstairsConnection) -> bool {
         let uuid = connection.upstairs_id;
         if let Some(id) = self.active_upstairs.get(&uuid) {
-            self.connection_state[&id].upstairs_connection() == Some(connection)
+            self.connection_state[id].upstairs_connection() == Some(connection)
         } else {
             false
         }

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -1,6 +1,4 @@
 // Copyright 2023 Oxide Computer Company
-#![cfg_attr(usdt_need_asm, feature(asm))]
-#![cfg_attr(all(target_os = "macos", usdt_need_asm_sym), feature(asm_sym))]
 
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -769,10 +769,10 @@ impl Region {
                         integrity_hash(&[
                             &encryption_context.nonce[..],
                             &encryption_context.tag[..],
-                            &block,
+                            block,
                         ])
                     } else {
-                        integrity_hash(&[&block])
+                        integrity_hash(&[block])
                     };
 
                 if computed_hash != ctx.hash {
@@ -1098,6 +1098,7 @@ impl Region {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(true)
             .open(&copy_path)?;
         Ok(file)
     }

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -2408,14 +2408,18 @@ pub(crate) enum ClientRunResult {
     /// The initial connection timed out
     ConnectionTimeout,
     /// We failed to make the initial connection
+    #[allow(dead_code)]
     ConnectionFailed(std::io::Error),
     /// We experienced a timeout after connecting
     Timeout,
     /// A socket write failed
+    #[allow(dead_code)]
     WriteFailed(anyhow::Error),
     /// We received an error while reading from the connection
+    #[allow(dead_code)]
     ReadFailed(anyhow::Error),
     /// The `DownstairsClient` requested that the task stop, so it did
+    #[allow(dead_code)]
     RequestedStop(ClientStopReason),
     /// The socket closed cleanly and the task exited
     Finished,

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -3316,10 +3316,7 @@ impl Downstairs {
         ds_id: JobId,
         client_id: ClientId,
     ) -> Option<CrucibleError> {
-        let Some(job) = self.ds_active.get(&ds_id) else {
-            return None;
-        };
-
+        let job = self.ds_active.get(&ds_id)?;
         let state = &job.state[client_id];
 
         if let IOState::Error(e) = state {

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1,6 +1,4 @@
 // Copyright 2023 Oxide Computer Company
-#![cfg_attr(usdt_need_asm, feature(asm))]
-#![cfg_attr(all(target_os = "macos", usdt_need_asm_sym), feature(asm_sym))]
 #![allow(clippy::mutex_atomic)]
 
 use std::clone::Clone;

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -378,11 +378,7 @@ impl Volume {
         if let Some(ref read_only_parent) = self.read_only_parent {
             // If requested, setup the pause between IOs as well as an initial
             // waiting period before the scrubber starts.
-            let pause_millis = if let Some(scrub_pause) = scrub_pause {
-                scrub_pause
-            } else {
-                0
-            };
+            let pause_millis = scrub_pause.unwrap_or(0);
 
             if let Some(start_delay) = start_delay {
                 info!(


### PR DESCRIPTION
These are fixes to clippy lints now that we bumped the toolchain to 1.80.0

The one place I was unsure about was the `enum ClientRunResult` in `upstairs/src/client.rs`.  We don't ever actually look at the value inside some of the members of the enum.  For example, `ConnectionFailed(std::io::Error),` we include the error, but never print or display it, and it's stripped out in `notify_nexus_of_client_task_stopped()`, which is also behind a feature flag so a default `cargo clippy` won't even consider that code path if we did print it.

So, I just put `#[allow(dead_code)]` around the members that clippy complained about, but I'm open to other suggestions or better ways of telling clippy to chill.   I do think leaving the additional data has value even if we don't use it now. 