### PR TITLE
Fix new `rustc` and `clippy` warnings

### DIFF
--- a/agent/src/smf_interface.rs
+++ b/agent/src/smf_interface.rs
@@ -487,6 +487,7 @@ pub struct MockSmfInstance {
     inner: Arc<Mutex<MockSmfInstanceInner>>,
 }
 
+#[cfg(test)]
 impl MockSmfInstance {
     pub fn new(name: String, fmri: String) -> MockSmfInstance {
         MockSmfInstance {

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -2343,7 +2343,7 @@ async fn replace_while_reconcile(
     info!(log, "Begin replacement while reconciliation test");
     loop {
         info!(log, "[{c}] Touch every extent part 1");
-        fill_sparse_workload(&volume, ri).await?;
+        fill_sparse_workload(volume, ri).await?;
 
         info!(log, "[{c}] Stop a downstairs");
         // Stop a downstairs, wait for dsc to confirm it is stopped.
@@ -2357,7 +2357,7 @@ async fn replace_while_reconcile(
             tokio::time::sleep(tokio::time::Duration::from_secs(4)).await;
         }
         info!(log, "[{c}] Touch every extent part 2");
-        fill_sparse_workload(&volume, ri).await?;
+        fill_sparse_workload(volume, ri).await?;
 
         info!(log, "[{c}] Deactivate");
         volume.deactivate().await.unwrap();
@@ -2541,7 +2541,7 @@ async fn replace_before_active(
     let mut new_ds = targets.len() - 1;
     for c in 1.. {
         info!(log, "[{c}] Touch every extent");
-        fill_sparse_workload(&volume, ri).await?;
+        fill_sparse_workload(volume, ri).await?;
 
         volume.deactivate().await.unwrap();
         loop {
@@ -2692,7 +2692,7 @@ async fn replace_workload(
     let ds_total = targets.len() - 1;
 
     if fill {
-        fill_sparse_workload(&volume, ri).await?;
+        fill_sparse_workload(volume, ri).await?;
     }
     // Make a copy of the stop at counter if one was provided so the
     // IO task and the replace task don't have to share wtq

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -893,7 +893,7 @@ struct ConnectionData {
     repair_addr: SocketAddr,
 
     /// Token used to cancel the IO tasks
-    #[allow(unused)]
+    #[expect(unused)]
     cancel: tokio_util::sync::DropGuard,
 
     /// IO channel to the reply task

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -133,11 +133,7 @@ async fn main() -> Result<()> {
         bsz as usize
     };
 
-    let io_depth = if let Some(io_depth) = opt.io_depth {
-        io_depth
-    } else {
-        1
-    };
+    let io_depth = opt.io_depth.unwrap_or(1);
 
     let mut io_operations_sent = 0;
     let mut bw_consumed = 0;

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -18,7 +18,7 @@ fn handle_nbd_client<T: crucible::BlockIO>(
     cpf: &mut crucible::CruciblePseudoFile<T>,
     mut stream: NetTcpStream,
 ) -> Result<()> {
-    let e = Export {
+    let e: Export<()> = Export {
         size: cpf.sz(),
         readonly: false,
         ..Default::default()


### PR DESCRIPTION
`cargo check --all-targets` and `cargo clippy --all-targets` are now both clean, after the bump to `rustc 1.81.0`

In addition, we can use the new `#[expect(unused)]` for a `DropGuard` that is held purely for its on-drop side effects.