### PR TITLE
Remove unprinted header item from sled_upstairs_info

### DIFF
--- a/tools/dtrace/sled_upstairs_info.d
+++ b/tools/dtrace/sled_upstairs_info.d
@@ -25,7 +25,7 @@ tick-1s
 {
     printf("%5s %8s ", "PID", "SESSION");
     printf("%17s %17s %17s", "DS STATE 0", "DS STATE 1", "DS STATE 2");
-    printf(" %5s %5s %9s %5s", "UPW", "DSW", "NEXT_JOB", "BAKPR");
+    printf(" %5s %5s %9s", "UPW", "DSW", "NEXT_JOB");
     printf(" %10s", "WRITE_BO");
     printf("  %5s %5s %5s", "IP0", "IP1", "IP2");
     printf("  %5s %5s %5s", "D0", "D1", "D2");
@@ -46,7 +46,7 @@ crucible_upstairs*:::up-status
      * we don't print it all on one line, then multiple sessions will
      * clobber each others output.
      */
-    printf("%5d %8s %17s %17s %17s %5s %5s %5s %10s  %5s %5s %5s  %5s %5s %5s  %5s %5s %5s  %5s %5s %5s  %5s %5s %5s\n",
+    printf("%5d %8s %17s %17s %17s %5s %5s %9s %10s  %5s %5s %5s  %5s %5s %5s  %5s %5s %5s  %5s %5s %5s  %5s %5s %5s\n",
     pid,
     substr(session_id, 0, 8),
 


### PR DESCRIPTION
The BAKPR is not printed, so let's take it out the header.