### PR TITLE
Compute reconciliation from `ClientMap` instead of three clients

### DIFF
--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -1959,15 +1959,14 @@ impl Downstairs {
     /// # Panics
     /// If any downstairs client does not have region metadata populated
     fn mismatch_list(&self) -> Option<DownstairsMend> {
-        let c = |i| {
-            self.clients[ClientId::new(i)]
-                .region_metadata
-                .as_ref()
-                .unwrap()
-        };
-
         let log = self.log.new(o!("" => "mend".to_string()));
-        DownstairsMend::new(c(0), c(1), c(2), log)
+        let mut meta = ClientMap::new();
+        for i in ClientId::iter() {
+            // XXX once we start doing reconciliation with only 2 downstairs,
+            // this may only insert region_metadata that is present.
+            meta.insert(i, self.clients[i].region_metadata.as_ref().unwrap());
+        }
+        DownstairsMend::new(&meta, log)
     }
 
     pub(crate) fn submit_flush(

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -433,7 +433,7 @@ impl<T> ClientData<T> {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
-    pub fn iter(&self) -> impl Iterator<Item = &T> {
+    pub fn iter(&self) -> impl Iterator<Item = &T> + DoubleEndedIterator {
         self.0.iter()
     }
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
@@ -477,8 +477,11 @@ impl<T> ClientMap<T> {
     pub fn insert(&mut self, c: ClientId, v: T) -> Option<T> {
         self.0.insert(c, Some(v))
     }
-    pub fn iter(&self) -> impl Iterator<Item = (ClientId, &T)> {
+    pub fn iter(
+        &self,
+    ) -> impl Iterator<Item = (ClientId, &T)> + DoubleEndedIterator {
         self.0
+             .0
             .iter()
             .enumerate()
             .flat_map(|(i, v)| v.as_ref().map(|v| (ClientId::new(i as u8), v)))
@@ -491,6 +494,13 @@ impl<T> ClientMap<T> {
     }
     pub fn take(&mut self, c: &ClientId) -> Option<T> {
         self.0[*c].take()
+    }
+    /// Builds a new `ClientMap` by applying a function to each item
+    pub fn map<U, F: FnMut(T) -> U>(self, mut f: F) -> ClientMap<U> {
+        ClientMap(self.0.map(move |v| match v {
+            Some(v) => Some(f(v)),
+            None => None,
+        }))
     }
 }
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -433,7 +433,7 @@ impl<T> ClientData<T> {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
-    pub fn iter(&self) -> impl Iterator<Item = &T> + DoubleEndedIterator {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &T> {
         self.0.iter()
     }
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
@@ -477,9 +477,7 @@ impl<T> ClientMap<T> {
     pub fn insert(&mut self, c: ClientId, v: T) -> Option<T> {
         self.0.insert(c, Some(v))
     }
-    pub fn iter(
-        &self,
-    ) -> impl Iterator<Item = (ClientId, &T)> + DoubleEndedIterator {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = (ClientId, &T)> {
         self.0
              .0
             .iter()
@@ -497,10 +495,7 @@ impl<T> ClientMap<T> {
     }
     /// Builds a new `ClientMap` by applying a function to each item
     pub fn map<U, F: FnMut(T) -> U>(self, mut f: F) -> ClientMap<U> {
-        ClientMap(self.0.map(move |v| match v {
-            Some(v) => Some(f(v)),
-            None => None,
-        }))
+        ClientMap(self.0.map(move |v| v.map(&mut f)))
     }
 }
 

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -497,6 +497,12 @@ impl<T> ClientMap<T> {
     pub fn map<U, F: FnMut(T) -> U>(self, mut f: F) -> ClientMap<U> {
         ClientMap(self.0.map(move |v| v.map(&mut f)))
     }
+    pub fn is_empty(&self) -> bool {
+        self.0.iter().all(|i| i.is_none())
+    }
+    pub fn len(&self) -> usize {
+        self.0.iter().filter(|i| i.is_some()).count()
+    }
 }
 
 impl<T> std::ops::Index<ClientId> for ClientMap<T> {


### PR DESCRIPTION
[In the future](https://rfd.shared.oxide.computer/rfd/542), reconciliation may happen with only two downstairs.  This PR paves the way by making `DownstairsMend::new` take a `ClientMap<&RegionMetadata>`, instead of exactly three metadata objects.