### PR TITLE
Do fast-ack immediately after a write is submitted

### DIFF
--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -2791,7 +2791,8 @@ impl ClientIoTask {
         // the global backpressure system and cannot build up an unbounded
         // queue.  This is admittedly quite subtle; see crucible#1167 for
         // discussions and graphs.
-        if !matches!(m, Message::Write { .. }) {
+        if !matches!(m, Message::Write { .. } | Message::WriteUnwritten { .. })
+        {
             let d = self.client_delay_us.load(Ordering::Relaxed);
             if d > 0 {
                 tokio::time::sleep(Duration::from_micros(d)).await;

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -2533,8 +2533,7 @@ impl Downstairs {
             }
         }
 
-        let is_write =
-            matches!(io.work, IOop::Write { .. } | IOop::WriteUnwritten { .. });
+        let is_write = io.work.is_write();
         let ds_id = io.ds_id;
         if skipped == 3 {
             if !is_write {
@@ -4504,8 +4503,7 @@ pub(crate) mod test {
             );
         }
         // Writes are fast-acked when first submitted
-        if !matches!(ds.ds_active.get(&ds_id).unwrap().work, IOop::Write { .. })
-        {
+        if !ds.ds_active.get(&ds_id).unwrap().work.is_write() {
             ds.ack(ds_id);
         }
     }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1213,6 +1213,11 @@ impl IOop {
         )
     }
 
+    /// Returns `true` if the `IOop` is a `Write` or `WriteUnwritten`
+    fn is_write(&self) -> bool {
+        matches!(self, IOop::Write { .. } | IOop::WriteUnwritten { .. })
+    }
+
     /**
      * Take a IOop work operation and just return:
      * A string of the job type.

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -7,7 +7,7 @@ use crate::{
     deadline_secs,
     deferred::{
         DeferredBlockOp, DeferredMessage, DeferredQueue, DeferredRead,
-        DeferredWrite, EncryptedWrite,
+        DeferredWrite, EncryptedWrite, WriteRes,
     },
     downstairs::{Downstairs, DownstairsAction},
     extent_from_offset,
@@ -1475,12 +1475,19 @@ impl Upstairs {
 
         let guard = self.downstairs.early_write_backpressure(data.len() as u64);
 
+        // Fast-ack, pretending to be done immediately for Write operations
+        let res = if is_write_unwritten {
+            WriteRes::WriteUnwritten(res)
+        } else {
+            res.send_ok(());
+            WriteRes::Write
+        };
+
         Some(DeferredWrite {
             ddef,
             impacted_blocks,
             data,
             res,
-            is_write_unwritten,
             cfg: self.cfg.clone(),
             guard,
         })
@@ -1498,9 +1505,10 @@ impl Upstairs {
          * Grab this ID after extent_from_offset: in case of Err we don't
          * want to create a gap in the IDs.
          */
+        let is_write_unwritten = write.is_write_unwritten();
         let (gw_id, _) = self.guest.guest_work.submit_job(
             |gw_id| {
-                if write.is_write_unwritten {
+                if is_write_unwritten {
                     cdt::gw__write__unwritten__start!(|| (gw_id.0));
                 } else {
                     cdt::gw__write__start!(|| (gw_id.0));
@@ -1509,14 +1517,17 @@ impl Upstairs {
                     gw_id,
                     write.impacted_blocks,
                     write.data,
-                    write.is_write_unwritten,
+                    is_write_unwritten,
                     write.guard,
                 )
             },
-            Some(GuestBlockRes::Other(write.res)),
+            Some(match write.res {
+                WriteRes::Write => GuestBlockRes::Acked,
+                WriteRes::WriteUnwritten(res) => GuestBlockRes::Other(res),
+            }),
         );
 
-        if write.is_write_unwritten {
+        if is_write_unwritten {
             cdt::up__to__ds__write__unwritten__start!(|| (gw_id.0));
         } else {
             cdt::up__to__ds__write__start!(|| (gw_id.0));


### PR DESCRIPTION
Staged on top of #1444

This PR moves the fast-ack reply to happen before encryption, to avoid an accidental source of backpressure.

Before:
```
                ┌────────────┐                  
             ┌──┤backpressure│                  
             │  └─▲──────────┘                  
             │    │incr                         
┌─────┐  ┌───▼──┐ │  ┌──────────┐      ┌───────┐
│Guest├─►│submit├─┴─►│encryption├─┬───►│clients│
└───▲─┘  └──────┘    └──────────┘ │    └───────┘
    │                             │             
    └─────────────────────────────┘             
              ack                               
```

After:
```
                ┌────────────┐                  
             ┌──┤backpressure│                  
             │  └─▲──────────┘                  
             │    │incr                         
┌─────┐  ┌───▼──┐ │  ┌──────────┐      ┌───────┐
│Guest├─►│submit├─┼─►│encryption├─────►│clients│
└───▲─┘  └──────┘ │  └──────────┘      └───────┘
    │             │                             
    └─────────────┘                             
              ack                               
```

This requires a bunch of changes to unit tests in the `Downstairs`, because of changes in `submit_write`:

- Previously, writes were added to `ackable_work`
- Now, writes must be acked _beforehand_ by the `Upstairs`, and are created with `acked: true`

Opening as a draft for now, because we should decide whether we want to keep the difference in behavior between `Write` (which does fast-ack) and `WriteUnwritten` (which does not).