### PR TITLE
Correctly print 'connecting' state

### DIFF
--- a/tools/dtrace/get-ds-state.d
+++ b/tools/dtrace/get-ds-state.d
@@ -19,7 +19,7 @@ inline string short_state[string ss] =
     ss == "reconcile" ? "REC" :
     ss == "wait_quorum" ? "WQ" :
     ss == "wait_active" ? "WA" :
-    ss == "replaced" ? "RPL" :
+    ss == "connecting" ? "CON" :
     ss;
 
 crucible_upstairs*:::up-status

--- a/tools/dtrace/get-up-state.d
+++ b/tools/dtrace/get-up-state.d
@@ -44,7 +44,7 @@ inline string short_state[string ss] =
     ss == "reconcile" ? "REC" :
     ss == "wait_quorum" ? "WQ" :
     ss == "wait_active" ? "WA" :
-    ss == "replaced" ? "RPL" :
+    ss == "connecting" ? "CON" :
     ss;
 
 /*

--- a/tools/dtrace/simple.d
+++ b/tools/dtrace/simple.d
@@ -38,6 +38,7 @@ inline string short_state[string ss] =
     ss == "wait_quorum" ? "WQ" :
     ss == "wait_active" ? "WA" :
     ss == "replaced" ? "RPL" :
+    ss == "connecting" ? "CON" :
     ss;
 
 /*

--- a/tools/dtrace/single_up_info.d
+++ b/tools/dtrace/single_up_info.d
@@ -50,6 +50,7 @@ inline string short_state[string ss] =
     ss == "wait_quorum" ? "WQ" :
     ss == "wait_active" ? "WA" :
     ss == "replaced" ? "RPL" :
+    ss == "connecting" ? "CON" :
     ss;
 
 crucible_upstairs*:::up-status

--- a/tools/dtrace/up-info.d
+++ b/tools/dtrace/up-info.d
@@ -41,7 +41,6 @@ tick-1s
 inline string short_state[string ss] =
     ss == "active" ? "ACT" :
     ss == "new" ? "NEW" :
-    ss == "replaced" ? "RPL" :
     ss == "live_repair_ready" ? "LRR" :
     ss == "live_repair" ? "LR" :
     ss == "faulted" ? "FLT" :
@@ -50,6 +49,7 @@ inline string short_state[string ss] =
     ss == "wait_quorum" ? "WQ" :
     ss == "wait_active" ? "WA" :
     ss == "replaced" ? "RPL" :
+    ss == "connecting" ? "CON" :
     ss;
 
 /*

--- a/tools/dtrace/upstairs_info.d
+++ b/tools/dtrace/upstairs_info.d
@@ -43,6 +43,7 @@ inline string short_state[string ss] =
     ss == "wait_quorum" ? "WQ" :
     ss == "wait_active" ? "WA" :
     ss == "replaced" ? "RPL" :
+    ss == "connecting" ? "CON" :
     ss;
 
 crucible_upstairs*:::up-status

--- a/tools/dtrace/upstairs_repair.d
+++ b/tools/dtrace/upstairs_repair.d
@@ -46,6 +46,7 @@ inline string short_state[string ss] =
     ss == "wait_quorum" ? "WQ" :
     ss == "wait_active" ? "WA" :
     ss == "replaced" ? "RPL" :
+    ss == "connecting" ? "CON" :
     ss;
 
 crucible_upstairs*:::up-status


### PR DESCRIPTION
Fix formatting while in `DsState::Connecting`

```
james@gravytrain:~/crucible/tools/dtrace$ pfexec dtrace -s upstairs_info.d 
   PID DS0 DS1 DS2   UPW   DSW      JOBID   WRITE_BO    IP0   IP1   IP2     D0    D1    D2     S0    S1    S2
 21650 ACT ACT ACT     0   159     333547   78643200      0     0    81    159   159    78      0     0     0
 21650 connecting connecting connecting     0     0      30548          0      0     0     0      0     0     0      0     0     0
 21650 ACT ACT ACT     0     0      76532          0      0     0     0      0     0     0      0     0     0
 21650 connecting connecting connecting     0     0      30548          0      0     0     0      0     0     0      0     0     0
 21650 ACT ACT ACT     0   127     333594   78643200      0     0    81    127   127    46      0     0     0
 21650 ACT ACT ACT     0     0      76532          0      0     0     0      0     0     0      0     0     0
 21650 ACT ACT ACT     1   113     333627   78643200      0     1    81    113   112    32      0     0     0
 21650 connecting connecting connecting     0     0      30548          0      0     0     0      0     0     0      0     0     0
 21650 ACT ACT ACT     0     0      76532          0      0     0     0      0     0     0      0     0     0
 ```

(there were also duplicates of the `replaced` state in a few of the scripts)