### PR TITLE
Simplify fault and restart code (1/3)

### DIFF
--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -989,7 +989,7 @@ impl DownstairsClient {
         self.checked_state_transition(up_state, DsState::Replacing);
         self.stats.replaced += 1;
 
-        self.halt_io_task(ClientStopReason::Replaced);
+        self.halt_io_task(ClientStopReason::Replacing);
     }
 
     /// Sets `self.state` to `new_state`, with logging and validity checking
@@ -2180,7 +2180,7 @@ pub(crate) struct DownstairsStats {
 #[derive(Debug)]
 pub(crate) enum ClientStopReason {
     /// We are about to replace the client task
-    Replaced,
+    Replacing,
 
     /// We have disabled the downstairs client for some reason
     ///

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -1185,26 +1185,8 @@ impl DownstairsClient {
         }
     }
 
-    /// Aborts an in-progress live repair, conditionally restarting the task
-    ///
-    /// # Panics
-    /// If this client is not in `DsState::LiveRepair` and `restart_task` is
-    /// `true`, or vice versa.
-    pub(crate) fn abort_repair(
-        &mut self,
-        up_state: &UpstairsState,
-        restart_task: bool,
-    ) {
-        if restart_task {
-            assert_eq!(self.state, DsState::LiveRepair);
-            self.checked_state_transition(up_state, DsState::Faulted);
-            self.halt_io_task(ClientStopReason::FailedLiveRepair);
-        } else {
-            // Someone else (i.e. receiving an error upon IO completion) already
-            // restarted the IO task and kicked us out of the live-repair state,
-            // but we'll do further cleanup here.
-            assert_ne!(self.state, DsState::LiveRepair);
-        }
+    /// Sets `repair_info` to `None` and increments `live_repair_aborted`
+    pub(crate) fn clear_repair_state(&mut self) {
         self.repair_info = None;
         self.stats.live_repair_aborted += 1;
     }

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -9,8 +9,8 @@ use std::{
 use crate::{
     cdt,
     client::{
-        ClientAction, ClientFaultReason, ClientStopReason, DownstairsClient,
-        EnqueueResult,
+        ClientAction, ClientFaultReason, ClientNegotiationFailed,
+        DownstairsClient, EnqueueResult,
     },
     guest::GuestBlockRes,
     io_limits::{IOLimitGuard, IOLimits},
@@ -1916,9 +1916,9 @@ impl Downstairs {
             if c.state() == DsState::Reconcile {
                 // Restart the IO task.  This will cause the Upstairs to
                 // deactivate through a ClientAction::TaskStopped.
-                c.restart_connection(
+                c.abort_negotiation(
                     up_state,
-                    ClientStopReason::FailedReconcile,
+                    ClientNegotiationFailed::FailedReconcile,
                 );
                 error!(self.log, "Mark {} as FAILED REPAIR", i);
             }

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1159,8 +1159,8 @@ impl Upstairs {
 
             #[cfg(test)]
             BlockOp::FaultDownstairs { client_id, done } => {
-                self.downstairs.skip_all_jobs(client_id);
-                self.downstairs.clients[client_id].fault(
+                self.downstairs.fault_client(
+                    client_id,
                     &self.state,
                     crate::client::ClientStopReason::RequestedFault,
                 );

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1162,7 +1162,7 @@ impl Upstairs {
                 self.downstairs.fault_client(
                     client_id,
                     &self.state,
-                    crate::client::ClientStopReason::RequestedFault,
+                    crate::client::ClientFaultReason::RequestedFault,
                 );
                 done.send_ok(());
             }


### PR DESCRIPTION
The conditions under which we restart a client IO task are somewhat baroque:

- It may halt spontaneously (e.g. upon a socket error)
- We may **fault** it explicitly (e.g. upon IO error).  In this case, we want to skip all work associated with this client.
- We may restart the IO task if initial negotiation fails
- ...and when replacing a Downstairs
- ...and when deactivated

This PR adds more specific types: `enum ClientNegotiationFailed` and `enum ClientFaultReason`.  Mid-negotiation restarts must provide a `ClientNegotiationFailed`; faulting the IO task must provide a `ClientFaultReason`.  Both of these types are then converted into a `ClientStopReason` for logging.

In addition, faulting a client is now done through `Downstairs::fault_client` instead of calling both `Downstairs::skip_all_jobs` and `DownstairsClient::fault`.  Having a single function makes this harder to mess up!