### PR TITLE
Remove unnecessary argument

### DIFF
--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -1016,11 +1016,7 @@ impl Downstairs {
     ///
     /// This function is idempotent; it returns without doing anything if
     /// live-repair either can't be started or is already running.
-    pub(crate) fn check_live_repair_start(
-        &mut self,
-        up_state: &UpstairsState,
-        extent_count: u32,
-    ) {
+    pub(crate) fn check_live_repair_start(&mut self, up_state: &UpstairsState) {
         // If we're already doing live-repair, then we can't start live-repair
         if self.live_repair_in_progress() {
             return;
@@ -1067,7 +1063,7 @@ impl Downstairs {
         // Submit the initial repair jobs, which kicks everything off
         self.begin_repair_for(
             ExtentId(0),
-            Some(extent_count),
+            Some(self.ddef.unwrap().extent_count()),
             false,
             &repair_downstairs,
             source_downstairs,
@@ -9760,7 +9756,7 @@ pub(crate) mod test {
 
         // Start the repair normally. This enqueues the close & reopen jobs, and
         // reserves Job IDs for the repair/noop
-        ds.check_live_repair_start(&UpstairsState::Active, 3);
+        ds.check_live_repair_start(&UpstairsState::Active);
         assert!(ds.live_repair_in_progress());
 
         // Submit a write.

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -918,10 +918,7 @@ impl Upstairs {
         }
 
         // Try to start live-repair
-        self.downstairs.check_live_repair_start(
-            &self.state,
-            self.ddef.get_def().unwrap().extent_count(),
-        );
+        self.downstairs.check_live_repair_start(&self.state);
     }
 
     /// Returns `true` if we're ready to accept guest IO


### PR DESCRIPTION
The `Downstairs` already has the region definition available locally, so we don't need to pass in the extent count.