### PR TITLE
Remove `LastFlushAck`

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -2957,11 +2957,11 @@ impl Downstairs {
                 *state = ConnectionState::Running(ActiveConnection::new(
                     data,
                     upstairs_connection,
-                    Some(last_flush_number),
+                    last_flush_number,
                     &self.log,
                 ));
 
-                info!(self.log, "Set last flush {}", last_flush_number);
+                info!(self.log, "Set last flush {:?}", last_flush_number);
 
                 /*
                  * Once this command is received, we are ready to exit

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -2963,15 +2963,8 @@ impl Downstairs {
 
                 info!(self.log, "Set last flush {}", last_flush_number);
 
-                let state = &self.connection_state[&conn_id]; // reborrow
-                if let Err(e) =
-                    state.reply(Message::LastFlushAck { last_flush_number })
-                {
-                    bail!("Failed sending LastFlushAck: {}", e);
-                }
-
                 /*
-                 * Once this command is sent, we are ready to exit
+                 * Once this command is received, we are ready to exit
                  * the loop and move forward with receiving IOs
                  */
                 info!(self.log, "Downstairs has completed Negotiation");

--- a/openapi/crucible-control.json
+++ b/openapi/crucible-control.json
@@ -405,7 +405,7 @@
         ]
       },
       "NegotiationState": {
-        "description": "Tracks client negotiation progress\n\nThe exact path through negotiation depends on the [`ConnectionMode`].\n\nThere are three main paths, shown below:\n\n```text ┌───────┐ │ Start ├────────┐ └───┬───┘        │ │            │ ┌─────▼──────┐     │ │ WaitActive │     │ auto-promote └─────┬──────┘     │ │            │ ┌───────▼────────┐   │ │ WaitForPromote ◄───┘ └───────┬────────┘ │ ┌────────▼──────────┐ │ WaitForRegionInfo │ └──┬──────────────┬─┘ Offline │              │ New / Faulted / Replaced ┌──────▼─────┐   ┌────▼────────────┐ │GetLastFlush│   │GetExtentVersions│ └──────┬─────┘   └─┬─────────────┬─┘ │           │ New         │ Faulted / Replaced │    ┌──────▼───┐    ┌────▼──────────┐ │    │WaitQuorum│    │LiveRepairReady│ │    └────┬─────┘    └────┬──────────┘ │         │               │ │    ┌────▼────┐          │ │    │Reconcile│          │ │    └────┬────┘          │ │         │               │ │     ┌───▼──┐            │ └─────► Done ◄────────────┘ └──────┘ ```\n\n`Done` isn't actually present in the state machine; it's indicated by returning a [`NegotiationResult`] other than [`NegotiationResult::NotDone`].",
+        "description": "Tracks client negotiation progress\n\nThe exact path through negotiation depends on the [`ConnectionMode`].\n\nThere are three main paths, shown below:\n\n```text ┌───────┐ │ Start ├────────┐ └───┬───┘        │ │            │ ┌─────▼──────┐     │ │ WaitActive │     │ auto-promote └─────┬──────┘     │ │            │ ┌───────▼────────┐   │ │ WaitForPromote ◄───┘ └───────┬────────┘ │ ┌────────▼──────────┐ │ WaitForRegionInfo │ └──┬──────────────┬─┘ Offline │              │ New / Faulted / Replaced (replay) │         ┌────▼────────────┐ │         │GetExtentVersions│ │         └─┬─────────────┬─┘ │           │ New         │ Faulted / Replaced │    ┌──────▼───┐    ┌────▼──────────┐ │    │WaitQuorum│    │LiveRepairReady│ │    └────┬─────┘    └────┬──────────┘ │         │               │ │    ┌────▼────┐          │ │    │Reconcile│          │ │    └────┬────┘          │ │         │               │ │     ┌───▼──┐            │ └─────► Done ◄────────────┘ └──────┘ ```\n\n`Done` isn't actually present in the state machine; it's indicated by returning a [`NegotiationResult`] other than [`NegotiationResult::NotDone`].",
         "oneOf": [
           {
             "description": "Initial state, waiting to hear `YesItsMe` from the client\n\nOnce this message is heard, transitions to either `WaitActive` (if `auto_promote` is `false`) or `WaitQuorum` (if `auto_promote` is `true`)",
@@ -472,21 +472,6 @@
                 "type": "string",
                 "enum": [
                   "wait_for_region_info"
-                ]
-              }
-            },
-            "required": [
-              "type"
-            ]
-          },
-          {
-            "description": "Waiting to hear `LastFlushAck` from the client",
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "get_last_flush"
                 ]
               }
             },

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -472,7 +472,7 @@ pub enum Message {
     },
 
     LastFlush {
-        last_flush_number: JobId,
+        last_flush_number: Option<JobId>,
     },
 
     /*

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -162,6 +162,9 @@ pub struct SnapshotDetails {
 #[repr(u32)]
 #[derive(IntoPrimitive)]
 pub enum MessageVersion {
+    /// Remove `LastFlushAck`
+    V13 = 13,
+
     /// Add `Barrier` and `BarrierAck`
     V12 = 12,
 
@@ -210,7 +213,7 @@ pub enum MessageVersion {
 }
 impl MessageVersion {
     pub const fn current() -> Self {
-        Self::V12
+        Self::V13
     }
 }
 
@@ -471,9 +474,6 @@ pub enum Message {
     LastFlush {
         last_flush_number: JobId,
     },
-    LastFlushAck {
-        last_flush_number: JobId,
-    },
 
     /*
      * IO related
@@ -628,7 +628,6 @@ impl Message {
             | Message::ExtentVersionsPlease { .. }
             | Message::ExtentVersions { .. }
             | Message::LastFlush { .. }
-            | Message::LastFlushAck { .. }
             | Message::Write { .. }
             | Message::ExtentLiveClose { .. }
             | Message::ExtentLiveFlushClose { .. }

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -1362,12 +1362,12 @@ impl DownstairsClient {
          * For WaitActive, it means this downstairs never was "Active" and we
          * have to go through the full compare of this downstairs with other
          * downstairs and make sure they are consistent.  To do that, we will
-         * request extent versions and skip over NegotiationState::GetLastFlush.
+         * request extent versions, instead of setting the last flush.
          *
          * For Faulted, we don't know the condition of the data on the
          * Downstairs, so we transition this downstairs to LiveRepairReady.  We
          * also request extent versions and will have to repair this
-         * downstairs, skipping over NegotiationState::GetLastFlush as well.
+         * downstairs, skipping over LastFlush as well.
          *
          * Replay (offline only)
          * ------------------------------

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -215,14 +215,12 @@ impl DownstairsHandle {
 
     pub async fn negotiate_step_last_flush(
         &mut self,
-        last_flush_number: JobId,
+        expected_last_flush: JobId,
     ) {
         let packet = self.recv().await.unwrap();
-        if let Message::LastFlush { .. } = &packet {
+        if let Message::LastFlush { last_flush_number } = &packet {
+            assert_eq!(*last_flush_number, expected_last_flush);
             info!(self.log, "negotiate packet {:?}", packet);
-
-            self.send(Message::LastFlushAck { last_flush_number })
-                .unwrap();
         } else {
             panic!("wrong packet: {packet:?}, expected LastFlush");
         }
@@ -2845,7 +2843,7 @@ async fn test_no_send_offline() {
     // Start negotiation
     harness.ds1().negotiate_start().await;
 
-    // Check that a write doesn't make it to DS1
+    // Check that a write doesn't make it to DS1 before replay
     let write_handle = harness.spawn(|guest| async move {
         let mut data = BytesMut::new();
         data.resize(512, 1u8);
@@ -2854,27 +2852,15 @@ async fn test_no_send_offline() {
     harness.ds2.ack_write().await;
     harness.ds3.ack_write().await;
 
-    // We expect to receive the next negotiation packet, not the Write
+    // We expect to receive the final negotiation packet, followed by the Write
     tokio::time::sleep(Duration::from_secs(1)).await;
-    let last_flush_number = match harness.ds1().try_recv() {
+    match harness.ds1().try_recv() {
         Ok(Message::LastFlush { last_flush_number }) => last_flush_number,
         m => panic!("unexpected message {m:?}"),
     };
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
-    assert_eq!(harness.ds1().try_recv(), Err(TryRecvError::Empty));
-
     // The write should be done
     write_handle.await.unwrap();
-
-    // Now, bring the Downstairs up, which should trigger replay
-    harness
-        .ds1()
-        .send(Message::LastFlushAck { last_flush_number })
-        .unwrap();
-
-    // Give the replay a moment to happen
-    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // We should see that write sent as a replay
     match harness.ds1().try_recv() {

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -215,7 +215,7 @@ impl DownstairsHandle {
 
     pub async fn negotiate_step_last_flush(
         &mut self,
-        expected_last_flush: JobId,
+        expected_last_flush: Option<JobId>,
     ) {
         let packet = self.recv().await.unwrap();
         if let Message::LastFlush { last_flush_number } = &packet {
@@ -708,7 +708,7 @@ async fn test_replay_occurs() {
     harness.restart_ds1().await;
 
     harness.ds1().negotiate_start().await;
-    harness.ds1().negotiate_step_last_flush(JobId(0)).await;
+    harness.ds1().negotiate_step_last_flush(None).await;
 
     let mut ds1_message_second_time = None;
 
@@ -2781,7 +2781,7 @@ async fn test_write_replay() {
     harness.restart_ds1().await;
 
     harness.ds1().negotiate_start().await;
-    harness.ds1().negotiate_step_last_flush(JobId(0)).await;
+    harness.ds1().negotiate_step_last_flush(None).await;
 
     // Ensure that we get the same Write
     // Send a reply, which is the second time this Write operation completes

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1656,7 +1656,6 @@ impl Upstairs {
             | Message::ReadOnlyMismatch { .. }
             | Message::YouAreNowActive { .. }
             | Message::RegionInfo { .. }
-            | Message::LastFlushAck { .. }
             | Message::ExtentVersions { .. } => {
                 // negotiation and initial reconciliation
                 let r = self.downstairs.clients[client_id]


### PR DESCRIPTION
Right now, if a downstairs is coming online through replay (`ConnectionMode::Offline`), the Upstairs goes through the following steps to finish negotiation:

- From`WaitForRegionInfo`, it sends `LastFlush`, which gives the Downstairs a lower bound for job IDs
  - This assignment is infallible on the Downstairs side
  - The upstairs enters `NegotiationState::GetLastFlush` while waiting for a reply
- The Downstairs then sends back that same flush ID in a `LastFlushAck` message
- Once the Upstairs receives this message, it exits negotiation and replays all previous jobs

There are two things that are awkward about this sequence
- If someone is continuing to send IO, the Downstairs can become ineligible for replay between sending `LastFlush` and `LastFlushAck`, because we could exceed our "how much IO to buffer" limit.  It's not _wrong_ in the current implementation – we disconnect and restart negotiation from the start – but having that window of fallibility is awkward.
- The `LastFlushAck` reply does not convey much information.  Message handling in the Downstairs is infallible and will always return the same job ID.

This PR removes the `LastFlushAck` reply and `GetLastFlush` negotiation state; instead, replayed jobs are sent immediately following the `LastFlush` message.  We already assume that messages are reliable and strongly ordered (thanks, TCP!), so when the Downstairs gets the first replayed job, it **must** have already received the `LastFlush` message.

Because we're still doing rack-wide updates, I'm bumping the Crucible message version and removing the `LastFlushAck` entirely.  I _think_ this is still fine; otherwise, we can keep that variant (but mark it as deprecated).

(This is secretly a building block for Stateless Negotiation™, but makes sense as a stand-alone change)