### PR TITLE
Update tests to honor REGION_SETS env if provided.

### DIFF
--- a/tools/test_live_repair.sh
+++ b/tools/test_live_repair.sh
@@ -63,7 +63,7 @@ if [[ ! -f "$crucible_test" ]] || [[ ! -f "$dsc" ]] || [[ ! -f "$downstairs" ]];
 fi
 
 loops=5
-region_sets=1
+region_sets=${REGION_SETS:-1}
 
 usage () {
     echo "Usage: $0 [-l #] [-r #]" >&2

--- a/tools/test_live_repair.sh
+++ b/tools/test_live_repair.sh
@@ -68,7 +68,7 @@ region_sets=${REGION_SETS:-1}
 usage () {
     echo "Usage: $0 [-l #] [-r #]" >&2
     echo " -l loops       Number of replacement loops to perform (default 5)" >&2
-    echo " -r region_sets Number of region sets to create (default 1)" >&2
+    echo ' -r region_sets Number of region sets to create (default 1, or $REGION_SETS)' >&2
 }
 
 while getopts 'l:r:' opt; do

--- a/tools/test_nightly.sh
+++ b/tools/test_nightly.sh
@@ -17,6 +17,11 @@ export BINDIR=${BINDIR:-$ROOT/target/release}
 echo "Nightly starts at $(date)" | tee "$output_file"
 echo "Running on $(git log -1 --no-color | head -20)" | tee -a "$output_file"
 echo "" >> "$output_file"
+echo "Environment settings are (Some may be unset):" | tee -a "$output_file"
+echo "BINDIR is: $BINDIR" | tee -a "$output_file"
+echo "REGION_ROOT is: $REGION_ROOT" | tee -a "$output_file"
+echo "WORK_ROOT is: $WORK_ROOT" | tee -a "$output_file"
+echo "REGION_SETS is: $REGION_SETS" | tee -a "$output_file"
 echo "$(date) hammer start" >> "$output_file"
 banner hammer
 banner loop
@@ -93,7 +98,7 @@ sleep 1
 banner replace
 banner special
 echo "$(date) test_replace_special start" >> "$output_file"
-./tools/test_replace_special.sh -l 30
+./tools/test_replace_special.sh -l 50
 res=$?
 if [[ "$res" -eq 0 ]]; then
     echo "$(date) test_replace_special pass" >> "$output_file"

--- a/tools/test_replace_special.sh
+++ b/tools/test_replace_special.sh
@@ -64,7 +64,7 @@ region_sets=${REGION_SETS:-1}
 usage () {
     echo "Usage: $0 [-l #] [-r #]" >&2
     echo " -l loops       Number of test loops to perform (default 5)" >&2
-    echo " -r region_sets Number of region sets to create (default 1)" >&2
+    echo ' -r region_sets Number of region sets to create (default 1, or $REGION_SETS)' >&2
 }
 
 while getopts 'l:r:' opt; do
@@ -149,7 +149,6 @@ ${dsc} cmd shutdown
 wait "$dsc_pid"
 
 echo "$(date) Test ends with $result" | tee -a "$test_log"
-cp /tmp/test_replace_special/test_replace_special.log ~
 echo "copied log"
 
 if [[ $result -eq 0 ]]; then

--- a/tools/test_replace_special.sh
+++ b/tools/test_replace_special.sh
@@ -59,7 +59,7 @@ if [[ ! -f "$crucible_test" ]] || [[ ! -f "$dsc" ]] || [[ ! -f "$downstairs" ]];
 fi
 
 loops=5
-region_sets=1
+region_sets=${REGION_SETS:-1}
 
 usage () {
     echo "Usage: $0 [-l #] [-r #]" >&2
@@ -149,6 +149,8 @@ ${dsc} cmd shutdown
 wait "$dsc_pid"
 
 echo "$(date) Test ends with $result" | tee -a "$test_log"
+cp /tmp/test_replace_special/test_replace_special.log ~
+echo "copied log"
 
 if [[ $result -eq 0 ]]; then
     # Cleanup

--- a/tools/test_replay.sh
+++ b/tools/test_replay.sh
@@ -60,7 +60,7 @@ region_sets=${REGION_SETS:-1}
 usage () {
     echo "Usage: $0 [-l #]]" >&2
     echo " -l loops     Number of times to cause a replay." >&2
-    echo " -r regions   Number of region sets to create (default 1)" >&2
+    echo ' -r regions   Number of region sets to create (default 1, or $REGION_SETS)' >&2
 }
 
 while getopts 'l:r:' opt; do

--- a/tools/test_replay.sh
+++ b/tools/test_replay.sh
@@ -55,7 +55,7 @@ if [[ ! -f "$crucible_test" ]] || [[ ! -f "$dsc" ]] || [[ ! -f "$downstairs" ]];
 fi
 
 loops=30
-region_sets=1
+region_sets=${REGION_SETS:-1}
 
 usage () {
     echo "Usage: $0 [-l #]]" >&2


### PR DESCRIPTION
Some tests can make use of multiple region sets.  
For those tests that do, use the env REGION_SETS if it is set, otherwise use a default. 
Updated the nightly test to print env variables on start as well.

Run a few more loops of the test_replace_special.