### PR TITLE
Switch to using `Duration` for times

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -424,11 +424,14 @@ impl From<CrucibleError> for dropshot::HttpError {
 ///
 /// This object waits for `tick * count`, printing a log message every `tick`
 pub struct VerboseTimeout {
+    /// Interval at which we log a timeout warning
     pub tick: Duration,
+    /// Number of intervals before returning
     pub count: u32,
 }
 
 impl VerboseTimeout {
+    /// Wait for `tick * count` duration, logging every `tick`
     pub async fn wait(&self, log: &slog::Logger) {
         for i in 0..self.count {
             tokio::time::sleep(self.tick).await;
@@ -436,6 +439,7 @@ impl VerboseTimeout {
         }
     }
 
+    /// Returns the total timeout duration for this object
     pub fn timeout(&self) -> Duration {
         self.tick * self.count
     }

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -663,7 +663,7 @@ pub async fn start_cli_client(attach: SocketAddr) -> Result<()> {
 
         println!("cli connecting to {0}", attach);
 
-        let deadline = tokio::time::sleep_until(deadline_secs(100.0));
+        let deadline = tokio::time::sleep(Duration::from_secs(100));
         tokio::pin!(deadline);
         let tcp = sock.connect(attach);
         tokio::pin!(tcp);
@@ -682,7 +682,7 @@ pub async fn start_cli_client(attach: SocketAddr) -> Result<()> {
                     Err(e) => {
                         println!("connect to {0} failure: {1:?}",
                             attach, e);
-                        tokio::time::sleep_until(deadline_secs(10.0)).await;
+                        tokio::time::sleep(Duration::from_secs(10)).await;
                         continue 'outer;
                     }
                 }

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -2057,6 +2057,7 @@ async fn recv_task<RT>(
 ) where
     RT: tokio::io::AsyncRead + std::marker::Unpin + std::marker::Send,
 {
+    // Disconnect from the upstairs after 45 sec, logging a warning every 15s
     const TIMEOUT: VerboseTimeout = VerboseTimeout {
         tick: Duration::from_secs(15),
         count: 3,

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -31,6 +31,7 @@ use tokio::{
 use tokio_util::codec::FramedRead;
 use uuid::Uuid;
 
+// Disconnect from downstairs upstairs after 45 sec, logging a warning every 15s
 pub(crate) const CLIENT_TIMEOUT: VerboseTimeout = VerboseTimeout {
     tick: Duration::from_secs(15),
     count: 3,

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -7,7 +7,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::client::{CLIENT_RECONNECT_DELAY, CLIENT_TIMEOUT_SECS};
+use crate::client::{CLIENT_RECONNECT_DELAY, CLIENT_TIMEOUT};
 use crate::guest::Guest;
 use crate::up_main;
 use crate::BlockIO;
@@ -47,6 +47,7 @@ use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
+use tokio::time::Instant;
 use tokio_util::codec::FramedRead;
 use tokio_util::codec::FramedWrite;
 use uuid::Uuid;
@@ -1476,13 +1477,13 @@ async fn test_byte_fault_condition() {
     }
 
     // Sleep until we're confident that the Downstairs is kicked out
-    let sleep_time = CLIENT_TIMEOUT_SECS + 5.0;
+    let sleep_time = CLIENT_TIMEOUT.timeout() + Duration::from_secs(5);
     info!(
         harness.log,
-        "waiting {sleep_time} secs for Upstairs to kick out DS1"
+        "waiting {sleep_time:?} secs for Upstairs to kick out DS1"
     );
     tokio::select! {
-        _ = tokio::time::sleep(Duration::from_secs_f32(sleep_time)) => {
+        _ = tokio::time::sleep(sleep_time) => {
             // we're done!
         }
         // we don't listen to ds1 here, so we won't acknowledge any pings!
@@ -1516,8 +1517,8 @@ async fn test_byte_fault_condition_offline() {
     //   Active -> Offline (after 45 seconds).
     // - Then, after its job count hits IO_OUTSTANDING_MAX_BYTES, it will
     //   transition from Offline -> Faulted
-    const MARGIN_SECS: f32 = 2.0;
-    const SEND_JOBS_TIME: f32 = CLIENT_TIMEOUT_SECS - MARGIN_SECS;
+    const MARGIN: Duration = Duration::from_secs(2);
+    let send_jobs_time = CLIENT_TIMEOUT.timeout() - MARGIN;
     let start_time = tokio::time::Instant::now();
 
     // `num_jobs` sends enough bytes to hit the IO_OUTSTANDING_MAX_BYTES
@@ -1530,12 +1531,9 @@ async fn test_byte_fault_condition_offline() {
 
     // First, we'll send jobs until the timeout
     for i in 0..num_jobs / 2 {
-        // Delay so that we hit SEND_JOBS_TIME at the end of this loop
+        // Delay so that we hit `send_jobs_time` at the end of this loop
         tokio::time::sleep_until(
-            start_time
-                + Duration::from_secs_f32(
-                    SEND_JOBS_TIME * i as f32 / (num_jobs / 2) as f32,
-                ),
+            start_time + (send_jobs_time * i as u32) / (num_jobs as u32 / 2),
         )
         .await;
 
@@ -1566,7 +1564,7 @@ async fn test_byte_fault_condition_offline() {
 
     // Sleep until we're confident that the Downstairs is kicked out
     info!(harness.log, "waiting for Upstairs to kick out DS1");
-    tokio::time::sleep(Duration::from_secs_f32(2.0 * MARGIN_SECS)).await;
+    tokio::time::sleep(2 * MARGIN).await;
 
     // Check to make sure that happened
     let ds = harness.guest.downstairs_state().await.unwrap();
@@ -1598,7 +1596,7 @@ async fn test_byte_fault_condition_offline() {
         h.await.unwrap();
 
         let ds = harness.guest.downstairs_state().await.unwrap();
-        if (i + 1) * WRITE_SIZE < IO_OUTSTANDING_MAX_BYTES as usize {
+        if (i as usize + 1) * WRITE_SIZE < IO_OUTSTANDING_MAX_BYTES as usize {
             assert_eq!(ds[ClientId::new(0)], DsState::Offline);
             assert_eq!(ds[ClientId::new(1)], DsState::Active);
             assert_eq!(ds[ClientId::new(2)], DsState::Active);
@@ -1622,24 +1620,21 @@ async fn test_offline_can_deactivate() {
 
     // We're not replying to pings, so DS1 will eventually transition from
     // Active -> Offline (after CLIENT_TIMEOUT_SECS seconds).
-    const MARGIN_SECS: f32 = 5.0;
+    const MARGIN: Duration = Duration::from_secs(5);
 
     // Sleep until we're confident that the Downstairs is kicked out.  We do
     // a loop here so the other downstairs will have a chance to respond to
     // pings.
-    let sleep_time = 5.0;
-    let loop_stop_time = CLIENT_TIMEOUT_SECS + MARGIN_SECS;
-    let mut loop_time = 0.0;
+    let sleep_time = Duration::from_secs(5);
+    let loop_stop_time = Instant::now() + CLIENT_TIMEOUT.timeout() + MARGIN;
 
     // Sleep until we're confident that the Downstairs is kicked out
-    while loop_time < loop_stop_time {
-        tokio::time::sleep(Duration::from_secs_f32(sleep_time)).await;
+    while Instant::now() < loop_stop_time {
+        tokio::time::sleep(sleep_time).await;
         // Respond to pings, but drop anything else (we should not get
         // anything else)
         let _ = harness.ds2.try_recv();
         let _ = harness.ds3.try_recv();
-
-        loop_time += sleep_time;
     }
 
     // Check to make sure downstairs 1 is now offline.
@@ -1662,24 +1657,21 @@ async fn test_offline_with_io_can_deactivate() {
 
     // We're not replying to pings, so DS1 will eventually transition from
     // Active -> Offline (after CLIENT_TIMEOUT_SECS seconds).
-    const MARGIN_SECS: f32 = 5.0;
+    const MARGIN: Duration = Duration::from_secs(5);
 
     // Sleep until we're confident that the Downstairs is kicked out.  We do
     // a loop here so the other downstairs will have a chance to respond to
     // pings.
-    let sleep_time = 5.0;
-    let loop_stop_time = CLIENT_TIMEOUT_SECS + MARGIN_SECS;
-    let mut loop_time = 0.0;
+    let sleep_time = Duration::from_secs(5);
+    let loop_stop_time = Instant::now() + CLIENT_TIMEOUT.timeout() + MARGIN;
 
     // Sleep until we're confident that the Downstairs is kicked out
-    while loop_time < loop_stop_time {
-        tokio::time::sleep(Duration::from_secs_f32(sleep_time)).await;
+    while Instant::now() < loop_stop_time {
+        tokio::time::sleep(sleep_time).await;
         // Respond to pings, but drop anything else (we should not get
         // anything else)
         let _ = harness.ds2.try_recv();
         let _ = harness.ds3.try_recv();
-
-        loop_time += sleep_time;
     }
 
     // Check to make sure downstairs 1 is now offline.
@@ -1727,11 +1719,11 @@ async fn test_all_offline_with_io_can_deactivate() {
 
     // We're not replying to pings, so DS1 will eventually transition from
     // Active -> Offline (after CLIENT_TIMEOUT_SECS seconds).
-    const MARGIN_SECS: f32 = 5.0;
+    const MARGIN: Duration = Duration::from_secs(5);
 
     // Sleep until we're confident that all Downstairs are kicked out.
-    let wait_time = CLIENT_TIMEOUT_SECS + MARGIN_SECS;
-    tokio::time::sleep(Duration::from_secs_f32(wait_time)).await;
+    let wait_time = CLIENT_TIMEOUT.timeout() + MARGIN;
+    tokio::time::sleep(wait_time).await;
 
     // Check to make sure all downstairs are offline.
     let ds = harness.guest.downstairs_state().await.unwrap();
@@ -1801,14 +1793,14 @@ async fn test_job_fault_condition() {
     // Because it has so many pending jobs, it will become Faulted instead of
     // Offline (or rather, will transition Active -> Offline -> Faulted
     // immediately).
-    let sleep_time = CLIENT_TIMEOUT_SECS + 5.0;
+    let sleep_time = CLIENT_TIMEOUT.timeout() + Duration::from_secs(5);
     info!(harness.log, "waiting for Upstairs to kick out DS1");
     info!(
         harness.log,
-        "waiting {sleep_time} secs for Upstairs to kick out DS1"
+        "waiting {sleep_time:?} secs for Upstairs to kick out DS1"
     );
     tokio::select! {
-        _ = tokio::time::sleep(Duration::from_secs_f32(sleep_time)) => {
+        _ = tokio::time::sleep(sleep_time) => {
             // we're done!
         }
         // we don't listen to ds1 here, so we won't acknowledge any pings!
@@ -1843,18 +1835,15 @@ async fn test_job_fault_condition_offline() {
     // - Then, after its job count hits IO_OUTSTANDING_MAX_JOBS, it will
     //   transition from Offline -> Faulted
 
-    const MARGIN_SECS: f32 = 2.0;
-    const SEND_JOBS_TIME: f32 = CLIENT_TIMEOUT_SECS - MARGIN_SECS;
+    const MARGIN: Duration = Duration::from_secs(2);
+    let send_jobs_time = CLIENT_TIMEOUT.timeout() - MARGIN;
     let num_jobs = IO_OUTSTANDING_MAX_JOBS / 2;
     let start_time = tokio::time::Instant::now();
 
     for i in 0..num_jobs {
-        // Delay so that we hit SEND_JOBS_TIME at the end of this loop
+        // Delay so that we hit `send_jobs_time` at the end of this loop
         tokio::time::sleep_until(
-            start_time
-                + Duration::from_secs_f32(
-                    SEND_JOBS_TIME * i as f32 / num_jobs as f32,
-                ),
+            start_time + (send_jobs_time * i as u32) / num_jobs as u32,
         )
         .await;
 
@@ -1887,7 +1876,7 @@ async fn test_job_fault_condition_offline() {
 
     // Sleep until we're confident that the Downstairs is kicked out
     info!(harness.log, "waiting for Upstairs to kick out DS1");
-    tokio::time::sleep(Duration::from_secs_f32(2.0 * MARGIN_SECS)).await;
+    tokio::time::sleep(2 * MARGIN).await;
 
     // Check to make sure that happened
     let ds = harness.guest.downstairs_state().await.unwrap();
@@ -2656,7 +2645,7 @@ async fn test_no_send_offline() {
     // Sleep until we're confident that the Downstairs is kicked out, answering
     // pings from the other two Downstairs
     info!(harness.log, "waiting for Upstairs to kick out DS1");
-    let sleep_time = Duration::from_secs_f32(CLIENT_TIMEOUT_SECS + 5.0);
+    let sleep_time = CLIENT_TIMEOUT.timeout() + Duration::from_secs(5);
     tokio::select! {
         e = harness.ds1.as_mut().unwrap().recv() => {
             // We've been kicked out!

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -4,7 +4,6 @@ use crate::{
     cdt,
     client::{ClientAction, ClientRunResult},
     control::ControlRequest,
-    deadline_secs,
     deferred::{
         DeferredBlockOp, DeferredMessage, DeferredQueue, DeferredRead,
         DeferredWrite, EncryptedWrite,
@@ -19,9 +18,12 @@ use crate::{
 use crucible_common::{BlockIndex, CrucibleError};
 use serde::{Deserialize, Serialize};
 
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Arc,
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::Duration,
 };
 
 use bytes::BytesMut;
@@ -34,7 +36,13 @@ use tokio::{
 use uuid::Uuid;
 
 /// How often to log stats for DTrace
-const STAT_INTERVAL_SECS: f32 = 1.0;
+const STAT_INTERVAL: Duration = Duration::from_secs(1);
+
+/// How often to do IO / bandwidth limit checking
+const LEAK_INTERVAL: Duration = Duration::from_millis(1000);
+
+/// How often to do live-repair status checking
+const REPAIR_CHECK_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Minimum IO size (in bytes) before encryption / decryption is done off-thread
 const MIN_DEFER_SIZE_BYTES: u64 = 8192;
@@ -226,7 +234,7 @@ pub(crate) struct Upstairs {
     pub(crate) log: Logger,
 
     /// Next time to check for repairs
-    repair_check_interval: Option<Instant>,
+    repair_check_deadline: Option<Instant>,
 
     /// Next time to leak IOP / bandwidth tokens from the Guest
     leak_deadline: Instant,
@@ -238,7 +246,7 @@ pub(crate) struct Upstairs {
     stat_deadline: Instant,
 
     /// Interval between automatic flushes
-    flush_timeout_secs: f32,
+    flush_interval: Duration,
 
     /// Receiver queue for control requests
     control_rx: mpsc::Receiver<ControlRequest>,
@@ -394,20 +402,22 @@ impl Upstairs {
             log.new(o!("" => "downstairs")),
         );
         let flush_timeout_secs = opt.flush_timeout.unwrap_or(0.5);
+        let flush_interval = Duration::from_secs_f32(flush_timeout_secs);
         let (control_tx, control_rx) = tokio::sync::mpsc::channel(500);
 
         if let Some(ddef) = expected_region_def {
             downstairs.set_ddef(ddef);
         }
 
+        let now = Instant::now();
         Upstairs {
             state: UpstairsState::Initializing,
             cfg,
-            repair_check_interval: None,
-            leak_deadline: deadline_secs(1.0),
-            flush_deadline: deadline_secs(flush_timeout_secs),
-            stat_deadline: deadline_secs(STAT_INTERVAL_SECS),
-            flush_timeout_secs,
+            repair_check_deadline: None,
+            leak_deadline: now + LEAK_INTERVAL,
+            flush_deadline: now + flush_interval,
+            stat_deadline: now + STAT_INTERVAL,
+            flush_interval,
             guest,
             guest_dropped: false,
             ddef: rd_status,
@@ -482,7 +492,7 @@ impl Upstairs {
             d = self.guest.recv(), if !self.guest_dropped => {
                 d
             }
-            _ = self.repair_check_interval
+            _ = self.repair_check_deadline
                 .map(|r| Either::Left(sleep_until(r)))
                 .unwrap_or(Either::Right(pending()))
             => {
@@ -569,12 +579,8 @@ impl Upstairs {
                 cdt::up__action_leak_check!(|| (self
                     .counters
                     .action_leak_check));
-                const LEAK_MS: usize = 1000;
                 // XXX Leak check is currently not implemented
-                let leak_tick =
-                    tokio::time::Duration::from_millis(LEAK_MS as u64);
-                self.leak_deadline =
-                    Instant::now().checked_add(leak_tick).unwrap();
+                self.leak_deadline = Instant::now() + LEAK_INTERVAL;
             }
             UpstairsAction::FlushCheck => {
                 self.counters.action_flush_check += 1;
@@ -584,7 +590,7 @@ impl Upstairs {
                 if self.need_flush {
                     self.submit_flush(None, None);
                 }
-                self.flush_deadline = deadline_secs(self.flush_timeout_secs);
+                self.flush_deadline = Instant::now() + self.flush_interval;
             }
             UpstairsAction::StatUpdate => {
                 self.counters.action_stat_check += 1;
@@ -592,7 +598,7 @@ impl Upstairs {
                     .counters
                     .action_stat_check));
                 self.on_stat_update();
-                self.stat_deadline = deadline_secs(STAT_INTERVAL_SECS);
+                self.stat_deadline = Instant::now() + STAT_INTERVAL;
             }
             UpstairsAction::RepairCheck => {
                 self.counters.action_repair_check += 1;
@@ -847,7 +853,7 @@ impl Upstairs {
     /// the [DsState::LiveRepairReady] state, indicating it needs to be
     /// repaired. If a Downstairs needs to be repaired, try to start repairing
     /// it. When starting the repair fails, this function will schedule a task
-    /// to retry the repair by setting [Self::repair_check_interval].
+    /// to retry the repair by setting [Self::repair_check_deadline].
     ///
     /// If this Upstairs is [UpstairsConfig::read_only], this function will move
     /// any Downstairs from [DsState::LiveRepairReady] back to [DsState::Active]
@@ -856,7 +862,7 @@ impl Upstairs {
         info!(self.log, "Checking if live repair is needed");
         if !matches!(self.state, UpstairsState::Active) {
             info!(self.log, "inactive, no live repair needed");
-            self.repair_check_interval = None;
+            self.repair_check_deadline = None;
             return;
         }
 
@@ -868,7 +874,7 @@ impl Upstairs {
             for c in self.downstairs.clients.iter_mut() {
                 c.skip_live_repair(&self.state);
             }
-            self.repair_check_interval = None;
+            self.repair_check_deadline = None;
             return;
         }
 
@@ -886,12 +892,13 @@ impl Upstairs {
             info!(self.log, "Live Repair already running");
             // Queue up a later check if we need it
             if any_in_repair_ready {
-                self.repair_check_interval = Some(deadline_secs(10.0));
+                self.repair_check_deadline =
+                    Some(Instant::now() + REPAIR_CHECK_INTERVAL);
             } else {
-                self.repair_check_interval = None;
+                self.repair_check_deadline = None;
             }
         } else if !any_in_repair_ready {
-            self.repair_check_interval = None;
+            self.repair_check_deadline = None;
             info!(self.log, "No Live Repair required at this time");
         } else if !self.downstairs.start_live_repair(
             &self.state,
@@ -900,7 +907,8 @@ impl Upstairs {
             // It's hard to hit this condition; we need a Downstairs to be in
             // LiveRepairReady, but for no other downstairs to be in Active.
             warn!(self.log, "Could not start live repair, trying again later");
-            self.repair_check_interval = Some(deadline_secs(10.0));
+            self.repair_check_deadline =
+                Some(Instant::now() + REPAIR_CHECK_INTERVAL);
         } else {
             // We started the repair in the call to start_live_repair above
         }
@@ -1660,14 +1668,14 @@ impl Upstairs {
                                 if self.connect_region_set() {
                                     // We connected normally, so there's no need
                                     // to check for live-repair.
-                                    self.repair_check_interval = None;
+                                    self.repair_check_deadline = None;
                                 }
                             }
 
                             DsState::LiveRepairReady => {
                                 // Immediately check for live-repair
-                                self.repair_check_interval =
-                                    Some(deadline_secs(0.0));
+                                self.repair_check_deadline =
+                                    Some(Instant::now());
                             }
 
                             s => panic!("bad state after negotiation: {s:?}"),
@@ -2114,7 +2122,7 @@ pub(crate) mod test {
 
         // Assert that the repair started
         up.on_repair_check();
-        assert!(up.repair_check_interval.is_none());
+        assert!(up.repair_check_deadline.is_none());
         assert!(up.downstairs.live_repair_in_progress());
 
         // The first thing that should happen after we start repair_exetnt
@@ -3353,14 +3361,14 @@ pub(crate) mod test {
         // Before we are active, we have no need to repair or check for future
         // repairs.
         up.on_repair_check();
-        assert!(up.repair_check_interval.is_none());
+        assert!(up.repair_check_deadline.is_none());
         assert!(!up.downstairs.live_repair_in_progress());
 
         up.force_active().unwrap();
 
         // No need to repair or check for future repairs here either
         up.on_repair_check();
-        assert!(up.repair_check_interval.is_none());
+        assert!(up.repair_check_deadline.is_none());
         assert!(!up.downstairs.live_repair_in_progress());
 
         // No downstairs should change state.
@@ -3385,7 +3393,7 @@ pub(crate) mod test {
         up.ds_transition(ClientId::new(1), DsState::Faulted);
         up.ds_transition(ClientId::new(1), DsState::LiveRepairReady);
         up.on_repair_check();
-        assert!(up.repair_check_interval.is_none());
+        assert!(up.repair_check_deadline.is_none());
         assert!(up.downstairs.live_repair_in_progress());
         assert_eq!(up.ds_state(ClientId::new(1)), DsState::LiveRepair);
         assert!(up.downstairs.repair().is_some());
@@ -3408,7 +3416,7 @@ pub(crate) mod test {
             up.ds_transition(i, DsState::LiveRepairReady);
         }
         up.on_repair_check();
-        assert!(up.repair_check_interval.is_none());
+        assert!(up.repair_check_deadline.is_none());
         assert!(up.downstairs.live_repair_in_progress());
 
         assert_eq!(up.ds_state(ClientId::new(0)), DsState::Active);
@@ -3434,17 +3442,17 @@ pub(crate) mod test {
         // Start the live-repair
         up.on_repair_check();
         assert!(up.downstairs.live_repair_in_progress());
-        assert!(up.repair_check_interval.is_none());
+        assert!(up.repair_check_deadline.is_none());
 
         // Pretend that DS 0 faulted then came back through to LiveRepairReady;
         // we won't halt the existing repair, but will configure
-        // repair_check_interval to check again in the future.
+        // repair_check_deadline to check again in the future.
         up.ds_transition(ClientId::new(0), DsState::Faulted);
         up.ds_transition(ClientId::new(0), DsState::LiveRepairReady);
 
         up.on_repair_check();
         assert!(up.downstairs.live_repair_in_progress());
-        assert!(up.repair_check_interval.is_some());
+        assert!(up.repair_check_deadline.is_some());
     }
 
     #[test]
@@ -3460,12 +3468,12 @@ pub(crate) mod test {
         up.ds_transition(ClientId::new(1), DsState::LiveRepairReady);
 
         up.on_repair_check();
-        assert!(up.repair_check_interval.is_none());
+        assert!(up.repair_check_deadline.is_none());
         assert!(up.downstairs.live_repair_in_progress());
 
         // Checking again is idempotent
         up.on_repair_check();
-        assert!(up.repair_check_interval.is_none());
+        assert!(up.repair_check_deadline.is_none());
         assert!(up.downstairs.live_repair_in_progress());
     }
 


### PR DESCRIPTION
In Crucible, we often see things like
```rust
const TIMEOUT_SECS: f32 = 10.0;
```

`Duration::from_secs` is now a `const fn`, so we can store actual `Duration` values for timeout intervals (instead of `f32`).

This PR also replaces the pattern of `sleep_until(deadline_secs(..))` with a plain `sleep`, e.g.
```diff
-tokio::time::sleep_until(deadline_secs(100.0));
+tokio::time::sleep(Duration::from_secs(100));
```

Finally, it makes time-related names more consistent: `*_interval` for the interval between periodic actions, and `*_deadline` for a time at which we perform an action.

This should be a pure cleanup PR, without any logic changes.