### PR TITLE
Remove separate validation array

### DIFF
--- a/upstairs/src/buffer.rs
+++ b/upstairs/src/buffer.rs
@@ -1,5 +1,4 @@
 // Copyright 2023 Oxide Computer Company
-use crate::RawReadResponse;
 use bytes::{Bytes, BytesMut};
 use crucible_protocol::ReadBlockContext;
 use itertools::Itertools;
@@ -141,14 +140,17 @@ impl Buffer {
     /// # Panics
     /// The response data length must be the same as our buffer length (which
     /// must be an even multiple of block size, ensured at construction)
-    pub(crate) fn write_read_response(&mut self, response: RawReadResponse) {
-        assert!(response.data.len() == self.data.len());
-        assert_eq!(response.data.len() % self.block_size, 0);
+    pub(crate) fn write_read_response(
+        &mut self,
+        blocks: &[ReadBlockContext],
+        data: &mut BytesMut,
+    ) {
+        assert!(data.len() == self.data.len());
+        assert_eq!(data.len() % self.block_size, 0);
         let bs = self.block_size;
 
         // Build contiguous chunks which are all owned, to copy in bulk
-        for (empty, mut group) in &response
-            .blocks
+        for (empty, mut group) in &blocks
             .iter()
             .enumerate()
             .chunk_by(|(_i, b)| matches!(b, ReadBlockContext::Empty))
@@ -164,16 +166,13 @@ impl Buffer {
 
             // Special case: if the entire buffer is owned, then we swap it
             // instead of copying element-by-element.
-            if count == response.blocks.len()
-                && self.data.len() == response.data.len()
-            {
-                self.data = response.data;
+            if count == blocks.len() && self.data.len() == data.len() {
+                self.data = std::mem::take(data);
                 break;
             } else {
                 // Otherwise, just copy the sub-region
-                self.data[(block * bs)..][..(count * bs)].copy_from_slice(
-                    &response.data[(block * bs)..][..(count * bs)],
-                );
+                self.data[(block * bs)..][..(count * bs)]
+                    .copy_from_slice(&data[(block * bs)..][..(count * bs)]);
             }
         }
     }
@@ -493,7 +492,7 @@ mod test {
         let mut rng = rand::thread_rng();
         rng.fill_bytes(&mut data);
 
-        let blocks = (0..10)
+        let blocks: Vec<_> = (0..10)
             .map(|i| {
                 if f(i) {
                     ReadBlockContext::Unencrypted { hash: 123 }
@@ -503,10 +502,7 @@ mod test {
             })
             .collect();
 
-        buf.write_read_response(RawReadResponse {
-            blocks,
-            data: data.clone(),
-        });
+        buf.write_read_response(&blocks, &mut data.clone());
 
         for i in 0..10 {
             let buf_chunk = &buf[i * 512..][..512];
@@ -564,12 +560,12 @@ mod test {
         let mut rng = rand::thread_rng();
         rng.fill_bytes(&mut data);
 
-        let blocks = (0..10)
+        let blocks: Vec<_> = (0..10)
             .map(|_| ReadBlockContext::Unencrypted { hash: 123 })
             .collect();
 
         let prev_data_ptr = data.as_ptr();
-        buf.write_read_response(RawReadResponse { blocks, data });
+        buf.write_read_response(&blocks, &mut data);
 
         assert_eq!(buf.data.as_ptr(), prev_data_ptr);
     }

--- a/upstairs/src/deferred.rs
+++ b/upstairs/src/deferred.rs
@@ -5,11 +5,11 @@ use std::sync::Arc;
 use crate::{
     backpressure::BackpressureGuard, client::ConnectionId,
     upstairs::UpstairsConfig, BlockContext, BlockOp, ClientData, ClientId,
-    ImpactedBlocks, Message, RawWrite, Validation,
+    ImpactedBlocks, Message, RawWrite,
 };
 use bytes::BytesMut;
 use crucible_common::{integrity_hash, CrucibleError, RegionDefinition};
-use crucible_protocol::ReadBlockContext;
+use crucible_protocol::{ReadBlockContext, ReadResponseHeader};
 use futures::{
     future::{ready, Either, Ready},
     stream::FuturesOrdered,
@@ -192,10 +192,12 @@ impl DeferredWrite {
 
 #[derive(Debug)]
 pub(crate) struct DeferredMessage {
+    /// Message received from the client
+    ///
+    /// If the deferred message was a read, then the data and context blocks in
+    /// this [Message::ReadResponse] has been validated (and decrypted if
+    /// necessary).
     pub message: Message,
-
-    /// If this was a `ReadResponse`, then the validation result is stored here
-    pub hashes: Vec<Validation>,
 
     pub client_id: ClientId,
 
@@ -205,8 +207,8 @@ pub(crate) struct DeferredMessage {
 
 /// Standalone data structure which can perform decryption
 pub(crate) struct DeferredRead {
-    /// Message, which must be a `ReadResponse`
-    pub message: Message,
+    pub header: ReadResponseHeader,
+    pub data: BytesMut,
 
     /// Unique ID for this particular connection to the downstairs
     ///
@@ -225,20 +227,16 @@ impl DeferredRead {
     /// Consume the `DeferredRead` and perform decryption
     ///
     /// If decryption fails, then the resulting `Message` has an error in the
-    /// `responses` field, and `hashes` is empty.
+    /// `responses` field.
     pub fn run(mut self) -> DeferredMessage {
         use crate::client::{
             validate_encrypted_read_response,
             validate_unencrypted_read_response,
         };
-        let Message::ReadResponse { header, data } = &mut self.message else {
-            panic!("invalid DeferredRead");
-        };
-        let mut hashes = vec![];
 
-        if let Ok(rs) = header.blocks.as_mut() {
-            assert_eq!(data.len() % rs.len(), 0);
-            let block_size = data.len() / rs.len();
+        if let Ok(rs) = self.header.blocks.as_mut() {
+            assert_eq!(self.data.len() % rs.len(), 0);
+            let block_size = self.data.len() / rs.len();
             for (i, r) in rs.iter_mut().enumerate() {
                 let v = if let Some(ctx) = &self.cfg.encryption_context {
                     match r {
@@ -256,7 +254,7 @@ impl DeferredRead {
                     .and_then(|r| {
                         validate_encrypted_read_response(
                             r,
-                            &mut data[i * block_size..][..block_size],
+                            &mut self.data[i * block_size..][..block_size],
                             ctx,
                             &self.log,
                         )
@@ -279,28 +277,27 @@ impl DeferredRead {
                     .and_then(|r| {
                         validate_unencrypted_read_response(
                             r,
-                            &mut data[i * block_size..][..block_size],
+                            &mut self.data[i * block_size..][..block_size],
                             &self.log,
                         )
                     })
                 };
-                match v {
-                    Ok(hash) => hashes.push(hash),
-                    Err(e) => {
-                        error!(self.log, "decryption failure: {e:?}");
-                        header.blocks = Err(e);
-                        hashes.clear();
-                        break;
-                    }
+                if let Err(e) = v {
+                    error!(self.log, "decryption failure: {e:?}");
+                    self.header.blocks = Err(e);
+                    break;
                 }
             }
         }
 
+        let message = Message::ReadResponse {
+            header: self.header,
+            data: self.data,
+        };
         DeferredMessage {
             client_id: self.client_id,
-            message: self.message,
+            message,
             connection_id: self.connection_id,
-            hashes,
         }
     }
 }

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -882,17 +882,6 @@ impl std::fmt::Display for DsState {
     }
 }
 
-/// Results of validating a single block
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub(crate) enum Validation {
-    /// The block has no hash / context and is empty
-    Empty,
-    /// For an unencrypted block, the result is the hash
-    Unencrypted(u64),
-    /// For an encrypted block, the result is the tag + nonce
-    Encrypted(crucible_protocol::EncryptionContext),
-}
-
 /*
  * A unit of work for downstairs that is put into the hashmap.
  */
@@ -918,12 +907,12 @@ struct DownstairsIO {
      */
     replay: bool,
 
-    /*
-     * If the operation is a Read, this holds the resulting buffer
-     * The validation vec holds the validation results for the read
-     */
+    /// If the operation is a Read, this holds the resulting buffer and hashes
+    ///
+    /// The buffer _may_ be removed during the transfer to the Guest, to reduce
+    /// `memcpy` overhead.  If this occurs, the hashes remain present for
+    /// consistency checking with subsequent replies.
     data: Option<RawReadResponse>,
-    read_validations: Vec<Validation>,
 
     /// Handle for this job's contribution to guest backpressure
     ///

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -384,14 +384,14 @@ pub(crate) mod up_test {
         };
 
         // Validate it
-        let successful_hash = validate_encrypted_read_response(
+        let r = validate_encrypted_read_response(
             Some(ctx),
             &mut data,
             &Arc::new(context),
             &csl(),
-        )?;
+        );
 
-        assert_eq!(successful_hash, Validation::Encrypted(ctx));
+        assert!(r.is_ok());
 
         // `validate_encrypted_read_response` will mutate the read
         // response's data value, make sure it decrypted
@@ -430,15 +430,15 @@ pub(crate) mod up_test {
         data.resize(512, 0u8);
 
         // Validate the read response
-        let successful_hash = validate_encrypted_read_response(
+        let r = validate_encrypted_read_response(
             None,
             &mut data,
             &Arc::new(context),
             &csl(),
-        )?;
+        );
 
         // The above function will return None for a blank block
-        assert_eq!(successful_hash, Validation::Empty);
+        assert!(r.is_ok());
         assert_eq!(data, vec![0u8; 512]);
 
         Ok(())
@@ -456,16 +456,13 @@ pub(crate) mod up_test {
         let original_data = data.clone();
 
         // Validate it
-        let successful_hash = validate_unencrypted_read_response(
+        let r = validate_unencrypted_read_response(
             Some(read_response_hash),
             &mut data,
             &csl(),
-        )?;
-
-        assert_eq!(
-            successful_hash,
-            Validation::Unencrypted(read_response_hash)
         );
+
+        assert!(r.is_ok());
         assert_eq!(data, original_data);
 
         Ok(())
@@ -480,10 +477,9 @@ pub(crate) mod up_test {
         let original_data = data.clone();
 
         // Validate a read response
-        let successful_hash =
-            validate_unencrypted_read_response(None, &mut data, &csl())?;
+        let r = validate_unencrypted_read_response(None, &mut data, &csl());
 
-        assert_eq!(successful_hash, Validation::Empty);
+        assert!(r.is_ok());
         assert_eq!(data, original_data);
 
         Ok(())


### PR DESCRIPTION
Right now, we have two types with the same shape:

```rust
/// Results of validating a single block
#[derive(Copy, Clone, Eq, PartialEq, Debug)]
pub(crate) enum Validation {
    /// The block has no hash / context and is empty
    Empty,
    /// For an unencrypted block, the result is the hash
    Unencrypted(u64),
    /// For an encrypted block, the result is the tag + nonce
    Encrypted(crucible_protocol::EncryptionContext),
}
```

```rust
#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
pub enum ReadBlockContext {
    Empty,
    Encrypted { ctx: EncryptionContext },
    Unencrypted { hash: u64 },
}
```

The `DownstairsIO` stores both of these types:
```rust
struct DownstairsIO {
    // other members elided
    data: Option<RawReadResponse>, // contains blocks: Vec<ReadBlockContext>
    pub hashes: Vec<Validation>,
}
```

By the time we write to `data`, the block contexts have _already_ been validated, so storing them again in `hashes` adds unnecessary duplication (and they're guaranteed to be the same).

This PR removes the duplicate `Validation` hashes, using the `RawReadResponse::blocks` member instead.

There are small changes to `GuestBlockRes::transfer_and_notify` and `Buffer::write_read_response`, because we can't take the entire `Option<RawReadResponse>`; instead, we pass the `&mut BytesMut` separately, so it can be sent back to the host.