### PR TITLE
Add more extents for repair tests

### DIFF
--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -390,8 +390,8 @@ echo "Begin replace reconcile test" >> "${log_prefix}_out.txt"
 # region so we have one to use for replacement.
 ((region_count+=1))
 echo "Creating $region_count larger downstairs regions"
-echo "${dsc}" create "${dsc_create_args[@]}" --region-count "$region_count" --extent-count 300 --block-size 4096 "${dsc_args[@]}" >> "$dsc_output"
-"${dsc}" create "${dsc_create_args[@]}" --region-count "$region_count" --extent-count 100 --block-size 4096 "${dsc_args[@]}" >> "$dsc_output" 2>&1
+echo "${dsc}" create "${dsc_create_args[@]}" --region-count "$region_count" --extent-count 400 --block-size 4096 "${dsc_args[@]}" >> "$dsc_output"
+"${dsc}" create "${dsc_create_args[@]}" --region-count "$region_count" --extent-count 400 --block-size 4096 "${dsc_args[@]}" >> "$dsc_output" 2>&1
 
 echo "Starting $region_count downstairs"
 echo "${dsc}" start --region-count $region_count "${dsc_args[@]}" >> "$dsc_output"


### PR DESCRIPTION
The repair tests in tools/test_up.sh were not creating enough extents.
The replace-reconcile test wants enough extents to repair such that we can
start things repairing and then interrupt it before it finishes.

Fix for the flake: https://github.com/oxidecomputer/crucible/issues/1686

Also, the "echo" was out of sync with the actual command we ran, fixed that too.