### PR TITLE
Update rand dependencies, and fallout from that.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
  "crucible-workspace-hack",
  "futures",
  "futures-core",
- "rand 0.8.5",
+ "rand 0.9.2",
  "reqwest",
  "serde",
  "signal-hook",
@@ -932,8 +932,8 @@ dependencies = [
  "oximeter",
  "oximeter-producer",
  "proptest",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rayon",
  "reqwest",
  "ringbuffer",
@@ -1091,8 +1091,8 @@ dependencies = [
  "opentelemetry-jaeger",
  "oximeter",
  "oximeter-producer",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rangemap",
  "rayon",
  "repair-client",
@@ -1135,7 +1135,7 @@ dependencies = [
  "crucible-workspace-hack",
  "opentelemetry 0.29.1",
  "opentelemetry-jaeger",
- "rand 0.8.5",
+ "rand 0.9.2",
  "tokio",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -1160,7 +1160,7 @@ dependencies = [
  "futures-core",
  "hex",
  "httptest",
- "rand 0.8.5",
+ "rand 0.9.2",
  "repair-client",
  "reqwest",
  "serde",
@@ -1415,8 +1415,8 @@ dependencies = [
  "omicron-common",
  "oximeter",
  "oximeter-producer",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "reedline",
  "repair-client",
  "ringbuffer",
@@ -1762,8 +1762,8 @@ dependencies = [
  "expectorate",
  "openapi-lint",
  "openapiv3",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "schemars",
  "semver 1.0.26",
  "serde",
@@ -3129,7 +3129,7 @@ dependencies = [
  "crucible",
  "crucible-common",
  "crucible-workspace-hack",
- "rand 0.8.5",
+ "rand 0.9.2",
  "statistical",
  "tokio",
  "uuid",
@@ -3610,7 +3610,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -4838,6 +4838,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4855,6 +4865,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4879,6 +4899,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.11",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,8 +76,8 @@ progenitor = "0.10.0"
 progenitor-client = "0.10.0"
 proptest = "1.6.0"
 rayon = "1.10.0"
-rand = { version = "0.8.5", features = ["min_const_gen", "small_rng"] }
-rand_chacha = "0.3.1"
+rand = { version = "0.9.1", features = [ "small_rng"] }
+rand_chacha = "0.9.0"
 reedline = "0.39.0"
 rangemap = "1.5.1"
 reqwest = { version = "0.12", features = ["default", "blocking", "json", "stream"] }

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -260,7 +260,7 @@ async fn rand_write(
     /*
      * TODO: Allow the user to specify a seed here.
      */
-    let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
+    let mut rng = rand_chacha::ChaCha8Rng::from_os_rng();
 
     /*
      * Once we have our IO size, decide where the starting offset should
@@ -269,7 +269,7 @@ async fn rand_write(
      */
     let size = 1;
     let block_max = di.volume_info.total_blocks() - size + 1;
-    let block_index = rng.gen_range(0..block_max);
+    let block_index = rng.random_range(0..block_max);
 
     cli_write(volume, di, block_index, size).await
 }
@@ -350,8 +350,7 @@ async fn cli_write_unwritten(
         let mut data =
             BytesMut::with_capacity(di.volume_info.block_size as usize);
         data.extend(
-            (0..di.volume_info.block_size)
-                .map(|_| rand::thread_rng().gen::<u8>()),
+            (0..di.volume_info.block_size).map(|_| rand::rng().random::<u8>()),
         );
         data
     };
@@ -914,10 +913,10 @@ async fn process_cli_command(
         }
         CliMessage::RandRead => {
             if let Some(di) = di_option {
-                let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
+                let mut rng = rand_chacha::ChaCha8Rng::from_os_rng();
                 let size = 1;
                 let block_max = di.volume_info.total_blocks() - size + 1;
-                let offset = rng.gen_range(0..block_max);
+                let offset = rng.random_range(0..block_max);
 
                 let res = cli_read(volume, di, offset, size).await;
                 fw.send(CliMessage::ReadResponse(offset, res)).await

--- a/downstairs/src/dynamometer.rs
+++ b/downstairs/src/dynamometer.rs
@@ -35,17 +35,17 @@ pub fn dynamometer(
 
     // Fill test: write bytes in whole region
 
-    let mut rng = SmallRng::from_entropy();
+    let mut rng = SmallRng::from_os_rng();
 
     'outer: loop {
         let block = (0..ddef.block_size() as usize)
-            .map(|_| rng.sample(rand::distributions::Standard))
+            .map(|_| rng.sample(rand::distr::StandardUniform))
             .collect::<Vec<u8>>();
         let nonce = (0..12)
-            .map(|_| rng.sample(rand::distributions::Standard))
+            .map(|_| rng.sample(rand::distr::StandardUniform))
             .collect::<Vec<u8>>();
         let tag = (0..16)
-            .map(|_| rng.sample(rand::distributions::Standard))
+            .map(|_| rng.sample(rand::distr::StandardUniform))
             .collect::<Vec<u8>>();
 
         let hash = integrity_hash(&[&nonce, &tag, &block]);

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -1558,8 +1558,8 @@ mod test {
         assert!(inner.get_block_context(1)?.is_none());
 
         // Set and verify a new context for block 0
-        let blob1 = rand::thread_rng().gen::<[u8; 12]>();
-        let blob2 = rand::thread_rng().gen::<[u8; 16]>();
+        let blob1 = rand::rng().random::<[u8; 12]>();
+        let blob2 = rand::rng().random::<[u8; 16]>();
 
         // Set and verify block 0's context
         inner.set_dirty_and_block_context(&DownstairsBlockContext {
@@ -1686,10 +1686,10 @@ mod test {
             inner.set_dirty_and_block_context(&DownstairsBlockContext {
                 block_context: BlockContext {
                     encryption_context: Some(EncryptionContext {
-                        nonce: rand::thread_rng().gen::<[u8; 12]>(),
-                        tag: rand::thread_rng().gen::<[u8; 16]>(),
+                        nonce: rand::rng().random::<[u8; 12]>(),
+                        tag: rand::rng().random::<[u8; 16]>(),
                     }),
-                    hash: rand::thread_rng().gen::<u64>(),
+                    hash: rand::rng().random::<u64>(),
                 },
                 block: 0,
                 on_disk_hash: i,
@@ -1697,10 +1697,10 @@ mod test {
             inner.set_dirty_and_block_context(&DownstairsBlockContext {
                 block_context: BlockContext {
                     encryption_context: Some(EncryptionContext {
-                        nonce: rand::thread_rng().gen::<[u8; 12]>(),
-                        tag: rand::thread_rng().gen::<[u8; 16]>(),
+                        nonce: rand::rng().random::<[u8; 12]>(),
+                        tag: rand::rng().random::<[u8; 16]>(),
                     }),
-                    hash: rand::thread_rng().gen::<u64>(),
+                    hash: rand::rng().random::<u64>(),
                 },
                 block: 1,
                 on_disk_hash: i,

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -1349,8 +1349,8 @@ mod test {
 
         // Set and verify a new context for block 0
 
-        let blob1 = rand::thread_rng().gen::<[u8; 12]>();
-        let blob2 = rand::thread_rng().gen::<[u8; 16]>();
+        let blob1 = rand::rng().random::<[u8; 12]>();
+        let blob2 = rand::rng().random::<[u8; 16]>();
 
         // Set and verify block 0's context
         inner.set_dirty_and_block_context(&DownstairsBlockContext {
@@ -1553,10 +1553,10 @@ mod test {
             inner.set_dirty_and_block_context(&DownstairsBlockContext {
                 block_context: BlockContext {
                     encryption_context: Some(EncryptionContext {
-                        nonce: rand::thread_rng().gen::<[u8; 12]>(),
-                        tag: rand::thread_rng().gen::<[u8; 16]>(),
+                        nonce: rand::rng().random::<[u8; 12]>(),
+                        tag: rand::rng().random::<[u8; 16]>(),
                     }),
-                    hash: rand::thread_rng().gen::<u64>(),
+                    hash: rand::rng().random::<u64>(),
                 },
                 block: 0,
                 on_disk_hash: i,
@@ -1564,10 +1564,10 @@ mod test {
             inner.set_dirty_and_block_context(&DownstairsBlockContext {
                 block_context: BlockContext {
                     encryption_context: Some(EncryptionContext {
-                        nonce: rand::thread_rng().gen::<[u8; 12]>(),
-                        tag: rand::thread_rng().gen::<[u8; 16]>(),
+                        nonce: rand::rng().random::<[u8; 12]>(),
+                        tag: rand::rng().random::<[u8; 16]>(),
                     }),
-                    hash: rand::thread_rng().gen::<u64>(),
+                    hash: rand::rng().random::<u64>(),
                 },
                 block: 1,
                 on_disk_hash: i,
@@ -1762,7 +1762,7 @@ mod test {
         .unwrap();
 
         let mut data = BytesMut::from(&vec![0u8; 512 * 2] as &[u8]);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         rng.fill_bytes(&mut data);
         let data = data.freeze();
 

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -1469,7 +1469,7 @@ impl ActiveConnection {
             .get_next(&mut stop_at)
             .or_else(|| retry.pop_front())
         {
-            if flags.lossy && random() && random() {
+            if flags.lossy && rand::random_bool(0.25) {
                 // Skip a job that needs to be done, moving it to the back of
                 // the list.  This exercises job dependency tracking in the face
                 // of arbitrary reordering.
@@ -1617,7 +1617,7 @@ impl ActiveConnection {
     ) -> Message {
         let upstairs_connection = self.upstairs_connection;
 
-        if flags.lossy && random() && random() {
+        if flags.lossy && rand::random_bool(0.25) {
             info!(self.log, "lossy pause {:?}", job_id);
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
@@ -1630,7 +1630,7 @@ impl ActiveConnection {
                  * Any error from an IO should be intercepted here and passed
                  * back to the upstairs.
                  */
-                let response = if flags.read_errors && random() && random() {
+                let response = if flags.read_errors && rand::random_bool(0.25) {
                     warn!(self.log, "returning error on read!");
                     Err(CrucibleError::GenericError("test error".to_string()))
                 } else {
@@ -1665,7 +1665,7 @@ impl ActiveConnection {
                  * Any error from an IO should be intercepted here and passed
                  * back to the upstairs.
                  */
-                let result = if flags.write_errors && random() && random() {
+                let result = if flags.write_errors && rand::random_bool(0.25) {
                     warn!(self.log, "returning error on writeunwritten!");
                     Err(CrucibleError::GenericError("test error".to_string()))
                 } else {
@@ -1685,7 +1685,7 @@ impl ActiveConnection {
                 writes,
                 dependencies,
             } => {
-                let result = if flags.write_errors && random() && random() {
+                let result = if flags.write_errors && rand::random_bool(0.25) {
                     warn!(self.log, "returning error on write!");
                     Err(CrucibleError::GenericError("test error".to_string()))
                 } else {
@@ -1713,7 +1713,7 @@ impl ActiveConnection {
                 snapshot_details,
                 extent_limit,
             } => {
-                let result = if flags.flush_errors && random() && random() {
+                let result = if flags.flush_errors && rand::random_bool(0.25) {
                     warn!(self.log, "returning error on flush!");
                     Err(CrucibleError::GenericError("test error".to_string()))
                 } else {
@@ -5249,7 +5249,7 @@ mod test {
         let mut random_data = vec![0; total_bytes as usize];
         random_data.resize(total_bytes as usize, 0);
 
-        let mut rng = ChaCha20Rng::from_entropy();
+        let mut rng = ChaCha20Rng::from_os_rng();
         rng.fill_bytes(&mut random_data);
 
         // write random_data to file
@@ -5317,7 +5317,7 @@ mod test {
         let mut random_data = vec![0; total_bytes as usize];
         random_data.resize(total_bytes as usize, 0);
 
-        let mut rng = ChaCha20Rng::from_entropy();
+        let mut rng = ChaCha20Rng::from_os_rng();
         rng.fill_bytes(&mut random_data);
 
         // write random_data to file
@@ -5399,7 +5399,7 @@ mod test {
         let mut random_data = vec![0; total_bytes as usize];
         random_data.resize(total_bytes as usize, 0);
 
-        let mut rng = ChaCha20Rng::from_entropy();
+        let mut rng = ChaCha20Rng::from_os_rng();
         rng.fill_bytes(&mut random_data);
 
         // write random_data to file
@@ -5482,7 +5482,7 @@ mod test {
         let mut random_data = vec![0u8; total_bytes as usize];
         random_data.resize(total_bytes as usize, 0u8);
 
-        let mut rng = ChaCha20Rng::from_entropy();
+        let mut rng = ChaCha20Rng::from_os_rng();
         rng.fill_bytes(&mut random_data);
 
         // write random_data to file

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -2193,7 +2193,7 @@ pub(crate) mod test {
         only_write_unwritten: bool,
     ) -> Vec<u8> {
         let total_size: usize = ddef.total_size() as usize;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut buffer: Vec<u8> = vec![0; total_size];
         rng.fill_bytes(&mut buffer);
 
@@ -2900,7 +2900,7 @@ pub(crate) mod test {
         // Now use region_write to fill four blocks
         //
         // They're all within the same extent, so we just need one ExtentWrite
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut buffer: Vec<u8> = vec![0; total_size];
         println!("buffer size:{}", buffer.len());
         rng.fill_bytes(&mut buffer);
@@ -3305,7 +3305,7 @@ pub(crate) mod test {
                     .iter()
                     .map(|range| {
                         let n = range.clone().count();
-                        let mut rng = rand::thread_rng();
+                        let mut rng = rand::rng();
                         let mut data: Vec<u8> = vec![0; 512 * n];
                         rng.fill_bytes(&mut data);
 
@@ -3387,7 +3387,7 @@ pub(crate) mod test {
         let writes: Vec<ExtentWrite> = (0..3)
             .map(|_| {
                 let mut data = vec![0u8; 512 * EXTENT_SIZE as usize];
-                rand::thread_rng().fill_bytes(&mut data);
+                rand::rng().fill_bytes(&mut data);
                 let block_contexts = data
                     .chunks(512)
                     .map(|chunk| BlockContext {
@@ -3537,7 +3537,7 @@ pub(crate) mod test {
             ddef.extent_size().value as usize * ddef.extent_count() as usize;
 
         // Write in random data
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut buffer: Vec<u8> = vec![0; total_size];
         rng.fill_bytes(&mut buffer);
 
@@ -3601,7 +3601,7 @@ pub(crate) mod test {
         data: &mut [u8],
     ) -> Vec<RegionWriteReq> {
         let mut writes = vec![];
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         // Offsets are given as blocks; we convert to extents here
         const EXTENT_SIZE: usize = 10; // hard-coded default

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -810,7 +810,7 @@ async fn do_dsc_work(
     work: DscCmd,
     action_tx_list: &[mpsc::Sender<DownstairsAction>],
 ) {
-    let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
+    let mut rng = rand_chacha::ChaCha8Rng::from_os_rng();
 
     match work {
         DscCmd::Start(cid) => {
@@ -834,7 +834,7 @@ async fn do_dsc_work(
                 .unwrap();
         }
         DscCmd::StopRand => {
-            let cid = rng.gen_range(0..3) as usize;
+            let cid = rng.random_range(0..3) as usize;
             println!("stop rand {}", cid);
             action_tx_list[cid]
                 .send(DownstairsAction::Stop)
@@ -979,7 +979,7 @@ async fn start_dsc(
         }
     }
 
-    let mut rng = rand_chacha::ChaCha8Rng::from_entropy();
+    let mut rng = rand_chacha::ChaCha8Rng::from_os_rng();
     let mut timeout_deadline = Instant::now() + Duration::from_secs(5);
     let mut shutdown_sent = false;
     let mut random_restart = false;
@@ -1016,14 +1016,14 @@ async fn start_dsc(
                     }
                 } else if random_restart {
                     println!("Random restart");
-                    let cid = rng.gen_range(0..3) as usize;
+                    let cid = rng.random_range(0..3) as usize;
                     println!("stop rand {}", cid);
                     action_tx_list[cid].send(DownstairsAction::Stop).await.unwrap();
-                    Duration::from_secs(rng.gen_range(restart_min..restart_max))
+                    Duration::from_secs(rng.random_range(restart_min..restart_max))
                 } else {
                     // Set the timeout to be a random value between our
                     // min and max.
-                    Duration::from_secs(rng.gen_range(restart_min..restart_max))
+                    Duration::from_secs(rng.random_range(restart_min..restart_max))
                 };
                 timeout_deadline = Instant::now() + timeout;
             },

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -129,7 +129,7 @@ async fn main() -> Result<()> {
     }
 
     use rand::Rng;
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     let rounds = 1500;
     let handoff_amount = rounds / opt.num_upstairs;
@@ -184,18 +184,18 @@ async fn main() -> Result<()> {
 
         let sz = cpf.sz();
 
-        let mut offset: u64 = rng.gen::<u64>() % sz;
-        let mut bsz: usize = rng.gen::<usize>() % 4096;
+        let mut offset: u64 = rng.random::<u64>() % sz;
+        let mut bsz: usize = rng.random_range(0..4096);
 
         while ((offset + bsz as u64) > sz) || (bsz == 0) {
-            offset = rng.gen::<u64>() % sz;
-            bsz = rng.gen::<usize>() % 4096;
+            offset = rng.random::<u64>() % sz;
+            bsz = rng.random_range(0..4096);
         }
 
         // println!("testing {}: offset {} sz {}", idx, offset, bsz);
 
         let vec: Vec<u8> = (0..bsz)
-            .map(|_| rng.sample(rand::distributions::Standard))
+            .map(|_| rng.sample(rand::distr::StandardUniform))
             .collect();
 
         let mut vec2 = vec![0; bsz];

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -614,7 +614,7 @@ mod integration_tests {
             .await?;
 
             // Generate random data for our key
-            let key_bytes = rand::thread_rng().gen::<[u8; 32]>();
+            let key_bytes = rand::rng().random::<[u8; 32]>();
             let key_string =
                 engine::general_purpose::STANDARD.encode(key_bytes);
 
@@ -815,7 +815,7 @@ mod integration_tests {
 
         for i in 0..10 {
             let mut data = vec![0; BLOCK_SIZE * NUM_BLOCKS];
-            rand::thread_rng().fill(&mut data[..]);
+            rand::rng().fill(&mut data[..]);
             volume
                 .write(BlockIndex(i), BytesMut::from(data.as_slice()))
                 .await?;
@@ -2492,7 +2492,7 @@ mod integration_tests {
         let random_buffer = {
             let mut random_buffer =
                 vec![0u8; volume.total_size().await? as usize];
-            rand::thread_rng().fill(&mut random_buffer[..]);
+            rand::rng().fill(&mut random_buffer[..]);
             random_buffer
         };
 
@@ -2656,7 +2656,7 @@ mod integration_tests {
         let random_buffer = {
             let mut random_buffer =
                 vec![0u8; volume.total_size().await? as usize];
-            rand::thread_rng().fill(&mut random_buffer[..]);
+            rand::rng().fill(&mut random_buffer[..]);
             random_buffer
         };
 
@@ -2833,7 +2833,7 @@ mod integration_tests {
         let random_buffer = {
             let mut random_buffer =
                 vec![0u8; volume.total_size().await? as usize];
-            rand::thread_rng().fill(&mut random_buffer[..]);
+            rand::rng().fill(&mut random_buffer[..]);
             random_buffer
         };
 
@@ -2928,7 +2928,7 @@ mod integration_tests {
         let random_buffer = {
             let mut random_buffer =
                 vec![0u8; volume.total_size().await? as usize];
-            rand::thread_rng().fill(&mut random_buffer[..]);
+            rand::rng().fill(&mut random_buffer[..]);
             random_buffer
         };
 
@@ -3088,7 +3088,7 @@ mod integration_tests {
         let random_buffer = {
             let mut random_buffer =
                 vec![0u8; volume.total_size().await? as usize];
-            rand::thread_rng().fill(&mut random_buffer[..]);
+            rand::rng().fill(&mut random_buffer[..]);
             random_buffer
         };
 
@@ -3406,7 +3406,7 @@ mod integration_tests {
         let random_buffer = {
             let mut random_buffer =
                 vec![0u8; volume.total_size().await? as usize];
-            rand::thread_rng().fill(&mut random_buffer[..]);
+            rand::rng().fill(&mut random_buffer[..]);
             random_buffer
         };
 
@@ -3498,7 +3498,7 @@ mod integration_tests {
         let random_buffer = {
             let mut random_buffer =
                 vec![0u8; volume.total_size().await? as usize];
-            rand::thread_rng().fill(&mut random_buffer[..]);
+            rand::rng().fill(&mut random_buffer[..]);
             random_buffer
         };
 
@@ -3827,7 +3827,7 @@ mod integration_tests {
         let random_buffer = {
             let mut random_buffer =
                 vec![0u8; volume.total_size().await? as usize];
-            rand::thread_rng().fill(&mut random_buffer[..]);
+            rand::rng().fill(&mut random_buffer[..]);
             random_buffer
         };
 
@@ -3952,7 +3952,7 @@ mod integration_tests {
                         i / 512, // block offset!
                         {
                             let mut random_buffer = vec![0u8; CHUNK_SIZE];
-                            rand::thread_rng().fill(&mut random_buffer[..]);
+                            rand::rng().fill(&mut random_buffer[..]);
                             random_buffer
                         },
                     )
@@ -5647,7 +5647,7 @@ mod integration_tests {
 
         for i in 0..(total_size / CHUNK_SIZE) {
             let mut data = vec![0u8; CHUNK_SIZE];
-            rand::thread_rng().fill(&mut data[..]);
+            rand::rng().fill(&mut data[..]);
             let base64_encoded_data =
                 engine::general_purpose::STANDARD.encode(&data);
 
@@ -5777,7 +5777,7 @@ mod integration_tests {
 
         for i in 0..(total_size / CHUNK_SIZE) {
             let mut data = vec![0u8; CHUNK_SIZE];
-            rand::thread_rng().fill(&mut data[..]);
+            rand::rng().fill(&mut data[..]);
             let base64_encoded_data =
                 engine::general_purpose::STANDARD.encode(&data);
 

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -87,7 +87,7 @@ async fn main() -> Result<()> {
 
     guest.activate().await?;
 
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     let bsz: u64 = guest.get_block_size().await?;
     let total_blocks: u64 = guest.total_size().await? / bsz;
@@ -122,9 +122,9 @@ async fn main() -> Result<()> {
         let mut ops = Vec::with_capacity(io_depth);
         for _ in 0..io_depth {
             let offset: u64 =
-                rng.gen::<u64>() % (total_blocks - io_size as u64 / bsz);
+                rng.random::<u64>() % (total_blocks - io_size as u64 / bsz);
 
-            if rng.gen::<bool>() {
+            if rng.random::<bool>() {
                 ops.push(RandomOp::Read(
                     offset,
                     Buffer::new(io_size / bsz as usize, bsz as usize),
@@ -135,7 +135,7 @@ async fn main() -> Result<()> {
                     bytes.resize(io_size, 0);
                 } else {
                     bytes.extend((0..io_size).map(|_| -> u8 {
-                        rng.sample(rand::distributions::Standard)
+                        rng.sample(rand::distr::StandardUniform)
                     }));
                 }
                 ops.push(RandomOp::Write(offset, bytes));

--- a/upstairs/src/buffer.rs
+++ b/upstairs/src/buffer.rs
@@ -489,7 +489,7 @@ mod test {
         // Build a write which only writes the first 4 blocks
         let mut data = BytesMut::new();
         data.resize(10 * 512, 0u8);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         rng.fill_bytes(&mut data);
 
         let blocks: Vec<_> = (0..10)
@@ -557,7 +557,7 @@ mod test {
         // Build a write which only writes the first 4 blocks
         let mut data = BytesMut::new();
         data.resize(10 * 512, 0u8);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         rng.fill_bytes(&mut data);
 
         let blocks: Vec<_> = (0..10)

--- a/upstairs/src/notify.rs
+++ b/upstairs/src/notify.rs
@@ -5,7 +5,7 @@
 //! Nexus-flavored types internally.
 
 use chrono::{DateTime, Utc};
-use rand::prelude::SliceRandom;
+use rand::prelude::*;
 use slog::{debug, error, info, o, warn, Logger};
 use std::net::{Ipv6Addr, SocketAddr};
 use tokio::sync::mpsc;
@@ -432,8 +432,8 @@ pub(crate) async fn get_nexus_client(
                     error!(log, "no Nexus addresses returned!");
                     return None;
                 }
-
-                let Some(addr) = addrs.choose(&mut rand::thread_rng()) else {
+                let mut rng = rand::rng();
+                let Some(addr) = addrs.choose(&mut rng) else {
                     error!(log, "somehow, choose failed!");
                     return None;
                 };

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -442,20 +442,20 @@ mod test {
         let mut cpf = CruciblePseudoFile::from(in_memory)?;
         cpf.activate().await?;
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let sz = cpf.sz();
 
         for _ in 0..1000 {
-            let mut offset: u64 = rng.gen::<u64>() % sz;
-            let mut bsz: usize = rng.gen::<usize>() % 4096;
+            let mut offset: u64 = rng.random::<u64>() % sz;
+            let mut bsz: usize = rng.random_range(0..4096);
 
             while ((offset + bsz as u64) > sz) || (bsz == 0) {
-                offset = rng.gen::<u64>() % sz;
-                bsz = rng.gen::<usize>() % 4096;
+                offset = rng.random::<u64>() % sz;
+                bsz = rng.random_range(0..4096);
             }
 
             let vec: Vec<u8> = (0..bsz)
-                .map(|_| rng.sample(rand::distributions::Standard))
+                .map(|_| rng.sample(rand::distr::StandardUniform))
                 .collect();
 
             let mut vec2 = vec![0; bsz];

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -254,7 +254,7 @@ pub(crate) mod up_test {
     // key material made with `openssl rand -base64 32`
     #[test]
     pub fn test_upstairs_encryption_context_ok() -> Result<()> {
-        use rand::{thread_rng, Rng};
+        use rand::{rng, Rng};
 
         let key_bytes = engine::general_purpose::STANDARD
             .decode("ClENKTXD2bCyXSHnKXY7GGnk+NvQKbwpatjWP2fJzk0=")
@@ -262,7 +262,7 @@ pub(crate) mod up_test {
         let context = EncryptionContext::new(key_bytes, 512);
 
         let mut block = [0u8; 512];
-        thread_rng().fill(&mut block[..]);
+        rng().fill(&mut block[..]);
 
         let orig_block = block;
 
@@ -277,7 +277,7 @@ pub(crate) mod up_test {
 
     #[test]
     pub fn test_upstairs_encryption_context_wrong_nonce() -> Result<()> {
-        use rand::{thread_rng, Rng};
+        use rand::{rng, Rng};
 
         let key_bytes = engine::general_purpose::STANDARD
             .decode("EVrH+ABhMP0MLfxynCalDq1vWCCWCWFfsSsJoJeDCx8=")
@@ -285,7 +285,7 @@ pub(crate) mod up_test {
         let context = EncryptionContext::new(key_bytes, 512);
 
         let mut block = [0u8; 512];
-        thread_rng().fill(&mut block[..]);
+        rng().fill(&mut block[..]);
 
         let orig_block = block;
 
@@ -311,7 +311,7 @@ pub(crate) mod up_test {
 
     #[test]
     pub fn test_upstairs_encryption_context_wrong_tag() -> Result<()> {
-        use rand::{thread_rng, Rng};
+        use rand::{rng, Rng};
 
         let key_bytes = engine::general_purpose::STANDARD
             .decode("EVrH+ABhMP0MLfxynCalDq1vWCCWCWFfsSsJoJeDCx8=")
@@ -319,7 +319,7 @@ pub(crate) mod up_test {
         let context = EncryptionContext::new(key_bytes, 512);
 
         let mut block = [0u8; 512];
-        thread_rng().fill(&mut block[..]);
+        rng().fill(&mut block[..]);
 
         let orig_block = block;
 
@@ -348,15 +348,15 @@ pub(crate) mod up_test {
     #[test]
     pub fn test_upstairs_validate_encrypted_read_response() -> Result<()> {
         // Set up the encryption context
-        use rand::{thread_rng, Rng};
+        use rand::{rng, Rng};
         let mut key = vec![0u8; 32];
-        thread_rng().fill(&mut key[..]);
+        rng().fill(&mut key[..]);
         let context = EncryptionContext::new(key.clone(), 512);
 
         // Encrypt some random data
         let mut data = BytesMut::with_capacity(512);
         data.resize(512, 0u8);
-        thread_rng().fill(&mut data[..]);
+        rng().fill(&mut data[..]);
 
         let original_data = data.clone();
 
@@ -408,9 +408,9 @@ pub(crate) mod up_test {
     pub fn test_upstairs_validate_encrypted_read_response_blank_block(
     ) -> Result<()> {
         // Set up the encryption context
-        use rand::{thread_rng, Rng};
+        use rand::{rng, Rng};
         let mut key = vec![0u8; 32];
-        thread_rng().fill(&mut key[..]);
+        rng().fill(&mut key[..]);
         let context = EncryptionContext::new(key.clone(), 512);
 
         let mut data = BytesMut::with_capacity(512);
@@ -433,11 +433,11 @@ pub(crate) mod up_test {
 
     #[test]
     pub fn test_upstairs_validate_unencrypted_read_response() -> Result<()> {
-        use rand::{thread_rng, Rng};
+        use rand::{rng, Rng};
 
         let mut data = BytesMut::with_capacity(512);
         data.resize(512, 0u8);
-        thread_rng().fill(&mut data[..]);
+        rng().fill(&mut data[..]);
 
         let read_response_hash = integrity_hash(&[&data[..]]);
         let original_data = data.clone();

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -3473,7 +3473,7 @@ mod test {
     // Return a generic set of CrucibleOpts
     fn generic_crucible_opts(vol_id: Uuid) -> CrucibleOpts {
         // Generate random data for our key
-        let key_bytes = rand::thread_rng().gen::<[u8; 32]>();
+        let key_bytes = rand::rng().random::<[u8; 32]>();
         let key_string = engine::general_purpose::STANDARD.encode(key_bytes);
 
         let ds_ip = gen_ipv4();
@@ -4967,7 +4967,7 @@ mod test {
         let mut n_opts = o_opts.clone();
 
         n_opts.target[1] = "127.0.0.1:8888".parse().unwrap();
-        let key_bytes = rand::thread_rng().gen::<[u8; 32]>();
+        let key_bytes = rand::rng().random::<[u8; 32]>();
         let key_string = engine::general_purpose::STANDARD.encode(key_bytes);
         n_opts.key = Some(key_string);
 


### PR DESCRIPTION
Update rand dependencies.
This is 98% changing functions/methods to the new names, but there are two places where the change is a tiny bit more.

To address https://github.com/oxidecomputer/crucible/issues/1763, we now use rand::random_bool(0.25).  This should result in no functional difference, if I've used the proper lossy boolean.

There were a few places where we picked a random usize, then % by
4096.  Instead of that, we do a random_range(0..4096)