### PR TITLE
Fine-tuning backpressure clamping, and API cleanups

### DIFF
--- a/upstairs/src/backpressure.rs
+++ b/upstairs/src/backpressure.rs
@@ -204,7 +204,7 @@ impl BackpressureChannelConfig {
         };
 
         BackpressureAmount::Duration(
-            self.delay_scale.mul_f64(v).min(self.delay_max),
+            self.delay_scale.mul_f64(v.powi(2)).min(self.delay_max),
         )
     }
 }

--- a/upstairs/src/backpressure.rs
+++ b/upstairs/src/backpressure.rs
@@ -192,7 +192,7 @@ impl BackpressureChannelConfig {
             return BackpressureAmount::Saturated;
         }
 
-        // This ratio start at 0 (at start_value) and hits 1 when backpressure
+        // This ratio starts at 0 (at start_value) and hits 1 when backpressure
         // should be maxed out.
         let frac = value.saturating_sub(self.start_value) as f64
             / (self.max_value - self.start_value) as f64;

--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -2,16 +2,16 @@
 use std::{
     collections::HashMap,
     net::SocketAddr,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
+    sync::atomic::{AtomicU64, Ordering},
     time::Duration,
 };
 
 use crate::{
-    backpressure::BackpressureConfig, BlockIO, BlockOp, BlockOpWaiter,
-    BlockRes, Buffer, JobId, RawReadResponse, ReplaceResult, UpstairsAction,
+    backpressure::{
+        BackpressureAmount, BackpressureConfig, SharedBackpressureAmount,
+    },
+    BlockIO, BlockOp, BlockOpWaiter, BlockRes, Buffer, JobId, RawReadResponse,
+    ReplaceResult, UpstairsAction,
 };
 use crucible_common::{build_logger, Block, BlockIndex, CrucibleError};
 use crucible_protocol::SnapshotDetails;
@@ -19,7 +19,7 @@ use crucible_protocol::SnapshotDetails;
 use async_trait::async_trait;
 use bytes::BytesMut;
 use ringbuffer::{AllocRingBuffer, RingBuffer};
-use slog::{info, warn, Logger};
+use slog::{error, info, warn, Logger};
 use tokio::sync::{mpsc, Mutex};
 use tracing::{instrument, span, Level};
 use uuid::Uuid;
