### PR TITLE
Add explicit Stopping state (2/3)

### DIFF
--- a/cmon/src/main.rs
+++ b/cmon/src/main.rs
@@ -8,7 +8,7 @@ use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 use tokio::time::{sleep, Duration};
 
-use crucible::{Arg, DsState};
+use crucible::{Arg, ClientStopReason, DsState};
 
 /// Connect to crucible control server
 #[derive(Parser, Debug)]
@@ -87,18 +87,23 @@ enum Action {
 // Translate a DsState into a three letter string for printing.
 fn short_state(dss: DsState) -> String {
     match dss {
-        DsState::New => "NEW".to_string(),
+        DsState::New
+        | DsState::Stopping(ClientStopReason::NegotiationFailed(..)) => {
+            "NEW".to_string()
+        }
         DsState::WaitActive => "WAC".to_string(),
         DsState::WaitQuorum => "WAQ".to_string(),
         DsState::Reconcile => "REC".to_string(),
         DsState::Active => "ACT".to_string(),
-        DsState::Faulted => "FLT".to_string(),
+        DsState::Faulted | DsState::Stopping(ClientStopReason::Fault(..)) => {
+            "FLT".to_string()
+        }
         DsState::LiveRepairReady => "LRR".to_string(),
         DsState::LiveRepair => "LR".to_string(),
         DsState::Offline => "OFF".to_string(),
-        DsState::Deactivated => "DAV".to_string(),
-        DsState::Disabled => "DIS".to_string(),
-        DsState::Replacing => "RPC".to_string(),
+        DsState::Stopping(ClientStopReason::Deactivated) => "DAV".to_string(),
+        DsState::Stopping(ClientStopReason::Disabled) => "DIS".to_string(),
+        DsState::Stopping(ClientStopReason::Replacing) => "RPC".to_string(),
         DsState::Replaced => "RPD".to_string(),
     }
 }

--- a/openapi/crucible-control.json
+++ b/openapi/crucible-control.json
@@ -154,7 +154,7 @@
               "type": {
                 "type": "string",
                 "enum": [
-                  "replaced"
+                  "replacing"
                 ]
               }
             },

--- a/openapi/crucible-control.json
+++ b/openapi/crucible-control.json
@@ -65,6 +65,173 @@
           "acked"
         ]
       },
