### PR TITLE
Fix write reordering bug

### DIFF
--- a/upstairs/src/deferred.rs
+++ b/upstairs/src/deferred.rs
@@ -93,6 +93,12 @@ impl<T> DeferredQueue<T> {
     pub fn is_empty(&self) -> bool {
         self.empty
     }
+
+    /// Returns the number of futures in the queue
+    #[allow(dead_code)] // only used in unit tests
+    pub fn len(&self) -> usize {
+        self.stream.len()
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
If we have _any_ block operations in the deferred queue (i.e. because we're encrypting a large write in the thread pool), then every block operation must go through the queue to preserve ordering.

Unfortunately, we were checking the **wrong** `DeferredQueue` when checking whether to defer writes.  This means that a large (deferred) write followed by a short (non-deferred) write could be reordered so that the short write happens first.

This is probably the root cause of CI failures that we saw in #1445: fast-ack means that the Guest is able to send the short write with less delay, making it more likely to hit this race condition.