### PR TITLE
Adjust backpressure tuning

### DIFF
--- a/upstairs/src/backpressure.rs
+++ b/upstairs/src/backpressure.rs
@@ -139,7 +139,7 @@ impl BackpressureChannelConfig {
         let v = if frac < 1.0 {
             frac
         } else {
-            (1.0 / (2.0 - frac)).max(MAX_MUL)
+            (1.0 / (2.0 - frac)).min(MAX_MUL)
         };
 
         BackpressureAmount::Duration(self.scale.mul_f64(v))

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -89,13 +89,13 @@ use upstairs::{UpCounters, UpstairsAction};
 ///
 /// If we exceed this value, the upstairs will give
 /// up and mark the offline downstairs as faulted.
-const IO_OUTSTANDING_MAX_BYTES: u64 = 1024 * 1024 * 1024; // 1 GiB
+const IO_OUTSTANDING_MAX_BYTES: u64 = 32 * 1024u64.pow(2); // 32 MiB
 
 /// Max number of outstanding IOs between the upstairs and an offline downstairs
 ///
 /// If we exceed this value, the upstairs will give up and mark that offline
 /// downstairs as faulted.
-pub const IO_OUTSTANDING_MAX_JOBS: usize = 10000;
+pub const IO_OUTSTANDING_MAX_JOBS: usize = 1000;
 
 /// The BlockIO trait behaves like a physical NVMe disk (or a virtio virtual
 /// disk): there is no contract about what order operations that are submitted


### PR DESCRIPTION
Testing with `crutest bufferbloat` reveals that we can get multi-second delays if we send a single read after filling up the write queues.

This PR turns up backpressure gain to make steady-state queue lengths less egregiously long.

I've done some casual testing, and now see turnaround times in the 10-100s of milliseconds.  @faithanalog it would be great to get an `iodriver` run on this PR as well.

