### PR TITLE
Consolidate `DownstairsClient::reinitialize`

### DIFF
--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -1847,7 +1847,6 @@ impl DownstairsClient {
                             String::new()
                         },
                     );
-                    self.checked_state_transition(up_state, DsState::New);
                     if !match_gen {
                         let gen_error = format!(
                             "Generation requested:{} found:{}",

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -505,7 +505,6 @@ impl Downstairs {
     pub(crate) fn reinitialize(
         &mut self,
         client_id: ClientId,
-        auto_promote: bool,
         up_state: &UpstairsState,
     ) {
         // If the IO task stops on its own, then under certain circumstances,
@@ -522,7 +521,7 @@ impl Downstairs {
 
         // Restart the IO task for that specific client, transitioning to a new
         // state.
-        self.clients[client_id].reinitialize(up_state, auto_promote);
+        self.clients[client_id].reinitialize(up_state);
 
         for i in ClientId::iter() {
             // Clear per-client delay, because we're starting a new session

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -528,6 +528,12 @@ impl Downstairs {
             self.clients[i].set_delay_us(0);
         }
 
+        // Special-case: if a Downstairs goes away midway through initial
+        // reconciliation, then we have to manually abort reconciliation.
+        if self.clients.iter().any(|c| c.state() == DsState::Reconcile) {
+            self.abort_reconciliation(up_state);
+        }
+
         // If this client is coming back from being offline, then mark that its
         // jobs must be replayed when it completes negotiation.
         if self.clients[client_id].state() == DsState::Offline {

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -508,13 +508,6 @@ impl Downstairs {
         auto_promote: bool,
         up_state: &UpstairsState,
     ) {
-        let prev_state = self.clients[client_id].state();
-
-        // If the connection goes down here, we need to know what state we were
-        // in to decide what state to transition to.  The on_missing method will
-        // do that for us!
-        self.clients[client_id].on_missing();
-
         // If the IO task stops on its own, then under certain circumstances,
         // we want to skip all of its jobs.  (If we requested that the IO task
         // stop, then whoever made that request is responsible for skipping jobs
@@ -523,25 +516,17 @@ impl Downstairs {
         // Specifically, we want to skip jobs if the only path back online for
         // that client goes through live-repair; if that client can come back
         // through replay, then the jobs must remain live.
-        let new_state = self.clients[client_id].state();
-        if matches!(prev_state, DsState::LiveRepair | DsState::Active)
-            && matches!(new_state, DsState::Faulted)
-        {
+        if matches!(self.clients[client_id].state(), DsState::LiveRepair) {
             self.skip_all_jobs(client_id);
         }
 
-        // Restart the IO task for that specific client
-        self.clients[client_id].reinitialize(auto_promote);
+        // Restart the IO task for that specific client, transitioning to a new
+        // state.
+        self.clients[client_id].reinitialize(up_state, auto_promote);
 
         for i in ClientId::iter() {
             // Clear per-client delay, because we're starting a new session
             self.clients[i].set_delay_us(0);
-        }
-
-        // Special-case: if a Downstairs goes away midway through initial
-        // reconciliation, then we have to manually abort reconciliation.
-        if self.clients.iter().any(|c| c.state() == DsState::Reconcile) {
-            self.abort_reconciliation(up_state);
         }
 
         // If this client is coming back from being offline, then mark that its

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -2008,8 +2008,7 @@ impl Upstairs {
         self.downstairs
             .notify_nexus_of_client_task_stopped(client_id, reason);
 
-        self.downstairs
-            .reinitialize(client_id, &self.state);
+        self.downstairs.reinitialize(client_id, &self.state);
     }
 
     /// Sets both guest and per-client backpressure

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -2008,17 +2008,8 @@ impl Upstairs {
         self.downstairs
             .notify_nexus_of_client_task_stopped(client_id, reason);
 
-        // If the upstairs is already active (or trying to go active), then the
-        // downstairs should automatically call PromoteToActive when it reaches
-        // the relevant state.
-        let auto_promote = match self.state {
-            UpstairsState::Active | UpstairsState::GoActive(..) => true,
-            UpstairsState::Initializing
-            | UpstairsState::Deactivating { .. } => false,
-        };
-
         self.downstairs
-            .reinitialize(client_id, auto_promote, &self.state);
+            .reinitialize(client_id, &self.state);
     }
 
     /// Sets both guest and per-client backpressure


### PR DESCRIPTION
Previously, `Downstairs::reinitialize` would do the following:

- Call `DownstairsClient::on_missing`, which updates the client state
- Skip jobs (if necessary)
- Call `DownstairsClient::reinitialize`, which also updates client state

These used to be separate tasks, but they're now in the same place, so it's silly to have them both.

This PR consolidates all of the logic into `DownstairsClient::reinitialize`.