+      "ClientFaultReason": {
+        "description": "Subset of [`ClientStopReason`] for faulting a client",
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "requested_fault"
+            ]
+          },
+          {
+            "description": "Received an error from some non-recoverable IO (write or flush)",
+            "type": "string",
+            "enum": [
+              "i_o_error"
+            ]
+          },
+          {
+            "description": "Live-repair failed",
+            "type": "string",
+            "enum": [
+              "failed_live_repair"
+            ]
+          },
+          {
+            "description": "Too many jobs in the queue",
+            "type": "string",
+            "enum": [
+              "too_many_outstanding_jobs"
+            ]
+          },
+          {
+            "description": "Too many bytes in the queue",
+            "type": "string",
+            "enum": [
+              "too_many_outstanding_bytes"
+            ]
+          },
+          {
+            "description": "The upstairs has requested that we deactivate when we were offline",
+            "type": "string",
+            "enum": [
+              "offline_deactivated"
+            ]
+          },
+          {
+            "description": "The Upstairs has dropped jobs that would be needed for replay",
+            "type": "string",
+            "enum": [
+              "ineligible_for_replay"
+            ]
+          }
+        ]
+      },
+      "ClientNegotiationFailed": {
+        "description": "Subset of [`ClientStopReason`] for faulting a client",
+        "oneOf": [
+          {
+            "description": "Reconcile failed and we're restarting",
+            "type": "string",
+            "enum": [
+              "failed_reconcile"
+            ]
+          },
+          {
+            "description": "Negotiation message received out of order",
+            "type": "string",
+            "enum": [
+              "bad_negotiation_order"
+            ]
+          },
+          {
+            "description": "Negotiation says that we are incompatible",
+            "type": "string",
+            "enum": [
+              "incompatible"
+            ]
+          }
+        ]
+      },
+      "ClientStopReason": {
+        "description": "When the upstairs halts the IO client task, it must provide a reason",
+        "oneOf": [
+          {
+            "description": "We are about to replace the client task",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "replaced"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "We have disabled the downstairs client for some reason\n\n(for example, we have received `Message::YouAreNoLongerActive`)",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "disabled"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "The upstairs has requested that we deactivate",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "deactivated"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "Something went wrong during negotiation",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "negotiation_failed"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/ClientNegotiationFailed"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "description": "We have explicitly faulted the client",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "fault"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/ClientFaultReason"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
       "DownstairsWork": {
         "description": "`DownstairsWork` holds the information gathered from the downstairs",
         "type": "object",
@@ -88,21 +255,166 @@
         ]
       },
       "DsState": {
-        "type": "string",
-        "enum": [
-          "new",
-          "wait_active",
-          "wait_quorum",
-          "reconcile",
-          "active",
-          "faulted",
-          "live_repair_ready",
-          "live_repair",
-          "offline",
-          "deactivated",
-          "disabled",
-          "replacing",
-          "replaced"
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "new"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "wait_active"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "wait_quorum"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "reconcile"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "active"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "faulted"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "live_repair_ready"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "live_repair"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "offline"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "replaced"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "The IO task for the client is being stopped",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "stopping"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/ClientStopReason"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
         ]
       },
       "Error": {

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -10,7 +10,7 @@ use crate::{
     cdt,
     client::{
         ClientAction, ClientFaultReason, ClientNegotiationFailed,
-        DownstairsClient, EnqueueResult,
+        ClientStopReason, DownstairsClient, EnqueueResult,
     },
     guest::GuestBlockRes,
     io_limits::{IOLimitGuard, IOLimits},
@@ -2556,7 +2556,7 @@ impl Downstairs {
             // We don't really know if the "old" matches what was old,
             // as that info is gone to us now, so assume it was true.
             match self.clients[new_client_id].state() {
-                DsState::Replacing
+                DsState::Stopping(ClientStopReason::Replacing)
                 | DsState::Replaced
                 | DsState::LiveRepairReady
                 | DsState::LiveRepair => {
@@ -2586,7 +2586,9 @@ impl Downstairs {
                 continue;
             }
             match self.clients[client_id].state() {
-                DsState::Replacing
+                // XXX there are a bunch of states that aren't ready for IO but
+                // aren't listed here, e.g. all of the negotiation states.
+                DsState::Stopping(..)
                 | DsState::Replaced
                 | DsState::LiveRepairReady
                 | DsState::LiveRepair => {
@@ -2706,17 +2708,21 @@ impl Downstairs {
     /// The live-repair may continue after this point to clean up reserved jobs,
     /// to avoid blocking dependencies, but jobs are replaced with no-ops.
     fn abort_repair(&mut self, up_state: &UpstairsState) {
-        assert!(self.clients.iter().any(|c| {
-            c.state() == DsState::LiveRepair ||
+        assert!(self.clients.iter().any(|c| matches!(
+            c.state(),
+            DsState::LiveRepair |
                 // If connection aborted, and restarted, then the re-negotiation
                 // could have won this race, and transitioned the reconnecting
                 // downstairs from LiveRepair to Faulted to LiveRepairReady.
-                c.state() == DsState::LiveRepairReady ||
+                DsState::LiveRepairReady |
                 // If just a single IO reported failure, we will fault this
                 // downstairs and it won't yet have had a chance to move back
                 // around to LiveRepairReady yet.
-                c.state() == DsState::Faulted
-        }));
+                DsState::Faulted |
+                // It's also possible for a Downstairs to be in the process of
+                // stopping, due a fault or disconnection
+                DsState::Stopping(..) // XXX should we be more specific here?
+        )));
         for i in ClientId::iter() {
             match self.clients[i].state() {
                 DsState::LiveRepair => {
@@ -3356,9 +3362,7 @@ impl Downstairs {
                     "Saw CrucibleError::UpstairsInactive on client {}!",
                     client_id
                 );
-                self.clients[client_id]
-                    .checked_state_transition(up_state, DsState::Disabled);
-                // TODO should we also restart the IO task here?
+                self.clients[client_id].disable(up_state);
             }
             Some(CrucibleError::DecryptionError) => {
                 // We should always be able to decrypt the data.  If we
@@ -4341,7 +4345,10 @@ struct DownstairsBackpressureConfig {
 
 #[cfg(test)]
 pub(crate) mod test {
-    use super::{ClientFaultReason, Downstairs, PendingJob};
+    use super::{
+        ClientFaultReason, ClientNegotiationFailed, ClientStopReason,
+        Downstairs, PendingJob,
+    };
     use crate::{
         downstairs::{LiveRepairData, LiveRepairState, ReconcileData},
         live_repair::ExtentInfo,
@@ -4363,6 +4370,17 @@ pub(crate) mod test {
     };
 
     use uuid::Uuid;
+
+    // Helper constants for verbose stopping states
+    const STOP_FAULT_REQUESTED: DsState = DsState::Stopping(
+        ClientStopReason::Fault(ClientFaultReason::RequestedFault),
+    );
+    const STOP_IO_ERROR: DsState =
+        DsState::Stopping(ClientStopReason::Fault(ClientFaultReason::IOError));
+    const STOP_FAILED_RECONCILE: DsState =
+        DsState::Stopping(ClientStopReason::NegotiationFailed(
+            ClientNegotiationFailed::FailedReconcile,
+        ));
 
     /// Builds a single-block reply from the given request and response data
     pub fn build_read_response(data: &[u8]) -> RawReadResponse {
@@ -6069,9 +6087,10 @@ pub(crate) mod test {
 
         // Fault client 1, so that later event handling will kick us out of
         // repair
-        ds.clients[ClientId::new(1)].checked_state_transition(
-            &UpstairsState::Initializing,
-            DsState::Faulted,
+        ds.fault_client(
+            ClientId::new(1),
+            &UpstairsState::Active,
+            ClientFaultReason::RequestedFault,
         );
 
         // Send an ack to trigger the reconciliation state check
@@ -6083,9 +6102,9 @@ pub(crate) mod test {
         assert!(!nw);
 
         // The two troublesome tasks will end up in DsState::New.
-        assert_eq!(ds.clients[ClientId::new(0)].state(), DsState::New);
-        assert_eq!(ds.clients[ClientId::new(1)].state(), DsState::Faulted);
-        assert_eq!(ds.clients[ClientId::new(2)].state(), DsState::New);
+        assert_eq!(ds.clients[ClientId::new(0)].state(), STOP_FAILED_RECONCILE,);
+        assert_eq!(ds.clients[ClientId::new(1)].state(), STOP_FAULT_REQUESTED);
+        assert_eq!(ds.clients[ClientId::new(2)].state(), STOP_FAILED_RECONCILE);
 
         // Verify that reconciliation has been stopped
         assert!(ds.reconcile.is_none());
@@ -6126,9 +6145,9 @@ pub(crate) mod test {
 
         // Getting the next work to do should verify the previous is done,
         // and handle a state change for a downstairs.
-        assert_eq!(ds.clients[ClientId::new(0)].state(), DsState::New);
-        assert_eq!(ds.clients[ClientId::new(1)].state(), DsState::New);
-        assert_eq!(ds.clients[ClientId::new(2)].state(), DsState::New);
+        for c in ds.clients.iter() {
+            assert_eq!(c.state(), STOP_FAILED_RECONCILE);
+        }
 
         // Verify that reconciliation has stopped
         assert!(ds.reconcile.is_none());
@@ -6587,7 +6606,7 @@ pub(crate) mod test {
             None,
         ));
         // client 0 is failed, the others should be okay still
-        assert_eq!(ds.clients[ClientId::new(0)].state(), DsState::Faulted);
+        assert_eq!(ds.clients[ClientId::new(0)].state(), STOP_IO_ERROR,);
         assert_eq!(ds.clients[ClientId::new(1)].state(), DsState::Active);
         assert_eq!(ds.clients[ClientId::new(2)].state(), DsState::Active);
 
@@ -6599,8 +6618,8 @@ pub(crate) mod test {
             &UpstairsState::Active,
             None,
         ));
-        assert_eq!(ds.clients[ClientId::new(0)].state(), DsState::Faulted);
-        assert_eq!(ds.clients[ClientId::new(1)].state(), DsState::Faulted);
+        assert_eq!(ds.clients[ClientId::new(0)].state(), STOP_IO_ERROR,);
+        assert_eq!(ds.clients[ClientId::new(1)].state(), STOP_IO_ERROR,);
         assert_eq!(ds.clients[ClientId::new(2)].state(), DsState::Active);
 
         // Three failures, But since this is a write we already have marked
@@ -6613,9 +6632,9 @@ pub(crate) mod test {
             &UpstairsState::Active,
             None,
         ));
-        assert_eq!(ds.clients[ClientId::new(0)].state(), DsState::Faulted);
-        assert_eq!(ds.clients[ClientId::new(1)].state(), DsState::Faulted);
-        assert_eq!(ds.clients[ClientId::new(2)].state(), DsState::Faulted);
+        assert_eq!(ds.clients[ClientId::new(0)].state(), STOP_IO_ERROR,);
+        assert_eq!(ds.clients[ClientId::new(1)].state(), STOP_IO_ERROR,);
+        assert_eq!(ds.clients[ClientId::new(2)].state(), STOP_IO_ERROR,);
 
         // Verify that this work should have been fast-acked
         assert!(ds.ds_active.get(&next_id).unwrap().acked);
@@ -6646,7 +6665,7 @@ pub(crate) mod test {
             None
         ));
         // client 0 should be marked failed.
-        assert_eq!(ds.clients[ClientId::new(0)].state(), DsState::Faulted);
+        assert_eq!(ds.clients[ClientId::new(0)].state(), STOP_IO_ERROR,);
 
         let ok_response = || Ok(Default::default());
         // Process the good operation for client 1
@@ -6666,7 +6685,7 @@ pub(crate) mod test {
             &UpstairsState::Active,
             None
         ));
-        assert_eq!(ds.clients[ClientId::new(0)].state(), DsState::Faulted);
+        assert_eq!(ds.clients[ClientId::new(0)].state(), STOP_IO_ERROR,);
         assert_eq!(ds.clients[ClientId::new(1)].state(), DsState::Active);
         assert_eq!(ds.clients[ClientId::new(2)].state(), DsState::Active);
 
@@ -6775,7 +6794,7 @@ pub(crate) mod test {
             None,
         ));
         // client 0 is failed, the others should be okay still
-        assert_eq!(ds.clients[ClientId::new(0)].state(), DsState::Faulted);
+        assert_eq!(ds.clients[ClientId::new(0)].state(), STOP_IO_ERROR,);
         assert_eq!(ds.clients[ClientId::new(1)].state(), DsState::Active);
         assert_eq!(ds.clients[ClientId::new(2)].state(), DsState::Active);
 
@@ -6787,8 +6806,8 @@ pub(crate) mod test {
             &UpstairsState::Active,
             None
         ));
-        assert_eq!(ds.clients[ClientId::new(0)].state(), DsState::Faulted);
-        assert_eq!(ds.clients[ClientId::new(1)].state(), DsState::Faulted);
+        assert_eq!(ds.clients[ClientId::new(0)].state(), STOP_IO_ERROR,);
+        assert_eq!(ds.clients[ClientId::new(1)].state(), STOP_IO_ERROR,);
         assert_eq!(ds.clients[ClientId::new(2)].state(), DsState::Active);
 
         let ok_response = Ok(Default::default());
@@ -6800,8 +6819,8 @@ pub(crate) mod test {
             &UpstairsState::Active,
             None
         ));
-        assert_eq!(ds.clients[ClientId::new(0)].state(), DsState::Faulted);
-        assert_eq!(ds.clients[ClientId::new(1)].state(), DsState::Faulted);
+        assert_eq!(ds.clients[ClientId::new(0)].state(), STOP_IO_ERROR,);
+        assert_eq!(ds.clients[ClientId::new(1)].state(), STOP_IO_ERROR,);
         assert_eq!(ds.clients[ClientId::new(2)].state(), DsState::Active);
 
         // Verify we should have fast-ackd this work
@@ -6880,7 +6899,7 @@ pub(crate) mod test {
 
         // Verify client states
         assert_eq!(ds.clients[ClientId::new(0)].state(), DsState::Active);
-        assert_eq!(ds.clients[ClientId::new(1)].state(), DsState::Faulted);
+        assert_eq!(ds.clients[ClientId::new(1)].state(), STOP_IO_ERROR,);
         assert_eq!(ds.clients[ClientId::new(2)].state(), DsState::Active);
 
         // A faulted write won't change skipped job count.
@@ -7022,7 +7041,7 @@ pub(crate) mod test {
 
         // Verify client states
         assert_eq!(ds.clients[ClientId::new(0)].state(), DsState::Active);
-        assert_eq!(ds.clients[ClientId::new(1)].state(), DsState::Faulted);
+        assert_eq!(ds.clients[ClientId::new(1)].state(), STOP_IO_ERROR,);
         assert_eq!(ds.clients[ClientId::new(2)].state(), DsState::Active);
 
         // Verify the read switched from InProgress to Skipped
@@ -7087,7 +7106,7 @@ pub(crate) mod test {
 
         // Verify client states
         assert_eq!(ds.clients[ClientId::new(0)].state(), DsState::Active);
-        assert_eq!(ds.clients[ClientId::new(1)].state(), DsState::Faulted);
+        assert_eq!(ds.clients[ClientId::new(1)].state(), STOP_IO_ERROR,);
         assert_eq!(ds.clients[ClientId::new(2)].state(), DsState::Active);
 
         // The write was fast-acked, and the read is still going
@@ -7197,7 +7216,7 @@ pub(crate) mod test {
         // Verify client states
         assert_eq!(ds.clients[ClientId::new(0)].state(), DsState::Active);
         assert_eq!(ds.clients[ClientId::new(1)].state(), DsState::Active);
-        assert_eq!(ds.clients[ClientId::new(2)].state(), DsState::Faulted);
+        assert_eq!(ds.clients[ClientId::new(2)].state(), STOP_IO_ERROR,);
 
         // Verify all IOs are done
         for cid in ClientId::iter() {
@@ -7306,7 +7325,7 @@ pub(crate) mod test {
         // Verify client states
         assert_eq!(ds.clients[ClientId::new(0)].state(), DsState::Active);
         assert_eq!(ds.clients[ClientId::new(1)].state(), DsState::Active);
-        assert_eq!(ds.clients[ClientId::new(2)].state(), DsState::Faulted);
+        assert_eq!(ds.clients[ClientId::new(2)].state(), STOP_IO_ERROR,);
 
         // Verify all IOs are done
         for cid in ClientId::iter() {
@@ -9628,14 +9647,14 @@ pub(crate) mod test {
             &UpstairsState::Active,
             ClientFaultReason::RequestedFault,
         );
-        ds.clients[to_repair].checked_state_transition(
-            &UpstairsState::Active,
+        for s in [
+            DsState::Faulted,
             DsState::LiveRepairReady,
-        );
-        ds.clients[to_repair].checked_state_transition(
-            &UpstairsState::Active,
             DsState::LiveRepair,
-        );
+        ] {
+            ds.clients[to_repair]
+                .checked_state_transition(&UpstairsState::Active, s);
+        }
 
         let next_id = ds.peek_next_id().0;
         ds.repair = Some(LiveRepairData {
@@ -9797,14 +9816,14 @@ pub(crate) mod test {
             &UpstairsState::Active,
             ClientFaultReason::RequestedFault,
         );
-        ds.clients[to_repair].checked_state_transition(
-            &UpstairsState::Active,
+        for s in [
+            DsState::Faulted,
             DsState::LiveRepairReady,
-        );
-        ds.clients[to_repair].checked_state_transition(
-            &UpstairsState::Active,
             DsState::LiveRepair,
-        );
+        ] {
+            ds.clients[to_repair]
+                .checked_state_transition(&UpstairsState::Active, s);
+        }
 
         let next_id = ds.peek_next_id().0;
 
@@ -9953,10 +9972,10 @@ pub(crate) mod test {
             &UpstairsState::Active,
             ClientFaultReason::RequestedFault,
         );
-        ds.clients[to_repair].checked_state_transition(
-            &UpstairsState::Active,
-            DsState::LiveRepairReady,
-        );
+        for s in [DsState::Faulted, DsState::LiveRepairReady] {
+            ds.clients[to_repair]
+                .checked_state_transition(&UpstairsState::Active, s);
+        }
 
         // Start the repair normally. This enqueues the close & reopen jobs, and
         // reserves Job IDs for the repair/noop


### PR DESCRIPTION
Staged on top of #1568

There's an unfortunate ambiguity in certain states (e.g. `DsState::Faulted`), which represent two different things:

- We've stopped the IO task due to a fault, and are waiting for it to restart
- The IO task has restarted, and we're doing negotiation from a faulted state (i.e. will do live-repair)

This PR adds a new `DsState::Stopping(ClientStopReason)` state, which represents the former.  The previous states (`DsState::Faulted`) now _only_ mean that we're doing negotiation.

The new state subsumes `DsState::Deactivated`, `DsState::Replacing`, `DsState::Disabled`, which were specialized states that waited for the IO task to exit.  Each of those states is now `DsState::Stopping(..)` with an appropriate `ClientStopReason`.

The vast majority of this PR is automatic OpenAPI changes.  I don't think anyone is relying on the specific shape of `DsState` (which is only used in `UpstairsInfo` / the `info` endpoint), but please let me know if I'm wrong!