### PR TITLE
Split out Downstairs-specific stats

### DIFF
--- a/upstairs/src/stats.rs
+++ b/upstairs/src/stats.rs
@@ -7,72 +7,72 @@ use oximeter::{
 };
 
 // These structs are used to construct the desired stats for Oximeter.
-#[derive(Debug, Copy, Clone, Target)]
+#[derive(Debug, Target)]
 pub struct CrucibleUpstairs {
     /// The UUID of the region
     pub upstairs_uuid: Uuid,
 }
-#[derive(Debug, Default, Copy, Clone, Metric)]
+#[derive(Debug, Default, Metric)]
 pub struct Activated {
     /// Count of times this upstairs has activated.
     #[datum]
     pub count: Cumulative<i64>,
 }
-#[derive(Debug, Default, Copy, Clone, Metric)]
+#[derive(Debug, Default, Metric)]
 pub struct Write {
     /// Count of region writes this upstairs has completed
     #[datum]
     pub count: Cumulative<i64>,
 }
-#[derive(Debug, Default, Copy, Clone, Metric)]
+#[derive(Debug, Default, Metric)]
 pub struct WriteBytes {
     /// Count of bytes written
     #[datum]
     pub count: Cumulative<i64>,
 }
-#[derive(Debug, Default, Copy, Clone, Metric)]
+#[derive(Debug, Default, Metric)]
 pub struct Read {
     /// Count of region reads this upstairs has completed
     #[datum]
     pub count: Cumulative<i64>,
 }
-#[derive(Debug, Default, Copy, Clone, Metric)]
+#[derive(Debug, Default, Metric)]
 pub struct ReadBytes {
     /// Count of bytes read
     #[datum]
     pub count: Cumulative<i64>,
 }
-#[derive(Debug, Default, Copy, Clone, Metric)]
+#[derive(Debug, Default, Metric)]
 pub struct Flush {
     /// Count of region flushes this upstairs has completed
     #[datum]
     pub count: Cumulative<i64>,
 }
-#[derive(Debug, Default, Copy, Clone, Metric)]
+#[derive(Debug, Default, Metric)]
 pub struct Barrier {
     /// Count of region barriers this upstairs has completed
     #[datum]
     pub count: Cumulative<i64>,
 }
-#[derive(Debug, Default, Copy, Clone, Metric)]
+#[derive(Debug, Default, Metric)]
 pub struct FlushClose {
     /// Count of extent flush close operations this upstairs has completed
     #[datum]
     pub count: Cumulative<i64>,
 }
-#[derive(Debug, Default, Copy, Clone, Metric)]
+#[derive(Debug, Default, Metric)]
 pub struct ExtentRepair {
     /// Count of extent repair operations this upstairs has completed
     #[datum]
     pub count: Cumulative<i64>,
 }
-#[derive(Debug, Default, Copy, Clone, Metric)]
+#[derive(Debug, Default, Metric)]
 pub struct ExtentNoOp {
     /// Count of extent NoOp operations this upstairs has completed
     #[datum]
     pub count: Cumulative<i64>,
 }
