### PR TITLE
get-up-state.sh needs more columns

### DIFF
--- a/tools/dtrace/get-up-state.d
+++ b/tools/dtrace/get-up-state.d
@@ -16,7 +16,7 @@ dtrace:::BEGIN
     last_id["string"] = (int64_t)1;
     printf("%5s %8s ", "PID", "SESSION");
     printf("%3s %3s %3s", "DS0", "DS1", "DS2");
-    printf(" %10s %5s %4s", "NEXT_JOB", "DELTA", "CONN");
+    printf(" %10s %6s %4s", "NEXT_JOB", "DELTA", "CONN");
     printf(" %5s %5s", "ELR", "ELC");
     printf(" %5s %5s", "ERR", "ERN");
     printf("\n");
@@ -118,7 +118,7 @@ crucible_upstairs*:::up-status
         strtoll(json(copyinstr(arg1), "ok.ds_connected[1]")) +
         strtoll(json(copyinstr(arg1), "ok.ds_connected[2]"));
 
-    printf("%5d %8s %3s %3s %3s %10s %5d %4d %5d %5d %5s %5s\n",
+    printf("%5d %8s %3s %3s %3s %10s %6d %4d %5d %5d %5s %5s\n",
         pid,
         this->session_id,
         /*

--- a/tools/dtrace/get-up-state.sh
+++ b/tools/dtrace/get-up-state.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
+set -o pipefail
+
 filename='/tmp/get-up-state.out'
 final='/tmp/get-up-state.final'
 rm -f $final
 
 # Gather our output first.
 dtrace -s /opt/oxide/crucible_dtrace/get-up-state.d | awk 'NF' > "$filename"
+if [[ $? -ne 0 ]]; then
+    exit 1
+fi
 
 # For each session we find, get the latest line and store that in
 # the result file.


### PR DESCRIPTION
6 columns for delta (10 seconds of iops) may be enough?

```
25  BRM44220010        ok: BRM44220010
  PID  SESSION DS0 DS1 DS2   NEXT_JOB  DELTA CONN   ELR   ELC   ERR   ERN
 4307 e043bc73 ACT ACT ACT     119004      0    3     0     0     0     0
 4307 fd4cc154 ACT ACT ACT      94791      8    3     0     0     0     0
14065 2a572053 ACT ACT ACT      94254      4    3     0     0     0     0
14243 109f3e15 ACT ACT ACT     299838      0    3     0     0     0     0
14243 4f1c8ea5 ACT ACT ACT     299885      0    3     0     0     0     0
14243 79966e3f ACT ACT ACT     300103      0    3     0     0     0     0
14243 99bc5538 ACT ACT ACT     300015      0    3     0     0     0     0
14243 d0ffa0be ACT ACT ACT     299918      0    3     0     0     0     0
14243 e30b11fe ACT ACT ACT      58337      0    3     0     0     0     0
14243 e68620e4 ACT ACT ACT     299941      0    3     0     0     0     0
14243 edfd4e5d ACT ACT ACT       2426      0    3     0     0     0     0
14250 2b2a3abc ACT ACT ACT      16854      0    3     0     0     0     0
14475 91ab7e08 ACT ACT ACT       1218      0    3     0     0     0     0
14475 db8a9152 ACT ACT ACT     428409     10    3     0     0    48     0
15828 a7c612e0 ACT ACT ACT 3455456787 133826    3     0     0   424     0
```

Now I wonder if `NEXT_JOB` needs another column?