### PR TITLE
Make Downstairs stoppable

### DIFF
--- a/downstairs/src/admin.rs
+++ b/downstairs/src/admin.rs
@@ -73,15 +73,17 @@ pub async fn run_downstairs_for_region(
         .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
 
     let handle = d.handle();
-    let _join_handle = start_downstairs(
+    let _join_handle = DownstairsClient::spawn(
         d,
-        run_params.address,
-        run_params.oximeter,
-        run_params.port,
-        run_params.rport,
-        run_params.cert_pem,
-        run_params.key_pem,
-        run_params.root_cert_pem,
+        DownstairsClientSettings {
+            address: run_params.address,
+            oximeter: run_params.oximeter,
+            port: run_params.port,
+            rport: run_params.rport,
+            cert_pem: run_params.cert_pem,
+            key_pem: run_params.key_pem,
+            root_cert_pem: run_params.root_cert_pem,
+        },
     )
     .await
     .map_err(|e| HttpError::for_internal_error(e.to_string()))?;

--- a/downstairs/src/admin.rs
+++ b/downstairs/src/admin.rs
@@ -62,6 +62,29 @@ pub async fn run_downstairs_for_region(
         ));
     }
 
+    let certs = match (
+        run_params.cert_pem,
+        run_params.key_pem,
+        run_params.root_cert_pem,
+    ) {
+        (Some(cert_pem), Some(key_pem), Some(root_cert_pem)) => {
+            Some(DownstairsClientCerts {
+                cert_pem,
+                key_pem,
+                root_cert_pem,
+            })
+        }
+        (None, None, None) => None,
+        _ => {
+            return Err(HttpError::for_bad_request(
+                Some(String::from("BadInput")),
+                "must provide all of cert_pem, key_pem, root_cert_pem \
+                 if any are provided"
+                    .to_owned(),
+            ))
+        }
+    };
+
     let d = Downstairs::new_builder(&run_params.data, run_params.read_only)
         .set_lossy(run_params.lossy)
         .set_test_errors(
@@ -80,9 +103,7 @@ pub async fn run_downstairs_for_region(
             oximeter: run_params.oximeter,
             port: run_params.port,
             rport: run_params.rport,
-            cert_pem: run_params.cert_pem,
-            key_pem: run_params.key_pem,
-            root_cert_pem: run_params.root_cert_pem,
+            certs,
         },
     )
     .await

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -3691,6 +3691,7 @@ impl DownstairsClient {
     }
 
     /// Stops the running downstairs