-#[derive(Debug, Default, Copy, Clone, Metric)]
+#[derive(Debug, Default, Metric)]
 pub struct ExtentReopen {
     /// Count of extent reopen operations this upstairs has completed
     #[datum]
@@ -80,10 +80,23 @@ pub struct ExtentReopen {
 }
 
 // All the counter stats in one struct.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct UpCountStat {
     stat_name: CrucibleUpstairs,
     activated_count: Activated,
+}
+
+impl UpCountStat {
+    pub fn new(upstairs_uuid: Uuid) -> Self {
+        UpCountStat {
+            stat_name: CrucibleUpstairs { upstairs_uuid },
+            activated_count: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct DownstairsCountStat {
     write_count: Write,
     write_bytes: WriteBytes,
     read_count: Read,
@@ -96,31 +109,16 @@ pub struct UpCountStat {
     extent_reopen_count: ExtentReopen,
 }
 
-impl UpCountStat {
-    pub fn new(upstairs_uuid: Uuid) -> Self {
-        UpCountStat {
-            stat_name: CrucibleUpstairs { upstairs_uuid },
-            activated_count: Default::default(),
-            write_count: Default::default(),
-            write_bytes: Default::default(),
-            read_count: Default::default(),
-            read_bytes: Default::default(),
-            flush_count: Default::default(),
-            barrier_count: Default::default(),
-            flush_close_count: Default::default(),
-            extent_repair_count: Default::default(),
-            extent_noop_count: Default::default(),
-            extent_reopen_count: Default::default(),
-        }
-    }
-}
-
 // This struct wraps the stat struct in an Arc/Mutex so the worker tasks can
 // share it with the producer trait.
 #[derive(Clone, Debug)]
 pub struct UpStatOuter {
     pub up_stat_wrap: Arc<std::sync::Mutex<UpCountStat>>,
+    ds_stat_wrap: DownstairsStatOuter,
 }
+
+#[derive(Clone, Debug, Default)]
+pub struct DownstairsStatOuter(Arc<std::sync::Mutex<DownstairsCountStat>>);
 
 impl UpStatOuter {
     pub fn new(uuid: Uuid) -> Self {
@@ -128,57 +126,66 @@ impl UpStatOuter {
             up_stat_wrap: Arc::new(std::sync::Mutex::new(UpCountStat::new(
                 uuid,
             ))),
+            ds_stat_wrap: DownstairsStatOuter::default(),
         }
     }
-    // When an operation happens that we wish to record in Oximeter,
-    // one of these methods will be called.  Each method will get the
-    // correct field of UpCountStat to record the update.
+
     pub fn add_activation(&self) {
         let mut ups = self.up_stat_wrap.lock().unwrap();
         let datum = ups.activated_count.datum_mut();
         *datum += 1;
     }
+
+    /// Returns a handle to the nested `DownstairsStatOuter`
+    ///
+    /// The handle shares the same datums with the `UpStatOuter`
+    pub fn ds_stats(&self) -> DownstairsStatOuter {
+        self.ds_stat_wrap.clone()
+    }
+}
+
+impl DownstairsStatOuter {
     pub fn add_write(&self, bytes: i64) {
-        let mut ups = self.up_stat_wrap.lock().unwrap();
+        let mut ups = self.0.lock().unwrap();
         let datum = ups.write_bytes.datum_mut();
         *datum += bytes;
         let datum = ups.write_count.datum_mut();
         *datum += 1;
     }
     pub fn add_read(&self, bytes: i64) {
-        let mut ups = self.up_stat_wrap.lock().unwrap();
+        let mut ups = self.0.lock().unwrap();
         let datum = ups.read_bytes.datum_mut();
         *datum += bytes;
         let datum = ups.read_count.datum_mut();
         *datum += 1;
     }
     pub fn add_flush(&self) {
-        let mut ups = self.up_stat_wrap.lock().unwrap();
+        let mut ups = self.0.lock().unwrap();
         let datum = ups.flush_count.datum_mut();
         *datum += 1;
     }
     pub fn add_barrier(&self) {
-        let mut ups = self.up_stat_wrap.lock().unwrap();
+        let mut ups = self.0.lock().unwrap();
         let datum = ups.barrier_count.datum_mut();
         *datum += 1;
     }
     pub fn add_flush_close(&self) {
-        let mut ups = self.up_stat_wrap.lock().unwrap();
+        let mut ups = self.0.lock().unwrap();
         let datum = ups.flush_close_count.datum_mut();
         *datum += 1;
     }
     pub fn add_extent_repair(&self) {
-        let mut ups = self.up_stat_wrap.lock().unwrap();
+        let mut ups = self.0.lock().unwrap();
         let datum = ups.extent_repair_count.datum_mut();
         *datum += 1;
     }
     pub fn add_extent_noop(&self) {
-        let mut ups = self.up_stat_wrap.lock().unwrap();
+        let mut ups = self.0.lock().unwrap();
         let datum = ups.extent_noop_count.datum_mut();
         *datum += 1;
     }
     pub fn add_extent_reopen(&self) {
-        let mut ups = self.up_stat_wrap.lock().unwrap();
+        let mut ups = self.0.lock().unwrap();
         let datum = ups.extent_reopen_count.datum_mut();
         *datum += 1;
     }
@@ -194,19 +201,20 @@ impl Producer for UpStatOuter {
         &mut self,
     ) -> Result<Box<dyn Iterator<Item = Sample> + 'static>, MetricsError> {
         let ups = self.up_stat_wrap.lock().unwrap();
+        let dss = self.ds_stat_wrap.0.lock().unwrap();
 
         let name = &ups.stat_name;
         let data = vec![
             Sample::new(name, &ups.activated_count)?,
-            Sample::new(name, &ups.flush_count)?,
-            Sample::new(name, &ups.write_count)?,
-            Sample::new(name, &ups.write_bytes)?,
-            Sample::new(name, &ups.read_count)?,
-            Sample::new(name, &ups.read_bytes)?,
-            Sample::new(name, &ups.flush_close_count)?,
-            Sample::new(name, &ups.extent_repair_count)?,
-            Sample::new(name, &ups.extent_noop_count)?,
-            Sample::new(name, &ups.extent_reopen_count)?,
+            Sample::new(name, &dss.flush_count)?,
+            Sample::new(name, &dss.write_count)?,
+            Sample::new(name, &dss.write_bytes)?,
+            Sample::new(name, &dss.read_count)?,
+            Sample::new(name, &dss.read_bytes)?,
+            Sample::new(name, &dss.flush_close_count)?,
+            Sample::new(name, &dss.extent_repair_count)?,
+            Sample::new(name, &dss.extent_noop_count)?,
+            Sample::new(name, &dss.extent_reopen_count)?,
         ];
 
         // Yield the available samples.

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -390,6 +390,7 @@ impl Upstairs {
             cfg.clone(),
             ds_target,
             tls_context,
+            stats.ds_stats(),
             log.new(o!("" => "downstairs")),
         );
         let flush_timeout_secs = opt.flush_timeout.unwrap_or(0.5);
@@ -625,7 +626,7 @@ impl Upstairs {
 
         // Handle any jobs that have become ready for acks
         if self.downstairs.has_ackable_jobs() {
-            self.downstairs.ack_jobs(&self.stats)
+            self.downstairs.ack_jobs()
         }
 
         // Check for client-side deactivation


### PR DESCRIPTION
(staged on top of #1510)

This removes another bit of awkward plumbing!

Previously, we had to pass an `&UpStatOuter` to any functions in the `Downstairs` that needed to update our Oximeter statistics.  This PR splits the `UpStatOuter` into upstairs versus downstairs components, then stores a (shared) handle to the downstairs half in the `Downstairs` itself.

The Oximeter interface remains unchanged.

(Making the `Downstairs` more self-sufficient is a step towards doing immediate acks, i.e. eliminating `ackable_jobs` and simply sending acks as they become ready)