### PR TITLE
Make Offline -> Faulted transition happen without reconnecting

### DIFF
--- a/openapi/crucible-control.json
+++ b/openapi/crucible-control.json
@@ -89,31 +89,10 @@
             ]
           },
           {
-            "description": "Too many jobs in the queue",
-            "type": "string",
-            "enum": [
-              "too_many_outstanding_jobs"
-            ]
-          },
-          {
-            "description": "Too many bytes in the queue",
-            "type": "string",
-            "enum": [
-              "too_many_outstanding_bytes"
-            ]
-          },
-          {
             "description": "The upstairs has requested that we deactivate when we were offline",
             "type": "string",
             "enum": [
               "offline_deactivated"
-            ]
-          },
-          {
-            "description": "The Upstairs has dropped jobs that would be needed for replay",
-            "type": "string",
-            "enum": [
-              "ineligible_for_replay"
             ]
           }
         ]

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -766,7 +766,7 @@ impl Upstairs {
                     ..
                 }
             ) {
-                self.downstairs.check_gone_too_long(cid, &self.state);
+                self.downstairs.check_gone_too_long(cid);
             }
         }
     }


### PR DESCRIPTION
(Staged on top of #1722)

Right now, if we need to move a Downstairs from Offline (reconnect through replay) to Faulted (reconnect through live-repair), we do so by stopping the IO task then restarting it.

However, the faulted negotiation path is a strict superset of the replay path:
```mermaid
flowchart TD
    Start --> WaitForPromote
    WaitForPromote --> WaitForRegionInfo
    WaitForRegionInfo -- Replay --> Done
    WaitForRegionInfo -- Faulted --> GetExtentVersions
    GetExtentVersions -- Faulted --> LiveRepairReady
    LiveRepairReady --> Done
```
(irrelevant states aren't shown here)

In addition, replay is **atomic**: once we get region info, we queue up all replay jobs then exit negotiation in a single tick.

Therefore, we can swap the `ConnectionMode` from `Offline` to `Faulted` at any point, and the system will behave correctly: if we are still negotiating, then replay has necessarily not occurred.

This PR keeps the IO task connected and just swaps the connection mode.  This is a building block for connecting with 2/3 downstairs ([RFD 542](https://rfd.shared.oxide.computer/rfd/542)), which will need similar tricks.