### PR TITLE
Still more updates to support Volume layer activities.

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -103,6 +103,9 @@ pub enum CrucibleError {
     #[error("Subvolume size mismatch!")]
     SubvolumeSizeMismatch,
 
+    #[error("Subvolume type mismatch!")]
+    SubvolumeTypeMismatch,
+
     #[error("Cannot serve blocks: {0}")]
     CannotServeBlocks(String),
 
@@ -407,6 +410,7 @@ impl From<CrucibleError> for dropshot::HttpError {
             | CrucibleError::RwLockError(_)
             | CrucibleError::SendError(_)
             | CrucibleError::SubvolumeSizeMismatch
+            | CrucibleError::SubvolumeTypeMismatch
             | CrucibleError::UpstairsActivateInProgress
             | CrucibleError::UpstairsDeactivating
             | CrucibleError::UuidMismatch

--- a/crutest/src/protocol.rs
+++ b/crutest/src/protocol.rs
@@ -38,7 +38,7 @@ pub enum CliMessage {
     FillSparse,
     Flush,
     Generic(usize, bool),
-    Info(VolumeInfo, u64, usize),
+    Info(VolumeInfo),
     InfoPlease,
     IsActive,
     MyUuid(Uuid),
@@ -225,7 +225,7 @@ mod tests {
             block_size: 512,
             volumes: Vec::new(),
         };
-        let input = CliMessage::Info(vi, 2, 99);
+        let input = CliMessage::Info(vi);
         assert_eq!(input, round_trip(&input)?);
         Ok(())
     }

--- a/crutest/src/protocol.rs
+++ b/crutest/src/protocol.rs
@@ -34,9 +34,11 @@ pub enum CliMessage {
     Export,
     // Run the fill test.
     Fill(bool),
+    // Run the sparse fill test.
+    FillSparse,
     Flush,
     Generic(usize, bool),
-    Info(u64, u64, u64),
+    Info(VolumeInfo, u64, usize),
     InfoPlease,
     IsActive,
     MyUuid(Uuid),
@@ -219,7 +221,11 @@ mod tests {
 
     #[test]
     fn rt_info() -> Result<()> {
-        let input = CliMessage::Info(1, 2, 99);
+        let vi = VolumeInfo {
+            block_size: 512,
+            volumes: Vec::new(),
+        };
+        let input = CliMessage::Info(vi, 2, 99);
         assert_eq!(input, round_trip(&input)?);
         Ok(())
     }

--- a/upstairs/src/block_io.rs
+++ b/upstairs/src/block_io.rs
@@ -48,8 +48,10 @@ impl BlockIO for FileBlockIO {
         Ok(())
     }
 
-    async fn query_extent_size(&self) -> Result<Block, CrucibleError> {
-        crucible_bail!(Unsupported, "query_extent_size unsupported",)
+    async fn query_extent_info(
+        &self,
+    ) -> Result<Option<RegionExtentInfo>, CrucibleError> {
+        Ok(None)
     }
 
     async fn query_work_queue(&self) -> Result<WQCounts, CrucibleError> {
@@ -216,10 +218,10 @@ impl BlockIO for ReqwestBlockIO {
         })
     }
 
-    async fn query_extent_size(&self) -> Result<Block, CrucibleError> {
-        Err(CrucibleError::Unsupported(
-            "query_extent_size unsupported".to_string(),
-        ))
+    async fn query_extent_info(
+        &self,
+    ) -> Result<Option<RegionExtentInfo>, CrucibleError> {
+        Ok(None)
     }
 
     async fn query_is_active(&self) -> Result<bool, CrucibleError> {

--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -343,42 +343,6 @@ impl Guest {
         rx.wait().await
     }
 
-    pub async fn query_extent_info(
-        &self,
-    ) -> Result<Option<RegionExtentInfo>, CrucibleError> {
-        let ei = self
-            .send_and_wait(|done| BlockOp::QueryExtentInfo { done })
-            .await?;
-        Ok(Some(ei))
-    }
-
-    pub async fn query_work_queue(&self) -> Result<WQCounts, CrucibleError> {
-        self.send_and_wait(|done| BlockOp::QueryWorkQueue { done })
-            .await
-    }
-
-    // Maybe this can just be a guest specific thing, not a BlockIO
-    pub async fn activate_with_gen(
-        &self,
-        gen: u64,
-    ) -> Result<(), CrucibleError> {
-        let (rx, done) = BlockOpWaiter::pair();
-        self.send(BlockOp::GoActiveWithGen { gen, done }).await;
-        info!(
-            self.log,
-            "The guest has requested activation with gen:{}", gen
-        );
-
-        rx.wait().await?;
-
-        info!(
-            self.log,
-            "The guest has finished waiting for activation with:{}", gen
-        );
-
-        Ok(())
-    }
-
     /// Sleeps for a backpressure-dependent amount, holding the lock
     ///
     /// If backpressure is saturated, logs and returns an error.

--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -13,7 +13,8 @@ use crate::{
     BlockIO, BlockOp, BlockOpWaiter, BlockRes, Buffer, JobId, RawReadResponse,
     ReplaceResult, UpstairsAction,
 };
-use crucible_common::{build_logger, Block, BlockIndex, CrucibleError};
+use crucible_client_types::RegionExtentInfo;
+use crucible_common::{build_logger, BlockIndex, CrucibleError};
 use crucible_protocol::SnapshotDetails;
 
 use async_trait::async_trait;
@@ -342,9 +343,13 @@ impl Guest {
         rx.wait().await
     }
 
-    pub async fn query_extent_size(&self) -> Result<Block, CrucibleError> {
-        self.send_and_wait(|done| BlockOp::QueryExtentSize { done })
-            .await
+    pub async fn query_extent_info(
+        &self,
+    ) -> Result<Option<RegionExtentInfo>, CrucibleError> {
+        let ei = self
+            .send_and_wait(|done| BlockOp::QueryExtentInfo { done })
+            .await?;
+        Ok(Some(ei))
     }
 
     pub async fn query_work_queue(&self) -> Result<WQCounts, CrucibleError> {
@@ -463,10 +468,13 @@ impl BlockIO for Guest {
         self.send_and_wait(|done| BlockOp::QueryWorkQueue { done })
             .await
     }
-
-    async fn query_extent_size(&self) -> Result<Block, CrucibleError> {
-        self.send_and_wait(|done| BlockOp::QueryExtentSize { done })
-            .await
+    async fn query_extent_info(
+        &self,
+    ) -> Result<Option<RegionExtentInfo>, CrucibleError> {
+        let ei = self
+            .send_and_wait(|done| BlockOp::QueryExtentInfo { done })
+            .await?;
+        Ok(Some(ei))
     }
 
     async fn total_size(&self) -> Result<u64, CrucibleError> {

--- a/upstairs/src/in_memory.rs
+++ b/upstairs/src/in_memory.rs
@@ -41,8 +41,10 @@ impl BlockIO for InMemoryBlockIO {
         Ok(())
     }
 
-    async fn query_extent_size(&self) -> Result<Block, CrucibleError> {
-        crucible_bail!(Unsupported, "query_extent_size unsupported",)
+    async fn query_extent_info(
+        &self,
+    ) -> Result<Option<RegionExtentInfo>, CrucibleError> {
+        Ok(None)
     }
 
     async fn query_work_queue(&self) -> Result<WQCounts, CrucibleError> {

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 pub use crucible_client_types::{
-    CrucibleOpts, ReplaceResult, VolumeConstructionRequest,
+    CrucibleOpts, RegionExtentInfo, ReplaceResult, VolumeConstructionRequest,
 };
 pub use crucible_common::*;
 pub use crucible_protocol::*;
@@ -109,8 +109,9 @@ pub trait BlockIO: Sync {
     async fn deactivate(&self) -> Result<(), CrucibleError>;
 
     async fn query_is_active(&self) -> Result<bool, CrucibleError>;
-
-    async fn query_extent_size(&self) -> Result<Block, CrucibleError>;
+    async fn query_extent_info(
+        &self,
+    ) -> Result<Option<RegionExtentInfo>, CrucibleError>;
     async fn query_work_queue(&self) -> Result<WQCounts, CrucibleError>;
 
     // Total bytes of Volume
@@ -1595,8 +1596,8 @@ pub(crate) enum BlockOp {
         done: BlockRes<Uuid>,
     },
     // Begin testing options.
-    QueryExtentSize {
-        done: BlockRes<Block>,
+    QueryExtentInfo {
+        done: BlockRes<RegionExtentInfo>,
     },
     QueryWorkQueue {
         done: BlockRes<WQCounts>,

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1064,11 +1064,11 @@ impl Upstairs {
                     None => {
                         warn!(
                             self.log,
-                            "Extent size not available (active: {})",
+                            "Extent info not available (active: {})",
                             self.guest_io_ready()
                         );
                         done.send_err(CrucibleError::PropertyNotAvailable(
-                            "extent size".to_string(),
+                            "extent info".to_string(),
                         ));
                     }
                 };

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -17,6 +17,7 @@ use crate::{
     EncryptionContext, GuestIoHandle, Message, RegionDefinition,
     RegionDefinitionStatus, SnapshotDetails, WQCounts,
 };
+use crucible_client_types::RegionExtentInfo;
 use crucible_common::{BlockIndex, CrucibleError};
 use serde::{Deserialize, Serialize};
 
@@ -1049,11 +1050,16 @@ impl Upstairs {
                 };
             }
             // Testing options
-            BlockOp::QueryExtentSize { done } => {
+            BlockOp::QueryExtentInfo { done } => {
                 // Yes, test only
                 match self.ddef.get_def() {
                     Some(rd) => {
-                        done.send_ok(rd.extent_size());
+                        let ei = RegionExtentInfo {
+                            block_size: rd.block_size(),
+                            blocks_per_extent: rd.extent_size().value,
+                            extent_count: rd.extent_count(),
+                        };
+                        done.send_ok(ei);
                     }
                     None => {
                         warn!(


### PR DESCRIPTION
This is a re-do, re-work of what was in: Make crutest know extent info for each sub volume. #1474

Two new structs to describe a Volume:
```
pub struct VolumeInfo {
    pub block_size: u64,
    pub volumes: Vec<SubVolumeInfo>,
}
pub struct SubVolumeInfo {
    pub blocks_per_extent: u64,
    pub extent_count: u32,
}
```

Added a new method to the `Volume` type that will gather extent info from each sub-volume and return a `VolumeInfo` struct that describes the whole volume.

In the `BlockIO` trait, replaced `query_extent_size` with `query_extent_info`.  Objects that support this call will return the `RegionExtentInfo` type filled out.  Things that do not will just return `None`.

Updated crutest's `RegionInfo` struct to have a `VolumeInfo` field.

Updated the fill_sparse and span crutest tests to perform their work on all sub-volumes.

print_region_description looks like this:
```
----------------------------------------------
random read with 4 KiB chunks (1 block)
region info:
  block size:                   4096 bytes
  sub_volume 0 blocks / extent: 100
  sub_volume 0 extent count:    15
  sub_volume 0 extent size:     400 KiB
  sub_volume 1 blocks / extent: 100
  sub_volume 1 extent count:    15
  sub_volume 1 extent size:     400 KiB
  total blocks:                 3000
  total size:                   11.7 MiB
  encryption:                   no
----------------------------------------------
```

Added fill-sparse test to crutest cli

Coming in a follow up PR I would like to rename `RegionInfo` in crutest to be `DiskInfo`.  This would just be name changes, no functional changes.  I decided to break that out to reduce review overhead.