### PR TITLE
DTrace cleanup.

### DIFF
--- a/cmon/src/main.rs
+++ b/cmon/src/main.rs
@@ -92,12 +92,12 @@ fn short_state(dss: DsState) -> String {
         DsState::Connecting {
             state: NegotiationState::WaitActive,
             ..
-        } => "WAC".to_string(),
+        } => "WA".to_string(),
 
         DsState::Connecting {
             state: NegotiationState::WaitQuorum,
             ..
-        } => "WAQ".to_string(),
+        } => "WQ".to_string(),
         DsState::Connecting {
             state: NegotiationState::Reconcile,
             ..
@@ -121,14 +121,14 @@ fn short_state(dss: DsState) -> String {
         DsState::Connecting {
             mode: ConnectionMode::Offline,
             ..
-        } => "OFF".to_string(),
+        } => "OFL".to_string(),
         DsState::Stopping(ClientStopReason::Deactivated) => "DAV".to_string(),
         DsState::Stopping(ClientStopReason::Disabled) => "DIS".to_string(),
         DsState::Stopping(ClientStopReason::Replacing)
         | DsState::Connecting {
             mode: ConnectionMode::Replaced,
             ..
-        } => "RPD".to_string(),
+        } => "RPL".to_string(),
     }
 }
 

--- a/tools/dtrace/get-ds-state.d
+++ b/tools/dtrace/get-ds-state.d
@@ -18,19 +18,21 @@ inline string short_state[string ss] =
     ss == "offline" ? "OFL" :
     ss == "reconcile" ? "REC" :
     ss == "wait_quorum" ? "WQ" :
+    ss == "wait_active" ? "WA" :
+    ss == "replaced" ? "RPL" :
     ss;
 
 crucible_upstairs*:::up-status
 {
     my_sesh = json(copyinstr(arg1), "ok.session_id");
 
-    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0]");
+    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0].type");
     this->d0 = short_state[this->ds0state];
 
-    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1]");
+    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1].type");
     this->d1 = short_state[this->ds1state];
 
-    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2]");
+    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2].type");
     this->d2 = short_state[this->ds2state];
 
     printf("%6d %8s %3s %3s %3s\n",

--- a/tools/dtrace/get-up-state.d
+++ b/tools/dtrace/get-up-state.d
@@ -43,6 +43,8 @@ inline string short_state[string ss] =
     ss == "offline" ? "OFL" :
     ss == "reconcile" ? "REC" :
     ss == "wait_quorum" ? "WQ" :
+    ss == "wait_active" ? "WA" :
+    ss == "replaced" ? "RPL" :
     ss;
 
 /*
@@ -52,13 +54,13 @@ inline string short_state[string ss] =
  */
 crucible_upstairs*:::up-status
 {
-    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0]");
+    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0].type");
     this->d0 = short_state[this->ds0state];
 
-    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1]");
+    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1].type");
     this->d1 = short_state[this->ds1state];
 
-    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2]");
+    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2].type");
     this->d2 = short_state[this->ds2state];
 
     this->full_session_id = json(copyinstr(arg1), "ok.session_id");

--- a/tools/dtrace/simple.d
+++ b/tools/dtrace/simple.d
@@ -14,7 +14,7 @@ dtrace:::BEGIN
 /*
  * Print our header at some interval
  */
-tick-2s
+dtrace:::BEGIN, tick-20s
 {
     printf("%5s %8s ", "PID", "SESSION");
     printf("%3s %3s %3s", "DS0", "DS1", "DS2");
@@ -35,6 +35,9 @@ inline string short_state[string ss] =
     ss == "faulted" ? "FLT" :
     ss == "offline" ? "OFL" :
     ss == "reconcile" ? "REC" :
+    ss == "wait_quorum" ? "WQ" :
+    ss == "wait_active" ? "WA" :
+    ss == "replaced" ? "RPL" :
     ss;
 
 /*
@@ -44,13 +47,13 @@ inline string short_state[string ss] =
  */
 crucible_upstairs*:::up-status
 {
-    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0]");
+    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0].type");
     this->d0 = short_state[this->ds0state];
 
-    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1]");
+    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1].type");
     this->d1 = short_state[this->ds1state];
 
-    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2]");
+    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2].type");
     this->d2 = short_state[this->ds2state];
 
     this->full_session_id = json(copyinstr(arg1), "ok.session_id");

--- a/tools/dtrace/up-info.d
+++ b/tools/dtrace/up-info.d
@@ -48,6 +48,8 @@ inline string short_state[string ss] =
     ss == "offline" ? "OFL" :
     ss == "reconcile" ? "REC" :
     ss == "wait_quorum" ? "WQ" :
+    ss == "wait_active" ? "WA" :
+    ss == "replaced" ? "RPL" :
     ss;
 
 /*
@@ -63,13 +65,13 @@ crucible_upstairs*:::up-status
 /$target == 0 | $target == pid/
 {
     show = show + 1;
-    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0]");
+    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0].type");
     this->d0 = short_state[this->ds0state];
 
-    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1]");
+    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1].type");
     this->d1 = short_state[this->ds1state];
 
-    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2]");
+    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2].type");
     this->d2 = short_state[this->ds2state];
 
     this->full_session_id = json(copyinstr(arg1), "ok.session_id");


### PR DESCRIPTION
Update all the places where we print downstairs status able to handle the new format.  
Standardize the three letter name printed.

Use 10 for column width for next job ID
Use 6 for column width for job ID delta

For places where we print a header, print that header right away.

Updated `cmon` to use the same three letter strings as all the DTrace scripts.