### PR TITLE
Clear `repair_check_deadline` if repair is successfully started

### DIFF
--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -921,6 +921,7 @@ impl Upstairs {
                 Some(Instant::now() + REPAIR_CHECK_INTERVAL);
         } else {
             // We started the repair in the call to start_live_repair above
+            self.repair_check_deadline = None;
         }
     }
 


### PR DESCRIPTION
Otherwise, we immediately check for live-repair again, which is confusing in the logs (see #1579)