### PR TITLE
Don't log every region's metadata

### DIFF
--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -459,6 +459,11 @@ impl<T> ClientData<T> {
         ClientData(self.0.map(f))
     }
 
+    /// Builds a `ClientData` by applying a function to each item by reference
+    pub fn map_ref<U, F: FnMut(&T) -> U>(&self, mut f: F) -> ClientData<U> {
+        ClientData([f(&self.0[0]), f(&self.0[1]), f(&self.0[2])])
+    }
+
     #[cfg(test)]
     pub fn get(&self) -> &[T; 3] {
         &self.0
@@ -497,6 +502,12 @@ impl<T> ClientMap<T> {
     pub fn map<U, F: FnMut(T) -> U>(self, mut f: F) -> ClientMap<U> {
         ClientMap(self.0.map(move |v| v.map(&mut f)))
     }
+
+    /// Builds a `ClientMap` by applying a function to each item by reference
+    pub fn map_ref<U, F: FnMut(&T) -> U>(&self, mut f: F) -> ClientMap<U> {
+        ClientMap(self.0.map_ref(move |v| v.as_ref().map(&mut f)))
+    }
+
     pub fn is_empty(&self) -> bool {
         self.0.iter().all(|i| i.is_none())
     }

--- a/upstairs/src/mend.rs
+++ b/upstairs/src/mend.rs
@@ -112,7 +112,11 @@ impl DownstairsMend {
                 m.dirty || m != base_value
             });
             if any_diff {
-                info!(log, "extent {i} needs reconciliation: {meta:?}",);
+                info!(
+                    log,
+                    "extent {i} needs reconciliation: {:?}",
+                    meta.map_ref(|r| r.get(i).unwrap())
+                );
                 let ef = make_repair_list(i, meta, &log);
                 dsm.mend.insert(ExtentId(i as u32), ef);
             }


### PR DESCRIPTION
When computing the reconciliation job list, we logged all of `meta` for each extent that is mismatched.  `meta` is all three regions' **complete** metadata; we should instead be logging that particular extent's metadata.