### PR TITLE
Remove optionality for `BlockRes` in `DeferredWrite`

### DIFF
--- a/upstairs/src/block_req.rs
+++ b/upstairs/src/block_req.rs
@@ -24,6 +24,12 @@ impl<T, E> BlockRes<T, E> {
         // XXX this eats the result!
         let _ = self.0.take().expect("sender was populated").send(result);
     }
+
+    /// Builds an empty `BlockRes`, for use in unit testing
+    #[cfg(test)]
+    pub fn dummy() -> Self {
+        Self(None)
+    }
 }
 
 impl<T, E> Drop for BlockRes<T, E> {

--- a/upstairs/src/block_req.rs
+++ b/upstairs/src/block_req.rs
@@ -28,7 +28,8 @@ impl<T, E> BlockRes<T, E> {
     /// Builds an empty `BlockRes`, for use in unit testing
     #[cfg(test)]
     pub fn dummy() -> Self {
-        Self(None)
+        let (tx, _) = oneshot::channel();
+        Self(Some(tx))
     }
 }
 

--- a/upstairs/src/deferred.rs
+++ b/upstairs/src/deferred.rs
@@ -105,7 +105,7 @@ pub(crate) struct DeferredWrite {
     pub ddef: RegionDefinition,
     pub impacted_blocks: ImpactedBlocks,
     pub data: BytesMut,
-    pub res: Option<BlockRes>,
+    pub res: BlockRes,
     pub is_write_unwritten: bool,
     pub cfg: Arc<UpstairsConfig>,
 }
@@ -127,7 +127,7 @@ pub(crate) struct EncryptedWrite {
     /// An `RawWrite` containing our encrypted data
     pub data: RawWrite,
     pub impacted_blocks: ImpactedBlocks,
-    pub res: Option<BlockRes>,
+    pub res: BlockRes,
     pub is_write_unwritten: bool,
 }
 


### PR DESCRIPTION
The `Option<BlockRes>` is always `Some(..)`, _except_ in unit testing, so it has too many degrees of freedom during normal operation.  This PR turns it into a plain `BlockRes`, and adds a `#[cfg(test)]` helper function to make an empty `BlockRes` during unit tests.