### PR TITLE
Log when pantry/volume layers activate things

### DIFF
--- a/pantry/src/pantry.rs
+++ b/pantry/src/pantry.rs
@@ -410,7 +410,9 @@ impl PantryEntry {
     }
 
     pub async fn detach(&self) -> Result<(), CrucibleError> {
+        let uuid = self.volume.get_uuid().await;
         self.volume.deactivate().await?;
+        info!(self.log, "Pantry detach and deactivated {:?}", uuid);
         Ok(())
     }
 
@@ -436,6 +438,11 @@ impl PantryEntry {
                     drop(inner);
 
                     self.volume.activate().await?;
+                    info!(
+                        self.log,
+                        "Pantry activated {:?}",
+                        self.volume.get_uuid().await
+                    );
                 }
 
                 ActiveObservation::SawActive => {

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -655,6 +655,11 @@ impl BlockIO for VolumeInner {
     async fn activate(&self) -> Result<(), CrucibleError> {
         for sub_volume in &self.sub_volumes {
             sub_volume.activate().await?;
+            info!(
+                self.log,
+                "Activated sub_volume {}",
+                sub_volume.get_uuid().await?
+            );
 
             let sub_volume_computed_size = self.block_size
                 * (sub_volume.lba_range.end - sub_volume.lba_range.start);
@@ -666,6 +671,11 @@ impl BlockIO for VolumeInner {
 
         if let Some(ref read_only_parent) = &self.read_only_parent {
             read_only_parent.activate().await?;
+            info!(
+                self.log,
+                "Activated read_only_parent {}",
+                read_only_parent.get_uuid().await?
+            );
         }
 
         Ok(())
@@ -673,6 +683,11 @@ impl BlockIO for VolumeInner {
     async fn activate_with_gen(&self, gen: u64) -> Result<(), CrucibleError> {
         for sub_volume in &self.sub_volumes {
             sub_volume.activate_with_gen(gen).await?;
+            info!(
+                self.log,
+                "Activated sub_volume {}",
+                sub_volume.get_uuid().await?
+            );
 
             let sub_volume_computed_size = self.block_size
                 * (sub_volume.lba_range.end - sub_volume.lba_range.start);
@@ -684,6 +699,11 @@ impl BlockIO for VolumeInner {
 
         if let Some(ref read_only_parent) = &self.read_only_parent {
             read_only_parent.activate_with_gen(gen).await?;
+            info!(
+                self.log,
+                "Activated read_only_parent {}",
+                read_only_parent.get_uuid().await?
+            );
         }
 
         Ok(())


### PR DESCRIPTION
While debugging other problems, we found it difficult to determine when a pantry had activated
which part of a multi level VCR.

This adds some log messages showing when each piece of the VCR is activated.