### PR TITLE
Make build / test consistent in buildomat

### DIFF
--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -72,7 +72,7 @@ banner rbuild
 ptime -m cargo build --verbose --release --all-features
 
 banner rtest
-ptime -m cargo test --verbose -- --nocapture > /tmp/cargo-test-out.log 2>&1
+ptime -m cargo test --verbose --release --all-features -- --nocapture > /tmp/cargo-test-out.log 2>&1
 
 banner output
 mkdir -p /work/rbins

--- a/.github/buildomat/jobs/build.sh
+++ b/.github/buildomat/jobs/build.sh
@@ -28,7 +28,7 @@ pfexec coreadm -i /tmp/core.%f.%p \
  -e global-setid
 
 banner build
-ptime -m cargo build --verbose
+ptime -m cargo build --verbose --all-features
 
 banner output
 
@@ -50,4 +50,4 @@ echo in_work_bins
 ls -l /work/bins
 
 banner test
-ptime -m cargo test --verbose -- --nocapture > /tmp/cargo-test-out.log 2>&1
+ptime -m cargo test --verbose --all-features -- --nocapture > /tmp/cargo-test-out.log 2>&1


### PR DESCRIPTION
- `build-release.sh` was already building with `--all-features,` but it should also run tests with `--release --all-features`
- `build.sh` should both build and run tests with `--all-features`

Using `--all-features` means we'll get `omicron-build` once #1427 is merged and will start testing `syncfs`