### PR TITLE
Add early rejection of IOs if too many Downstairs are inactive

### DIFF
--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -1891,7 +1891,20 @@ impl DownstairsClient {
         self.client_delay_us.load(Ordering::Relaxed)
     }
 
-    /// Looks up the region UUID
+    /// Checks whether the client is in a state where it can accept IO
+    pub(crate) fn is_accepting_io(&self) -> bool {
+        matches!(
+            self.state,
+            DsState::Active
+                | DsState::LiveRepair
+                | DsState::Connecting {
+                    mode: ConnectionMode::Offline,
+                    ..
+                }
+        )
+    }
+
+    #[cfg(feature = "notify-nexus")]
     pub(crate) fn id(&self) -> Option<Uuid> {
         self.region_uuid
     }

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -1904,7 +1904,6 @@ impl DownstairsClient {
         )
     }
 
-    #[cfg(feature = "notify-nexus")]
     pub(crate) fn id(&self) -> Option<Uuid> {
         self.region_uuid
     }

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -3330,12 +3330,7 @@ impl Downstairs {
     ///
     /// A client can accept IO if it is in the `Active` or `LiveRepair` state.
     pub fn active_client_count(&self) -> usize {
-        self.clients
-            .iter()
-            .filter(|c| {
-                matches!(c.state(), DsState::Active | DsState::LiveRepair)
-            })
-            .count()
+        self.clients.iter().filter(|c| c.is_accepting_io()).count()
     }
 
     /// Wrapper for marking a single job as done from the given client

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -3326,6 +3326,18 @@ impl Downstairs {
         }
     }
 
+    /// Returns the number of clients that can accept IO
+    ///
+    /// A client can accept IO if it is in the `Active` or `LiveRepair` state.
+    pub fn active_client_count(&self) -> usize {
+        self.clients
+            .iter()
+            .filter(|c| {
+                matches!(c.state(), DsState::Active | DsState::LiveRepair)
+            })
+            .count()
+    }
+
     /// Wrapper for marking a single job as done from the given client
     ///
     /// This can be used to test handling of job acks, etc

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -3191,7 +3191,7 @@ async fn read_with_one_fault() {
     h.await.unwrap(); // we have > 1x reply, so the read will return
     harness.ds3.ack_read().await;
 
-    // Take out DS1 next
+    // Take out DS2 next
     harness
         .guest
         .write(BlockIndex(0), write_buf.clone())

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -952,6 +952,11 @@ impl DownstairsIO {
 
         let bad_job = match &self.work {
             IOop::Read { .. } => wc.done == 0,
+            // Flushes with snapshots must be good on all 3x Downstairs
+            IOop::Flush {
+                snapshot_details: Some(..),
+                ..
+            } => wc.skipped + wc.error > 0,
             IOop::Write { .. }
             | IOop::WriteUnwritten { .. }
             | IOop::Flush { .. }


### PR DESCRIPTION
This aborts the IO before passing it to the Downstairs, so it's not assigned a `JobId` or put into the `ActiveJobs` map.  The most noticeable change is that writes are now fast-err'd instead of fast-acked if > 1 Downstairs is inactive.