### PR TITLE
Remove `WaitActive` state during negotiation

### DIFF
--- a/cmon/src/main.rs
+++ b/cmon/src/main.rs
@@ -90,11 +90,6 @@ enum Action {
 fn short_state(dss: DsState) -> String {
     match dss {
         DsState::Connecting {
-            state: NegotiationState::WaitActive,
-            ..
-        } => "WA".to_string(),
-
-        DsState::Connecting {
             state: NegotiationState::WaitQuorum,
             ..
         } => "WQ".to_string(),

--- a/openapi/crucible-control.json
+++ b/openapi/crucible-control.json
@@ -405,16 +405,16 @@
         ]
       },
       "NegotiationState": {
-        "description": "Tracks client negotiation progress\n\nThe exact path through negotiation depends on the [`ConnectionMode`].\n\nThere are three main paths, shown below:\n\n```text ┌───────┐ │ Start ├────────┐ └───┬───┘        │ │            │ ┌─────▼──────┐     │ │ WaitActive │     │ auto-promote └─────┬──────┘     │ │            │ ┌───────▼────────┐   │ │ WaitForPromote ◄───┘ └───────┬────────┘ │ ┌────────▼──────────┐ │ WaitForRegionInfo │ └──┬──────────────┬─┘ Offline │              │ New / Faulted / Replaced (replay) │         ┌────▼────────────┐ │         │GetExtentVersions│ │         └─┬─────────────┬─┘ │           │ New         │ Faulted / Replaced │    ┌──────▼───┐    ┌────▼──────────┐ │    │WaitQuorum│    │LiveRepairReady│ │    └────┬─────┘    └────┬──────────┘ │         │               │ │    ┌────▼────┐          │ │    │Reconcile│          │ │    └────┬────┘          │ │         │               │ │     ┌───▼──┐            │ └─────► Done ◄────────────┘ └──────┘ ```\n\n`Done` isn't actually present in the state machine; it's indicated by returning a [`NegotiationResult`] other than [`NegotiationResult::NotDone`].",
+        "description": "Tracks client negotiation progress\n\nThe exact path through negotiation depends on the [`ConnectionMode`].\n\nThere are three main paths, shown below:\n\n```text ┌───────┐ │ Start │ └───┬───┘ │ ┌───────▼────────┐ │ WaitForPromote │ └───────┬────────┘ │ ┌────────▼──────────┐ │ WaitForRegionInfo │ └──┬──────────────┬─┘ Offline │              │ New / Faulted / Replaced (replay) │         ┌────▼────────────┐ │         │GetExtentVersions│ │         └─┬─────────────┬─┘ │           │ New         │ Faulted / Replaced │    ┌──────▼───┐    ┌────▼──────────┐ │    │WaitQuorum│    │LiveRepairReady│ │    └────┬─────┘    └────┬──────────┘ │         │               │ │    ┌────▼────┐          │ │    │Reconcile│          │ │    └────┬────┘          │ │         │               │ │     ┌───▼──┐            │ └─────► Done ◄────────────┘ └──────┘ ```\n\n`Done` isn't actually present in the state machine; it's indicated by returning a [`NegotiationResult`] other than [`NegotiationResult::NotDone`].",
         "oneOf": [
           {
-            "description": "Initial state, waiting to hear `YesItsMe` from the client\n\nOnce this message is heard, transitions to either `WaitActive` and wait for the Upstairs to decide whether to promote.",
+            "description": "Waiting for the connection request to be sent",
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
                 "enum": [
-                  "start"
+                  "wait_connect"
                 ]
               }
             },
@@ -423,13 +423,13 @@
             ]
           },
           {
-            "description": "Waiting for activation by the guest",
+            "description": "After connecting, waiting to hear `YesItsMe` from the client\n\nOnce this message is heard, sends `PromoteToActive` and transitions to `WaitForPromote`",
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
                 "enum": [
-                  "wait_active"
+                  "start"
                 ]
               }
             },

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -467,7 +467,7 @@ impl DownstairsClient {
         match &self.state {
             DsState::Connecting {
                 mode: ConnectionMode::New,
-                state: NegotiationState::Start | NegotiationState::WaitActive,
+                state: NegotiationState::Start,
             } => {
                 info!(
                     self.log,
@@ -743,77 +743,6 @@ impl DownstairsClient {
                 );
             }
         }
-        // If we're already in the point of negotiation where we're waiting to
-        // go active, then immediately go active!
-        match &mut self.state {
-            DsState::Connecting {
-                state: NegotiationState::Start,
-                mode: ConnectionMode::New,
-            } => {
-                info!(
-                    self.log,
-                    "client set_active_request while in {:?}; waiting...",
-                    self.state,
-                );
-            }
-            DsState::Connecting {
-                state: NegotiationState::WaitActive,
-                mode: ConnectionMode::New,
-            } => {
-                info!(
-                    self.log,
-                    "client set_active_request while in {:?} -> WaitForPromote",
-                    self.state,
-                );
-                self.promote_to_active();
-            }
-            // This client is currently being stopped to be replaced. If an activation
-            // request (from `UpstairsState::GoActive`) arrives now, we cannot
-            // process it immediately and must avoid panicking.
-            //
-            // This is safe due to the following recovery path:
-            // 1. The client will complete its stopping sequence.
-            // 2. `DownstairsClient::reinitialize` will be called.
-            // 3. `reinitialize` inspects the current `UpstairsState`:
-            //    - If `UpstairsState` is `GoActive` or `Active` at the time of
-            //      `reinitialize`, then `auto_promote = true` is set for the
-            //      new connection. This ensures the client attempts to activate
-            //      upon reconnecting.
-            //    - If `UpstairsState` is not `GoActive` at that specific moment
-            //      (e.g., if this client is lagging or the `GoActive` call hasn't
-            //      been processed for it yet), `auto_promote` might be `false`.
-            //      However, the `set_active_request` method (this very method)
-            //      will be called again for this client once it's in a suitable
-            //      `Connecting` state (like `Start { auto_promote: false }` or
-            //      `WaitActive`). At that point, this method will correctly
-            //      set `auto_promote = true` or send `PromoteToActive` directly.
-            //
-            // In essence, the activation request isn't lost; its processing is deferred
-            // until the client is in a state capable of handling it, ensuring that
-            // region replacement before overall volume activation is supported.
-            DsState::Stopping(ClientStopReason::Replacing) => {
-                info!(
-                    self.log,
-                    "ignoring activation request while client is in Stopping(ClientStopReason::Replacing) state; \
-                     activation will be handled post-reinitialization"
-                );
-            }
-            s => panic!("invalid state for set_active_request: {s:?}"),
-        }
-    }
-
-    pub(crate) fn promote_to_active(&mut self) {
-        let DsState::Connecting { state, .. } = &mut self.state else {
-            panic!("invalid state for promote_to_active: {:?}", self.state);
-        };
-        assert_eq!(*state, NegotiationState::WaitActive);
-        *state = NegotiationState::WaitForPromote;
-
-        self.send(Message::PromoteToActive {
-            upstairs_id: self.cfg.upstairs_id,
-            session_id: self.cfg.session_id,
-            gen: self.cfg.generation(),
-        });
     }
 
     /// Accessor method for client connection state
@@ -1306,97 +1235,6 @@ impl DownstairsClient {
         up_state: &UpstairsState,
         ddef: &mut RegionDefinitionStatus,
     ) -> Result<NegotiationResult, NegotiationError> {
-        /*
-         * Either we get all the way through the negotiation, or we hit the
-         * timeout and exit to retry.
-         *
-         * The negotiation flow starts as follows, with the value of the
-         * negotiated variable on the left:
-         *
-         * NegotiationState::Start
-         * -----------------------
-         *          Upstairs             Downstairs
-         *           HereIAm(...)  --->
-         *                         <---  YesItsMe(...)
-         *
-         * At this point, a downstairs will wait for a PromoteToActive message
-         * to be sent to it.  If this is a new upstairs that has not yet
-         * connected to a downstairs, then we will wait for the guest to send
-         * us this message and pass it down to the downstairs.  If a downstairs
-         * is reconnecting after having already been active, then we look at our
-         * upstairs guest_io_ready() and, if the upstairs is ready, we send the
-         * downstairs the message ourselves that they should promote to active.
-         * For downstairs currently in Disconnected or New states, we move to
-         * WaitActive, for Faulted or Offline states, we stay in that state..
-         *
-         * NegotiationState::WaitForPromote
-         * --------------------------------
-         *    PromoteToActive(uuid)--->
-         *                         <---  YouAreNowActive(uuid)
-         *
-         * YouAreNowActive includes information about the upstairs and session
-         * ID and we do some sanity checking here to make sure it all still
-         * matches with what we expect.  We next request RegionInfo from the
-         * downstairs.
-         *
-         * NegotiationState::WaitForRegionInfo
-         * -----------------------------------
-         *       RegionInfoPlease  --->
-         *                         <---  RegionInfo(r)
-         *
-         * At this point the upstairs looks to see what state the downstairs is
-         * currently in.  It will be WaitActive, Faulted, or Offline.
-         *
-         * Depending on which state, we will either exit negotiation to replay
-         * or continue with NegotiationState::GetExtentVersions next.
-         *
-         * For the Offline state, the downstairs was connected and verified
-         * and some point after that, the connection was lost.  To handle this
-         * condition we want to know the last flush this downstairs had ACKd
-         * so we can give it whatever work it missed.
-         *
-         * For WaitActive, it means this downstairs never was "Active" and we
-         * have to go through the full compare of this downstairs with other
-         * downstairs and make sure they are consistent.  To do that, we will
-         * request extent versions, instead of setting the last flush.
-         *
-         * For Faulted, we don't know the condition of the data on the
-         * Downstairs, so we transition this downstairs to LiveRepairReady.  We
-         * also request extent versions and will have to repair this
-         * downstairs, skipping over LastFlush as well.
-         *
-         * Replay (offline only)
-         * ------------------------------
-         *          Upstairs             Downstairs
-         *          LastFlush(lf)) --->
-         *            [negotiation finishes]
-         *          Replayed jobs  --->
-         *
-         * After sending our last flush, we now replay all saved jobs for this
-         * Downstairs and skip ahead to NegotiationState::Done.  Note that the
-         * Downstairs does not reply to `LastFlush`; it simply sets the internal
-         * `last_flush` state in the Downstairs.  Not having the Downstairs
-         * reply means that there's no window in which we could become
-         * ineligible for replay.
-         *
-         * NegotiationState::GetExtentVersions
-         * (WaitActive and LiveRepairReady come here from WaitForRegionInfo)
-         * -----------------------------------
-         *          Upstairs             Downstairs
-         *    ExtentVersionsPlease --->
-         *                         <---  ExtentVersions(g, v, d)
-         *
-         * Now with the extent info, Upstairs calls process_downstairs() and
-         * if no problems, sends connected=true to the up_listen() task,
-         * we set the downstairs to DsState::WaitQuorum and we exit the
-         * while loop.
-         *
-         * NegotiationState::Done
-         * ----------------------
-         *    Now the downstairs is ready to receive replay IOs from the
-         *    upstairs. We set the downstairs to DsState::Active and the while
-         *    loop is exited.
-         */
         let DsState::Connecting { state, mode } = &mut self.state else {
             error!(
                 self.log,
@@ -1427,10 +1265,13 @@ impl DownstairsClient {
                     });
                 }
                 self.repair_addr = Some(repair_addr);
-                // Nothing to do here, return a marker that tells the Upstairs
-                // to promote if it's time.
-                *state = NegotiationState::WaitActive;
-                Ok(NegotiationResult::WaitActive)
+                *state = NegotiationState::WaitForPromote;
+                self.send(Message::PromoteToActive {
+                    upstairs_id: self.cfg.upstairs_id,
+                    session_id: self.cfg.session_id,
+                    gen: self.cfg.generation(),
+                });
+                Ok(NegotiationResult::NotDone)
             }
             Message::VersionMismatch { version } => {
                 error!(
@@ -1890,15 +1731,11 @@ impl DownstairsClient {
 ///
 /// ```text
 ///              ┌───────┐
-///              │ Start ├────────┐
-///              └───┬───┘        │
-///                  │            │
-///            ┌─────▼──────┐     │
-///            │ WaitActive │     │ auto-promote
-///            └─────┬──────┘     │
-///                  │            │
-///          ┌───────▼────────┐   │
-///          │ WaitForPromote ◄───┘
+///              │ Start │
+///              └───┬───┘
+///                  │
+///          ┌───────▼────────┐
+///          │ WaitForPromote │
 ///          └───────┬────────┘
 ///                  │
 ///         ┌────────▼──────────┐
@@ -1930,14 +1767,14 @@ impl DownstairsClient {
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "type", content = "value")]
 pub enum NegotiationState {
-    /// Initial state, waiting to hear `YesItsMe` from the client
-    ///
-    /// Once this message is heard, transitions to either `WaitActive` and wait
-    /// for the Upstairs to decide whether to promote.
-    Start,
+    /// Waiting for the connection request to be sent
+    WaitConnect,
 
-    /// Waiting for activation by the guest
-    WaitActive,
+    /// After connecting, waiting to hear `YesItsMe` from the client
+    ///
+    /// Once this message is heard, sends `PromoteToActive` and transitions to
+    /// `WaitForPromote`
+    Start,
 
     /// Waiting to hear `YouAreNowActive` from the client
     WaitForPromote,
@@ -1970,9 +1807,9 @@ impl NegotiationState {
     ) -> bool {
         matches!(
             (prev_state, next_state, mode),
-            (NegotiationState::Start, NegotiationState::WaitActive, _,)
+            (NegotiationState::WaitConnect, NegotiationState::Start, _)
                 | (
-                    NegotiationState::WaitActive,
+                    NegotiationState::Start,
                     NegotiationState::WaitForPromote,
                     _
                 )
@@ -2009,7 +1846,6 @@ impl NegotiationState {
 /// Result value returned when negotiation is complete
 pub(crate) enum NegotiationResult {
     NotDone,
-    WaitActive,
     WaitQuorum,
     Replay,
     LiveRepair,

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -422,7 +422,6 @@ impl Downstairs {
         let up_state = UpstairsState::GoActive(BlockRes::dummy());
         for cid in ClientId::iter() {
             for state in [
-                NegotiationState::WaitActive,
                 NegotiationState::WaitForPromote,
                 NegotiationState::WaitForRegionInfo,
                 NegotiationState::GetExtentVersions,
@@ -4030,7 +4029,6 @@ pub(crate) mod test {
         let mode = ConnectionMode::Faulted;
         for state in [
             NegotiationState::Start,
-            NegotiationState::WaitActive,
             NegotiationState::WaitForPromote,
             NegotiationState::WaitForRegionInfo,
             NegotiationState::GetExtentVersions,
@@ -4060,7 +4058,6 @@ pub(crate) mod test {
         let up_state = UpstairsState::GoActive(BlockRes::dummy());
         for cid in ClientId::iter() {
             for state in [
-                NegotiationState::WaitActive,
                 NegotiationState::WaitForPromote,
                 NegotiationState::WaitForRegionInfo,
                 NegotiationState::GetExtentVersions,

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -758,12 +758,6 @@ impl std::fmt::Display for DsState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             DsState::Connecting {
-                state: NegotiationState::WaitActive,
-                ..
-            } => {
-                write!(f, "WaitActive")
-            }
-            DsState::Connecting {
                 state: NegotiationState::WaitQuorum,
                 ..
             } => {

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -1119,7 +1119,6 @@ pub mod repair_test {
         let mode = ConnectionMode::Faulted;
         for state in [
             NegotiationState::Start,
-            NegotiationState::WaitActive,
             NegotiationState::WaitForPromote,
             NegotiationState::WaitForRegionInfo,
             NegotiationState::GetExtentVersions,

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1744,20 +1744,6 @@ impl Upstairs {
                         }
                     }
                     Ok(NegotiationResult::NotDone) => (),
-                    Ok(NegotiationResult::WaitActive) => {
-                        match self.state {
-                            UpstairsState::Active
-                            | UpstairsState::GoActive(..) => {
-                                self.downstairs.clients[client_id]
-                                    .promote_to_active()
-                            }
-                            UpstairsState::Initializing
-                            | UpstairsState::Disabled
-                            | UpstairsState::Deactivating(..) => {
-                                // don't do anything here
-                            }
-                        }
-                    }
                     Ok(NegotiationResult::WaitQuorum) => {
                         // Copy the region definition into the Downstairs
                         self.downstairs.set_ddef(self.ddef.get_def().unwrap());
@@ -2303,7 +2289,6 @@ pub(crate) mod test {
         }));
         let mode = ConnectionMode::Faulted;
         for state in [
-            NegotiationState::WaitActive,
             NegotiationState::WaitForPromote,
             NegotiationState::WaitForRegionInfo,
             NegotiationState::GetExtentVersions,
@@ -2322,7 +2307,6 @@ pub(crate) mod test {
         let mut up = Upstairs::test_default(None, false);
         for cid in [ClientId::new(0), ClientId::new(1)] {
             for state in [
-                NegotiationState::WaitActive,
                 NegotiationState::WaitForPromote,
                 NegotiationState::WaitForRegionInfo,
                 NegotiationState::GetExtentVersions,
@@ -2352,7 +2336,6 @@ pub(crate) mod test {
         for cid in ClientId::iter() {
             let mut up = Upstairs::test_default(None, true);
             for state in [
-                NegotiationState::WaitActive,
                 NegotiationState::WaitForPromote,
                 NegotiationState::WaitForRegionInfo,
                 NegotiationState::GetExtentVersions,
@@ -2381,7 +2364,6 @@ pub(crate) mod test {
         let mut up = Upstairs::test_default(None, true);
         for cid in [ClientId::new(0), ClientId::new(1)] {
             for state in [
-                NegotiationState::WaitActive,
                 NegotiationState::WaitForPromote,
                 NegotiationState::WaitForRegionInfo,
                 NegotiationState::GetExtentVersions,


### PR DESCRIPTION
Staged on top of #1721

The `WaitActive` state has outlived its usefulness.

Right now, there are two wait points in the Upstair's client task:

- It waits for a oneshot (`client_connect_tx/rx`) to be fired before connecting to the Downstairs
- After receiving `YesItsMe` from the downstairs, it waits for the upstairs to be activated before sending `PromoteToActive`.  This is implemented through a runtime check when it reaches the `WaitForActive` state

It turns out that these two things always happen together; there's no case where we want to connect to a Downstairs, get to `YesItsMe`, then _not_ promote it to active.

This PR removes the `WaitActive` state, moving straight from `Start` to `WaitForPromote` once the connection oneshot fires.  I believe this fixes the (hypothetical) panic proposed in #1721, although I haven't written out a unit test for it.

Most of the LOC changes are removing the increasingly-outdated block comment about negotiation; it's all nicely represented the `NegotiationState` docstring, which has been kept up to date.