### PR TITLE
Increment write backpressure before deferred encryption

### DIFF
--- a/upstairs/src/deferred.rs
+++ b/upstairs/src/deferred.rs
@@ -3,8 +3,9 @@
 use std::sync::Arc;
 
 use crate::{
-    client::ConnectionId, upstairs::UpstairsConfig, BlockContext, BlockOp,
-    BlockRes, ClientId, ImpactedBlocks, Message, RawWrite, Validation,
+    backpressure::BackpressureGuard, client::ConnectionId,
+    upstairs::UpstairsConfig, BlockContext, BlockOp, BlockRes, ClientData,
+    ClientId, ImpactedBlocks, Message, RawWrite, Validation,
 };
 use bytes::BytesMut;
 use crucible_common::{integrity_hash, CrucibleError, RegionDefinition};
@@ -114,6 +115,7 @@ pub(crate) struct DeferredWrite {
     pub res: BlockRes,
     pub is_write_unwritten: bool,
     pub cfg: Arc<UpstairsConfig>,
+    pub guard: ClientData<BackpressureGuard>,
 }
 
 /// Result of a deferred `BlockOp`
@@ -135,6 +137,7 @@ pub(crate) struct EncryptedWrite {
     pub impacted_blocks: ImpactedBlocks,
     pub res: BlockRes,
     pub is_write_unwritten: bool,
+    pub guard: ClientData<BackpressureGuard>,
 }
 
 impl DeferredWrite {
@@ -183,6 +186,7 @@ impl DeferredWrite {
             impacted_blocks: self.impacted_blocks,
             res: self.res,
             is_write_unwritten: self.is_write_unwritten,
+            guard: self.guard,
         }
     }
 }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -427,6 +427,15 @@ impl<T> ClientData<T> {
         std::mem::swap(&mut self[c], &mut v);
         v
     }
+
+    /// Builds a `ClientData` from a builder function
+    pub fn from_fn<F: FnMut(ClientId) -> T>(mut f: F) -> Self {
+        Self([
+            f(ClientId::new(0)),
+            f(ClientId::new(1)),
+            f(ClientId::new(2)),
+        ])
+    }
 }
 
 /// Map of data associated with clients, keyed by `ClientId`
@@ -463,6 +472,12 @@ impl<T> std::ops::Index<ClientId> for ClientMap<T> {
     type Output = T;
     fn index(&self, index: ClientId) -> &Self::Output {
         self.get(&index).unwrap()
+    }
+}
+
+impl<T> From<ClientData<T>> for ClientMap<T> {
+    fn from(c: ClientData<T>) -> Self {
+        Self(ClientData(c.0.map(Option::Some)))
     }
 }
 

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1439,6 +1439,8 @@ impl Upstairs {
         let impacted_blocks =
             extent_from_offset(&ddef, offset, ddef.bytes_to_blocks(data.len()));
 
+        let guard = self.downstairs.early_write_backpressure(data.len() as u64);
+
         Some(DeferredWrite {
             ddef,
             impacted_blocks,
@@ -1446,6 +1448,7 @@ impl Upstairs {
             res,
             is_write_unwritten,
             cfg: self.cfg.clone(),
+            guard,
         })
     }
 
@@ -1473,6 +1476,7 @@ impl Upstairs {
                     write.impacted_blocks,
                     write.data,
                     write.is_write_unwritten,
+                    write.guard,
                 )
             },
             Some(GuestBlockRes::Other(write.res)),


### PR DESCRIPTION
(Staged on top of #1443 )

This PR tightens the feedback loop for backpressure, by incrementing our counters _before_ encryption is complete.  It uses the new RAII `BackpressureGuard` type, so we don't need to worry about weird accounting failures.

Before:
```
                ┌────────────┐ incr             
             ┌──┤backpressure│◄───┐             
             │  └────────────┘    │             
┌─────┐  ┌───▼──┐    ┌──────────┐ │    ┌───────┐
│Guest├─►│submit├───►│encryption├─┼───►│clients│
└───▲─┘  └──────┘    └──────────┘ │    └───────┘
    │                             │             
    └─────────────────────────────┘             
              ack                               
```

After:
```
                ┌────────────┐                  
             ┌──┤backpressure│                  
             │  └─▲──────────┘                  
             │    │incr                         
┌─────┐  ┌───▼──┐ │  ┌──────────┐      ┌───────┐
│Guest├─►│submit├─┴─►│encryption├─┬───►│clients│
└───▲─┘  └──────┘    └──────────┘ │    └───────┘
    │                             │             
    └─────────────────────────────┘             
              ack                               
```