### PR TITLE
Make `IOop` use absolute block indices

### DIFF
--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -26,7 +26,7 @@ use crate::{
     RawWrite, ReconcileIO, ReconciliationId, RegionDefinition, ReplaceResult,
     SnapshotDetails, WorkSummary,
 };
-use crucible_common::{BlockIndex, BlockOffset, ExtentId, NegotiationError};
+use crucible_common::{BlockIndex, ExtentId, NegotiationError};
 use crucible_protocol::WriteHeader;
 
 use ringbuffer::RingBuffer;
@@ -1510,8 +1510,7 @@ impl Downstairs {
 
         let aread = IOop::Read {
             dependencies,
-            start_eid: ExtentId(0),
-            start_offset: BlockOffset(7),
+            start_block: BlockIndex(7),
             count: 1,
             block_size: 512,
         };
@@ -1565,25 +1564,17 @@ impl Downstairs {
 
         // TODO: can anyone actually give us an empty write?
         let start = blocks.start().unwrap_or(BlockIndex(0));
-
-        // XXX change IOop to take `BlockIndex` instead?
-        let extent_size = self.ddef.unwrap().extent_size().value;
-        let start_eid = ExtentId((start.0 / extent_size) as u32);
-        let start_offset = BlockOffset(start.0 % extent_size);
-
         let awrite = if is_write_unwritten {
             IOop::WriteUnwritten {
                 dependencies,
-                start_eid,
-                start_offset,
+                start_block: start,
                 data: write.data.freeze(),
                 blocks: write.blocks,
             }
         } else {
             IOop::Write {
                 dependencies,
-                start_eid,
-                start_offset,
+                start_block: start,
                 data: write.data.freeze(),
                 blocks: write.blocks,
             }
@@ -2164,16 +2155,9 @@ impl Downstairs {
         // TODO: can anyone actually give us an empty write?
         let start = blocks.start().unwrap_or(BlockIndex(0));
         let ddef = self.ddef.unwrap();
-
-        // XXX change IOop to take `BlockIndex` instead?
-        let extent_size = ddef.extent_size().value;
-        let start_eid = ExtentId((start.0 / extent_size) as u32);
-        let start_offset = BlockOffset(start.0 % extent_size);
-
         let aread = IOop::Read {
             dependencies,
-            start_eid,
-            start_offset,
+            start_block: start,
             count: blocks.blocks().len() as u64,
             block_size: ddef.block_size(),
         };
@@ -2267,7 +2251,10 @@ impl Downstairs {
             let r = match client.should_send() {
                 Ok(r) => r,
                 Err(ShouldSendError::InLiveRepair) => {
-                    if io.send_io_live_repair(last_repair_extent) {
+                    if io.send_io_live_repair(
+                        last_repair_extent,
+                        self.ddef.as_ref().unwrap(),
+                    ) {
                         EnqueueResult::Send
                     } else {
                         EnqueueResult::Skip
@@ -2320,9 +2307,6 @@ impl Downstairs {
 
     /// Sends the given job to the given client
     fn send(&mut self, ds_id: JobId, io: IOop, client_id: ClientId) {
-        let def = self.ddef.unwrap();
-        let blocks_per_extent = def.extent_size().value;
-
         let job = self.clients[client_id].prune_deps(
             ds_id,
             io,
@@ -2331,8 +2315,7 @@ impl Downstairs {
         let message = match job {
             IOop::Write {
                 dependencies,
-                start_eid,
-                start_offset,
+                start_block,
                 blocks,
                 data,
             } => {
@@ -2343,18 +2326,14 @@ impl Downstairs {
                         session_id: self.cfg.session_id,
                         job_id: ds_id,
                         dependencies,
-                        start: BlockIndex(
-                            start_eid.0 as u64 * blocks_per_extent
-                                + start_offset.0,
-                        ),
+                        start: start_block,
                         contexts: blocks,
                     },
                     data,
                 }
             }
             IOop::WriteUnwritten {
-                start_eid,
-                start_offset,
+                start_block,
                 blocks,
                 dependencies,
                 data,
@@ -2369,10 +2348,7 @@ impl Downstairs {
                         session_id: self.cfg.session_id,
                         job_id: ds_id,
                         dependencies,
-                        start: BlockIndex(
-                            start_eid.0 as u64 * blocks_per_extent
-                                + start_offset.0,
-                        ),
+                        start: start_block,
                         contexts: blocks,
                     },
                     data,
@@ -2408,8 +2384,7 @@ impl Downstairs {
             }
             IOop::Read {
                 dependencies,
-                start_eid,
-                start_offset,
+                start_block,
                 count,
                 ..
             } => {
@@ -2419,9 +2394,7 @@ impl Downstairs {
                     session_id: self.cfg.session_id,
                     job_id: ds_id,
                     dependencies,
-                    start: BlockIndex(
-                        start_eid.0 as u64 * blocks_per_extent + start_offset.0,
-                    ),
+                    start: start_block,
                     count,
                 }
             }
@@ -3544,7 +3517,7 @@ impl Downstairs {
     fn submit_test_write_block(
         &mut self,
         eid: ExtentId,
-        block: BlockOffset,
+        block: crucible_common::BlockOffset,
         is_write_unwritten: bool,
     ) -> JobId {
         let extent_size = self.ddef.unwrap().extent_size().value;
@@ -3597,7 +3570,7 @@ impl Downstairs {
     fn submit_read_block(
         &mut self,
         eid: ExtentId,
-        block: BlockOffset,
+        block: crucible_common::BlockOffset,
     ) -> JobId {
         let extent_size = self.ddef.unwrap().extent_size().value;
         let block = BlockIndex(u64::from(eid.0) * extent_size + block.0);

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -473,8 +473,6 @@ pub(crate) mod up_test {
     }
 
     fn test_ddef(blocks_per_extent: u64) -> RegionDefinition {
-        // Check the send_io_live_repair for a read below extent limit,
-        // at extent limit, and above extent limit.
         let mut region_options = RegionOptions::default();
         region_options.set_block_size(512);
         region_options.set_extent_size(Block::new(blocks_per_extent, 9));
@@ -489,6 +487,8 @@ pub(crate) mod up_test {
 
     #[test]
     fn send_io_live_repair_read() {
+        // Check the send_io_live_repair for a read below extent limit,
+        // at extent limit, and above extent limit.
         const BLOCKS_PER_EXTENT: u64 = 8;
         let ddef = test_ddef(BLOCKS_PER_EXTENT);
 

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -472,69 +472,85 @@ pub(crate) mod up_test {
         Ok(())
     }
 
-    #[test]
-    fn send_io_live_repair_read() {
+    fn test_ddef(blocks_per_extent: u64) -> RegionDefinition {
         // Check the send_io_live_repair for a read below extent limit,
         // at extent limit, and above extent limit.
+        let mut region_options = RegionOptions::default();
+        region_options.set_block_size(512);
+        region_options.set_extent_size(Block::new(blocks_per_extent, 9));
+        region_options.set_uuid(Uuid::new_v4());
+        region_options.set_encrypted(false);
+        region_options.validate().unwrap();
+
+        let mut ddef = RegionDefinition::from_options(&region_options).unwrap();
+        ddef.set_extent_count(15);
+        ddef
+    }
+
+    #[test]
+    fn send_io_live_repair_read() {
+        const BLOCKS_PER_EXTENT: u64 = 8;
+        let ddef = test_ddef(BLOCKS_PER_EXTENT);
 
         // Below limit
         let op = IOop::Read {
             dependencies: vec![],
-            start_eid: ExtentId(0),
-            start_offset: BlockOffset(7),
+            start_block: BlockIndex(7),
             count: 1,
             block_size: 512,
         };
-        assert!(op.send_io_live_repair(Some(ExtentId(2))));
+        assert!(op.send_io_live_repair(Some(ExtentId(2)), &ddef));
 
         // At limit
         let op = IOop::Read {
             dependencies: vec![],
-            start_eid: ExtentId(2),
-            start_offset: BlockOffset(7),
+            start_block: BlockIndex(2 * BLOCKS_PER_EXTENT + 7),
             count: 1,
             block_size: 512,
         };
-        assert!(op.send_io_live_repair(Some(ExtentId(2))));
+        assert!(op.send_io_live_repair(Some(ExtentId(2)), &ddef));
 
         let op = IOop::Read {
             dependencies: vec![],
-            start_eid: ExtentId(3),
-            start_offset: BlockOffset(7),
+            start_block: BlockIndex(3 * BLOCKS_PER_EXTENT + 7),
             count: 1,
             block_size: 512,
         };
         // We are past the extent limit, so this should return false
-        assert!(!op.send_io_live_repair(Some(ExtentId(2))));
+        assert!(!op.send_io_live_repair(Some(ExtentId(2)), &ddef));
 
         // If we change the extent limit, it should become true
-        assert!(op.send_io_live_repair(Some(ExtentId(3))));
+        assert!(op.send_io_live_repair(Some(ExtentId(3)), &ddef));
     }
 
     // Construct an IOop::Write or IOop::WriteUnwritten at the given extent
-    fn write_at_extent(eid: ExtentId, wu: bool) -> IOop {
+    fn write_at_extent(
+        eid: ExtentId,
+        wu: bool,
+        ddef: &RegionDefinition,
+    ) -> IOop {
+        let blocks_per_extent = ddef.extent_size().value;
         let request = BlockContext {
             encryption_context: None,
             hash: 0,
         };
-        let data = BytesMut::from(vec![1].as_slice());
+        let data = BytesMut::from(vec![1].as_slice()).freeze();
         let blocks = vec![request];
+        let start_block = BlockIndex(u64::from(eid.0) * blocks_per_extent + 7);
 
         if wu {
             IOop::WriteUnwritten {
                 dependencies: vec![],
                 blocks,
-                start_eid: eid,
-                start_offset: BlockOffset(7),
-                data: data.freeze(),
+                start_block,
+                data,
             }
         } else {
             IOop::Write {
                 dependencies: vec![],
                 blocks,
-                start_eid: eid,
-                start_offset: BlockOffset(7),
-                data: data.freeze(),
+                start_block,
+                data,
             }
         }
     }
@@ -543,41 +559,45 @@ pub(crate) mod up_test {
     fn send_io_live_repair_write() {
         // Check the send_io_live_repair for a write below extent limit,
         // at extent limit, and above extent limit.
+        const BLOCKS_PER_EXTENT: u64 = 8;
+        let ddef = test_ddef(BLOCKS_PER_EXTENT);
 
         // Below limit
-        let wr = write_at_extent(ExtentId(0), false);
-        assert!(wr.send_io_live_repair(Some(ExtentId(2))));
+        let wr = write_at_extent(ExtentId(0), false, &ddef);
+        assert!(wr.send_io_live_repair(Some(ExtentId(2)), &ddef));
 
         // At the limit
-        let wr = write_at_extent(ExtentId(2), false);
-        assert!(wr.send_io_live_repair(Some(ExtentId(2))));
+        let wr = write_at_extent(ExtentId(2), false, &ddef);
+        assert!(wr.send_io_live_repair(Some(ExtentId(2)), &ddef));
 
         // Above the limit
-        let wr = write_at_extent(ExtentId(3), false);
-        assert!(!wr.send_io_live_repair(Some(ExtentId(2))));
+        let wr = write_at_extent(ExtentId(3), false, &ddef);
+        assert!(!wr.send_io_live_repair(Some(ExtentId(2)), &ddef));
 
         // Back to being below the limit
-        assert!(wr.send_io_live_repair(Some(ExtentId(3))));
+        assert!(wr.send_io_live_repair(Some(ExtentId(3)), &ddef));
     }
 
     #[test]
     fn send_io_live_repair_unwritten_write() {
         // Check the send_io_live_repair for a write unwritten below extent
         // at extent limit, and above extent limit.
+        const BLOCKS_PER_EXTENT: u64 = 8;
+        let ddef = test_ddef(BLOCKS_PER_EXTENT);
 
         // Below limit
-        let wr = write_at_extent(ExtentId(0), true);
-        assert!(wr.send_io_live_repair(Some(ExtentId(2))));
+        let wr = write_at_extent(ExtentId(0), true, &ddef);
+        assert!(wr.send_io_live_repair(Some(ExtentId(2)), &ddef));
 
         // At the limit
-        let wr = write_at_extent(ExtentId(2), true);
-        assert!(wr.send_io_live_repair(Some(ExtentId(2))));
+        let wr = write_at_extent(ExtentId(2), true, &ddef);
+        assert!(wr.send_io_live_repair(Some(ExtentId(2)), &ddef));
 
         // Above the limit
-        let wr = write_at_extent(ExtentId(3), true);
-        assert!(!wr.send_io_live_repair(Some(ExtentId(2))));
+        let wr = write_at_extent(ExtentId(3), true, &ddef);
+        assert!(!wr.send_io_live_repair(Some(ExtentId(2)), &ddef));
 
         // Back to being below the limit
-        assert!(wr.send_io_live_repair(Some(ExtentId(3))));
+        assert!(wr.send_io_live_repair(Some(ExtentId(3)), &ddef));
     }
 }


### PR DESCRIPTION
Following up from #1685, the upstairs only cares about the block → extent mapping when checking live-repair stuff.  However, all of our `IOop` variants store `(ExtentId, BlockOffset)` tuples.

This PR makes the `IOop` more compact by using an absolute `BlockIndex` instead, then unpacks it into an `(ExtentId, BlockOffset)` only when needed for live-repair checks.