### PR TITLE
Add back job delays in the downstairs with the --lossy flag

### DIFF
--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1617,6 +1617,10 @@ impl ActiveConnection {
     ) -> Message {
         let upstairs_connection = self.upstairs_connection;
 
+        if flags.lossy && random() && random() {
+            info!(self.log, "lossy pause {:?}", job_id);
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
         match &work {
             IOop::Read {
                 dependencies,


### PR DESCRIPTION
Somewhere in the past we lost the ability for the `--lossy` flag in the downstairs to make some jobs take longer.  The test test_repair.sh was counting on this behavior.  Things still generally behaved the same, but the volume of repair that the test would do was greatly reduced.  This change adds back the delay and will result in whatever downstairs has the lossy flag falling much further behind the other downstairs, which is what we want for that test.