### PR TITLE
Remove remaining `Arc<Volume>` instances

### DIFF
--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -681,7 +681,7 @@ mod test {
                 let mut builder =
                     VolumeBuilder::new(BLOCK_SIZE as u64, log.clone());
                 builder.add_subvolume(in_memory_data.clone()).await?;
-                Arc::new(Volume::from(builder))
+                Volume::from(builder).as_blockio()
             })
             .await?;
         let volume = Volume::from(builder);
@@ -1807,7 +1807,7 @@ mod test {
                 let mut builder =
                     VolumeBuilder::new(BLOCK_SIZE as u64, log.clone());
                 builder.add_subvolume(in_memory_data).await?;
-                Arc::new(Volume::from(builder))
+                Volume::from(builder).as_blockio()
             })
             .await?;
 
@@ -1931,7 +1931,7 @@ mod test {
                 let mut builder =
                     VolumeBuilder::new(BLOCK_SIZE as u64, log.clone());
                 builder.add_subvolume(in_memory_data).await?;
-                Arc::new(Volume::from(builder))
+                Volume::from(builder).as_blockio()
             })
             .await?;
 


### PR DESCRIPTION
Nested volumes use an `Arc<dyn BlockIO + Send + Sync>` to represent the inner `BlockIO` device.

Previously, we implemented the `BlockIO` trait on the `struct Volume` itself, so we needed to make an `Arc<Volume>` to create nested volumes.

This PR moves the `BlockIO` implementation to the `VolumeInner`.  Because the `VolumeInner` is already stored in an `Arc`, we can now cast from `Arc<VolumeInner>` to `Arc<dyn BlockIO + Send + Sync>`, removing the extra level of indirection.