### PR TITLE
More crutest and dsc updates to support Volume layer activities.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,6 +1750,7 @@ dependencies = [
  "statistical",
  "tempfile",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -1764,6 +1765,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -445,18 +445,13 @@ async fn handle_dsc(
                 println!("Got res: {:?}", res);
             }
         }
+    } else if let DscCommand::Connect { server } = dsc_cmd {
+        let url = format!("http://{}", server).to_string();
+        println!("Connecting to {:?}", url);
+        let rs = Client::new(&url);
+        *dsc_client = Some(rs);
     } else {
-        match dsc_cmd {
-            DscCommand::Connect { server } => {
-                let url = format!("http://{}", server).to_string();
-                println!("Connecting to {:?}", url);
-                let rs = Client::new(&url);
-                *dsc_client = Some(rs);
-            }
-            _ => {
-                println!("dsc: Need to be connected first");
-            }
-        }
+        println!("dsc: Need to be connected first");
     }
 }
 /*

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -25,8 +25,9 @@ pub struct CliAction {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Parser, PartialEq)]
 pub enum DscCommand {
-    /// Connect to the default DSC server (http://127.0.0.1:9998)
-    Connect,
+    /// IP:Port for a dsc server
+    ///  #[clap(long, global = true, default_value = "127.0.0.1:9998", action)]
+    Connect { server: SocketAddr },
     /// Disable random stopping of downstairs
     DisableRandomStop,
     /// Disable auto restart on the given downstairs client ID
@@ -380,7 +381,7 @@ async fn handle_dsc(
 ) {
     if let Some(dsc_client) = dsc_client {
         match dsc_cmd {
-            DscCommand::Connect => {
+            DscCommand::Connect { .. } => {
                 println!("Already connected");
             }
             DscCommand::DisableRandomStop => {
@@ -444,13 +445,18 @@ async fn handle_dsc(
                 println!("Got res: {:?}", res);
             }
         }
-    } else if dsc_cmd == DscCommand::Connect {
-        let url = "http://127.0.0.1:9998".to_string();
-        println!("Connect to {:?}", url);
-        let rs = Client::new(&url);
-        *dsc_client = Some(rs);
     } else {
-        println!("dsc: Need to be connected first");
+        match dsc_cmd {
+            DscCommand::Connect { server } => {
+                let url = format!("http://{}", server).to_string();
+                println!("Connecting to {:?}", url);
+                let rs = Client::new(&url);
+                *dsc_client = Some(rs);
+            }
+            _ => {
+                println!("dsc: Need to be connected first");
+            }
+        }
     }
 }
 /*

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -760,7 +760,7 @@ async fn make_a_volume(
     let mut crucible_opts = CrucibleOpts {
         id: up_uuid,
         target: opt.target.clone(),
-        lossy: opt.lossy,
+        lossy: false,
         flush_timeout: opt.flush_timeout,
         key: opt.key.clone(),
         cert_pem: opt.cert_pem.clone(),
@@ -940,21 +940,6 @@ async fn main() -> Result<()> {
     if matches!(opt.workload, Workload::Verify) && opt.verify_in.is_none() {
         bail!("Verify requires verify_in file");
     }
-
-    let up_uuid = opt.uuid.unwrap_or_else(Uuid::new_v4);
-
-    let crucible_opts = CrucibleOpts {
-        id: up_uuid,
-        target: opt.target.clone(),
-        lossy: false,
-        flush_timeout: opt.flush_timeout,
-        key: opt.key,
-        cert_pem: opt.cert_pem,
-        key_pem: opt.key_pem,
-        root_cert_pem: opt.root_cert_pem,
-        control: opt.control,
-        read_only: opt.read_only,
-    };
 
     // If just want the cli, then start that after our runtime.  The cli
     // does not need upstairs started, as that should happen in the

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -18,6 +18,7 @@ use futures::stream::FuturesOrdered;
 use futures::StreamExt;
 use human_bytes::human_bytes;
 use indicatif::{ProgressBar, ProgressStyle};
+use oximeter::types::ProducerRegistry;
 use rand::prelude::*;
 use rand_chacha::rand_core::SeedableRng;
 use serde::{Deserialize, Serialize};
@@ -117,11 +118,8 @@ enum Workload {
     /// Test the downstairs replay path.
     /// Stop a downstairs, then run some IO, then start that downstairs back
     /// up.  Verify all IO to all downstairs finishes.
-    Replay {
-        /// URL location of the running dsc server
-        #[clap(long, default_value = "http://127.0.0.1:9998", action)]
-        dsc: String,
-    },
+    /// This test requires a dsc server to control the downstairs.
+    Replay,
     /// Test the downstairs replacement path.
     /// Run IO to the upstairs, then replace a downstairs, then run
     /// more IO and verify it all works as expected.
@@ -139,7 +137,7 @@ enum Workload {
     ReplaceBeforeActive {
         /// URL location of the running dsc server
         #[clap(long, default_value = "http://127.0.0.1:9998", action)]
-        dsc: String,
+        dsc_str: String,
 
         /// The address:port of a running downstairs for replacement
         #[clap(long, action)]
@@ -149,7 +147,7 @@ enum Workload {
     ReplaceReconcile {
         /// URL location of the running dsc server
         #[clap(long, default_value = "http://127.0.0.1:9998", action)]
-        dsc: String,
+        dsc_str: String,
 
         /// The address:port of a running downstairs for replacement
         #[clap(long, action)]
@@ -183,6 +181,12 @@ pub struct Opt {
     /// of loops the test should do.
     #[clap(short, long, global = true, action)]
     count: Option<usize>,
+
+    /// IP:Port for a dsc server.
+    /// Some tests require a dsc enpoint to control the downstairs.
+    /// A dsc endpoint can also be used to construct the initial Volume.
+    #[clap(long, global = true, action)]
+    dsc: Option<SocketAddr>,
 
     /// How long to wait before the auto flush check fires
     #[clap(long, global = true, action)]
@@ -255,13 +259,7 @@ pub struct Opt {
     stable: bool,
 
     /// The IP:Port where each downstairs is listening.
-    #[clap(
-        short,
-        long,
-        global = true,
-        default_value = "127.0.0.1:9000",
-        action
-    )]
+    #[clap(short, long, global = true, action)]
     target: Vec<SocketAddr>,
 
     /// A UUID to use for the upstairs.
@@ -744,9 +742,190 @@ async fn handle_signals(
     }
 }
 
+// Construct a volume for use by the tests.
+// Our choice of how to construct the volume depends on what options we
+// have been given.
+//
+// If we have been provided a vcr file, this will get first priority and all
+// other options will be ignored.
+//
+// Second choice is if we are provided the address for a dsc server.  We can
+// use the dsc server to determine part of what we need to create a Volume.
+// The rest of what we need we can gather from the CrucibleOpts, which are
+// built from options provided on the command line, or their defaults.
+//
+// For the final choice we have to construct a Volume by asking our downstairs
+// for information that we need up front, which we then combine with
+// CrucibleOpts.  This will work as long as one of the downstairs is up
+// already.  If we have a test that requires no downstairs to be running on
+// startup, then we need to provide a VCR file, or use the dsc server.
+async fn make_a_volume(
+    opt: &Opt,
+    block_io_logger: Logger,
+    test_log: &Logger,
+    pr: Option<ProducerRegistry>,
+) -> Result<Arc<Volume>> {
+    let up_uuid = opt.uuid.unwrap_or_else(Uuid::new_v4);
+    let mut crucible_opts = CrucibleOpts {
+        id: up_uuid,
+        target: opt.target.clone(),
+        lossy: opt.lossy,
+        flush_timeout: opt.flush_timeout,
+        key: opt.key.clone(),
+        cert_pem: opt.cert_pem.clone(),
+        key_pem: opt.key_pem.clone(),
+        root_cert_pem: opt.root_cert_pem.clone(),
+        control: opt.control,
+        read_only: opt.read_only,
+    };
+
+    if let Some(vcr_file) = &opt.vcr_file {
+        let vcr: VolumeConstructionRequest = match read_json(vcr_file) {
+            Ok(vcr) => vcr,
+            Err(e) => {
+                bail!("Error {:?} reading VCR from {:?}", e, vcr_file)
+            }
+        };
+        info!(test_log, "Using VCR: {:?}", vcr);
+
+        if opt.gen != 0 {
+            warn!(test_log, "gen option is ignored when VCR is provided");
+        }
+        if !opt.target.is_empty() {
+            warn!(test_log, "targets are ignored when VCR is provided");
+        }
+        let volume = Volume::construct(vcr, pr, block_io_logger).await.unwrap();
+        Ok(Arc::new(volume))
+    } else if opt.dsc.is_some() {
+        // We were given a dsc endpoint, use that to create a VCR that
+        // represents our Volume.
+        if !opt.target.is_empty() {
+            warn!(test_log, "targets are ignored when dsc option is provided");
+        }
+        let dsc = opt.dsc.unwrap();
+        let dsc_url = format!("http://{}", dsc);
+        let dsc_client = Client::new(&dsc_url);
+        let ri = match dsc_client.dsc_get_region_info().await {
+            Ok(res) => res.into_inner(),
+            Err(e) => {
+                bail!("Failed to get region info from {:?}: {}", dsc_url, e);
+            }
+        };
+        info!(test_log, "use region info: {:?}", ri);
+        let extent_info = RegionExtentInfo {
+            block_size: ri.block_size,
+            blocks_per_extent: ri.blocks_per_extent,
+            extent_count: ri.extent_count,
+        };
+
+        let res = dsc_client.dsc_get_region_count().await.unwrap();
+        let regions = res.into_inner();
+
+        let sv_count = regions / 3;
+        let region_remainder = regions % 3;
+        info!(
+            test_log,
+            "dsc has {} regions.  This means {} sub_volumes", regions, sv_count
+        );
+        if region_remainder != 0 {
+            warn!(
+                test_log,
+                "{} regions from dsc will not be part of any sub_volume",
+                region_remainder,
+            );
+        }
+
+        // We start by creating the overall volume.
+        let mut volume = Volume::new(extent_info.block_size, block_io_logger);
+
+        // Now, loop over regions we found from dsc and make a
+        // sub_volume at every three.
+        let mut cid = 0;
+        for sv in 0..sv_count {
+            let mut targets = Vec::new();
+            for _ in 0..3 {
+                let port = dsc_client.dsc_get_port(cid).await.unwrap();
+                let tar: SocketAddr =
+                    format!("{}:{}", dsc.ip(), port.into_inner())
+                        .parse()
+                        .unwrap();
+                targets.push(tar);
+                cid += 1;
+            }
+            info!(test_log, "SV {:?} has targets: {:?}", sv, targets);
+            crucible_opts.target = targets;
+
+            volume
+                .add_subvolume_create_guest(
+                    crucible_opts.clone(),
+                    extent_info.clone(),
+                    opt.gen,
+                    pr.clone(),
+                )
+                .await
+                .unwrap();
+        }
+
+        Ok(Arc::new(volume))
+    } else {
+        // We were not provided a VCR, so, we have to make one by using
+        // the repair port on a downstairs to get region information that
+        // we require.  Once we have that information, we can build a VCR
+        // from it.
+
+        // For each sub-volume, we need to know:
+        // block_size, blocks_per_extent, and extent_size.  We can get any
+        // of the target downstairs to give us this info, if they are
+        // running.  We don't care which one responds.  Any mismatch will
+        // be detected later in the process and handled by the upstairs.
+        let mut extent_info_result = None;
+        for target in &crucible_opts.target {
+            let port = target.port() + crucible_common::REPAIR_PORT_OFFSET;
+            println!("look at: http://{}:{} ", target.ip(), port);
+            let repair_url = format!("http://{}:{}", target.ip(), port);
+            let repair_client = repair_client::new(&repair_url);
+            match repair_client.get_region_info().await {
+                Ok(ri) => {
+                    println!("RI is: {:?}", ri);
+                    extent_info_result = Some(RegionExtentInfo {
+                        block_size: ri.block_size(),
+                        blocks_per_extent: ri.extent_size().value,
+                        extent_count: ri.extent_count(),
+                    });
+                    break;
+                }
+                Err(e) => {
+                    println!(
+                        "Failed to get info from {:?} {:?}",
+                        repair_url, e
+                    );
+                }
+            }
+        }
+        let extent_info = match extent_info_result {
+            Some(ei) => ei,
+            None => {
+                bail!("Can't determine extent info to build a Volume");
+            }
+        };
+
+        let mut volume = Volume::new(extent_info.block_size, block_io_logger);
+        volume
+            .add_subvolume_create_guest(
+                crucible_opts.clone(),
+                extent_info,
+                opt.gen,
+                pr,
+            )
+            .await
+            .unwrap();
+
+        Ok(Arc::new(volume))
+    }
+}
+
 /**
- * This is an example Crucible client.
- * Here we make use of the interfaces that Crucible exposes.
+ * A test program that makes use use of the interfaces that Crucible exposes.
  */
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -768,26 +947,9 @@ async fn main() -> Result<()> {
         bail!("Verify requires verify_in file");
     }
 
