### PR TITLE
Print version on startup for pantry and agent

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -261,6 +261,8 @@ async fn main() -> Result<()> {
             }
             .to_logger(PROG)?;
 
+            let info = crucible_common::BuildInfo::default();
+            info!(log, "Crucible Version: {}", info);
             info!(log, "dataset: {:?}", dataset);
             info!(log, "listen IP: {:?}", listen);
             info!(

--- a/pantry/src/lib.rs
+++ b/pantry/src/lib.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use dropshot::{ConfigLogging, ConfigLoggingIfExists, ConfigLoggingLevel};
-use slog::{o, Logger};
+use slog::{info, o, Logger};
 
 pub const PROG: &str = "crucible-pantry";
 
@@ -19,6 +19,8 @@ pub fn initialize_pantry() -> Result<(Logger, Arc<pantry::Pantry>)> {
     }
     .to_logger(PROG)?;
 
+    let info = crucible_common::BuildInfo::default();
+    info!(log, "Crucible Version: {}", info);
     let pantry =
         Arc::new(pantry::Pantry::new(log.new(o!("component" => "datafile")))?);
 

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -1390,7 +1390,7 @@ impl Volume {
         log: &Logger,
     ) -> Result<Option<(SocketAddr, SocketAddr)>, CrucibleError> {
         let compare_result =
-            Self::compare_vcr_for_replacement(log, &original, &replacement)?;
+            Self::compare_vcr_for_replacement(&original, &replacement)?;
 
         info!(log, "compare result is {:?}", compare_result);
 
@@ -1522,7 +1522,6 @@ impl Volume {
     // parsing the CompareResult and deciding what to do if there are
     // multiple changes.
     fn compare_vcr_for_replacement(
-        log: &Logger,
         o_vol: &VolumeConstructionRequest,
         n_vol: &VolumeConstructionRequest,
     ) -> Result<CompareResult, CrucibleError> {
@@ -1578,7 +1577,7 @@ impl Volume {
                     o_sub_volumes.iter().zip(n_sub_volumes.iter())
                 {
                     let sv_res =
-                        Self::compare_vcr_for_replacement(log, o_sv, new_sv)?;
+                        Self::compare_vcr_for_replacement(o_sv, new_sv)?;
                     sv_results.push(sv_res);
                 }
                 let read_only_parent_compare =
@@ -1601,9 +1600,7 @@ impl Volume {
                         }
 
                         (Some(o_vol), Some(n_vol)) => {
-                            Self::compare_vcr_for_replacement(
-                                log, o_vol, n_vol,
-                            )?
+                            Self::compare_vcr_for_replacement(o_vol, n_vol)?
                         }
                     });
 


### PR DESCRIPTION
Added the same version printing on startup that the upstairs and downstairs have to pantry and the agent.

Fixed a clippy lint in the upstairs.

Agent log looks like this now:
```
root@oxz_crucible_a22da429:~# cat /var/svc/log/oxide-crucible-agent:default.log | looker                                                                                                                                                                                                                                                                          
[ May 28 16:53:10 Enabled. ]                                                                                                                                                                               
[ May 28 16:53:10 Executing start method ("/opt/oxide/crucible/bin/crucible-agent run -D /opt/oxide/crucible/bin/crucible-downstairs --dataset oxp_243db6c1-e3d4-47cc-bd99-86c24b733e6e/crucible -l [fd00:1
122:3344:101::12]:32345 -P 19000 -p downstairs -s snapshot"). ]
note: configured to log to "/dev/stdout"
16:53:10.274Z INFO crucible-agent: Crucible Version: Crucible Version: 0.0.1
    Commit SHA: dd892d47062b1dcb23800b8bbb5d2946e1dd1cb7
    Commit timestamp: 2025-05-27T20:18:55.000000000Z  branch: alan/agent-needs-workers
    rustc: 1.86.0 stable x86_64-unknown-illumos
    Cargo: x86_64-unknown-illumos  Debug: false Opt level: 3
16:53:10.282Z INFO crucible-agent: dataset: "oxp_243db6c1-e3d4-47cc-bd99-86c24b733e6e/crucible"
16:53:10.282Z INFO crucible-agent: listen IP: [fd00:1122:3344:101::12]:32345
16:53:10.282Z INFO crucible-agent: SMF instance name downstairs_prefix: "downstairs"
16:53:10.304Z INFO crucible-agent (datafile): Using conf_path:"/data/crucible.json"
16:53:10.346Z INFO crucible-agent (dropshot): listening
...
```