### PR TITLE
Simplify `CompleteJobs`

### DIFF
--- a/downstairs/src/complete_jobs.rs
+++ b/downstairs/src/complete_jobs.rs
@@ -1,10 +1,6 @@
 use crate::JobId;
 
-/// Stores a flush operation and a set of complete jobs
-///
-/// The flush operation is not included in the list of complete jobs, but acts
-/// as a lower bound for dependencies; any job older than the flush is assumed
-/// to have completed.
+/// Stores a set of complete jobs
 #[derive(Debug)]
 pub struct CompletedJobs {
     completed: Vec<JobId>,
@@ -17,6 +13,7 @@ impl CompletedJobs {
         }
     }
 
+    #[cfg(test)]
     pub fn is_empty(&self) -> bool {
         self.completed.is_empty()
     }
@@ -26,7 +23,10 @@ impl CompletedJobs {
         self.completed.push(id);
     }
 
-    /// Resets the data structure given a new barrier operation
+    /// Resets the data structure, given a new barrier operation
+    ///
+    /// All older jobs are forgotten, and the provided operation becomes the
+    /// oldest complete job.
     pub fn reset(&mut self, id: JobId) {
         self.completed.clear();
         self.completed.push(id);
@@ -41,6 +41,7 @@ impl CompletedJobs {
         self.completed.iter().rev().any(|j| *j == id)
     }
 
+    /// Returns the list of completed jobs
     pub fn completed(&self) -> &[JobId] {
         &self.completed
     }

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -3668,17 +3668,13 @@ mod test {
     }
 
     fn complete(work: &mut Work, ds_id: JobId, job: IOop) {
-        let is_flush = {
-            // validate that deps are done
-            let dep_list = job.deps();
-            for &dep in dep_list {
-                assert!(work.completed.is_complete(dep));
-            }
+        // validate that deps are done
+        assert!(job
+            .deps()
+            .iter()
+            .all(|dep| work.completed.is_complete(*dep)));
 
-            matches!(job, IOop::Flush { .. })
-        };
-
-        if is_flush {
+        if matches!(job, IOop::Flush { .. }) {
             work.completed.reset(ds_id);
         } else {
             work.completed.push(ds_id);


### PR DESCRIPTION
We never actually use the "jobs before `last_flush` count as completed" property of `CompleteJobs`.

From discussions in chat, this may have been a legacy from when we sent literally every previous job in the dependency list.
Now that flushes act as a full dependency barrier, it shouldn't be possible to depend on anything before a flush.

This PR removes special-casing of `last_flush`; instead it becomes first among equals in `completed: Vec<JobId>`.  Most of the changes are to edit test cases that violate the "flushes are a full barrier" property.

(This is preparation for a new `Barrier` operation, which is part of RFD 518)