### PR TITLE
Use `RangeSet` instead of tracking every complete job

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,7 @@ dependencies = [
  "oximeter-producer",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "rangemap",
  "rayon",
  "repair-client",
  "reqwest",
@@ -4757,6 +4758,12 @@ checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rangemap"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
 name = "rayon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ rayon = "1.10.0"
 rand = { version = "0.8.5", features = ["min_const_gen", "small_rng"] }
 rand_chacha = "0.3.1"
 reedline = "0.38.0"
+rangemap = "1.5.1"
 reqwest = { version = "0.12", features = ["default", "blocking", "json", "stream"] }
 ringbuffer = "0.15.0"
 rusqlite = { version = "0.32" }

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -31,6 +31,7 @@ opentelemetry.workspace = true
 oximeter-producer.workspace = true
 oximeter.workspace = true
 rand.workspace = true
+rangemap.workspace = true
 rayon.workspace = true
 repair-client.workspace = true
 reqwest.workspace = true

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -3288,8 +3288,8 @@ impl Work {
         }
     }
 
-    fn completed(&self) -> &[JobId] {
-        self.completed.completed()
+    fn completed(&self) -> Vec<JobId> {
+        self.completed.completed().collect()
     }
 
     /// Pushes a new job to the back of the queue
@@ -4947,7 +4947,7 @@ mod test {
         test_do_work(&mut work, next_jobs);
         assert_eq!(
             work.completed(),
-            vec![JobId(1000), JobId(2000), JobId(1001), JobId(2001)]
+            vec![JobId(1000), JobId(1001), JobId(2000), JobId(2001)]
         );
 
         let next_jobs = test_push_next_jobs(&mut work);


### PR DESCRIPTION
(staged on top of #1662)

Right now, we store each completed `JobId` and search linearly through the list when checking for dependencies.  This means that a flush, which is dependent on all previous jobs, takes `O(N^2)` time to check its dependencies.

This PR switches to a [`RangeSet`](https://docs.rs/rangemap/latest/rangemap/set/struct.RangeSet.html), which provides `O(log N)` lookup.  In practice, we expect it to be `O(1)`: jobs are completed in order, so the `RangeSet` will only contain a single contiguous range.

I did a quick audit of the `rangemap` crate, and it seems reasonable:

- No dependencies
- `proptest` based testing, Github CI
- Consistent docstrings

There are two small behavior changes:

- `completed()` now allocates, expanding the `RangeSet` into a `Vec<JobId>` (instead of a `&[JobId]`).  It's only used in unit tests and our debug work-printing function, so I think that's fine.
- The output of `completed()` is now sorted.  This required changing one test assertion.