### PR TITLE
Minor cleanups to `print_last_completed`

### DIFF
--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -2756,10 +2756,7 @@ impl Downstairs {
 
     /// Prints the last `n` completed jobs to `stdout`
     pub(crate) fn print_last_completed(&self, n: usize) {
-        // TODO this is a ringbuffer, why are we turning it to a Vec to look at
-        // the last five items?
-        let done = self.completed.to_vec();
-        for j in done.iter().rev().take(n) {
+        for j in self.completed.iter().rev().take(n) {
             print!(" {:4}", j);
         }
     }

--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -205,7 +205,6 @@ impl GuestWork {
     }
 
     pub fn print_last_completed(&self, n: usize) {
-        print!("Upstairs last five completed:  ");
         for j in self.completed.iter().rev().take(n) {
             print!(" {:4}", j);
         }

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1171,6 +1171,7 @@ impl Upstairs {
             .filter(|c| c.state() == DsState::Active)
             .count();
 
+        print!("Upstairs last five completed:  ");
         self.guest.guest_work.print_last_completed(5);
         println!();
 


### PR DESCRIPTION
- Don't reallocate into a `Vec<..>`; just print from the `AllocRingBuf<..>`
- Don't print (incorrect) header in `print_last_completed`; instead, print it in the caller