### PR TITLE
Update test mem to also show physical space used by regions.

### DIFF
--- a/.github/buildomat/jobs/test-memory.sh
+++ b/.github/buildomat/jobs/test-memory.sh
@@ -59,5 +59,7 @@ vmstat -T d -p 1 < /dev/null > /tmp/debug/paging.txt 2>&1 &
 pfexec dtrace -Z -s $input/scripts/perf-downstairs-tick.d > /tmp/debug/perf.txt 2>&1 &
 pfexec dtrace -Z -s $input/scripts/upstairs_info.d > /tmp/debug/upinfo.txt 2>&1 &
 
-banner memtest
-ptime -m bash $input/scripts/test_mem.sh
+banner 512-memtest
+ptime -m bash $input/scripts/test_mem.sh -b 512 -e 131072 -c 160
+banner 4k-memtest
+ptime -m bash $input/scripts/test_mem.sh -b 4096 -e 16384 -c 160


### PR DESCRIPTION
Made the test_mem.sh test also calculate and display how much space is consumed by the region directories after a region has been used.

Updated the buildomat job to test and display results for both 4k and 512b block sizes with typical omicron region sizes.

Example output:
```
alan@atrium:crucible$ ./tools/test_mem.sh -b 4096 -e 16384 -c 1600
Using block size 4096
Using extent size 16384
Using extent count 1600
/home/alan/ws/crucible
Memory usage test begins at May 29, 2025 at 07:06:47 PM UTC
Memory usage values in kilobytes unless specified otherwise
Region with ES:16384 EC:1600 BS:4096  Size: 100 GiB  Extent Size: 64 MiB
   PID     RSS RSS/EC     VSZ VSZ/EC    HEAP HEAP/EC   TOTAL TOTAL/EC     EC
 10287  118140     73  149984     93   95124      59  149984       93   1600
 10286  120240     75  152080     95   97244      60  152080       95   1600
 10288  119068     74  150908     94   96088      60  150908       94   1600
Region:100 GiB  Extent:64 MiB  Total downstairs (pmap -x): 442 MiB
Size of volume user gets       : 107374182400
Size on disk of all region dirs: 329682283958 or 307G
Size on disk of a single region: 109894094651 or 102G
 Total Overage with 4096 block size:  307.04%
Region Overage with 4096 block size:  102.35%

Memory usage test finished on May 29, 2025 at 07:08:40 PM UTC
```