### PR TITLE
Test read from 3x faulted Downstairs

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1058,7 +1058,7 @@ impl DownstairsIO {
         let wc = self.state_count();
 
         let bad_job = match &self.work {
-            IOop::Read { .. } => wc.error == 3,
+            IOop::Read { .. } => wc.done == 0,
             IOop::Write { .. }
             | IOop::WriteUnwritten { .. }
             | IOop::Flush { .. } => wc.skipped + wc.error > 1,


### PR DESCRIPTION
This should return an error, because the IO is skipped on all 3x Downstairs.  Previously, it did not!