### PR TITLE
Make crutest use BlockIO trait instead of a Guest

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -76,7 +76,7 @@ pub enum CrucibleError {
     #[error("Offset past end of extent")]
     OffsetInvalid,
 
-    #[error("Upstairs is already active")]
+    #[error("Upstairs activation is in progress")]
     UpstairsActivateInProgress,
 
     #[error("Upstairs is deactivating")]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -77,7 +77,7 @@ pub enum CrucibleError {
     OffsetInvalid,
 
     #[error("Upstairs is already active")]
-    UpstairsAlreadyActive,
+    UpstairsActivateInProgress,
 
     #[error("Upstairs is deactivating")]
     UpstairsDeactivating,
@@ -132,6 +132,9 @@ pub enum CrucibleError {
 
     #[error("Generation number is too low: {0}")]
     GenerationNumberTooLow(String),
+
+    #[error("Active with different generation number")]
+    GenerationNumberInvalid,
 
     #[error("No longer active")]
     NoLongerActive,
@@ -389,6 +392,7 @@ impl From<CrucibleError> for dropshot::HttpError {
             | CrucibleError::Disconnect
             | CrucibleError::EncryptionError(_)
             | CrucibleError::GenerationNumberTooLow(_)
+            | CrucibleError::GenerationNumberInvalid
             | CrucibleError::GenericError(_)
             | CrucibleError::HashMismatch
             | CrucibleError::InvalidExtent
@@ -403,7 +407,7 @@ impl From<CrucibleError> for dropshot::HttpError {
             | CrucibleError::RwLockError(_)
             | CrucibleError::SendError(_)
             | CrucibleError::SubvolumeSizeMismatch
-            | CrucibleError::UpstairsAlreadyActive
+            | CrucibleError::UpstairsActivateInProgress
             | CrucibleError::UpstairsDeactivating
             | CrucibleError::UuidMismatch
             | CrucibleError::MissingContextSlot(..)

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -223,8 +223,8 @@ enum CliCommand {
  * After verify, we truncate the data to 10 fields and return that so
  * the cli server can send it back to the client for display.
  */
-async fn cli_read(
-    guest: &Arc<Guest>,
+async fn cli_read<T: BlockIO + Send + Sync + 'static>(
+    guest: &Arc<T>,
     ri: &mut RegionInfo,
     block_index: usize,
     size: usize,
@@ -264,8 +264,8 @@ async fn cli_read(
 /*
  * A wrapper around write that just picks a random offset.
  */
-async fn rand_write(
-    guest: &Arc<Guest>,
+async fn rand_write<T: BlockIO + Send + Sync + 'static>(
+    guest: &Arc<T>,
     ri: &mut RegionInfo,
 ) -> Result<(), CrucibleError> {
     /*
@@ -290,8 +290,8 @@ async fn rand_write(
  * Data is generated based on the value in the internal write counter.
  * Update the internal write counter so we have something to compare to.
  */
-async fn cli_write(
-    guest: &Arc<Guest>,
+async fn cli_write<T: BlockIO + Send + Sync + 'static>(
+    guest: &Arc<T>,
     ri: &mut RegionInfo,
     block_index: usize,
     size: usize,
@@ -334,8 +334,8 @@ async fn cli_write(
  * If we do believe the block is written to, then we don't update our
  * internal counter and we don't expect our write to change the contents.
  */
-async fn cli_write_unwritten(
-    guest: &Arc<Guest>,
+async fn cli_write_unwritten<T: BlockIO + Send + Sync + 'static>(
+    guest: &Arc<T>,
     ri: &mut RegionInfo,
     block_index: usize,
 ) -> Result<(), CrucibleError> {
@@ -744,8 +744,8 @@ pub async fn start_cli_client(attach: SocketAddr) -> Result<()> {
 /**
  * Process a CLI command from the client, we are the server side.
  */
-async fn process_cli_command(
-    guest: &Arc<Guest>,
+async fn process_cli_command<T: BlockIO + Send + Sync + 'static>(
+    guest: &Arc<T>,
     fw: &mut FramedWrite<tokio::net::tcp::OwnedWriteHalf, CliEncoder>,
     cmd: protocol::CliMessage,
     ri: &mut RegionInfo,
@@ -1040,14 +1040,14 @@ async fn process_cli_command(
 /*
  * Server for a crucible client CLI.
  * This opens a network port and listens for commands from the cli_client.
- * When it receives one, it translates it into the crucible Guest command
+ * When it receives one, it translates it into the crucible BlockIO command
  * and passes it on to the Upstairs.
  * State is kept here.
  * No checking is done.
  * Wait here if you want.
  */
-pub async fn start_cli_server(
-    guest: &Arc<Guest>,
+pub async fn start_cli_server<T: BlockIO + Send + Sync + 'static>(
+    guest: &Arc<T>,
     address: IpAddr,
     port: u16,
     verify_input: Option<PathBuf>,

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -3681,9 +3681,9 @@ mod test {
 
     #[tokio::test]
     async fn integration_test_guest_reactivate_same() -> Result<()> {
-        // Verify we fail activate_with_gen() if we are already active
-        // and the generation number we are requesting with does not
-        // match the number that the upstairs is already active with.
+        // Verify activate_with_gen() will work if we are already active
+        // and the new requested generation number matches what we activated
+        // with.
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();
 
@@ -3699,7 +3699,7 @@ mod test {
 
     #[tokio::test]
     async fn integration_test_guest_activate_with_gen_1() -> Result<()> {
-        // Verify activate_with_gen() works when we sent it with the
+        // Verify activate_with_gen() works when we send it with the
         // same number that we passed to up_main.
         let tds = TestDownstairsSet::small(false).await?;
         let opts = tds.opts();

--- a/upstairs/src/block_io.rs
+++ b/upstairs/src/block_io.rs
@@ -40,8 +40,24 @@ impl BlockIO for FileBlockIO {
         Ok(())
     }
 
+    async fn activate_with_gen(&self, _gen: u64) -> Result<(), CrucibleError> {
+        Ok(())
+    }
+
     async fn deactivate(&self) -> Result<(), CrucibleError> {
         Ok(())
+    }
+
+    async fn query_extent_size(&self) -> Result<Block, CrucibleError> {
+        crucible_bail!(Unsupported, "query_extent_size unsupported",)
+    }
+
+    async fn query_work_queue(&self) -> Result<WQCounts, CrucibleError> {
+        Ok(WQCounts {
+            up_count: 0,
+            ds_count: 0,
+            active_count: 0,
+        })
     }
 
     async fn query_is_active(&self) -> Result<bool, CrucibleError> {
@@ -184,8 +200,26 @@ impl BlockIO for ReqwestBlockIO {
         Ok(())
     }
 
+    async fn activate_with_gen(&self, _gen: u64) -> Result<(), CrucibleError> {
+        Ok(())
+    }
+
     async fn deactivate(&self) -> Result<(), CrucibleError> {
         Ok(())
+    }
+
+    async fn query_work_queue(&self) -> Result<WQCounts, CrucibleError> {
+        Ok(WQCounts {
+            up_count: 0,
+            ds_count: 0,
+            active_count: 0,
+        })
+    }
+
+    async fn query_extent_size(&self) -> Result<Block, CrucibleError> {
+        Err(CrucibleError::Unsupported(
+            "query_extent_size unsupported".to_string(),
+        ))
     }
 
     async fn query_is_active(&self) -> Result<bool, CrucibleError> {

--- a/upstairs/src/in_memory.rs
+++ b/upstairs/src/in_memory.rs
@@ -37,6 +37,21 @@ impl BlockIO for InMemoryBlockIO {
     async fn activate(&self) -> Result<(), CrucibleError> {
         Ok(())
     }
+    async fn activate_with_gen(&self, _gen: u64) -> Result<(), CrucibleError> {
+        Ok(())
+    }
+
+    async fn query_extent_size(&self) -> Result<Block, CrucibleError> {
+        crucible_bail!(Unsupported, "query_extent_size unsupported",)
+    }
+
+    async fn query_work_queue(&self) -> Result<WQCounts, CrucibleError> {
+        Ok(WQCounts {
+            up_count: 0,
+            ds_count: 0,
+            active_count: 0,
+        })
+    }
 
     async fn deactivate(&self) -> Result<(), CrucibleError> {
         Ok(())

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -103,10 +103,14 @@ pub const IO_OUTSTANDING_MAX_JOBS: usize = 10000;
 #[async_trait]
 pub trait BlockIO: Sync {
     async fn activate(&self) -> Result<(), CrucibleError>;
+    async fn activate_with_gen(&self, gen: u64) -> Result<(), CrucibleError>;
 
     async fn deactivate(&self) -> Result<(), CrucibleError>;
 
     async fn query_is_active(&self) -> Result<bool, CrucibleError>;
+
+    async fn query_extent_size(&self) -> Result<Block, CrucibleError>;
+    async fn query_work_queue(&self) -> Result<WQCounts, CrucibleError>;
 
     // Total bytes of Volume
     async fn total_size(&self) -> Result<u64, CrucibleError>;
@@ -214,6 +218,17 @@ pub trait BlockIO: Sync {
         }
 
         self.activate().await
+    }
+    /// Conditional activate if not active.
+    async fn conditional_activate_with_gen(
+        &self,
+        gen: u64,
+    ) -> Result<(), CrucibleError> {
+        if self.query_is_active().await? {
+            return Ok(());
+        }
+
+        self.activate_with_gen(gen).await
     }
 
     /// Checks that the data length is a multiple of block size

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -211,26 +211,6 @@ pub trait BlockIO: Sync {
             .await
     }
 
-    /// Activate if not active.
-    async fn conditional_activate(&self) -> Result<(), CrucibleError> {
-        if self.query_is_active().await? {
-            return Ok(());
-        }
-
-        self.activate().await
-    }
-    /// Conditional activate if not active.
-    async fn conditional_activate_with_gen(
-        &self,
-        gen: u64,
-    ) -> Result<(), CrucibleError> {
-        if self.query_is_active().await? {
-            return Ok(());
-        }
-
-        self.activate_with_gen(gen).await
-    }
-
     /// Checks that the data length is a multiple of block size
     ///
     /// Returns block size on success, since we have to look it up anyways.

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -221,6 +221,16 @@ impl<T: BlockIO> CruciblePseudoFile<T> {
 
         Ok(())
     }
+    pub async fn activate_with_gen(
+        &self,
+        gen: u64,
+    ) -> Result<(), CrucibleError> {
+        self.block_io.activate_with_gen(gen).await
+    }
+
+    pub async fn query_work_queue(&self) -> Result<WQCounts, CrucibleError> {
+        self.block_io.query_work_queue().await
+    }
 
     pub async fn show_work(&self) -> Result<WQCounts, CrucibleError> {
         self.block_io.show_work().await

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -211,10 +211,17 @@ impl<T: BlockIO> CruciblePseudoFile<T> {
         Ok(())
     }
     pub async fn activate_with_gen(
-        &self,
+        &mut self,
         gen: u64,
     ) -> Result<(), CrucibleError> {
-        self.block_io.activate_with_gen(gen).await
+        self.block_io.activate_with_gen(gen).await?;
+        self.sz = self.block_io.total_size().await?;
+        self.block_size = self.block_io.get_block_size().await?;
+        self.uuid = self.block_io.get_uuid().await?;
+
+        self.active = true;
+
+        Ok(())
     }
 
     pub async fn query_work_queue(&self) -> Result<WQCounts, CrucibleError> {

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -201,18 +201,7 @@ impl<T: BlockIO> CruciblePseudoFile<T> {
     }
 
     pub async fn activate(&mut self) -> Result<(), CrucibleError> {
-        if let Err(e) = self.block_io.activate().await {
-            match e {
-                CrucibleError::UpstairsAlreadyActive => {
-                    // underlying block io is already active, but pseudo file
-                    // needs fields below populated
-                }
-                _ => {
-                    return Err(e);
-                }
-            }
-        }
-
+        self.block_io.activate().await?;
         self.sz = self.block_io.total_size().await?;
         self.block_size = self.block_io.get_block_size().await?;
         self.uuid = self.block_io.get_uuid().await?;

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -594,7 +594,7 @@ impl Volume {
 impl BlockIO for Volume {
     async fn activate(&self) -> Result<(), CrucibleError> {
         for sub_volume in &self.sub_volumes {
-            sub_volume.conditional_activate().await?;
+            sub_volume.activate().await?;
 
             let sub_volume_computed_size = self.block_size
                 * (sub_volume.lba_range.end - sub_volume.lba_range.start);
@@ -605,14 +605,14 @@ impl BlockIO for Volume {
         }
 
         if let Some(ref read_only_parent) = &self.read_only_parent {
-            read_only_parent.conditional_activate().await?;
+            read_only_parent.activate().await?;
         }
 
         Ok(())
     }
     async fn activate_with_gen(&self, gen: u64) -> Result<(), CrucibleError> {
         for sub_volume in &self.sub_volumes {
-            sub_volume.conditional_activate_with_gen(gen).await?;
+            sub_volume.activate_with_gen(gen).await?;
 
             let sub_volume_computed_size = self.block_size
                 * (sub_volume.lba_range.end - sub_volume.lba_range.start);
@@ -623,7 +623,7 @@ impl BlockIO for Volume {
         }
 
         if let Some(ref read_only_parent) = &self.read_only_parent {
-            read_only_parent.conditional_activate_with_gen(gen).await?;
+            read_only_parent.activate_with_gen(gen).await?;
         }
 
         Ok(())


### PR DESCRIPTION
This enables future work where we plan to use a `Volume` in crutest instead of a `Guest`.

Update crutest to use `<T: BlockIO + Send + Sync + 'static>` instead of `Guest`.  
This involved adding a few more methods to the BlockIO trait, moving a few guest specific methods over to BlockIO, and adding support for these new methods in places where they did not have them.

This should result in no differences at run time as we are not doing anything different than before. 

I wanted this change first to reduce some of the boiler plate noise in future PRs.