### PR TITLE
Add `IOop::Barrier`

### DIFF
--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -69,6 +69,7 @@ impl ActiveJobs {
         // tracker have been recorded.
         match &io.work {
             IOop::Flush { .. }
+            | IOop::Barrier { .. }
             | IOop::Write { .. }
             | IOop::WriteUnwritten { .. }
             | IOop::Read { .. }

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -1517,7 +1517,7 @@ impl DownstairsClient {
                     assert!(read_data.data.is_empty());
                     assert!(extent_info.is_none());
 
-                    if jobs_completed_ok == 2 {
+                    if jobs_completed_ok == 3 {
                         ackable = true;
                         cdt::up__to__ds__barrier__done!(|| ds_id.0);
                     }

--- a/upstairs/src/stats.rs
+++ b/upstairs/src/stats.rs
@@ -49,6 +49,12 @@ pub struct Flush {
     pub count: Cumulative<i64>,
 }
 #[derive(Debug, Default, Copy, Clone, Metric)]
+pub struct Barrier {
+    /// Count of region barriers this upstairs has completed
+    #[datum]
+    pub count: Cumulative<i64>,
+}
+#[derive(Debug, Default, Copy, Clone, Metric)]
 pub struct FlushClose {
     /// Count of extent flush close operations this upstairs has completed
     #[datum]
@@ -83,6 +89,7 @@ pub struct UpCountStat {
     read_count: Read,
     read_bytes: ReadBytes,
     flush_count: Flush,
+    barrier_count: Barrier,
     flush_close_count: FlushClose,
     extent_repair_count: ExtentRepair,
     extent_noop_count: ExtentNoOp,
@@ -99,6 +106,7 @@ impl UpCountStat {
             read_count: Default::default(),
             read_bytes: Default::default(),
             flush_count: Default::default(),
+            barrier_count: Default::default(),
             flush_close_count: Default::default(),
             extent_repair_count: Default::default(),
             extent_noop_count: Default::default(),
@@ -147,6 +155,11 @@ impl UpStatOuter {
     pub fn add_flush(&self) {
         let mut ups = self.up_stat_wrap.lock().unwrap();
         let datum = ups.flush_count.datum_mut();
+        *datum += 1;
+    }
+    pub fn add_barrier(&self) {
+        let mut ups = self.up_stat_wrap.lock().unwrap();
+        let datum = ups.barrier_count.datum_mut();
         *datum += 1;
     }
     pub fn add_flush_close(&self) {

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1288,6 +1288,19 @@ impl Upstairs {
         cdt::up__to__ds__flush__start!(|| (ds_id.0));
     }
 
+    #[allow(dead_code)] // XXX this will be used soon!
+    fn submit_barrier(&mut self) {
+        // Notice that unlike submit_read and submit_write, we do not check for
+        // guest_io_ready here. The upstairs itself calls submit_barrier
+        // without the guest being involved; indeed the guest is not allowed to
+        // call it!
+
+        let ds_id = self.downstairs.submit_barrier();
+        self.guest.guest_work.submit_job(ds_id, None);
+
+        cdt::up__to__ds__barrier__start!(|| (ds_id.0));
+    }
+
     /// Submits a read job to the downstairs
     fn submit_read(
         &mut self,
@@ -1625,6 +1638,7 @@ impl Upstairs {
             Message::WriteAck { .. }
             | Message::WriteUnwrittenAck { .. }
             | Message::FlushAck { .. }
+            | Message::BarrierAck { .. }
             | Message::ReadResponse { .. }
             | Message::ExtentLiveCloseAck { .. }
             | Message::ExtentLiveAckId { .. }
@@ -1726,6 +1740,7 @@ impl Upstairs {
             Message::HereIAm { .. }
             | Message::Ruok
             | Message::Flush { .. }
+            | Message::Barrier { .. }
             | Message::LastFlush { .. }
             | Message::Write { .. }
             | Message::WriteUnwritten { .. }


### PR DESCRIPTION
(staged on top of #1493)

The `Barrier` op does no work, but serves as a full dependency barrier (like a flush) so that the Downstairs can reset its list of completed jobs.  Note that it does _not_ update `last_flush` or retire jobs in the Upstairs, because it doesn't actually persist data to disk.

This is a building block for removing automatic flushes (see RFD 518).