### PR TITLE
Skip backpressure guard when job is skipped; fix log

### DIFF
--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -2112,7 +2112,10 @@ impl Downstairs {
                         self.send(ds_id, io.clone(), cid);
                     }
                 }
-                EnqueueResult::Skip => skipped += 1,
+                EnqueueResult::Skip => {
+                    let _ = bp_guard.take(&cid);
+                    skipped += 1;
+                }
             }
             r.state()
         });
@@ -2653,7 +2656,7 @@ impl Downstairs {
                     if job.backpressure_guard.contains(&c) {
                         warn!(
                             self.log,
-                            "job {ds_id} had pending backpressure bytes \
+                            "job {id} had pending backpressure bytes \
                              for client {c}"
                         );
                         // Backpressure is decremented on drop


### PR DESCRIPTION
We normally use `set_job_state` when changing job state, which handles dropping backpressure guards when a job is skipped.  However, this wasn't being handled correctly if a job was skipped when initially created.