### PR TITLE
Update more tests to use dsc

### DIFF
--- a/.github/buildomat/jobs/test-up-encrypted.sh
+++ b/.github/buildomat/jobs/test-up-encrypted.sh
@@ -4,8 +4,8 @@
 #: variety = "basic"
 #: target = "helios-2.0"
 #: output_rules = [
-#:	"%/tmp/test_up/*.txt",
-#:	"%/tmp/test_up/dsc/*.txt",
+#:	"%/tmp/test_up*/*.txt",
+#:	"%/tmp/test_up*/dsc/*.txt",
 #:	"%/tmp/debug/*",
 #:	"/tmp/core.*",
 #: ]

--- a/.github/buildomat/jobs/test-up-unencrypted.sh
+++ b/.github/buildomat/jobs/test-up-unencrypted.sh
@@ -4,8 +4,8 @@
 #: variety = "basic"
 #: target = "helios-2.0"
 #: output_rules = [
-#:	"%/tmp/test_up/*.txt",
-#:	"%/tmp/test_up/dsc/*.txt",
+#:	"%/tmp/test_up*/*.txt",
+#:	"%/tmp/test_up*/dsc/*.txt",
 #:	"%/tmp/debug/*",
 #:	"/tmp/core.*",
 #: ]

--- a/crucible-client-types/src/lib.rs
+++ b/crucible-client-types/src/lib.rs
@@ -38,6 +38,27 @@ pub enum VolumeConstructionRequest {
     },
 }
 
+impl VolumeConstructionRequest {
+    pub fn targets(&self) -> Vec<SocketAddr> {
+        match self {
+            VolumeConstructionRequest::Volume {
+                id: _,
+                block_size: _,
+                sub_volumes,
+                read_only_parent: _,
+            } => sub_volumes.iter().flat_map(|s| s.targets()).collect(),
+            VolumeConstructionRequest::Region {
+                block_size: _,
+                blocks_per_extent: _,
+                extent_count: _,
+                opts,
+                gen: _,
+            } => opts.target.clone(),
+            _ => vec![],
+        }
+    }
+}
+
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(
     Debug, Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq,

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -1366,7 +1366,6 @@ async fn main() -> Result<()> {
 
             // Add to the list of targets for our volume the replacement
             // target provided on the command line
-            let mut targets = opt.target.clone();
             targets.push(replacement);
             replace_before_active(
                 &volume,
@@ -1401,7 +1400,6 @@ async fn main() -> Result<()> {
 
             // Add to the list of targets for our volume the replacement
             // target provided on the command line
-            let mut targets = opt.target.clone();
             targets.push(replacement);
             replace_while_reconcile(
                 &volume,

--- a/tools/test_replace_special.sh
+++ b/tools/test_replace_special.sh
@@ -63,6 +63,11 @@ echo "" > "$test_log"
 echo "starting $(date)" | tee "$loop_log"
 echo "Tail $test_log for test output"
 
+# NOTE: we are creating a single region set here plus one more region to be
+# used by the replacement, and with the assumption that # the default ports
+# will be used (8810, 8820, 8830).  The test relies on that # because we use
+# the fourth region-dir for our "replacement".  If you change # the number of
+# regions, you must also adjust the replacement below.
 if ! ${dsc} create --cleanup \
   --region-dir "$REGION_ROOT" \
   --region-count 4 \
@@ -82,14 +87,9 @@ if ! ps -p $dsc_pid > /dev/null; then
     exit 1
 fi
 
-args=()
-args+=( -t "127.0.0.1:8810" )
-args+=( -t "127.0.0.1:8820" )
-args+=( -t "127.0.0.1:8830" )
-
 gen=1
 # Initial seed for verify file
-if ! "$crucible_test" fill "${args[@]}" -q -g "$gen"\
+if ! "$crucible_test" fill --dsc 127.0.0.1:9998 -q -g "$gen"\
           --verify-out "$verify_log" >> "$test_log" 2>&1 ; then
     echo Failed on initial verify seed, check "$test_log"
     ${dsc} cmd shutdown
@@ -104,7 +104,8 @@ while [[ $count -le $loops ]]; do
     cp "$test_log" "$test_log".last
     echo "" > "$test_log"
     echo "New loop, $count starts now $(date)" >> "$test_log"
-    "$crucible_test" replace-reconcile "${args[@]}" -c 5 \
+    "$crucible_test" replace-reconcile -c 5 \
+            --dsc 127.0.0.1:9998 \
             --replacement 127.0.0.1:8840 \
             --stable -g "$gen" --verify-out "$verify_log" \
             --verify-at-start \


### PR DESCRIPTION
This is plucking out non `BlockIO` parts from: https://github.com/oxidecomputer/crucible/pull/1474

Give crutest the list of targets it will be operating on so some tests that need that list of targets can still get it.

Updated more tests to use dsc to determine targets instead of having to provide them on the command line.

Updated most of test_up.sh to use dsc for targets instead of supplying them on the command line.
There is still some work required to get hammer tests to use dsc, if we decide to do that.