### PR TITLE
No color for git output for nightly test

### DIFF
--- a/tools/test_nightly.sh
+++ b/tools/test_nightly.sh
@@ -15,7 +15,8 @@ cd "$ROOT" || (echo failed to cd "$ROOT"; exit 1)
 export BINDIR=${BINDIR:-$ROOT/target/release}
 
 echo "Nightly starts at $(date)" | tee "$output_file"
-echo "Running on $(git log -1 | head -20)" | tee -a "$output_file"
+echo "Running on $(git log -1 --no-color | head -20)" | tee -a "$output_file"
+echo "" >> "$output_file"
 echo "$(date) hammer start" >> "$output_file"
 banner hammer
 banner loop


### PR DESCRIPTION
Remove the color output from the git log info line for the nightly test.