@@ -282,7 +282,7 @@ pub struct Guest {
     ///
     /// It is stored in an `Arc` so that the `GuestIoHandle` can update it from
     /// the IO task.
-    backpressure_us: Arc<AtomicU64>,
+    backpressure: SharedBackpressureAmount,
 
     /// Lock held during backpressure delay
     ///
@@ -318,7 +318,7 @@ impl Guest {
         // time spent waiting for the queue versus time spent in Upstairs code).
         let (req_tx, req_rx) = mpsc::channel(500);
 
-        let backpressure_us = Arc::new(AtomicU64::new(0));
+        let backpressure = SharedBackpressureAmount::new();
         let limits = GuestLimits {
             iop_limit: None,
             bw_limit: None,
@@ -337,7 +337,7 @@ impl Guest {
 
             iop_tokens: 0,
             bw_tokens: 0,
-            backpressure_us: backpressure_us.clone(),
+            backpressure: backpressure.clone(),
             backpressure_config: BackpressureConfig::default(),
             log: log.clone(),
         };
@@ -346,7 +346,7 @@ impl Guest {
 
             block_size: AtomicU64::new(0),
 
-            backpressure_us,
+            backpressure,
             backpressure_lock: Mutex::new(()),
             log,
         };
@@ -413,13 +413,25 @@ impl Guest {
         Ok(())
     }
 
-    async fn backpressure_sleep(&self) {
-        let bp =
-            Duration::from_micros(self.backpressure_us.load(Ordering::SeqCst));
-        if bp > Duration::ZERO {
-            let _guard = self.backpressure_lock.lock().await;
-            tokio::time::sleep(bp).await;
-            drop(_guard);
+    /// Sleeps for a backpressure-dependent amount, holding the lock
+    ///
+    /// If backpressure is saturated, logs and returns an error.
+    async fn backpressure_sleep(&self) -> Result<(), CrucibleError> {
+        let bp = self.backpressure.load();
+        match bp {
+            BackpressureAmount::Saturated => {
+                let err = "write queue is saturated";
+                error!(self.log, "{err}");
+                Err(CrucibleError::IoError(err.to_owned()))
+            }
+            BackpressureAmount::Duration(d) => {
+                if d > Duration::ZERO {
+                    let _guard = self.backpressure_lock.lock().await;
+                    tokio::time::sleep(d).await;
+                    drop(_guard);
+                }
+                Ok(())
+            }
         }
     }
 
@@ -587,7 +599,7 @@ impl BlockIO for Guest {
             assert_eq!(buf.len() as u64 % bs, 0);
             let offset_change = buf.len() as u64 / bs;
 
-            self.backpressure_sleep().await;
+            self.backpressure_sleep().await?;
 
             let reply = self
                 .send_and_wait(|done| BlockOp::Write {
@@ -614,7 +626,7 @@ impl BlockIO for Guest {
             return Ok(());
         }
 
-        self.backpressure_sleep().await;
+        self.backpressure_sleep().await?;
         self.send_and_wait(|done| BlockOp::WriteUnwritten {
             offset,
             data,
@@ -719,7 +731,7 @@ pub struct GuestIoHandle {
     iop_tokens: usize,
 
     /// Current backpressure (shared with the `Guest`)
-    backpressure_us: Arc<AtomicU64>,
+    backpressure: SharedBackpressureAmount,
 
     /// Backpressure configuration, as a starting point and max delay
     backpressure_config: BackpressureConfig,
@@ -861,23 +873,23 @@ impl GuestIoHandle {
 
     #[cfg(test)]
     pub fn disable_queue_backpressure(&mut self) {
-        self.backpressure_config.queue.scale = Duration::ZERO;
+        self.backpressure_config.queue.delay_scale = Duration::ZERO;
     }
 
     #[cfg(test)]
     pub fn disable_byte_backpressure(&mut self) {
-        self.backpressure_config.bytes.scale = Duration::ZERO;
+        self.backpressure_config.bytes.delay_scale = Duration::ZERO;
     }
 
     #[cfg(test)]
     pub fn is_queue_backpressure_disabled(&self) -> bool {
-        self.backpressure_config.queue.scale == Duration::ZERO
+        self.backpressure_config.queue.delay_scale == Duration::ZERO
     }
 
-    /// Set `self.backpressure_us` based on outstanding IO ratio
+    /// Set `self.backpressure` based on outstanding IO ratio
     pub fn set_backpressure(&self, bytes: u64, jobs: u64) {
-        let bp_usec = self.backpressure_config.get_backpressure_us(bytes, jobs);
-        self.backpressure_us.store(bp_usec, Ordering::SeqCst);
+        let bp = self.backpressure_config.get_backpressure(bytes, jobs);
+        self.backpressure.store(bp);
     }
 
     pub fn set_iop_limit(&mut self, bytes_per_iop: usize, limit: usize) {
@@ -897,8 +909,8 @@ impl GuestIoHandle {
     }
 
     /// Looks up current backpressure
-    pub fn backpressure_us(&self) -> u64 {
-        self.backpressure_us.load(Ordering::Acquire)
+    pub fn get_backpressure(&self) -> BackpressureAmount {
+        self.backpressure.load()
     }
 
     /// Debug function to dump the guest work structure.

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -737,7 +737,7 @@ impl Upstairs {
                 up_count: self.guest.guest_work.len() as u32,
                 up_counters: self.counters,
                 next_job_id: self.downstairs.peek_next_id(),
-                up_backpressure: self.guest.backpressure_us(),
+                up_backpressure: self.guest.get_backpressure().as_micros(),
                 write_bytes_out: self.downstairs.write_bytes_outstanding(),
                 ds_count: self.downstairs.active_count() as u32,
                 ds_state: self.downstairs.collect_stats(|c| c.state()),


### PR DESCRIPTION
Right now, backpressure goes to infinity as you approach the `max` value.  However, it's possible to exceed `max` if you (1) start below `max` and (2) send a single job that pushes over the limit (e.g. a large write).  If this happens, then we special-case a 1 hour backpressure delay.

All of this is kinda awkward.

This PR cleans it up:
- There's an explicit `delay_max` stored in the backpressure configuration, which is both a clamp and the delay used if our counter exceeds `max_value`
- Backpressure now has an explicit `Saturated` value, which is used if we exceed `max_value`
- If backpressure is saturated, then we return an error to the guest immediately (instead of delaying the IO for 1 hour)