-    let up_uuid = opt.uuid.unwrap_or_else(Uuid::new_v4);
-
-    let crucible_opts = CrucibleOpts {
-        id: up_uuid,
-        target: opt.target.clone(),
-        lossy: opt.lossy,
-        flush_timeout: opt.flush_timeout,
-        key: opt.key,
-        cert_pem: opt.cert_pem,
-        key_pem: opt.key_pem,
-        root_cert_pem: opt.root_cert_pem,
-        control: opt.control,
-        read_only: opt.read_only,
-    };
-
-    /*
-     * If just want the cli, then start that after our runtime.  The cli
-     * does not need upstairs started, as that should happen in the
-     * cli-server code.
-     */
+    // If just want the cli, then just run that function. The cli itself does
+    // not need to start the upstairs, as that should happen in the cli-server
+    // code in another process.
     if let Workload::Cli { attach } = opt.workload {
         cli::start_cli_client(attach).await?;
         return Ok(());
@@ -844,80 +1006,9 @@ async fn main() -> Result<()> {
         pr = None;
     }
 
-    // We need to build a Volume for all the tests to use.
-    // If we have received a VCR as input, we can use that.  Otherwise we
-    // have to construct one by asking our downstairs for information that
-    // we need up front.  This will work as long as one of the downstairs
-    // is up already.  If we have a test that requires no downstairs to be
-    // running on startup, then we need to provide a VCR up front.
-    let block_io = {
-        if let Some(vcr_file) = opt.vcr_file {
-            let vcr: VolumeConstructionRequest = match read_json(&vcr_file) {
-                Ok(vcr) => vcr,
-                Err(e) => {
-                    bail!("Error {:?} reading VCR from {:?}", e, vcr_file)
-                }
-            };
-            let volume =
-                Volume::construct(vcr, pr, block_io_logger).await.unwrap();
-            Arc::new(volume)
-        } else {
-            // We were not provided a VCR, so, we have to make one by using
-            // the repair port on a downstairs to get region information that
-            // we require.  Once we have that information, we can build a VCR
-            // from it.
-
-            // For each sub-volume, we need to know:
-            // block_size, blocks_per_extent, and extent_size.  We can get any
-            // of the target downstairs to give us this info, if they are
-            // running.  We don't care which one responds.  Any mismatch will
-            // be detected later in the process and handled by the upstairs.
-            let mut extent_info_result = None;
-            for target in &crucible_opts.target {
-                let port = target.port() + crucible_common::REPAIR_PORT_OFFSET;
-                println!("look at: http://{}:{} ", target.ip(), port);
-                let repair_url = format!("http://{}:{}", target.ip(), port);
-                let repair_client = repair_client::new(&repair_url);
-                match repair_client.get_region_info().await {
-                    Ok(ri) => {
-                        println!("RI is: {:?}", ri);
-                        extent_info_result = Some(RegionExtentInfo {
-                            block_size: ri.block_size(),
-                            blocks_per_extent: ri.extent_size().value,
-                            extent_count: ri.extent_count(),
-                        });
-                        break;
-                    }
-                    Err(e) => {
-                        println!(
-                            "Failed to get info from {:?} {:?}",
-                            repair_url, e
-                        );
-                    }
-                }
-            }
-            let extent_info = match extent_info_result {
-                Some(ei) => ei,
-                None => {
-                    bail!("Can't determine extent info to build a Volume");
-                }
-            };
-
-            let mut volume =
-                Volume::new(extent_info.block_size, block_io_logger);
-            volume
-                .add_subvolume_create_guest(
-                    crucible_opts,
-                    extent_info,
-                    opt.gen,
-                    pr,
-                )
-                .await
-                .unwrap();
-
-            Arc::new(volume)
-        }
-    };
+    // Build a Volume for all the tests to use.
+    let block_io =
+        make_a_volume(&opt, block_io_logger.clone(), &test_log, pr).await?;
 
     if let Workload::CliServer { listen, port } = opt.workload {
         cli::start_cli_server(
@@ -1212,7 +1303,7 @@ async fn main() -> Result<()> {
             }
             return Ok(());
         }
-        Workload::Replay { dsc } => {
+        Workload::Replay => {
             // Either we have a count, or we run until we get a signal.
             let mut wtq = {
                 if opt.continuous {
@@ -1222,8 +1313,15 @@ async fn main() -> Result<()> {
                     WhenToQuit::Count { count }
                 }
             };
-
-            let dsc_client = Client::new(&dsc);
+            let dsc_client = match opt.dsc {
+                Some(dsc_addr) => {
+                    let dsc_url = format!("http://{}", dsc_addr);
+                    Client::new(&dsc_url)
+                }
+                None => {
+                    bail!("Replay workload requires a dsc endpoint");
+                }
+            };
             replay_workload(&block_io, &mut wtq, &mut region_info, dsc_client)
                 .await?;
         }
@@ -1255,8 +1353,11 @@ async fn main() -> Result<()> {
             )
             .await?;
         }
-        Workload::ReplaceBeforeActive { dsc, replacement } => {
-            let dsc_client = Client::new(&dsc);
+        Workload::ReplaceBeforeActive {
+            dsc_str,
+            replacement,
+        } => {
+            let dsc_client = Client::new(&dsc_str);
             // Either we have a count, or we run until we get a signal.
             let wtq = {
                 if opt.continuous {
@@ -1283,8 +1384,11 @@ async fn main() -> Result<()> {
             )
             .await?;
         }
-        Workload::ReplaceReconcile { dsc, replacement } => {
-            let dsc_client = Client::new(&dsc);
+        Workload::ReplaceReconcile {
+            dsc_str,
+            replacement,
+        } => {
+            let dsc_client = Client::new(&dsc_str);
             // Either we have a count, or we run until we get a signal.
             let wtq = {
                 if opt.continuous {
@@ -2145,8 +2249,8 @@ async fn replay_workload<T: BlockIO + Send + Sync + 'static>(
                 "CLIENT: Up:{} ds:{} act:{}",
                 wc.up_count, wc.ds_count, wc.active_count
             );
-            if wc.up_count + wc.ds_count == 0 && wc.active_count == 3 {
-                println!("Replay: All jobs finished, all DS active.");
+            if wc.up_count + wc.ds_count == 0 {
+                println!("Replay: All jobs finished");
                 break;
             }
             tokio::time::sleep(tokio::time::Duration::from_secs(4)).await;

--- a/dsc-client/Cargo.toml
+++ b/dsc-client/Cargo.toml
@@ -6,10 +6,11 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
+crucible-workspace-hack.workspace = true
 percent-encoding.workspace = true
 progenitor.workspace = true
 reqwest.workspace = true
 schemars.workspace = true
 serde_json.workspace = true
 serde.workspace = true
-crucible-workspace-hack.workspace = true
+uuid.workspace = true

--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -10,6 +10,7 @@ byte-unit.workspace = true
 clap.workspace = true
 crucible-client-types.workspace = true
 crucible-common.workspace = true
+crucible-workspace-hack.workspace = true
 csv.workspace = true
 dsc-client.workspace = true
 dropshot.workspace = true
@@ -19,7 +20,7 @@ schemars.workspace = true
 serde.workspace = true
 statistical.workspace = true
 tokio.workspace = true
-crucible-workspace-hack.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 expectorate.workspace = true

--- a/dsc/src/client.rs
+++ b/dsc/src/client.rs
@@ -8,6 +8,8 @@ use anyhow::Result;
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Debug, Parser, PartialEq)]
 pub enum ClientCommand {
+    /// Returns true if all downstairs are running
+    AllRunning,
     /// Disable random stopping of downstairs
     DisableRandomStop,
     /// Disable auto restart on the given downstairs client ID
@@ -46,6 +48,8 @@ pub enum ClientCommand {
         #[clap(long, short, action)]
         cid: u32,
     },
+    /// Get count of regions.
+    RegionCount,
     /// Get region info.
     RegionInfo,
     /// Shutdown all downstairs, then shutdown dsc itself.
@@ -71,6 +75,11 @@ pub enum ClientCommand {
     StopAll,
     /// Stop a random downstairs
     StopRand,
+    /// Get the UUID of the given client ID
+    Uuid {
+        #[clap(long, short, action)]
+        cid: u32,
+    },
 }
 
 // Connect to the DSC and run a command.
@@ -78,6 +87,10 @@ pub enum ClientCommand {
 pub async fn client_main(server: String, cmd: ClientCommand) -> Result<()> {
     let dsc = Client::new(&server);
     match cmd {
+        ClientCommand::AllRunning => {
+            let res = dsc.dsc_all_running().await.unwrap();
+            println!("{:?}", res);
+        }
         ClientCommand::DisableRandomStop => {
             let _ = dsc.dsc_disable_random_stop().await.unwrap();
         }
@@ -110,6 +123,10 @@ pub async fn client_main(server: String, cmd: ClientCommand) -> Result<()> {
             let res = dsc.dsc_get_port(cid).await.unwrap();
             println!("{:?}", res);
         }
+        ClientCommand::RegionCount => {
+            let res = dsc.dsc_get_region_count().await.unwrap();
+            println!("{:?}", res);
+        }
         ClientCommand::RegionInfo => {
             let res = dsc.dsc_get_region_info().await.unwrap();
             println!("{:?}", res);
@@ -135,6 +152,10 @@ pub async fn client_main(server: String, cmd: ClientCommand) -> Result<()> {
         }
         ClientCommand::StopRand => {
             let _ = dsc.dsc_stop_rand().await.unwrap();
+        }
+        ClientCommand::Uuid { cid } => {
+            let res = dsc.dsc_get_uuid(cid).await.unwrap();
+            println!("{:?}", res);
         }
     }
     Ok(())

--- a/openapi/dsc-control.json
+++ b/openapi/dsc-control.json
@@ -5,6 +5,31 @@
     "version": "0.0.0"
   },
   "paths": {
+    "/allrunning": {
+      "get": {
+        "summary": "Return true if all downstairs are running",
+        "operationId": "dsc_all_running",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Boolean",
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/disablerestart/all": {
       "post": {
         "summary": "Disable automatic restart on all downstairs",
@@ -268,6 +293,33 @@
         }
       }
     },
+    "/regioncount": {
+      "get": {
+        "summary": "Get the count of regions.",
+        "operationId": "dsc_get_region_count",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "uint",
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 0
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/regioninfo": {
       "get": {
         "summary": "Fetch the region info for our downstairs",
@@ -444,6 +496,44 @@
         "responses": {
           "204": {
             "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/uuid/cid/{cid}": {
+      "get": {
+        "summary": "Fetch the UUID for the requested client_id",
+        "operationId": "dsc_get_uuid",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "cid",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Uuid",
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
           },
           "4XX": {
             "$ref": "#/components/responses/Error"

--- a/tools/test_fail_live_repair.sh
+++ b/tools/test_fail_live_repair.sh
@@ -95,8 +95,7 @@ fi
 echo "starting $(date)" | tee ${loop_log}
 echo "Tail $test_log for test output"
 
-# Make enough extents that we can be sure to catch in while it
-# is repairing.
+# Make enough extents that we can be sure to catch it while it is repairing.
 if ! ${dsc} create --cleanup \
   --ds-bin "$cds" \
   --extent-count 400 \

--- a/tools/test_replay.sh
+++ b/tools/test_replay.sh
@@ -70,15 +70,11 @@ if ! ps -p $dsc_pid > /dev/null; then
     exit 1
 fi
 
-args=()
-args+=( -t "127.0.0.1:8810" )
-args+=( -t "127.0.0.1:8820" )
-args+=( -t "127.0.0.1:8830" )
-
 gen=1
 # Initial seed for verify file
 echo "Running initial fill" | tee -a "$test_log"
-if ! "$crucible_test" fill "${args[@]}" -q -g "$gen"\
+if ! "$crucible_test" fill -q -g "$gen"\
+          --dsc 127.0.0.1:9998 \
           --verify-out "$verify_log" --retry-activate >> "$test_log" 2>&1 ; then
     echo Failed on initial verify seed, check "$test_log"
     ${dsc} cmd shutdown
@@ -88,9 +84,10 @@ fi
 
 SECONDS=0
 echo "Replay loop starts now $(date)" | tee -a "$test_log"
-"$crucible_test" replay "${args[@]}" -c "$loops" \
+"$crucible_test" replay -c "$loops" \
         --stable -g "$gen" --verify-out "$verify_log" \
         --verify-in "$verify_log" \
+        --dsc 127.0.0.1:9998 \
         --retry-activate >> "$test_log" 2>&1
 result=$?
 duration=$SECONDS
@@ -103,7 +100,8 @@ else
       "$loops" $((duration / 60)) $((duration % 60)) | tee -a "$test_log"
 
     echo "Do final verify" | tee -a "$test_log"
-    if ! "$crucible_test" verify "${args[@]}" -q -g "$gen"\
+    if ! "$crucible_test" verify -q -g "$gen"\
+              --dsc 127.0.0.1:9998 \
               --verify-out "$verify_log" \
               --verify-in "$verify_log" >> "$test_log" 2>&1 ; then
         echo Failed on final verify, check "$test_log"

--- a/tools/test_restart_repair.sh
+++ b/tools/test_restart_repair.sh
@@ -25,17 +25,23 @@ function ctrl_c() {
 
 # Bring all downstairs online.
 function bring_all_downstairs_online() {
-    # dsc start all downstairs
-    if ! "$dsc" cmd start-all; then
-        echo "dsc: Failed to stop all downstairs"
+    # dsc turn on automatic restart
+    if ! "$dsc" cmd enable-restart-all; then
+        echo "dsc: Failed to enable automatic restart"
         exit 1
     fi
 
-    # dsc turn on automatic restart
-    if ! "$dsc" cmd enable-restart-all; then
-        echo "dsc: Failed to disable automatic restart"
+    # dsc start all downstairs
+    if ! "$dsc" cmd start-all; then
+        echo "dsc: Failed to start all downstairs"
         exit 1
     fi
+    ready=$("$dsc" cmd all-running)
+    while [[ "$ready" != "true" ]]; do
+        echo "Waiting for all downstairs to come online" >> "$test_log"
+        sleep 5
+        ready=$("$dsc" cmd all-running)
+    done
 }
 
 # Stop all downstairs.


### PR DESCRIPTION
This adds support for crutest to use a provided dsc endpoint to construct a Volume object.

These changes should be a fix for both issues:
https://github.com/oxidecomputer/crucible/issues/1451 and https://github.com/oxidecomputer/crucible/issues/1457

Moved the existing volume creation steps to a new function, and added another option on how we can create a Volume.  The two previous ways of creating a volume are not changed (though I changed a log message and added some warnings).  The new code is in taking the dsc provided endpoint and using that to construct a volume.

Additional dsc changes were made to help provide Volume info.
Renamed things in dsc to better reflect what information they hold. Specifically, update a bunch of region set comments, as dsc just controls crucible-downstairs processes, and does not know which ones are part of what region set.

**New dsc commands**
* get_ds_uuid: Returns the UUID for the given client ID
* all_running: Returns true if all downstairs that dsc knows about are currently in Running state.
* get_region_count: Returns the total number of regions that dsc knows about.

**New dsc behavior**
* dsc will now wait on all downstairs starting before taking any commands. The ability for dsc to answer a request can be used by a test to confirm that all downstairs had started.
* Add the ability to supply a dsc endpoint to crutest-cli (fix https://github.com/oxidecomputer/crucible/issues/1459)

**Other changes**
`tools/test_replay.sh` transitioned to using the new --dsc option, as that test already required a dsc endpoint and was using a hard coded default value for it.

`tools/test_restart_repair.sh` was updated to wait for dsc to report that all downstairs are online after a restart.  This avoids a race where we told dsc to start, and then start crutest, but the downstairs are not yet online.

All the tests that use dsc will eventually transition to using it to construct a Volume, but I'm pushing that work to another PR.

**There are more changes coming, specifically**
* Updating replace-before-acive and replace-reconcile to use the new dsc option correctly instead of a default.
* Updating tools/test_* to not require targets for crutest and instead use dsc option.
* More updates in crutest to update the current RegionInfo struct to be aware of multiple sub-volumes.
https://github.com/oxidecomputer/crucible/issues/1454
* Possibly some updates to the BlockIO trait.
https://github.com/oxidecomputer/crucible/issues/1455

**Other work this enables**
* Making tests that use multiple sub-volumes.
* Layering the current set of tests in a way so we can run the same tests with a single sub-volume and with multiple sub-volumes