### PR TITLE
Remove `fn in_progress` to simplify logic (2/n)

### DIFF
--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -424,7 +424,7 @@ impl DownstairsClient {
             panic!("[{}] This job was not acked: {:?}", self.client_id, job);
         }
 
-        let old_state = self.set_job_state(job, IOState::New);
+        let old_state = self.set_job_state(job, IOState::InProgress);
         job.replay = true;
         assert_ne!(
             old_state,

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -2208,7 +2208,7 @@ impl Downstairs {
         );
     }
 
-    /// Marks the given job as in-progress for this client, then sends it
+    /// Sends the given job to the given client
     fn send(&mut self, ds_id: JobId, io: IOop, client_id: ClientId) {
         let def = self.ddef.unwrap();
         let blocks_per_extent = def.extent_size().value;
@@ -7881,7 +7881,7 @@ pub(crate) mod test {
             );
         }
 
-        // Create a write and make them in-progress
+        // Create a write and send it to the downstairs clients
         let write_one = ds.create_and_enqueue_generic_write_eob(false);
 
         let job = ds.ds_active.get(&write_one).unwrap();


### PR DESCRIPTION
(staged on top of #1460)

Previously, we built a `DownstairsIO` relatively early in the process of submitting / sending a job.  There's a bunch of boilerplate involved, which is usually the same for all IO types.

This PR reorganizes code to keep using `IOops` until the very last minute, _then_ builds the `DownstairsIO` at the end of `enqueue` and `enqueue_repair`.  It simplifies code and removes duplication, but shouldn't be a functional change.