+    #[cfg(any(test, feature = "integration-tests"))]
     pub async fn stop(self) -> Result<(), CrucibleError> {
         self.join_handle.abort();
         self.repair_handle.abort();

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -2236,7 +2236,6 @@ impl DownstairsBuilder {
             active_upstairs: HashMap::new(),
             connection_state: HashMap::new(),
             dss,
-            address: None,
             repair_address: None,
             log,
             request_tx,
@@ -2277,7 +2276,6 @@ pub struct Downstairs {
     active_upstairs: HashMap<Uuid, ConnectionId>,
 
     dss: DsStatOuter,
-    pub address: Option<SocketAddr>,
     pub repair_address: Option<SocketAddr>,
     log: Logger,
 
@@ -3528,7 +3526,6 @@ impl DownstairsClient {
         // Establish a listen server on the port.
         let listener = TcpListener::bind(&listen_on).await?;
         let local_addr = listener.local_addr()?;
-        ds.address = Some(local_addr);
 
         let info = crucible_common::BuildInfo::default();
         info!(log, "Crucible Version: {}", info);

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -419,16 +419,18 @@ async fn main() -> Result<()> {
                 .set_test_errors(read_errors, write_errors, flush_errors)
                 .build()?;
 
-            let downstairs = start_downstairs(
+            let downstairs = DownstairsClient::spawn(
                 d,
-                address,
-                oximeter,
-                port,
-                // TODO accept as an argument?
-                port + crucible_common::REPAIR_PORT_OFFSET,
-                cert_pem,
-                key_pem,
-                root_cert_pem,
+                DownstairsClientSettings {
+                    address,
+                    oximeter,
+                    port,
+                    // TODO accept as an argument?
+                    rport: port + crucible_common::REPAIR_PORT_OFFSET,
+                    cert_pem,
+                    key_pem,
+                    root_cert_pem,
+                },
             )
             .await?;
 

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -200,11 +200,11 @@ enum Args {
         trace_endpoint: Option<String>,
 
         // TLS options
-        #[clap(long, action)]
+        #[clap(long, action, requires_all = ["key_pem", "root_cert_pem"])]
         cert_pem: Option<String>,
-        #[clap(long, action)]
+        #[clap(long, action, requires_all = ["cert_pem", "root_cert_pem"])]
         key_pem: Option<String>,
-        #[clap(long, action)]
+        #[clap(long, action, requires_all = ["cert_pem", "key_pem"])]
         root_cert_pem: Option<String>,
 
         #[clap(long, default_value = "rw", action)]
@@ -413,6 +413,15 @@ async fn main() -> Result<()> {
 
             let read_only = mode == Mode::Ro;
 
+            let certs = cert_pem.map(|cert_pem| {
+                // Clap ensures that these are all present together
+                DownstairsClientCerts {
+                    cert_pem,
+                    key_pem: key_pem.unwrap(),
+                    root_cert_pem: root_cert_pem.unwrap(),
+                }
+            });
+
             let d = Downstairs::new_builder(&data, read_only)
                 .set_lossy(lossy)
                 .set_logger(log)
@@ -427,9 +436,7 @@ async fn main() -> Result<()> {
                     port,
                     // TODO accept as an argument?
                     rport: port + crucible_common::REPAIR_PORT_OFFSET,
-                    cert_pem,
-                    key_pem,
-                    root_cert_pem,
+                    certs,
                 },
             )
             .await?;

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -432,7 +432,7 @@ async fn main() -> Result<()> {
             )
             .await?;
 
-            downstairs.join_handle.await?
+            downstairs.wait().await.map_err(anyhow::Error::from)
         }
         Args::RepairAPI => repair::write_openapi(&mut std::io::stdout()),
         Args::Serve {

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -35,7 +35,7 @@ mod test {
     struct TestDownstairs {
         address: IpAddr,
         tempdir: TempDir,
-        downstairs: Option<RunningDownstairs>,
+        downstairs: Option<DownstairsClient>,
     }
 
     impl TestDownstairs {
@@ -88,13 +88,12 @@ mod test {
                 downstairs.clone_region(*clone_source).await?
             }
 
-            let downstairs = start_downstairs(
-                downstairs, address, None, /* oximeter */
-                0,    /* any port */
-                0,    /* any rport */
-                None, /* cert_pem */
-                None, /* key_pem */
-                None, /* root_cert_pem */
+            let downstairs = DownstairsClient::spawn(
+                downstairs,
+                DownstairsClientSettings {
+                    address,
+                    ..DownstairsClientSettings::default()
+                },
             )
             .await?;
 
@@ -111,15 +110,12 @@ mod test {
                 .build()?;
 
             self.downstairs = Some(
-                start_downstairs(
+                DownstairsClient::spawn(
                     downstairs,
-                    self.address,
-                    None, /* oximeter */
-                    0,    /* any port */
-                    0,    /* any rport */
-                    None, /* cert_pem */
-                    None, /* key_pem */
-                    None, /* root_cert_pem */
+                    DownstairsClientSettings {
+                        address: self.address,
+                        ..DownstairsClientSettings::default()
+                    },
                 )
                 .await?,
             );
@@ -134,15 +130,12 @@ mod test {
                     .build()?;
 
             self.downstairs = Some(
-                start_downstairs(
+                DownstairsClient::spawn(
                     downstairs,
-                    self.address,
-                    None, /* oximeter */
-                    0,    /* any port */
-                    0,    /* any rport */
-                    None, /* cert_pem */
-                    None, /* key_pem */
-                    None, /* root_cert_pem */
+                    DownstairsClientSettings {
+                        address: self.address,
+                        ..DownstairsClientSettings::default()
+                    },
                 )
                 .await?,
             );
@@ -167,13 +160,13 @@ mod test {
 
         pub fn address(&self) -> SocketAddr {
             // If start_downstairs returned Ok, then address will be populated
-            self.downstairs.as_ref().unwrap().address
+            self.downstairs.as_ref().unwrap().address()
         }
 
         // Return the repair address for a running downstairs
         pub fn repair_address(&self) -> SocketAddr {
             // If start_downstairs returned Ok, then address will be populated
-            self.downstairs.as_ref().unwrap().repair_address
+            self.downstairs.as_ref().unwrap().repair_address()
         }
     }
 


### PR DESCRIPTION
Right now, `start_downstairs` returns a `RunningDownstairs` handle that includes a `JoinHandle` for the network listener task.  It also spawns several other tasks:

- The task running `Downstairs::run`
- The repair server
- An optional Oximeter server
- Per-connection tasks (spawned on demand)

The lifetime of these tasks is unclear, and it's hard to stop them all.  Aborting the network listener task doesn't actually stop any of the other tasks!

When writing unit tests (not currently pushed), I wanted to be able to stop and restart an entire Downstairs task group.  This would make it easier to write integration tests in Rust, instead of using separate processes orchestrated by Bash.

This PR renames `RunningDownstairs` to `DownstairsClient`, and gives it the power to halt the full set of Downstairs tasks.  In addition, `start_downstairs` is moved to `DownstairsClient::spawn`, and takes a new `DownstairsClientSettings` object (instead of 7 individual arguments).

Finally, certificate info is moved into a `Option<DownstairsClientCerts>` object, providing all-or-none behavior; previously, we could panic if only some certificate were provided.  This is an internal change; `CrucibleOpts` preserves the old behavior, because it has been serialized to disk.