### PR TITLE
Move `GuestBlockRes` into `DownstairsIO`

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -63,8 +63,8 @@ pub use mend::{DownstairsMend, ExtentFix, RegionMetadata};
 pub use pseudo_file::CruciblePseudoFile;
 
 pub(crate) mod guest;
-use guest::GuestIoHandle;
 pub use guest::{Guest, WQCounts};
+use guest::{GuestBlockRes, GuestIoHandle};
 
 mod stats;
 
@@ -938,6 +938,9 @@ struct DownstairsIO {
 
     /// Map of work status, tracked on a per-client basis
     state: ClientData<IOState>,
+
+    /// Reply handle to send data back to the guest
+    res: Option<GuestBlockRes>,
 
     /*
      * Has this been acked to the guest yet?


### PR DESCRIPTION
In our current code, we're maintaining two separate maps with `JobId` as their keys:

- `JobId` → `DownstairsIO` in `ActiveJobs`
- `JobId` → `GtoS` (wrapping a `GuestBlockRes`) in the `GuestWork`

Before #1482, the latter was keyed by a `GuestWorkId`, so the distinction made sense.  However, now that `GuestWorkId` is gone, having both maps doesn't buy us anything – and makes the code more error-prone to edit.

This PR moves the `GuestBlockRes` object from `GuestWork::active` onto the `DownstairsIO` object itself, so it can live with the rest of the per-IO data.

The `submit_*` functions in `Downstairs` now accept the relevant data to construct a `GuestBlockRes`, which also makes things more type-safe (i.e. you can't call `submit_read` without a buffer and reply object).