### PR TITLE
Send all flushes through the deferred jobs queue (if present)

### DIFF
--- a/upstairs/src/deferred.rs
+++ b/upstairs/src/deferred.rs
@@ -125,6 +125,8 @@ pub(crate) struct DeferredWrite {
 #[derive(Debug)]
 pub(crate) enum DeferredBlockOp {
     Write(EncryptedWrite),
+    AnonymousFlush(Option<IOLimitGuard>),
+    Barrier,
     Other(BlockOp),
 }
 


### PR DESCRIPTION
Unclear if this actually matters, but I'm worried that flushes and barriers can skip the deferred job queue.