### PR TITLE
Fix missing write stats in Oximeter.

### DIFF
--- a/tools/dtrace/get-ds-state.sh
+++ b/tools/dtrace/get-ds-state.sh
@@ -7,7 +7,7 @@ filename='/tmp/get-ds-state.out'
 # Clear out any previous state
 echo "" > "$filename"
 # Gather state on all running propolis servers, record summary to a file
-dtrace -s /opt/oxide/dtrace/crucible/get-ds-state.d | sort -n | uniq | awk 'NF' > "$filename"
+dtrace -s /opt/oxide/crucible_dtrace/get-ds-state.d | sort -n | uniq | awk 'NF' > "$filename"
 # Walk the lines in the file, append the zone name to each line.
 while read -r p; do
         # For each line in the file, pull out the PID we are looking at and

--- a/tools/dtrace/get-lr-state.sh
+++ b/tools/dtrace/get-lr-state.sh
@@ -7,7 +7,7 @@ filename='/tmp/get-lr-state.out'
 # Clear out any previous state
 echo "" > "$filename"
 # Gather state on all running propolis servers, record summary to a file
-dtrace -s /opt/oxide/dtrace/crucible/get-lr-state.d | sort -n | uniq | awk 'NF' > "$filename"
+dtrace -s /opt/oxide/crucible_dtrace/get-lr-state.d | sort -n | uniq | awk 'NF' > "$filename"
 # Walk the lines in the file, append the zone name to each line.
 while read -r p; do
         # For each line in the file, pull out the PID we are looking at and

--- a/tools/dtrace/get-up-state.sh
+++ b/tools/dtrace/get-up-state.sh
@@ -7,7 +7,7 @@ final='/tmp/get-up-state.final'
 rm -f $final
 
 # Gather our output first.
-dtrace -s /opt/oxide/dtrace/crucible/get-up-state.d | awk 'NF' > "$filename"
+dtrace -s /opt/oxide/crucible_dtrace/get-up-state.d | awk 'NF' > "$filename"
 if [[ $? -ne 0 ]]; then
     exit 1
 fi

--- a/tools/dtrace/upstairs_count.d
+++ b/tools/dtrace/upstairs_count.d
@@ -86,7 +86,7 @@ tick-1s
 
 tick-1s
 {
-    printa("%@4u %@4u %@4u %@4u %@5u %@5u %@4u %@4u %@4u %@4u",
+    printa("%@5u %@5u %@5u %@5u %@5u %@5u %@5u %@5u %@5u %@5u",
         @flush_start, @flush_done, @write_start, @write_done,
         @read_start, @read_done, @write_unwritten_start, @write_unwritten_done,
         @barrier_start, @barrier_done

--- a/tools/dtrace/upstairs_count.d
+++ b/tools/dtrace/upstairs_count.d
@@ -78,7 +78,7 @@ crucible_upstairs*:::gw-barrier-done
 tick-1s
 /show > 20/
 {
-    printf("%4s %4s %4s %4s %5s %5s %4s %4s %4s %4s",
+    printf("%5s %5s %5s %5s %5s %5s %5s %5s %5s %5s",
         "F>", "F<", "W>", "W<", "R>", "R<", "WU>", "WU<", "B>", "B<");
     printf("\n");
     show = 0;

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1487,6 +1487,11 @@ impl Upstairs {
         // Fast-ack, pretending to be done immediately operations
         res.send_ok(());
 
+        // Update Oximeter stats for this write.
+        if !is_write_unwritten {
+            self.downstairs.update_write_done_metrics(data.len());
+        }
+
         Some(DeferredWrite {
             ddef,
             impacted_blocks,


### PR DESCRIPTION
Write stats were not making it to Oximeter any longer.  Sometime in the recent changes we stopped calling the method that updated both DTrace probes for write completion and calling the `add_write` that would eventually make it to Oximeter.

To do this, I made a common "stat update" function and added a call to the stat update function when a write "would have" been acked had we not fast-acked it already.

While I was here, I also updated some paths for dtrace scripts and updated column width for upstairs_count.d script.

Fixes https://github.com/oxidecomputer/crucible/issues/1615

After the changes on my bench gimlet you can see writes now:
<img width="671" alt="WritesNow" src="https://github.com/user-attachments/assets/030f74cc-9d40-414f-b593-525bcfb9aba0" />

