### PR TITLE
Remove `IOStateCount::new` (7/n)

### DIFF
--- a/cmon/src/main.rs
+++ b/cmon/src/main.rs
@@ -206,7 +206,6 @@ fn print_dtrace_header(dd: &[DtraceDisplay]) {
                 print!(" {:>5}", "DSW");
             }
             DtraceDisplay::IoCount | DtraceDisplay::IoSummary => {
-                print!(" {:>5} {:>5} {:>5}", "NEW0", "NEW1", "NEW2");
                 print!(" {:>5} {:>5} {:>5}", "IP0", "IP1", "IP2");
                 print!(" {:>5} {:>5} {:>5}", "D0", "D1", "D2");
                 print!(" {:>5} {:>5} {:>5}", "S0", "S1", "S2");
@@ -272,12 +271,6 @@ fn print_dtrace_row(d_out: Arg, dd: &[DtraceDisplay], last_job_id: &mut u64) {
                 print!(" {:5}", d_out.ds_count);
             }
             DtraceDisplay::IoCount | DtraceDisplay::IoSummary => {
-                print!(
-                    " {:5} {:5} {:5}",
-                    d_out.ds_io_count.new[ClientId::new(0)],
-                    d_out.ds_io_count.new[ClientId::new(1)],
-                    d_out.ds_io_count.new[ClientId::new(2)],
-                );
                 print!(
                     " {:5} {:5} {:5}",
                     d_out.ds_io_count.in_progress[ClientId::new(0)],

--- a/tools/dtrace/README.md
+++ b/tools/dtrace/README.md
@@ -392,17 +392,17 @@ only that PID.  See upstairs_info.d for a description of the columns.
 
 ```
 EVT22200005 # dtrace -s single_up_info.d 15579
- SESSION        DS STATE 0        DS STATE 1        DS STATE 2   UPW   DSW  NEXT_JOB BAKPR   WRITE_BO   NEW0  NEW1  NEW2    IP0   IP1   IP2     D0    D1    D2     S0    S1    S2    ER0   ER1   ER2    EC0   EC1   EC2
-c0b92059       live_repair            active            active     3   435    570215  2761  226492416      0     0     0     40   241   241     24   194   194    371     0     0   9384     0     0      0     0     0
-a666a8bd       live_repair            active            active     2     3     90656     0          0      0     0     0      2     1     1      1     2     2      0     0     0   7561     0     0  11640     0     0
-a666a8bd       live_repair            active            active     2    11     90664     0          0      0     0     0      2     1     1      9    10    10      0     0     0   7563     0     0  11640     0     0
-c0b92059       live_repair            active            active     3   514    570762  3111  237219840      0     0     0     67   234   234     33   280   280    414     0     0   9385     0     0      0     0     0
-c0b92059       live_repair            active            active     3   329    571129  2929  231735296      0     0     0      1   227   251     59   102    78    269     0     0   9386     0     0      0     0     0
-a666a8bd       live_repair            active            active     2    19     90672     0          0      0     0     0      2     1     1     17    18    18      0     0     0   7565     0     0  11640     0     0
-c0b92059       live_repair            active            active     3   339    571544   512  127401984      0     0     0      1   139   137     54   200   202    284     0     0   9387     0     0      0     0     0
-a666a8bd       live_repair            active            active     2    23     90676     0          0      0     0     0      2     1     1     21    22    22      0     0     0   7566     0     0  11640     0     0
-c0b92059       live_repair            active            active     3   389    572038   221  101711872      0     0     0      1   112   112     67   277   277    321     0     0   9388     0     0      0     0     0
-a666a8bd       live_repair            active            active     2    31     90684     0          0      0     0     0      2     1     1     29    30    30      0     0     0   7568     0     0  11640     0     0
+ SESSION        DS STATE 0        DS STATE 1        DS STATE 2   UPW   DSW  NEXT_JOB BAKPR   WRITE_BO    IP0   IP1   IP2     D0    D1    D2     S0    S1    S2    ER0   ER1   ER2    EC0   EC1   EC2
+c0b92059       live_repair            active            active     3   435    570215  2761  226492416     40   241   241     24   194   194    371     0     0   9384     0     0      0     0     0
+a666a8bd       live_repair            active            active     2     3     90656     0          0      2     1     1      1     2     2      0     0     0   7561     0     0  11640     0     0
+a666a8bd       live_repair            active            active     2    11     90664     0          0      2     1     1      9    10    10      0     0     0   7563     0     0  11640     0     0
+c0b92059       live_repair            active            active     3   514    570762  3111  237219840     67   234   234     33   280   280    414     0     0   9385     0     0      0     0     0
+c0b92059       live_repair            active            active     3   329    571129  2929  231735296      1   227   251     59   102    78    269     0     0   9386     0     0      0     0     0
+a666a8bd       live_repair            active            active     2    19     90672     0          0      2     1     1     17    18    18      0     0     0   7565     0     0  11640     0     0
+c0b92059       live_repair            active            active     3   339    571544   512  127401984      1   139   137     54   200   202    284     0     0   9387     0     0      0     0     0
+a666a8bd       live_repair            active            active     2    23     90676     0          0      2     1     1     21    22    22      0     0     0   7566     0     0  11640     0     0
+c0b92059       live_repair            active            active     3   389    572038   221  101711872      1   112   112     67   277   277    321     0     0   9388     0     0      0     0     0
+a666a8bd       live_repair            active            active     2    31     90684     0          0      2     1     1     29    30    30      0     0     0   7568     0     0  11640     0     0
 ```
 ## sled_upstairs_info.d
 Similar to upstairs_info.d, this script prints out various counters in
@@ -413,19 +413,19 @@ reporting stats for.
 
 ```
 EVT22200005 # dtrace -s sled_upstairs_info.d 
-  PID  SESSION        DS STATE 0        DS STATE 1        DS STATE 2   UPW   DSW  NEXT_JOB BAKPR   WRITE_BO   NEW0  NEW1  NEW2    IP0   IP1   IP2     D0    D1    D2     S0    S1    S2    ER0   ER1   ER2    EC0   EC1   EC2
-15579 c0b92059       live_repair            active            active     3   367    656347  1616  185597952      0     0     0     75   195   195     69   172   172    223     0     0   9589     0     0      0     0     0
-15579 a666a8bd       live_repair            active            active     2    95     91960     0          0      0     0     0      2     1     1     93    94    94      0     0     0   7827     0     0  11667     0     0
-24948 fac8cbba               new               new               new     0     0      1000     0          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
-24948 fac8cbba               new               new               new     0     0      1000     0          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
-24948 79d92ceb            active            active            active     0     0      1000     0          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
-15579 c0b92059       live_repair            active            active     3   432    656863  2077  203423744      0     0     0    104   168   168     68   264   264    260     0     0   9590     0     0      0     0     0
-15579 a666a8bd       live_repair            active            active     2    99     91964     0          0      0     0     0      2     1     1     97    98    98      0     0     0   7828     0     0  11667     0     0
-24948 127b8de5               new               new               new     0     0      1000     0          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
-24948 fac8cbba               new               new               new     0     0      1000     0          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
-24948 79d92ceb            active            active            active     0     0      1000     0          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
-15579 c0b92059       live_repair            active            active     4   529    657227  4805  282066944      0     0     0     95   296   296     80   233   233    354     0     0   9591     0     0      0     0     0
-15579 a666a8bd       live_repair            active            active     2   107     91972     0          0      0     0     0      2     1     1    105   106   106      0     0     0   7830     0     0  11667     0     0
+  PID  SESSION        DS STATE 0        DS STATE 1        DS STATE 2   UPW   DSW  NEXT_JOB BAKPR   WRITE_BO    IP0   IP1   IP2     D0    D1    D2     S0    S1    S2    ER0   ER1   ER2    EC0   EC1   EC2
+15579 c0b92059       live_repair            active            active     3   367    656347  1616  185597952     75   195   195     69   172   172    223     0     0   9589     0     0      0     0     0
+15579 a666a8bd       live_repair            active            active     2    95     91960     0          0      2     1     1     93    94    94      0     0     0   7827     0     0  11667     0     0
+24948 fac8cbba               new               new               new     0     0      1000     0          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
+24948 fac8cbba               new               new               new     0     0      1000     0          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
+24948 79d92ceb            active            active            active     0     0      1000     0          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
+15579 c0b92059       live_repair            active            active     3   432    656863  2077  203423744    104   168   168     68   264   264    260     0     0   9590     0     0      0     0     0
+15579 a666a8bd       live_repair            active            active     2    99     91964     0          0      2     1     1     97    98    98      0     0     0   7828     0     0  11667     0     0
+24948 127b8de5               new               new               new     0     0      1000     0          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
+24948 fac8cbba               new               new               new     0     0      1000     0          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
+24948 79d92ceb            active            active            active     0     0      1000     0          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
+15579 c0b92059       live_repair            active            active     4   529    657227  4805  282066944     95   296   296     80   233   233    354     0     0   9591     0     0      0     0     0
+15579 a666a8bd       live_repair            active            active     2   107     91972     0          0      2     1     1    105   106   106      0     0     0   7830     0     0  11667     0     0
 
 ```
 
@@ -509,13 +509,13 @@ for the `Error` state which we don't print.
 Here is an example of how it might look:
 ```
 alan@cat:crucible$ pfexec dtrace -s upstairs_info.d
-   PID  DS STATE 0  DS STATE 1  DS STATE 2  UPW   DSW DELTA BAKPR  WRITE_BO  NEW0 NEW1 NEW2  IP0 IP1 IP2   D0  D1  D2  S0 S1 S2
-  1546      active      active      active    9   165   303    81  82837504     0    0    0   26  17 152  139 148  13   0  0  0
-  1546      active      active      active    7   158   314    33  72351744     0    0    0   32  15 137  126 143  21   0  0  0
-  1546      active      active      active    7   177   327     3  59768832     0    0    0   28  12 113  149 165  64   0  0  0
-  1546      active      active      active    5   154   315    20  68157440     0    0    0   21  11 121  133 143  33   0  0  0
-  1546      active      active      active    7   184   364     0  55574528     0    0    0   15  12 101  169 172  83   0  0  0
-  1546      active      active      active    7   192   362     0  46155264     0    0    0   26  10  95  166 182  97   0  0  0
+   PID  DS STATE 0  DS STATE 1  DS STATE 2  UPW   DSW DELTA BAKPR  WRITE_BO  IP0 IP1 IP2   D0  D1  D2  S0 S1 S2
+  1546      active      active      active    9   165   303    81  82837504   26  17 152  139 148  13   0  0  0
+  1546      active      active      active    7   158   314    33  72351744   32  15 137  126 143  21   0  0  0
+  1546      active      active      active    7   177   327     3  59768832   28  12 113  149 165  64   0  0  0
+  1546      active      active      active    5   154   315    20  68157440   21  11 121  133 143  33   0  0  0
+  1546      active      active      active    7   184   364     0  55574528   15  12 101  169 172  83   0  0  0
+  1546      active      active      active    7   192   362     0  46155264   26  10  95  166 182  97   0  0  0
 ```
 
 ## upstairs_count.d

--- a/tools/dtrace/single_up_info.d
+++ b/tools/dtrace/single_up_info.d
@@ -22,7 +22,6 @@ tick-1s
     printf("%17s %17s %17s", "DS STATE 0", "DS STATE 1", "DS STATE 2");
     printf(" %5s %5s %9s %5s", "UPW", "DSW", "NEXT_JOB", "BAKPR");
     printf(" %10s", "WRITE_BO");
-    printf("  %5s %5s %5s", "NEW0", "NEW1", "NEW2");
     printf("  %5s %5s %5s", "IP0", "IP1", "IP2");
     printf("  %5s %5s %5s", "D0", "D1", "D2");
     printf("  %5s %5s %5s", "S0", "S1", "S2");
@@ -65,13 +64,6 @@ crucible_upstairs*:::up-status
     json(copyinstr(arg1), "ok.next_job_id"),
     json(copyinstr(arg1), "ok.up_backpressure"),
     json(copyinstr(arg1), "ok.write_bytes_out"),
-
-    /*
-     * New jobs on the work list for each downstairs
-     */
-    json(copyinstr(arg1), "ok.ds_io_count.new[0]"),
-    json(copyinstr(arg1), "ok.ds_io_count.new[1]"),
-    json(copyinstr(arg1), "ok.ds_io_count.new[2]"),
 
     /*
      * In progress jobs on the work list for each downstairs

--- a/tools/dtrace/sled_upstairs_info.d
+++ b/tools/dtrace/sled_upstairs_info.d
@@ -27,7 +27,6 @@ tick-1s
     printf("%17s %17s %17s", "DS STATE 0", "DS STATE 1", "DS STATE 2");
     printf(" %5s %5s %9s %5s", "UPW", "DSW", "NEXT_JOB", "BAKPR");
     printf(" %10s", "WRITE_BO");
-    printf("  %5s %5s %5s", "NEW0", "NEW1", "NEW2");
     printf("  %5s %5s %5s", "IP0", "IP1", "IP2");
     printf("  %5s %5s %5s", "D0", "D1", "D2");
     printf("  %5s %5s %5s", "S0", "S1", "S2");
@@ -65,11 +64,6 @@ crucible_upstairs*:::up-status
     json(copyinstr(arg1), "ok.next_job_id"),
     json(copyinstr(arg1), "ok.up_backpressure"),
     json(copyinstr(arg1), "ok.write_bytes_out"),
-
-    /* New jobs on the work list for each downstairs */
-    json(copyinstr(arg1), "ok.ds_io_count.new[0]"),
-    json(copyinstr(arg1), "ok.ds_io_count.new[1]"),
-    json(copyinstr(arg1), "ok.ds_io_count.new[2]"),
 
     /* In progress jobs on the work list for each downstairs */
     json(copyinstr(arg1), "ok.ds_io_count.in_progress[0]"),

--- a/tools/dtrace/upstairs_info.d
+++ b/tools/dtrace/upstairs_info.d
@@ -23,7 +23,6 @@ tick-1s
     printf("%17s %17s %17s", "DS STATE 0", "DS STATE 1", "DS STATE 2");
     printf("  %5s %5s %9s %5s", "UPW", "DSW", "JOBID", "BAKPR");
     printf(" %10s", "WRITE_BO");
-    printf("  %5s %5s %5s", "NEW0", "NEW1", "NEW2");
     printf("  %5s %5s %5s", "IP0", "IP1", "IP2");
     printf("  %5s %5s %5s", "D0", "D1", "D2");
     printf("  %5s %5s %5s", "S0", "S1", "S2");
@@ -55,14 +54,6 @@ crucible_upstairs*:::up-status
     printf(" %9s", json(copyinstr(arg1), "ok.next_job_id"));
     printf(" %5s", json(copyinstr(arg1), "ok.up_backpressure"));
     printf(" %10s", json(copyinstr(arg1), "ok.write_bytes_out"));
-
-    /*
-     * New jobs on the work list for each downstairs
-     */
-    printf(" ");
-    printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.new[0]"));
-    printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.new[1]"));
-    printf(" %5s", json(copyinstr(arg1), "ok.ds_io_count.new[2]"));
 
     /*
      * In progress jobs on the work list for each downstairs

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -2826,7 +2826,6 @@ impl Downstairs {
             ClientData([g(d[0]), g(d[1]), g(d[2])])
         };
         IOStateCount {
-            new: f(|d| d.new),
             in_progress: f(|d| d.in_progress),
             done: f(|d| d.done),
             skipped: f(|d| d.skipped),

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1461,7 +1461,6 @@ impl ClientIOStateCount {
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct IOStateCount {
-    pub new: ClientData<u32>,
     pub in_progress: ClientData<u32>,
     pub done: ClientData<u32>,
     pub skipped: ClientData<u32>,


### PR DESCRIPTION
Staged on top of #1467 

Now that `IOState::New` is gone, we can remove it from the counters and DTrace scripts.