### PR TITLE
Nexus notifications have different importance

### DIFF
--- a/pantry/src/server.rs
+++ b/pantry/src/server.rs
@@ -324,6 +324,7 @@ async fn bulk_write(
 
     Ok(HttpResponseUpdatedNoContent())
 }
+
 #[derive(Deserialize, JsonSchema)]
 struct BulkReadRequest {
     pub offset: u64,


### PR DESCRIPTION
Even if it's best effort, notifications about progress should be low priority, and not starve out notifications related to processes starting and stopping. Otherwise, we see:

    00:16:18.781Z INFO propolis-server (vm_state_driver): live-repair completed successfully
         = downstairs
        session_id = 67a91355-4dd1-4e8d-9631-15f5fed073d9
    00:16:18.781Z WARN propolis-server (vm_state_driver): could not send notify "Full(..)"; queue is full
        job = notify_queue
        session_id = 67a91355-4dd1-4e8d-9631-15f5fed073d9