### PR TITLE
Update buildomat to 1.84 rust, new 2 region test

### DIFF
--- a/.github/buildomat/jobs/build-release.sh
+++ b/.github/buildomat/jobs/build-release.sh
@@ -3,7 +3,7 @@
 #: name = "rbuild"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "1.70.0"
+#: rust_toolchain = "1.84.0"
 #: output_rules = [
 #:	"/out/*",
 #:	"/work/rbins/*",

--- a/.github/buildomat/jobs/build.sh
+++ b/.github/buildomat/jobs/build.sh
@@ -3,7 +3,7 @@
 #: name = "build"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "1.70.0"
+#: rust_toolchain = "1.84.0"
 #: output_rules = [
 #:	"/work/bins/*",
 #:	"/work/scripts/*",

--- a/.github/buildomat/jobs/test-up-2region-encrypted.sh
+++ b/.github/buildomat/jobs/test-up-2region-encrypted.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#:
+#: name = "test-up-2region-encrypted"
+#: variety = "basic"
+#: target = "helios-2.0"
+#: output_rules = [
+#:	"%/tmp/test_up*/*.txt",
+#:	"%/tmp/test_up*/dsc/*.txt",
+#:	"%/tmp/debug/*",
+#:	"/tmp/core.*",
+#: ]
+#: skip_clone = true
+#:
+#: [dependencies.build]
+#: job = "build"
+
+input="/input/build/work"
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+banner cores
+pfexec coreadm -i /tmp/core.%f.%p \
+ -g /tmp/core.%f.%p \
+ -e global \
+ -e log \
+ -e proc-setid \
+ -e global-setid
+
+banner unpack
+mkdir -p /var/tmp/bins
+for t in "$input/bins/"*.gz; do
+	b=$(basename "$t")
+	b=${b%.gz}
+	gunzip < "$t" > "/var/tmp/bins/$b"
+	chmod +x "/var/tmp/bins/$b"
+done
+
+export BINDIR=/var/tmp/bins
+
+# Give this test one hour to finish
+jobpid=$$; (sleep $(( 60 * 60 )); banner fail-timeout; ps -ef; zfs list;kill $jobpid) &
+
+echo "Setup debug logging"
+mkdir /tmp/debug
+psrinfo -v > /tmp/debug/psrinfo.txt
+df -h > /tmp/debug/df.txt || true
+prstat -d d -mLc 1 > /tmp/debug/prstat.txt 2>&1 &
+iostat -T d -xn 1 > /tmp/debug/iostat.txt 2>&1 &
+mpstat -T d 1 > /tmp/debug/mpstat.txt 2>&1 &
+vmstat -T d -p 1 < /dev/null > /tmp/debug/paging.txt 2>&1 &
+pfexec dtrace -Z -s $input/scripts/perf-downstairs-tick.d > /tmp/debug/dtrace.txt 2>&1 &
+pfexec dtrace -Z -s $input/scripts/upstairs_info.d > /tmp/debug/upstairs-info.txt 2>&1 &
+
+banner test_up_2r_encrypted
+ptime -m bash "$input/scripts/test_up.sh" -r 2 -N encrypted
+
+echo "test-up-2region-encrypted ends"


### PR DESCRIPTION
Make buildomat use the 1.84 toolchain.
Put back the test-up-2region-encrypted.sh test, now that we have fixed the problem where dsc could get stuck.