### PR TITLE
Add explicit `UpstairsState::Disabled`

### DIFF
--- a/openapi/crucible-control.json
+++ b/openapi/crucible-control.json
@@ -408,7 +408,7 @@
         "description": "Tracks client negotiation progress\n\nThe exact path through negotiation depends on the [`ConnectionMode`].\n\nThere are three main paths, shown below:\n\n```text ┌───────┐ │ Start ├────────┐ └───┬───┘        │ │            │ ┌─────▼──────┐     │ │ WaitActive │     │ auto-promote └─────┬──────┘     │ │            │ ┌───────▼────────┐   │ │ WaitForPromote ◄───┘ └───────┬────────┘ │ ┌────────▼──────────┐ │ WaitForRegionInfo │ └──┬──────────────┬─┘ Offline │              │ New / Faulted / Replaced (replay) │         ┌────▼────────────┐ │         │GetExtentVersions│ │         └─┬─────────────┬─┘ │           │ New         │ Faulted / Replaced │    ┌──────▼───┐    ┌────▼──────────┐ │    │WaitQuorum│    │LiveRepairReady│ │    └────┬─────┘    └────┬──────────┘ │         │               │ │    ┌────▼────┐          │ │    │Reconcile│          │ │    └────┬────┘          │ │         │               │ │     ┌───▼──┐            │ └─────► Done ◄────────────┘ └──────┘ ```\n\n`Done` isn't actually present in the state machine; it's indicated by returning a [`NegotiationResult`] other than [`NegotiationResult::NotDone`].",
         "oneOf": [
           {
-            "description": "Initial state, waiting to hear `YesItsMe` from the client\n\nOnce this message is heard, transitions to either `WaitActive` (if `auto_promote` is `false`) or `WaitQuorum` (if `auto_promote` is `true`)",
+            "description": "Initial state, waiting to hear `YesItsMe` from the client\n\nOnce this message is heard, transitions to either `WaitActive` and wait for the Upstairs to decide whether to promote.",
             "type": "object",
             "properties": {
               "type": {
@@ -416,22 +416,10 @@
                 "enum": [
                   "start"
                 ]
-              },
-              "value": {
-                "type": "object",
-                "properties": {
-                  "auto_promote": {
-                    "type": "boolean"
-                  }
-                },
-                "required": [
-                  "auto_promote"
-                ]
               }
             },
             "required": [
-              "type",
-              "value"
+              "type"
             ]
           },
           {

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -221,9 +221,7 @@ impl DownstairsClient {
             repair_addr: None,
             state: DsState::Connecting {
                 mode: ConnectionMode::New,
-                state: NegotiationState::Start {
-                    auto_promote: false,
-                },
+                state: NegotiationState::Start,
             },
             last_flush: None,
             stats: DownstairsStats::default(),
@@ -469,8 +467,7 @@ impl DownstairsClient {
         match &self.state {
             DsState::Connecting {
                 mode: ConnectionMode::New,
-                state:
-                    NegotiationState::Start { .. } | NegotiationState::WaitActive,
+                state: NegotiationState::Start | NegotiationState::WaitActive,
             } => {
                 info!(
                     self.log,
@@ -505,15 +502,12 @@ impl DownstairsClient {
         // cases.
         self.repair_addr = None;
 
-        // If the upstairs is already active (or trying to go active), then the
-        // downstairs should automatically send the PromoteToActive message when
-        // it reaches the relevant state.
-        let auto_promote = match up_state {
-            UpstairsState::Active | UpstairsState::GoActive(..) => !matches!(
-                self.state,
-                DsState::Stopping(ClientStopReason::Disabled)
-            ),
-            UpstairsState::Initializing
+        // If the upstairs is already active (or trying to go active), then we
+        // should automatically connect to the Downstairs.
+        let auto_connect = match up_state {
+            UpstairsState::Active | UpstairsState::GoActive(..) => true,
+            UpstairsState::Disabled
+            | UpstairsState::Initializing
             | UpstairsState::Deactivating { .. } => false,
         };
 
@@ -554,6 +548,7 @@ impl DownstairsClient {
                     // start from New
                     UpstairsState::GoActive(..)
                     | UpstairsState::Initializing
+                    | UpstairsState::Disabled
                     | UpstairsState::Deactivating { .. } => ConnectionMode::New,
 
                     // Otherwise, use live-repair
@@ -566,6 +561,7 @@ impl DownstairsClient {
                 // start from New
                 UpstairsState::GoActive(..)
                 | UpstairsState::Initializing
+                | UpstairsState::Disabled
                 | UpstairsState::Deactivating { .. } => ConnectionMode::New,
 
                 // Otherwise, use live-repair; `ConnectionMode::Replaced`
@@ -575,7 +571,7 @@ impl DownstairsClient {
         };
         let new_state = DsState::Connecting {
             mode: new_mode,
-            state: NegotiationState::Start { auto_promote },
+            state: NegotiationState::Start,
         };
 
         // Note that jobs are skipped / replayed in `Downstairs::reinitialize`,
@@ -584,8 +580,8 @@ impl DownstairsClient {
         self.checked_state_transition(up_state, new_state);
         self.connection_id.update();
 
-        // Restart with a short delay, connecting if we're auto-promoting
-        self.start_task(true, auto_promote);
+        // Restart with a short delay, connecting if we're not disabled
+        self.start_task(true, auto_connect);
     }
 
     /// Returns the last flush ID handled by this client
@@ -751,13 +747,9 @@ impl DownstairsClient {
         // go active, then immediately go active!
         match &mut self.state {
             DsState::Connecting {
-                state: NegotiationState::Start { auto_promote },
+                state: NegotiationState::Start,
                 mode: ConnectionMode::New,
             } => {
-                if *auto_promote {
-                    panic!("called set_active_request while already waiting")
-                }
-                *auto_promote = true;
                 info!(
                     self.log,
                     "client set_active_request while in {:?}; waiting...",
@@ -773,15 +765,7 @@ impl DownstairsClient {
                     "client set_active_request while in {:?} -> WaitForPromote",
                     self.state,
                 );
-                self.send(Message::PromoteToActive {
-                    upstairs_id: self.cfg.upstairs_id,
-                    session_id: self.cfg.session_id,
-                    gen: self.cfg.generation(),
-                });
-                self.state = DsState::Connecting {
-                    state: NegotiationState::WaitForPromote,
-                    mode: ConnectionMode::New,
-                };
+                self.promote_to_active();
             }
             // This client is currently being stopped to be replaced. If an activation
             // request (from `UpstairsState::GoActive`) arrives now, we cannot
@@ -816,6 +800,20 @@ impl DownstairsClient {
             }
             s => panic!("invalid state for set_active_request: {s:?}"),
         }
+    }
+
+    pub(crate) fn promote_to_active(&mut self) {
+        let DsState::Connecting { state, .. } = &mut self.state else {
+            panic!("invalid state for promote_to_active: {:?}", self.state);
+        };
+        assert_eq!(*state, NegotiationState::WaitActive);
+        *state = NegotiationState::WaitForPromote;
+
+        self.send(Message::PromoteToActive {
+            upstairs_id: self.cfg.upstairs_id,
+            session_id: self.cfg.session_id,
+            gen: self.cfg.generation(),
+        });
     }
 
     /// Accessor method for client connection state
@@ -961,7 +959,7 @@ impl DownstairsClient {
             (
                 DsState::Connecting { .. },
                 DsState::Connecting {
-                    state: NegotiationState::Start { .. },
+                    state: NegotiationState::Start,
                     ..
                 },
             ) => true,
@@ -1043,25 +1041,23 @@ impl DownstairsClient {
                     (
                         R::Fault(..),
                         ConnectionMode::Faulted,
-                        NegotiationState::Start { .. }
+                        NegotiationState::Start
                     ) | (
                         R::Deactivated | R::Disabled,
                         ConnectionMode::New,
-                        NegotiationState::Start {
-                            auto_promote: false
-                        }
+                        NegotiationState::Start
                     ) | (
                         R::Replacing,
                         ConnectionMode::Replaced,
-                        NegotiationState::Start { auto_promote: true }
+                        NegotiationState::Start
                     ) | (
                         R::Replacing,
                         ConnectionMode::New,
-                        NegotiationState::Start { .. }
+                        NegotiationState::Start
                     ) | (
                         R::NegotiationFailed(..),
                         ConnectionMode::New,
-                        NegotiationState::Start { .. }
+                        NegotiationState::Start
                     )
                 )
             }
@@ -1073,7 +1069,7 @@ impl DownstairsClient {
                 _,
                 DsState::Connecting {
                     mode: ConnectionMode::Offline | ConnectionMode::Faulted,
-                    state: NegotiationState::Start { auto_promote: true },
+                    state: NegotiationState::Start,
                 },
             ) => matches!(up_state, UpstairsState::Active),
 
@@ -1414,7 +1410,7 @@ impl DownstairsClient {
                 version,
                 repair_addr,
             } => {
-                let NegotiationState::Start { auto_promote } = *state else {
+                let NegotiationState::Start = *state else {
                     error!(self.log, "got version already");
                     return Err(NegotiationError::OutOfOrder);
                 };
@@ -1431,22 +1427,10 @@ impl DownstairsClient {
                     });
                 }
                 self.repair_addr = Some(repair_addr);
-                if auto_promote {
-                    *state = NegotiationState::WaitForPromote;
-                    self.send(Message::PromoteToActive {
-                        upstairs_id: self.cfg.upstairs_id,
-                        session_id: self.cfg.session_id,
-                        gen: self.cfg.generation(),
-                    });
-                    info!(
-                        self.log,
-                        "version negotiation from state {:?}", self.state
-                    );
-                } else {
-                    // Nothing to do here, wait for set_active_request
-                    *state = NegotiationState::WaitActive;
-                }
-                Ok(NegotiationResult::NotDone)
+                // Nothing to do here, return a marker that tells the Upstairs
+                // to promote if it's time.
+                *state = NegotiationState::WaitActive;
+                Ok(NegotiationResult::WaitActive)
             }
             Message::VersionMismatch { version } => {
                 error!(
@@ -1948,9 +1932,9 @@ impl DownstairsClient {
 pub enum NegotiationState {
     /// Initial state, waiting to hear `YesItsMe` from the client
     ///
-    /// Once this message is heard, transitions to either `WaitActive` (if
-    /// `auto_promote` is `false`) or `WaitQuorum` (if `auto_promote` is `true`)
-    Start { auto_promote: bool },
+    /// Once this message is heard, transitions to either `WaitActive` and wait
+    /// for the Upstairs to decide whether to promote.
+    Start,
 
     /// Waiting for activation by the guest
     WaitActive,
@@ -1986,49 +1970,46 @@ impl NegotiationState {
     ) -> bool {
         matches!(
             (prev_state, next_state, mode),
-            (
-                NegotiationState::Start { auto_promote: true },
-                NegotiationState::WaitForPromote,
-                _
-            ) | (
-                NegotiationState::Start {
-                    auto_promote: false,
-                },
-                NegotiationState::WaitActive,
-                _,
-            ) | (
-                NegotiationState::WaitActive,
-                NegotiationState::WaitForPromote,
-                _
-            ) | (
-                NegotiationState::WaitForPromote,
-                NegotiationState::WaitForRegionInfo,
-                _
-            ) | (
-                NegotiationState::WaitForRegionInfo,
-                NegotiationState::GetExtentVersions,
-                ConnectionMode::New
-                    | ConnectionMode::Faulted
-                    | ConnectionMode::Replaced,
-            ) | (
-                NegotiationState::GetExtentVersions,
-                NegotiationState::WaitQuorum,
-                ConnectionMode::New
-            ) | (
-                NegotiationState::WaitQuorum,
-                NegotiationState::Reconcile,
-                ConnectionMode::New
-            ) | (
-                NegotiationState::GetExtentVersions,
-                NegotiationState::LiveRepairReady,
-                ConnectionMode::Faulted | ConnectionMode::Replaced,
-            )
+            (NegotiationState::Start, NegotiationState::WaitActive, _,)
+                | (
+                    NegotiationState::WaitActive,
+                    NegotiationState::WaitForPromote,
+                    _
+                )
+                | (
+                    NegotiationState::WaitForPromote,
+                    NegotiationState::WaitForRegionInfo,
+                    _
+                )
+                | (
+                    NegotiationState::WaitForRegionInfo,
+                    NegotiationState::GetExtentVersions,
+                    ConnectionMode::New
+                        | ConnectionMode::Faulted
+                        | ConnectionMode::Replaced,
+                )
+                | (
+                    NegotiationState::GetExtentVersions,
+                    NegotiationState::WaitQuorum,
+                    ConnectionMode::New
+                )
+                | (
+                    NegotiationState::WaitQuorum,
+                    NegotiationState::Reconcile,
+                    ConnectionMode::New
+                )
+                | (
+                    NegotiationState::GetExtentVersions,
+                    NegotiationState::LiveRepairReady,
+                    ConnectionMode::Faulted | ConnectionMode::Replaced,
+                )
         )
     }
 }
 /// Result value returned when negotiation is complete
 pub(crate) enum NegotiationResult {
     NotDone,
+    WaitActive,
     WaitQuorum,
     Replay,
     LiveRepair,

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -4029,7 +4029,8 @@ pub(crate) mod test {
         );
         let mode = ConnectionMode::Faulted;
         for state in [
-            NegotiationState::Start { auto_promote: true },
+            NegotiationState::Start,
+            NegotiationState::WaitActive,
             NegotiationState::WaitForPromote,
             NegotiationState::WaitForRegionInfo,
             NegotiationState::GetExtentVersions,

--- a/upstairs/src/dummy_downstairs_tests.rs
+++ b/upstairs/src/dummy_downstairs_tests.rs
@@ -1615,7 +1615,7 @@ async fn test_byte_fault_condition() {
         ds[ClientId::new(0)],
         DsState::Connecting {
             mode: ConnectionMode::Faulted,
-            state: NegotiationState::Start { auto_promote: true }
+            state: NegotiationState::Start
         }
     );
     assert_eq!(ds[ClientId::new(1)], DsState::Active);
@@ -1692,7 +1692,7 @@ async fn test_byte_fault_condition_offline() {
         ds[ClientId::new(0)],
         DsState::Connecting {
             mode: ConnectionMode::Offline,
-            state: NegotiationState::Start { auto_promote: true }
+            state: NegotiationState::Start
         }
     );
     assert_eq!(ds[ClientId::new(1)], DsState::Active);
@@ -1727,7 +1727,7 @@ async fn test_byte_fault_condition_offline() {
                 ds[ClientId::new(0)],
                 DsState::Connecting {
                     mode: ConnectionMode::Offline,
-                    state: NegotiationState::Start { auto_promote: true }
+                    state: NegotiationState::Start
                 }
             );
             assert_eq!(ds[ClientId::new(1)], DsState::Active);
@@ -1737,7 +1737,7 @@ async fn test_byte_fault_condition_offline() {
                 ds[ClientId::new(0)],
                 DsState::Connecting {
                     mode: ConnectionMode::Faulted,
-                    state: NegotiationState::Start { auto_promote: true }
+                    state: NegotiationState::Start
                 }
             );
             assert_eq!(ds[ClientId::new(1)], DsState::Active);
@@ -1788,7 +1788,7 @@ async fn test_offline_can_deactivate() {
         ds[ClientId::new(0)],
         DsState::Connecting {
             mode: ConnectionMode::Offline,
-            state: NegotiationState::Start { auto_promote: true }
+            state: NegotiationState::Start
         }
     );
     assert_eq!(ds[ClientId::new(1)], DsState::Active);
@@ -1831,7 +1831,7 @@ async fn test_offline_with_io_can_deactivate() {
         ds[ClientId::new(0)],
         DsState::Connecting {
             mode: ConnectionMode::Offline,
-            state: NegotiationState::Start { auto_promote: true }
+            state: NegotiationState::Start
         }
     );
     assert_eq!(ds[ClientId::new(1)], DsState::Active);
@@ -1889,7 +1889,7 @@ async fn test_all_offline_with_io_can_deactivate() {
             ds[cid],
             DsState::Connecting {
                 mode: ConnectionMode::Offline,
-                state: NegotiationState::Start { auto_promote: true }
+                state: NegotiationState::Start
             }
         );
     }
@@ -1993,7 +1993,7 @@ async fn test_job_fault_condition() {
         ds[ClientId::new(0)],
         DsState::Connecting {
             mode: ConnectionMode::Faulted,
-            state: NegotiationState::Start { auto_promote: true }
+            state: NegotiationState::Start
         }
     );
     assert_eq!(ds[ClientId::new(1)], DsState::Active);
@@ -2065,7 +2065,7 @@ async fn test_job_fault_condition_offline() {
         ds[ClientId::new(0)],
         DsState::Connecting {
             mode: ConnectionMode::Offline,
-            state: NegotiationState::Start { auto_promote: true }
+            state: NegotiationState::Start
         }
     );
     assert_eq!(ds[ClientId::new(1)], DsState::Active);
@@ -2114,7 +2114,7 @@ async fn test_job_fault_condition_offline() {
                 ds[ClientId::new(0)],
                 DsState::Connecting {
                     mode: ConnectionMode::Offline,
-                    state: NegotiationState::Start { auto_promote: true }
+                    state: NegotiationState::Start
                 }
             );
             assert_eq!(ds[ClientId::new(1)], DsState::Active);
@@ -2125,7 +2125,7 @@ async fn test_job_fault_condition_offline() {
                 ds[ClientId::new(0)],
                 DsState::Connecting {
                     mode: ConnectionMode::Faulted,
-                    state: NegotiationState::Start { auto_promote: true }
+                    state: NegotiationState::Start
                 }
             );
             assert_eq!(ds[ClientId::new(1)], DsState::Active);
@@ -2871,7 +2871,7 @@ async fn test_no_send_offline() {
         ds[ClientId::new(0)],
         DsState::Connecting {
             mode: ConnectionMode::Offline,
-            state: NegotiationState::Start { auto_promote: true }
+            state: NegotiationState::Start
         }
     );
     assert_eq!(ds[ClientId::new(1)], DsState::Active);

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -1118,7 +1118,8 @@ pub mod repair_test {
         );
         let mode = ConnectionMode::Faulted;
         for state in [
-            NegotiationState::Start { auto_promote: true },
+            NegotiationState::Start,
+            NegotiationState::WaitActive,
             NegotiationState::WaitForPromote,
             NegotiationState::WaitForRegionInfo,
             NegotiationState::GetExtentVersions,

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -78,6 +78,9 @@ pub(crate) enum UpstairsState {
     /// when all three Downstairs have stopped, the upstairs should enter
     /// `UpstairsState::Initializing` and reply on this channel.
     Deactivating(BlockRes),
+
+    /// The upstairs has been disabled due to a likely-persistent error
+    Disabled,
 }
 
 /// Crucible upstairs counters
@@ -857,6 +860,7 @@ impl Upstairs {
                 // TODO: remove this distinction?
                 let state = match &self.state {
                     UpstairsState::Initializing
+                    | UpstairsState::Disabled
                     | UpstairsState::GoActive(..) => {
                         crate::UpState::Initializing
                     }
@@ -1001,7 +1005,7 @@ impl Upstairs {
                     UpstairsState::Active | UpstairsState::GoActive(..) => {
                         if self.cfg.generation() == gen {
                             // Okay, we want to activate with what we already
-                            // have, that's valid., let the set_active_request
+                            // have, that's valid; let the set_active_request
                             // handle things.
                             self.set_active_request(done);
                         } else {
@@ -1016,7 +1020,7 @@ impl Upstairs {
                         // Don't update gen, return error
                         done.send_err(CrucibleError::UpstairsDeactivating);
                     }
-                    UpstairsState::Initializing => {
+                    UpstairsState::Initializing | UpstairsState::Disabled => {
                         // This case, we update our generation and then
                         // let set_active_request handle the rest.
                         self.cfg.generation.store(gen, Ordering::Release);
@@ -1222,7 +1226,7 @@ impl Upstairs {
     /// Request that the Upstairs go active
     fn set_active_request(&mut self, res: BlockRes) {
         match &self.state {
-            UpstairsState::Initializing => {
+            UpstairsState::Initializing | UpstairsState::Disabled => {
                 self.state = UpstairsState::GoActive(res);
                 info!(self.log, "{} active request set", self.cfg.upstairs_id);
 
@@ -1272,7 +1276,9 @@ impl Upstairs {
     fn set_deactivate(&mut self, res: BlockRes) {
         info!(self.log, "Request to deactivate this guest");
         match &self.state {
-            UpstairsState::Initializing | UpstairsState::GoActive(..) => {
+            UpstairsState::Initializing
+            | UpstairsState::Disabled
+            | UpstairsState::GoActive(..) => {
                 res.send_err(CrucibleError::UpstairsInactive);
                 return;
             }
@@ -1733,11 +1739,25 @@ impl Upstairs {
                             ClientNegotiationFailed::IncompatibleSession
                             | ClientNegotiationFailed::IncompatibleSettings
                                 => {
-                                self.set_inactive(e.into())
+                                self.set_disabled(e.into())
                             }
                         }
                     }
                     Ok(NegotiationResult::NotDone) => (),
+                    Ok(NegotiationResult::WaitActive) => {
+                        match self.state {
+                            UpstairsState::Active
+                            | UpstairsState::GoActive(..) => {
+                                self.downstairs.clients[client_id]
+                                    .promote_to_active()
+                            }
+                            UpstairsState::Initializing
+                            | UpstairsState::Disabled
+                            | UpstairsState::Deactivating(..) => {
+                                // don't do anything here
+                            }
+                        }
+                    }
                     Ok(NegotiationResult::WaitQuorum) => {
                         // Copy the region definition into the Downstairs
                         self.downstairs.set_ddef(self.ddef.get_def().unwrap());
@@ -1960,7 +1980,7 @@ impl Upstairs {
                 // to reset that activation request.  Call
                 // `abort_reconciliation` to abort reconciliation for all
                 // clients.
-                self.set_inactive(e.into());
+                self.set_disabled(e.into());
                 self.downstairs.abort_reconciliation(&self.state);
                 false
             }
@@ -2118,7 +2138,7 @@ impl Upstairs {
 
         // Restart the state machine for this downstairs client
         self.downstairs.clients[client_id].disable(&self.state);
-        self.set_inactive(CrucibleError::NoLongerActive);
+        self.set_disabled(CrucibleError::NoLongerActive);
     }
 
     fn on_uuid_mismatch(&mut self, client_id: ClientId, expected_id: Uuid) {
@@ -2130,7 +2150,7 @@ impl Upstairs {
 
         // Restart the state machine for this downstairs client
         self.downstairs.clients[client_id].disable(&self.state);
-        self.set_inactive(CrucibleError::UuidMismatch);
+        self.set_disabled(CrucibleError::UuidMismatch);
     }
 
     /// Forces the upstairs and downstairs into active states
@@ -2143,7 +2163,7 @@ impl Upstairs {
     #[cfg(test)]
     pub(crate) fn force_active(&mut self) -> Result<(), CrucibleError> {
         match &self.state {
-            UpstairsState::Initializing => {
+            UpstairsState::Initializing | UpstairsState::Disabled => {
                 self.downstairs.force_active();
                 self.state = UpstairsState::Active;
                 Ok(())
@@ -2163,9 +2183,8 @@ impl Upstairs {
         }
     }
 
-    fn set_inactive(&mut self, err: CrucibleError) {
-        let prev =
-            std::mem::replace(&mut self.state, UpstairsState::Initializing);
+    fn set_disabled(&mut self, err: CrucibleError) {
+        let prev = std::mem::replace(&mut self.state, UpstairsState::Disabled);
         if let UpstairsState::GoActive(res) = prev {
             res.send_err(err);
         }
@@ -2284,6 +2303,7 @@ pub(crate) mod test {
         }));
         let mode = ConnectionMode::Faulted;
         for state in [
+            NegotiationState::WaitActive,
             NegotiationState::WaitForPromote,
             NegotiationState::WaitForRegionInfo,
             NegotiationState::GetExtentVersions,
@@ -2458,9 +2478,7 @@ pub(crate) mod test {
             assert_eq!(
                 up.ds_state(client_id),
                 DsState::Connecting {
-                    state: NegotiationState::Start {
-                        auto_promote: false
-                    },
+                    state: NegotiationState::Start,
                     mode: ConnectionMode::New
                 }
             );
@@ -3832,9 +3850,7 @@ pub(crate) mod test {
                 c.state(),
                 DsState::Connecting {
                     mode: ConnectionMode::New,
-                    state: NegotiationState::Start {
-                        auto_promote: false
-                    }
+                    state: NegotiationState::Start
                 }
             );
         }


### PR DESCRIPTION
There's a weird phantom state that's been hiding in the Upstairs state machine; this PR makes it explicit.

In the handler for `YouAreNoLongerActive` and `on_uuid_mismatch`, the Upstairs performs a peculiar ritual:

```rust
        // Restart the state machine for this downstairs client
        self.downstairs.clients[client_id].disable(&self.state);
        self.set_inactive(CrucibleError::UuidMismatch);
```

The effects here are somewhat confusing:

- Calling `DownstairsClient::disable` stops a client with `ClientStopReason::Disabled`.  This stop reason is a special case – it means that the client does not try to reconnect when reinitialized.  In all other cases, whether the client connects depends on the upstairs state alone.
- `Upstairs::set_inactive` sets the upstairs state to `Initializing`.  It does not do anything else – for example, it doesn't try to stop the other Downstairs.

The end result is that the problematic client is restarted, and _does not connect_ to the Downstairs.

As we rethink the state machine for RFD 542, I'd like to remove this special case.  In this PR:

- `Upstairs::set_inactive` is renamed to `Upstairs::set_disabled` and now sets the upstairs state to a new `UpstairsState::Disabled` state
- `auto_promote: bool` is removed from the negotiation state, because we now only depend on the upstairs state

I still think the semantics of the `UpstairsState::Disabled` are fuzzy and could use some ironing out, but this PR is meant to be a step in the right direction.

For example, going straight to `Initializing` without shutting down the other Downstairs seems bad!  Once the upstairs is in `Initializing`, it will accept a `GoActive` request, which will hit [this panic](https://github.com/oxidecomputer/crucible/blob/3ede71e10a9cb6e39a58d882900275f5501c4142/upstairs/src/client.rs#L817) on the other Downstairs.  This issue remains true after the PR (although the Upstairs will be in `Disabled` instead).