### PR TITLE
Remove `ackable_work`; ack immediately instead

### DIFF
--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -170,7 +170,6 @@ impl UpCounters {
 ///
 /// For example, we _always_ do things like
 /// - Send all pending IO to the client work tasks
-/// - Ack all ackable jobs to the guest
 /// - Step through the live-repair state machine (if it's running)
 /// - Check for client-side deactivation (if it's pending)
 /// - Set backpressure time in the clients
@@ -1647,7 +1646,7 @@ impl Upstairs {
 
             // IO operation replies
             //
-            // This may cause jobs to become ackable!
+            // This may cause jobs to be acked!
             Message::WriteAck { .. }
             | Message::WriteUnwrittenAck { .. }
             | Message::FlushAck { .. }

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -611,15 +611,7 @@ impl Upstairs {
         }
 
         // Check to see whether live-repair can continue
-        //
-        // This must be called before acking jobs, because it looks in
-        // `Downstairs::ackable_jobs` to see which jobs are done.
         self.downstairs.check_and_continue_live_repair(&self.state);
-
-        // Handle any jobs that have become ready for acks
-        if self.downstairs.has_ackable_jobs() {
-            self.downstairs.ack_jobs()
-        }
 
         // Check for client-side deactivation
         if matches!(&self.state, UpstairsState::Deactivating(..)) {


### PR DESCRIPTION
A long time ago, one task accumulated ackable jobs into `Downstairs::ackable_work` and a different task periodically read out that set and sent acks back to the guest.

The tasks have long since been consolidated, but the `ackable_work` set remained.

This PR removes the `ackable_work` set, acking jobs immediately when they are ready.  It's a significant LOC simplification, because it's removing intermediate state (which previously had to be checked in unit tests).

There's one subtlety in handling live-repair: previously, the live-repair check would look in `ackable_work` to see if the next job was ackable, which indicates that live-repair can continue.  Now, we update the `LiveRepairState` directly in `Downstairs::ack`, storing a result for the pending live-repair job.