### PR TITLE
Update rust-version reqs to reflect reality

### DIFF
--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = ["Joshua M. Clulow <jmc@oxide.computer>", "Alan Hanson <alan@oxide.computer"]
 license = "MPL-2.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.81"
 
 [dependencies]
 anyhow.workspace = true

--- a/upstairs/Cargo.toml
+++ b/upstairs/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 authors = ["Joshua M. Clulow <jmc@oxide.computer>", "Alan Hanson <alan@oxide.computer"]
 license = "MPL-2.0"
 edition = "2021"
+rust-version = "1.81"
 
 [lib]
 name = "crucible"


### PR DESCRIPTION
With use of the now-stabilized #[expect] attribute, the upstairs and downstairs crates require at least Rust 1.81.