### PR TITLE
Add test and fix for replay race condition

### DIFF
--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -978,7 +978,7 @@ impl DownstairsClient {
             // cleared out by a subsequent flush (so we'll be able to bring that
             // client back into compliance by replaying jobs).
             DsState::Active => EnqueueResult::Send,
-            DsState::Offline => EnqueueResult::Store,
+            DsState::Offline => EnqueueResult::Hold,
 
             DsState::New
             | DsState::BadVersion
@@ -2351,7 +2351,7 @@ pub(crate) enum EnqueueResult {
     /// This is used when the Downstairs is Offline; we want to mark the job as
     /// in-progress so that it's eligible for replay, but the job should not
     /// actually go out on the wire.
-    Store,
+    Hold,
 
     /// The job should be marked as skipped and not sent
     Skip,
@@ -2360,7 +2360,7 @@ pub(crate) enum EnqueueResult {
 impl EnqueueResult {
     pub(crate) fn state(&self) -> IOState {
         match self {
-            EnqueueResult::Send | EnqueueResult::Store => IOState::InProgress,
+            EnqueueResult::Send | EnqueueResult::Hold => IOState::InProgress,
             EnqueueResult::Skip => IOState::Skipped,
         }
     }

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -44,6 +44,10 @@ const PING_INTERVAL_SECS: f32 = 5.0;
 #[cfg(test)]
 pub const CLIENT_TIMEOUT_SECS: f32 = TIMEOUT_SECS * TIMEOUT_LIMIT as f32;
 
+/// Delay before a client reconnects (to prevent spamming connections)
+pub const CLIENT_RECONNECT_DELAY: std::time::Duration =
+    std::time::Duration::from_secs(10);
+
 /// Handle to a running I/O task
 ///
 /// The I/O task is "thin"; it simply forwards messages around.  The task
@@ -911,7 +915,7 @@ impl DownstairsClient {
         ds_id: JobId,
         io: &IOop,
         last_repair_extent: Option<ExtentId>,
-    ) -> bool {
+    ) -> EnqueueResult {
         // If a downstairs is faulted or ready for repair, we can move
         // that job directly to IOState::Skipped
         // If a downstairs is in repair, then we need to see if this
@@ -922,18 +926,15 @@ impl DownstairsClient {
         let should_send = self.should_send(io, last_repair_extent);
 
         // Update our set of skipped jobs if we're not sending this one
-        if !should_send {
+        if matches!(should_send, EnqueueResult::Skip) {
             self.skipped_jobs.insert(ds_id);
         }
 
         // Update our state counters based on the job state
-        let state = if should_send {
-            &IOState::InProgress
-        } else {
-            &IOState::Skipped
-        };
-        self.io_state_job_count[state] += 1;
-        self.io_state_byte_count[state] += io.job_bytes();
+        let state = should_send.state();
+        self.io_state_job_count[&state] += 1;
+        self.io_state_byte_count[&state] += io.job_bytes();
+
         should_send
     }
 
@@ -946,13 +947,13 @@ impl DownstairsClient {
         &self,
         io: &IOop,
         last_repair_extent: Option<ExtentId>,
-    ) -> bool {
+    ) -> EnqueueResult {
         match self.state {
             // We never send jobs if we're in certain inactive states
             DsState::Faulted
             | DsState::Replaced
             | DsState::Replacing
-            | DsState::LiveRepairReady => false,
+            | DsState::LiveRepairReady => EnqueueResult::Skip,
 
             // We conditionally send jobs if we're in live-repair, depending on
             // the current extent.
@@ -962,7 +963,11 @@ impl DownstairsClient {
                 // there are no reserved repair jobs), or the last extent
                 // for which we have reserved a repair job ID; either way, the
                 // caller has provided it to us.
-                io.send_io_live_repair(last_repair_extent)
+                if io.send_io_live_repair(last_repair_extent) {
+                    EnqueueResult::Send
+                } else {
+                    EnqueueResult::Skip
+                }
             }
 
             // Send jobs if the client is active or offline
@@ -971,7 +976,8 @@ impl DownstairsClient {
             // means that those jobs are marked as InProgress, so they aren't
             // cleared out by a subsequent flush (so we'll be able to bring that
             // client back into compliance by replaying jobs).
-            DsState::Active | DsState::Offline => true,
+            DsState::Active => EnqueueResult::Send,
+            DsState::Offline => EnqueueResult::Drop,
 
             DsState::New
             | DsState::BadVersion
@@ -2334,6 +2340,31 @@ enum NegotiationState {
     Done,
 }
 
+/// Result value from [`DownstairsClient::enqueue`]
+pub(crate) enum EnqueueResult {
+    /// The given job should be marked as in progress and sent
+    Send,
+
+    /// The given job should be marked as in progress, but not sent
+    ///
+    /// This is used when the Downstairs is Offline; we want to mark the job as
+    /// in-progress so that it's eligible for replay, but the job should not
+    /// actually go out on the wire.
+    Drop,
+
+    /// The job should be marked as skipped and not sent
+    Skip,
+}
+
+impl EnqueueResult {
+    pub(crate) fn state(&self) -> IOState {
+        match self {
+            EnqueueResult::Send | EnqueueResult::Drop => IOState::InProgress,
+            EnqueueResult::Skip => IOState::Skipped,
+        }
+    }
+}
+
 /// Action requested by `DownstairsClient::select`
 ///
 /// This is split into a separate data structure because we need to distinguish
@@ -2619,7 +2650,7 @@ impl ClientIoTask {
                         }
                     }
                 }
-                _ = tokio::time::sleep(std::time::Duration::from_secs(10)) => {
+                _ = tokio::time::sleep(CLIENT_RECONNECT_DELAY) => {
                     // this is fine
                 },
             }

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -2117,7 +2117,7 @@ impl Downstairs {
             let client = &mut self.clients[cid];
             let r = client.enqueue(ds_id, &io, last_repair_extent);
             match r {
-                EnqueueResult::Send | EnqueueResult::Store => {
+                EnqueueResult::Send | EnqueueResult::Hold => {
                     // Update the per-client backpressure guard
                     if !bp_guard.contains(&cid) {
                         let g = client.backpressure_counters.increment(&io);

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -2117,7 +2117,7 @@ impl Downstairs {
             let client = &mut self.clients[cid];
             let r = client.enqueue(ds_id, &io, last_repair_extent);
             match r {
-                EnqueueResult::Send | EnqueueResult::Drop => {
+                EnqueueResult::Send | EnqueueResult::Store => {
                     // Update the per-client backpressure guard
                     if !bp_guard.contains(&cid) {
                         let g = client.backpressure_counters.increment(&io);

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -9,7 +9,7 @@ use std::{
 use crate::{
     backpressure::BackpressureGuard,
     cdt,
-    client::{ClientAction, ClientStopReason, DownstairsClient},
+    client::{ClientAction, ClientStopReason, DownstairsClient, EnqueueResult},
     guest::GuestBlockRes,
     live_repair::ExtentInfo,
     stats::DownstairsStatOuter,
@@ -2115,18 +2115,21 @@ impl Downstairs {
         // Send the job to each client!
         let state = ClientData::from_fn(|cid| {
             let client = &mut self.clients[cid];
-            if client.enqueue(ds_id, &io, last_repair_extent) {
-                // Update the per-client backpressure guard
-                if !bp_guard.contains(&cid) {
-                    let g = client.backpressure_counters.increment(&io);
-                    bp_guard.insert(cid, g);
+            let r = client.enqueue(ds_id, &io, last_repair_extent);
+            match r {
+                EnqueueResult::Send | EnqueueResult::Drop => {
+                    // Update the per-client backpressure guard
+                    if !bp_guard.contains(&cid) {
+                        let g = client.backpressure_counters.increment(&io);
+                        bp_guard.insert(cid, g);
+                    }
+                    if matches!(r, EnqueueResult::Send) {
+                        self.send(ds_id, io.clone(), cid);
+                    }
                 }
-                self.send(ds_id, io.clone(), cid);
-                IOState::InProgress
-            } else {
-                skipped += 1;
-                IOState::Skipped
+                EnqueueResult::Skip => skipped += 1,
             }
+            r.state()
         });
 
         // Writes are acked immediately, before being enqueued

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -7,7 +7,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::client::CLIENT_TIMEOUT_SECS;
+use crate::client::{CLIENT_RECONNECT_DELAY, CLIENT_TIMEOUT_SECS};
 use crate::guest::Guest;
 use crate::up_main;
 use crate::BlockIO;
@@ -2645,4 +2645,58 @@ async fn test_write_replay() {
     // Check that the guest hasn't panicked by sending it a message that
     // requires going to the worker thread.
     harness.guest.get_uuid().await.unwrap();
+}
+
+/// Test that messages do not make it to a Downstairs mid-negotiation
+#[tokio::test]
+async fn test_no_send_offline() {
+    let mut harness = TestHarness::new().await;
+    harness.ds1().cfg.reply_to_ping = false;
+
+    // Sleep until we're confident that the Downstairs is kicked out, answering
+    // pings from the other two Downstairs
+    info!(harness.log, "waiting for Upstairs to kick out DS1");
+    let sleep_time = Duration::from_secs_f32(CLIENT_TIMEOUT_SECS + 5.0);
+    tokio::select! {
+        e = harness.ds1.as_mut().unwrap().recv() => {
+            // We've been kicked out!
+            assert!(e.is_none());
+        }
+        _ = harness.ds2.recv() => panic!("unexpected message"),
+        _ = harness.ds3.recv() => panic!("unexpected message"),
+        _ = tokio::time::sleep(sleep_time) => panic!("unexpected timeout"),
+    }
+
+    // Check to make sure that happened
+    let ds = harness.guest.downstairs_state().await.unwrap();
+    assert_eq!(ds[ClientId::new(0)], DsState::Offline);
+    assert_eq!(ds[ClientId::new(1)], DsState::Active);
+    assert_eq!(ds[ClientId::new(2)], DsState::Active);
+    println!("WE'RE OFFLINE");
+
+    // Reconnect ds1
+    harness.restart_ds1().await;
+    println!("WE'RE RESTARTING");
+
+    // Wait for the Upstairs to try reconnecting, answering pings all the while
+    let reconnect_time = CLIENT_RECONNECT_DELAY + Duration::from_secs(2);
+    tokio::select! {
+        _ = harness.ds2.recv() => panic!("unexpected message"),
+        _ = harness.ds3.recv() => panic!("unexpected message"),
+        _ = tokio::time::sleep(reconnect_time) => (),
+    }
+
+    // Start negotiation
+    harness.ds1().negotiate_start().await;
+
+    // Check that a write doesn't make it to DS1
+    let write_handle = harness.spawn(|guest| async move {
+        let mut data = BytesMut::new();
+        data.resize(512, 1u8);
+        guest.write(BlockIndex(0), data).await.unwrap();
+    });
+    harness.ds2.ack_write().await;
+    harness.ds3.ack_write().await;
+    assert_eq!(harness.ds1().try_recv(), Err(TryRecvError::Empty));
+    write_handle.await.unwrap();
 }


### PR DESCRIPTION
Fix for #1513 

When submitting IO to a Dowstairs in `DsState::Offline`, we need to mark that IO as `IOState::InProgress` (and not `IOState::Skipped`), because it's eligible for replay.

However, we don't want to actually send that IO down the wire, because there's a race condition if the Downstairs has just finish negotiation and would actually reply to it (which would be bad).

This PR distinguishes between the three cases in `DownstairsClient::enqueue` with a new `enum EnqueueResult`.  Bikeshedding is welcome on the variant names.

It's hard to unit-test the race condition specifically, so I'm testing the more general rule that an Offline downstairs shouldn't receive IO messages.