### PR TITLE
Fix unused import

### DIFF
--- a/dsc/src/control.rs
+++ b/dsc/src/control.rs
@@ -11,7 +11,6 @@ use dropshot::Path;
 use dropshot::RequestContext;
 use dropshot::{HttpResponseOk, HttpResponseUpdatedNoContent};
 use schemars::JsonSchema;
-use semver::Version;
 use serde::Deserialize;
 use std::sync::Arc;
 


### PR DESCRIPTION
```
warning: unused import: `semver::Version`
  --> dsc/src/control.rs:14:5
   |
14 | use semver::Version;
   |     ^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```