### PR TITLE
Snapshots existing already are ok!

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -115,9 +115,6 @@ pub enum CrucibleError {
     #[error("Snapshot failed! {0}")]
     SnapshotFailed(String),
 
-    #[error("Snapshot {0} exists already")]
-    SnapshotExistsAlready(String),
-
     #[error("Attempting to modify read-only region!")]
     ModifyingReadOnlyRegion,
 
@@ -426,7 +423,6 @@ impl From<CrucibleError> for dropshot::HttpError {
             | CrucibleError::OffsetUnaligned
             | CrucibleError::RegionIncompatible(_)
             | CrucibleError::ReplaceRequestInvalid(_)
-            | CrucibleError::SnapshotExistsAlready(_)
             | CrucibleError::Unsupported(_) => {
                 dropshot::HttpError::for_bad_request(None, e.to_string())
             }

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -1147,19 +1147,6 @@ impl DownstairsClient {
                     "DS Reports error {e:?} on job {}, {:?} EC", ds_id, job,
                 );
                 match (&job.work, &e) {
-                    // Some errors can be returned without considering the
-                    // Downstairs bad. For example, it's still an error if a
-                    // snapshot exists already but we should not increment
-                    // `downstairs_errors` and transition that Downstairs to
-                    // Failed - that downstairs is still able to serve IO.
-                    (
-                        IOop::Flush {
-                            snapshot_details: Some(..),
-                            ..
-                        },
-                        CrucibleError::SnapshotExistsAlready(..),
-                    ) => (),
-
                     // If a read job fails, we sometimes need to panic
                     (IOop::Read { .. }, CrucibleError::HashMismatch) => {
                         panic!(

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -3387,9 +3387,6 @@ impl Downstairs {
                     client_id, ds_id
                 );
             }
-            Some(CrucibleError::SnapshotExistsAlready(_)) => {
-                // This is fine, nothing to worry about
-            }
             Some(_err) => {
                 let Some(job) = self.ds_active.get(&ds_id) else {
                     panic!("I don't think we should be here");


### PR DESCRIPTION
Previously, the Downstairs would consider a snapshot existing already as an error, and unfortunately the Upstairs would continuously retry in the face of these errors, leading to an indefinite retry loop if any previous flush (with snapshot) succeeded.

This commit removes the SnapshotExistsAlready error variant, and returns Ok if the snapshot exists already. This is ok as long as:

- job dependency lists are honoured, meaning no writes can land that would make each downstairs inconsistent

- snapshot names are random enough that collisions are rare, and therefore an existing snapshot can be treated as the previous attempt succeeding

Fixes #1758.