### PR TITLE
Add edition to `crucible-workspace-hack`

### DIFF
--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -6,6 +6,7 @@
 name = "crucible-workspace-hack"
 version = "0.1.0"
 description = "workspace-hack package, managed by hakari"
+edition = "2021"
 # You can choose to publish this crate: see https://docs.rs/cargo-hakari/latest/cargo_hakari/publishing.
 publish = false
 


### PR DESCRIPTION
This fixes a warning in the build:
```
warning: /Users/mjk/oxide/crucible/workspace-hack/Cargo.toml: no edition set: defaulting to the 2015 edition while the latest is 2021
```