### PR TITLE
Min-quorum reconciliation

### DIFF
--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -2608,7 +2608,8 @@ async fn replace_before_active(
             bail!("Requested volume verify failed: {:?}", e)
         }
 
-        // Start up the old downstairs so it is ready for the next loop.
+        // Start up all the stopped downstairs so they are ready for the next
+        // loop.
         for old_ds in [old_ds_a, old_ds_b] {
             let res = dsc_client.dsc_start(old_ds).await;
             info!(log, "[{c}] Replay: started {old_ds}, returned:{:?}", res);

--- a/tools/test_repair.sh
+++ b/tools/test_repair.sh
@@ -213,6 +213,9 @@ while [[ $count -lt $loops ]]; do
         ds2_pid=$!
     fi
 
+    # Wait for it to start up
+    sleep 10
+
     cp "$verify_file" ${verify_file}.last
     echo "Verifying data now"
     echo ${ct} verify ${target_args} --verify-out "$verify_file" --verify-in "$verify_file" --range -q -g "$generation" > "$test_log"
@@ -220,7 +223,7 @@ while [[ $count -lt $loops ]]; do
     then
         echo "Exit on verify fail, loop: $count, choice: $choice"
         echo "Check $test_log for details"
-	cleanup
+        cleanup
         exit 1
     fi
     set +o errexit

--- a/tools/test_up.sh
+++ b/tools/test_up.sh
@@ -289,6 +289,13 @@ if ! "$dsc" cmd start -c 2; then
     echo "Failed repair test part 1, starting downstairs 2" >> "$fail_log"
     echo
 fi
+state=$("$dsc" cmd state -c 2)
+while [[ "$state" != "Running" ]]; do
+    echo "downstairs 2 not restarted yet, waiting"
+    sleep 5
+    state=$("$dsc" cmd state -c 2)
+done
+echo "Downstairs 2 restarted"
 
 # Put a dump test in the middle of the repair test, so we
 # can see both a mismatch and that dump works.

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1049,6 +1049,11 @@ impl ReconcileIO {
             state: ClientData::new(ReconcileIOState::New),
         }
     }
+
+    /// Marks the job as skipped for the given client
+    fn skip(&mut self, i: ClientId) {
+        self.state[i] = ReconcileIOState::Skipped;
+    }
 }
 
 /*

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -2058,7 +2058,11 @@ impl Upstairs {
         });
         let ready_count = is_ready.iter().filter(|c| **c).count();
         if ready_count != 2 {
-            warn!(self.log, "min-quorum negotiation found {ready_count} ready downstairs; cancelling");
+            warn!(
+                self.log,
+                "min-quorum negotiation found {ready_count} \
+                 ready downstairs; cancelling"
+            );
             return;
         }
         info!(self.log, "Starting min-quorum negotiation");
@@ -2066,10 +2070,9 @@ impl Upstairs {
         match self.downstairs.collate() {
             Err(e) => {
                 error!(self.log, "Failed downstairs collate with: {e}");
-                // We failed to collate the three downstairs, so we need
-                // to reset that activation request.  Call
-                // `abort_reconciliation` to abort reconciliation for all
-                // clients.
+                // We failed to collate the two downstairs, so we need to reset
+                // that activation request.  Call `abort_reconciliation` to
+                // abort reconciliation for all clients.
                 self.set_disabled(e.into());
                 self.downstairs.abort_reconciliation(&self.state);
             }


### PR DESCRIPTION
(staged on #1732)

This implements [RFD 542](https://rfd.shared.oxide.computer/rfd/542) and closes #1690.

Here's the quick version:

- Once we have two downstairs in `WaitQuorum`, we schedule an event to fire after `NEGOTIATION_DELAY` (currently 500 ms)
- If the third Downstairs arrives before this event fires, then we do full-quorum reconciliation (our usual path)
- Otherwise, then we enter min-quorum reconciliation, marking the third Downstairs as faulted (so it must rejoin through live-repair)

I'm opening this as a draft because I want to see how the CI tests go.  The PR includes integration tests for common and uncommon orderings of events, but it's hard to hit every possible path due to specific timing requirements; I'm very open to suggestions for other tests.

Before merging, we also need to figure out https://github.com/oxidecomputer/crucible/pull/1661#issuecomment-2836793959