### PR TITLE
DTrace and log polish

### DIFF
--- a/cmon/src/main.rs
+++ b/cmon/src/main.rs
@@ -8,9 +8,7 @@ use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 use tokio::time::{sleep, Duration};
 
-use crucible::{
-    ClientStopReason, ConnectionMode, DsState, DtraceInfo, NegotiationState,
-};
+use crucible::DtraceInfo;
 
 /// Connect to crucible control server
 #[derive(Parser, Debug)]
@@ -86,44 +84,24 @@ enum Action {
     Repair,
 }
 
-/// Translate a [`DsState`] into a three letter string for printing.
-fn short_state(dss: DsState) -> String {
+/// Translate the DsState string into a three letter string for printing.
+fn short_state(dss: &str) -> String {
     match dss {
-        DsState::Connecting {
-            state: NegotiationState::WaitQuorum,
-            ..
-        } => "WQ".to_string(),
-        DsState::Connecting {
-            state: NegotiationState::Reconcile,
-            ..
-        } => "REC".to_string(),
-        DsState::Active => "ACT".to_string(),
-        DsState::Connecting {
-            state: NegotiationState::LiveRepairReady,
-            ..
-        } => "LRR".to_string(),
-        DsState::Stopping(ClientStopReason::NegotiationFailed(..))
-        | DsState::Connecting {
-            mode: ConnectionMode::New,
-            ..
-        } => "NEW".to_string(),
-        DsState::Connecting {
-            mode: ConnectionMode::Faulted,
-            ..
-        }
-        | DsState::Stopping(ClientStopReason::Fault(..)) => "FLT".to_string(),
-        DsState::LiveRepair => "LR".to_string(),
-        DsState::Connecting {
-            mode: ConnectionMode::Offline,
-            ..
-        } => "OFL".to_string(),
-        DsState::Stopping(ClientStopReason::Deactivated) => "DAV".to_string(),
-        DsState::Stopping(ClientStopReason::Disabled) => "DIS".to_string(),
-        DsState::Stopping(ClientStopReason::Replacing)
-        | DsState::Connecting {
-            mode: ConnectionMode::Replaced,
-            ..
-        } => "RPL".to_string(),
+        "Active" => "ACT".to_string(),
+        "WaitQuorum" => "WQ".to_string(),
+        "Reconcile" => "REC".to_string(),
+        "LiveRepairReady" => "LRR".to_string(),
+        "New" => "NEW".to_string(),
+        "Faulted" => "FLT".to_string(),
+        "Offline" => "OFL".to_string(),
+        "Replaced" => "RPL".to_string(),
+        "LiveRepair" => "LR".to_string(),
+        "Replacing" => "RPC".to_string(),
+        "Disabled" => "DIS".to_string(),
+        "Deactivated" => "DAV".to_string(),
+        "NegotiationFailed" => "NF".to_string(),
+        "Fault" => "FLT".to_string(),
+        x => x.to_string(),
     }
 }
 
@@ -277,9 +255,9 @@ fn print_dtrace_row(
             DtraceDisplay::State => {
                 print!(
                     " {:>3} {:>3} {:>3}",
-                    short_state(d_out.ds_state[0]),
-                    short_state(d_out.ds_state[1]),
-                    short_state(d_out.ds_state[2]),
+                    short_state(&d_out.ds_state[0]),
+                    short_state(&d_out.ds_state[1]),
+                    short_state(&d_out.ds_state[2]),
                 );
             }
             DtraceDisplay::UpCount => {

--- a/cmon/src/main.rs
+++ b/cmon/src/main.rs
@@ -84,7 +84,8 @@ enum Action {
     Repair,
 }
 
-/// Translate the DsState string into a three letter string for printing.
+/// Translate what the default DsState string is (that we are getting from DTrace)
+/// into a three letter string for printing.
 fn short_state(dss: &str) -> String {
     match dss {
         "Active" => "ACT".to_string(),

--- a/tools/dtrace/all_downstairs.d
+++ b/tools/dtrace/all_downstairs.d
@@ -57,9 +57,9 @@ crucible_downstairs*:::work-done
 
 tick-4s
 {
-    printf("%5s %4s %4s %4s %4s %5s %5s %5s %5s %5s\n",
+    printf("%5s %5s %5s %5s %5s %5s %5s %5s %5s %5s\n",
         "PID", "F>", "F<", "W>", "W<", "R>", "R<", "WS", "WIP", "WD");
-    printa("%05d %@4u %@4u %@4u %@4u %@5u %@5u %@5u %@5u %@5u\n",
+    printa("%05d %@5u %@5u %@5u %@5u %@5u %@5u %@5u %@5u %@5u\n",
         @sf_start, @sf_done, @sw_start, @sw_done, @sr_start, @sr_done,
         @work_start, @work_process, @work_done
     );

--- a/tools/dtrace/get-ds-state.d
+++ b/tools/dtrace/get-ds-state.d
@@ -3,7 +3,7 @@
  * Exit after 5 seconds.
  */
 #pragma D option quiet
-#pragma D option strsize=1k
+#pragma D option strsize=2k
 
 /*
  * Translate the longer state string into a shorter version

--- a/tools/dtrace/get-ds-state.d
+++ b/tools/dtrace/get-ds-state.d
@@ -18,6 +18,7 @@ inline string short_state[string ss] =
     ss == "Offline" ? "OFL" :
     ss == "LiveRepair" ? "LR" :
     ss == "Replacing" ? "RPC" :
+    ss == "Replaced" ? "RPL" :
     ss == "Disabled" ? "DIS" :
     ss == "Deactivated" ? "DAV" :
     ss == "NegotiationFailed" ? "NF" :

--- a/tools/dtrace/get-ds-state.d
+++ b/tools/dtrace/get-ds-state.d
@@ -9,17 +9,19 @@
  * Translate the longer state string into a shorter version
  */
 inline string short_state[string ss] =
-    ss == "active" ? "ACT" :
-    ss == "new" ? "NEW" :
-    ss == "replaced" ? "RPL" :
-    ss == "live_repair_ready" ? "LRR" :
-    ss == "live_repair" ? "LR" :
-    ss == "faulted" ? "FLT" :
-    ss == "offline" ? "OFL" :
-    ss == "reconcile" ? "REC" :
-    ss == "wait_quorum" ? "WQ" :
-    ss == "wait_active" ? "WA" :
-    ss == "connecting" ? "CON" :
+    ss == "Active" ? "ACT" :
+    ss == "WaitQuorum" ? "WQ" :
+    ss == "Reconcile" ? "REC" :
+    ss == "LiveRepairReady" ? "LRR" :
+    ss == "New" ? "NEW" :
+    ss == "Faulted" ? "FLT" :
+    ss == "Offline" ? "OFL" :
+    ss == "LiveRepair" ? "LR" :
+    ss == "Replacing" ? "RPC" :
+    ss == "Disabled" ? "DIS" :
+    ss == "Deactivated" ? "DAV" :
+    ss == "NegotiationFailed" ? "NF" :
+    ss == "Fault" ? "FLT" :
     ss;
 
 crucible_upstairs*:::up-status
@@ -27,13 +29,13 @@ crucible_upstairs*:::up-status
     my_id = json(copyinstr(arg1), "ok.upstairs_id");
     my_sesh = json(copyinstr(arg1), "ok.session_id");
 
-    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0].type");
+    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0]");
     this->d0 = short_state[this->ds0state];
 
-    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1].type");
+    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1]");
     this->d1 = short_state[this->ds1state];
 
-    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2].type");
+    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2]");
     this->d2 = short_state[this->ds2state];
 
     printf("%6d %8s %8s %3s %3s %3s\n",

--- a/tools/dtrace/get-up-state.d
+++ b/tools/dtrace/get-up-state.d
@@ -43,6 +43,7 @@ inline string short_state[string ss] =
     ss == "Offline" ? "OFL" :
     ss == "LiveRepair" ? "LR" :
     ss == "Replacing" ? "RPC" :
+    ss == "Replaced" ? "RPL" :
     ss == "Disabled" ? "DIS" :
     ss == "Deactivated" ? "DAV" :
     ss == "NegotiationFailed" ? "NF" :

--- a/tools/dtrace/get-up-state.d
+++ b/tools/dtrace/get-up-state.d
@@ -34,17 +34,19 @@ tick-10s
  * Translate the longer state string into a shorter version
  */
 inline string short_state[string ss] =
-    ss == "active" ? "ACT" :
-    ss == "new" ? "NEW" :
-    ss == "replaced" ? "RPL" :
-    ss == "live_repair_ready" ? "LRR" :
-    ss == "live_repair" ? "LR" :
-    ss == "faulted" ? "FLT" :
-    ss == "offline" ? "OFL" :
-    ss == "reconcile" ? "REC" :
-    ss == "wait_quorum" ? "WQ" :
-    ss == "wait_active" ? "WA" :
-    ss == "connecting" ? "CON" :
+    ss == "Active" ? "ACT" :
+    ss == "WaitQuorum" ? "WQ" :
+    ss == "Reconcile" ? "REC" :
+    ss == "LiveRepairReady" ? "LRR" :
+    ss == "New" ? "NEW" :
+    ss == "Faulted" ? "FLT" :
+    ss == "Offline" ? "OFL" :
+    ss == "LiveRepair" ? "LR" :
+    ss == "Replacing" ? "RPC" :
+    ss == "Disabled" ? "DIS" :
+    ss == "Deactivated" ? "DAV" :
+    ss == "NegotiationFailed" ? "NF" :
+    ss == "Fault" ? "FLT" :
     ss;
 
 /*
@@ -54,13 +56,13 @@ inline string short_state[string ss] =
  */
 crucible_upstairs*:::up-status
 {
-    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0].type");
+    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0]");
     this->d0 = short_state[this->ds0state];
 
-    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1].type");
+    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1]");
     this->d1 = short_state[this->ds1state];
 
-    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2].type");
+    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2]");
     this->d2 = short_state[this->ds2state];
 
     this->full_session_id = json(copyinstr(arg1), "ok.session_id");

--- a/tools/dtrace/get-up-state.d
+++ b/tools/dtrace/get-up-state.d
@@ -2,7 +2,7 @@
  * Display Upstairs status for all matching processes
  */
 #pragma D option quiet
-#pragma D option strsize=1k
+#pragma D option strsize=2k
 
 /*
  * Print the header right away

--- a/tools/dtrace/simple.d
+++ b/tools/dtrace/simple.d
@@ -28,17 +28,19 @@ dtrace:::BEGIN, tick-20s
  * Translate the longer state string into a shorter version
  */
 inline string short_state[string ss] =
-    ss == "active" ? "ACT" :
-    ss == "new" ? "NEW" :
-    ss == "live_repair_ready" ? "LRR" :
-    ss == "live_repair" ? "LR" :
-    ss == "faulted" ? "FLT" :
-    ss == "offline" ? "OFL" :
-    ss == "reconcile" ? "REC" :
-    ss == "wait_quorum" ? "WQ" :
-    ss == "wait_active" ? "WA" :
-    ss == "replaced" ? "RPL" :
-    ss == "connecting" ? "CON" :
+    ss == "Active" ? "ACT" :
+    ss == "WaitQuorum" ? "WQ" :
+    ss == "Reconcile" ? "REC" :
+    ss == "LiveRepairReady" ? "LRR" :
+    ss == "New" ? "NEW" :
+    ss == "Faulted" ? "FLT" :
+    ss == "Offline" ? "OFL" :
+    ss == "LiveRepair" ? "LR" :
+    ss == "Replacing" ? "RPC" :
+    ss == "Disabled" ? "DIS" :
+    ss == "Deactivated" ? "DAV" :
+    ss == "NegotiationFailed" ? "NF" :
+    ss == "Fault" ? "FLT" :
     ss;
 
 /*
@@ -48,13 +50,13 @@ inline string short_state[string ss] =
  */
 crucible_upstairs*:::up-status
 {
-    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0].type");
+    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0]");
     this->d0 = short_state[this->ds0state];
 
-    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1].type");
+    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1]");
     this->d1 = short_state[this->ds1state];
 
-    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2].type");
+    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2]");
     this->d2 = short_state[this->ds2state];
 
     this->full_upstairs_id = json(copyinstr(arg1), "ok.upstairs_id");

--- a/tools/dtrace/simple.d
+++ b/tools/dtrace/simple.d
@@ -37,6 +37,7 @@ inline string short_state[string ss] =
     ss == "Offline" ? "OFL" :
     ss == "LiveRepair" ? "LR" :
     ss == "Replacing" ? "RPC" :
+    ss == "Replaced" ? "RPL" :
     ss == "Disabled" ? "DIS" :
     ss == "Deactivated" ? "DAV" :
     ss == "NegotiationFailed" ? "NF" :

--- a/tools/dtrace/simple.d
+++ b/tools/dtrace/simple.d
@@ -1,5 +1,5 @@
 #pragma D option quiet
-#pragma D option strsize=1k
+#pragma D option strsize=2k
 
 dtrace:::BEGIN
 {

--- a/tools/dtrace/single_up_info.d
+++ b/tools/dtrace/single_up_info.d
@@ -49,6 +49,7 @@ inline string short_state[string ss] =
     ss == "Offline" ? "OFL" :
     ss == "LiveRepair" ? "LR" :
     ss == "Replacing" ? "RPC" :
+    ss == "Replaced" ? "RPL" :
     ss == "Disabled" ? "DIS" :
     ss == "Deactivated" ? "DAV" :
     ss == "NegotiationFailed" ? "NF" :

--- a/tools/dtrace/single_up_info.d
+++ b/tools/dtrace/single_up_info.d
@@ -40,17 +40,19 @@ dtrace:::BEGIN, tick-1s
  * Translate the longer state string into a shorter version
  */
 inline string short_state[string ss] =
-    ss == "active" ? "ACT" :
-    ss == "new" ? "NEW" :
-    ss == "live_repair_ready" ? "LRR" :
-    ss == "live_repair" ? "LR" :
-    ss == "faulted" ? "FLT" :
-    ss == "offline" ? "OFL" :
-    ss == "reconcile" ? "REC" :
-    ss == "wait_quorum" ? "WQ" :
-    ss == "wait_active" ? "WA" :
-    ss == "replaced" ? "RPL" :
-    ss == "connecting" ? "CON" :
+    ss == "Active" ? "ACT" :
+    ss == "WaitQuorum" ? "WQ" :
+    ss == "Reconcile" ? "REC" :
+    ss == "LiveRepairReady" ? "LRR" :
+    ss == "New" ? "NEW" :
+    ss == "Faulted" ? "FLT" :
+    ss == "Offline" ? "OFL" :
+    ss == "LiveRepair" ? "LR" :
+    ss == "Replacing" ? "RPC" :
+    ss == "Disabled" ? "DIS" :
+    ss == "Deactivated" ? "DAV" :
+    ss == "NegotiationFailed" ? "NF" :
+    ss == "Fault" ? "FLT" :
     ss;
 
 crucible_upstairs*:::up-status
@@ -61,13 +63,13 @@ crucible_upstairs*:::up-status
      * All these local variables require the "this->" so the probe firing
      * from different sessions don't collide with each other.
      */
-    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0].type");
+    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0]");
     this->d0 = short_state[this->ds0state];
 
-    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1].type");
+    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1]");
     this->d1 = short_state[this->ds1state];
 
-    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2].type");
+    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2]");
     this->d2 = short_state[this->ds2state];
 
     this->full_upstairs_id = json(copyinstr(arg1), "ok.upstairs_id");

--- a/tools/dtrace/single_up_info.d
+++ b/tools/dtrace/single_up_info.d
@@ -2,7 +2,7 @@
  * Display internal Upstairs status for the PID provided as $1
  */
 #pragma D option quiet
-#pragma D option strsize=1k
+#pragma D option strsize=2k
 /*
  * Print the header right away
  */

--- a/tools/dtrace/sled_upstairs_info.d
+++ b/tools/dtrace/sled_upstairs_info.d
@@ -49,6 +49,7 @@ inline string short_state[string ss] =
     ss == "Offline" ? "OFL" :
     ss == "LiveRepair" ? "LR" :
     ss == "Replacing" ? "RPC" :
+    ss == "Replaced" ? "RPL" :
     ss == "Disabled" ? "DIS" :
     ss == "Deactivated" ? "DAV" :
     ss == "NegotiationFailed" ? "NF" :

--- a/tools/dtrace/sled_upstairs_info.d
+++ b/tools/dtrace/sled_upstairs_info.d
@@ -40,17 +40,19 @@ tick-1s
  * Translate the longer state string into a shorter version
  */
 inline string short_state[string ss] =
-    ss == "active" ? "ACT" :
-    ss == "new" ? "NEW" :
-    ss == "live_repair_ready" ? "LRR" :
-    ss == "live_repair" ? "LR" :
-    ss == "faulted" ? "FLT" :
-    ss == "offline" ? "OFL" :
-    ss == "reconcile" ? "REC" :
-    ss == "wait_quorum" ? "WQ" :
-    ss == "wait_active" ? "WA" :
-    ss == "replaced" ? "RPL" :
-    ss == "connecting" ? "CON" :
+    ss == "Active" ? "ACT" :
+    ss == "WaitQuorum" ? "WQ" :
+    ss == "Reconcile" ? "REC" :
+    ss == "LiveRepairReady" ? "LRR" :
+    ss == "New" ? "NEW" :
+    ss == "Faulted" ? "FLT" :
+    ss == "Offline" ? "OFL" :
+    ss == "LiveRepair" ? "LR" :
+    ss == "Replacing" ? "RPC" :
+    ss == "Disabled" ? "DIS" :
+    ss == "Deactivated" ? "DAV" :
+    ss == "NegotiationFailed" ? "NF" :
+    ss == "Fault" ? "FLT" :
     ss;
 
 crucible_upstairs*:::up-status
@@ -59,13 +61,13 @@ crucible_upstairs*:::up-status
     this->upstairs_id = json(copyinstr(arg1), "ok.upstairs_id");
     this->session_id = json(copyinstr(arg1), "ok.session_id");
 
-    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0].type");
+    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0]");
     this->d0 = short_state[this->ds0state];
 
-    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1].type");
+    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1]");
     this->d1 = short_state[this->ds1state];
 
-    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2].type");
+    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2]");
     this->d2 = short_state[this->ds2state];
 
 

--- a/tools/dtrace/sled_upstairs_info.d
+++ b/tools/dtrace/sled_upstairs_info.d
@@ -7,7 +7,7 @@
  * will share the PID, but have unique SESSIONs.
  */
 #pragma D option quiet
-#pragma D option strsize=1k
+#pragma D option strsize=2k
 /*
  * Print the header right away
  */

--- a/tools/dtrace/up-info.d
+++ b/tools/dtrace/up-info.d
@@ -48,6 +48,7 @@ inline string short_state[string ss] =
     ss == "Offline" ? "OFL" :
     ss == "LiveRepair" ? "LR" :
     ss == "Replacing" ? "RPC" :
+    ss == "Replaced" ? "RPL" :
     ss == "Disabled" ? "DIS" :
     ss == "Deactivated" ? "DAV" :
     ss == "NegotiationFailed" ? "NF" :

--- a/tools/dtrace/up-info.d
+++ b/tools/dtrace/up-info.d
@@ -2,7 +2,7 @@
  * Example code from the 2024 DTrace.conf talk
  */
 #pragma D option quiet
-#pragma D option strsize=1k
+#pragma D option strsize=4k
 
 dtrace:::BEGIN
 {
@@ -39,17 +39,19 @@ tick-1s
  * Translate the longer state string into a shorter version
  */
 inline string short_state[string ss] =
-    ss == "active" ? "ACT" :
-    ss == "new" ? "NEW" :
-    ss == "live_repair_ready" ? "LRR" :
-    ss == "live_repair" ? "LR" :
-    ss == "faulted" ? "FLT" :
-    ss == "offline" ? "OFL" :
-    ss == "reconcile" ? "REC" :
-    ss == "wait_quorum" ? "WQ" :
-    ss == "wait_active" ? "WA" :
-    ss == "replaced" ? "RPL" :
-    ss == "connecting" ? "CON" :
+    ss == "Active" ? "ACT" :
+    ss == "WaitQuorum" ? "WQ" :
+    ss == "Reconcile" ? "REC" :
+    ss == "LiveRepairReady" ? "LRR" :
+    ss == "New" ? "NEW" :
+    ss == "Faulted" ? "FLT" :
+    ss == "Offline" ? "OFL" :
+    ss == "LiveRepair" ? "LR" :
+    ss == "Replacing" ? "RPC" :
+    ss == "Disabled" ? "DIS" :
+    ss == "Deactivated" ? "DAV" :
+    ss == "NegotiationFailed" ? "NF" :
+    ss == "Fault" ? "FLT" :
     ss;
 
 /*
@@ -65,13 +67,13 @@ crucible_upstairs*:::up-status
 /$target == 0 | $target == pid/
 {
     show = show + 1;
-    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0].type");
+    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0]");
     this->d0 = short_state[this->ds0state];
 
-    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1].type");
+    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1]");
     this->d1 = short_state[this->ds1state];
 
-    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2].type");
+    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2]");
     this->d2 = short_state[this->ds2state];
 
     this->full_upstairs_id = json(copyinstr(arg1), "ok.upstairs_id");

--- a/tools/dtrace/up-info.d
+++ b/tools/dtrace/up-info.d
@@ -2,7 +2,7 @@
  * Example code from the 2024 DTrace.conf talk
  */
 #pragma D option quiet
-#pragma D option strsize=4k
+#pragma D option strsize=2k
 
 dtrace:::BEGIN
 {

--- a/tools/dtrace/upstairs_info.d
+++ b/tools/dtrace/upstairs_info.d
@@ -2,7 +2,7 @@
  * Display internal Upstairs status.
  */
 #pragma D option quiet
-#pragma D option strsize=1k
+#pragma D option strsize=2k
 /*
  * Print the header right away
  */
@@ -18,7 +18,7 @@ dtrace:::BEGIN
 dtrace:::BEGIN, tick-1s
 /show > 20/
 {
-    printf("%6s ", "PID");
+    printf("%6s %8s ", "PID", "SESSION");
     printf("%3s %3s %3s", "DS0", "DS1", "DS2");
     printf(" %5s %5s %10s", "UPW", "DSW", "JOBID");
     printf(" %10s", "WRITE_BO");
@@ -33,32 +33,37 @@ dtrace:::BEGIN, tick-1s
  * Translate the longer state string into a shorter version
  */
 inline string short_state[string ss] =
-    ss == "active" ? "ACT" :
-    ss == "new" ? "NEW" :
-    ss == "live_repair_ready" ? "LRR" :
-    ss == "live_repair" ? "LR" :
-    ss == "faulted" ? "FLT" :
-    ss == "offline" ? "OFL" :
-    ss == "reconcile" ? "REC" :
-    ss == "wait_quorum" ? "WQ" :
-    ss == "wait_active" ? "WA" :
-    ss == "replaced" ? "RPL" :
-    ss == "connecting" ? "CON" :
+    ss == "Active" ? "ACT" :
+    ss == "WaitQuorum" ? "WQ" :
+    ss == "Reconcile" ? "REC" :
+    ss == "LiveRepairReady" ? "LRR" :
+    ss == "New" ? "NEW" :
+    ss == "Faulted" ? "FLT" :
+    ss == "Offline" ? "OFL" :
+    ss == "LiveRepair" ? "LR" :
+    ss == "Replacing" ? "RPC" :
+    ss == "Disabled" ? "DIS" :
+    ss == "Deactivated" ? "DAV" :
+    ss == "NegotiationFailed" ? "NF" :
+    ss == "Fault" ? "FLT" :
     ss;
 
 crucible_upstairs*:::up-status
 {
     show = show + 1;
-    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0].type");
+    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0]");
     this->d0 = short_state[this->ds0state];
 
-    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1].type");
+    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1]");
     this->d1 = short_state[this->ds1state];
 
-    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2].type");
+    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2]");
     this->d2 = short_state[this->ds2state];
 
-    printf("%6d", pid);
+    this->full_session_id = json(copyinstr(arg1), "ok.session_id");
+    this->session_id = substr(this->full_session_id, 0, 8);
+
+    printf("%6d %8s", pid, this->session_id);
     /*
      * State for the three downstairs
      */

--- a/tools/dtrace/upstairs_info.d
+++ b/tools/dtrace/upstairs_info.d
@@ -42,6 +42,7 @@ inline string short_state[string ss] =
     ss == "Offline" ? "OFL" :
     ss == "LiveRepair" ? "LR" :
     ss == "Replacing" ? "RPC" :
+    ss == "Replaced" ? "RPL" :
     ss == "Disabled" ? "DIS" :
     ss == "Deactivated" ? "DAV" :
     ss == "NegotiationFailed" ? "NF" :

--- a/tools/dtrace/upstairs_raw.d
+++ b/tools/dtrace/upstairs_raw.d
@@ -4,7 +4,7 @@
  * can display whatever fields of the structure you wish.
  */
 #pragma D option quiet
-#pragma D option strsize=1k
+#pragma D option strsize=2k
 crucible_upstairs*:::up-status
 {
     trace(json(copyinstr(arg1), "ok"));

--- a/tools/dtrace/upstairs_repair.d
+++ b/tools/dtrace/upstairs_repair.d
@@ -45,6 +45,7 @@ inline string short_state[string ss] =
     ss == "Offline" ? "OFL" :
     ss == "LiveRepair" ? "LR" :
     ss == "Replacing" ? "RPC" :
+    ss == "Replaced" ? "RPL" :
     ss == "Disabled" ? "DIS" :
     ss == "Deactivated" ? "DAV" :
     ss == "NegotiationFailed" ? "NF" :

--- a/tools/dtrace/upstairs_repair.d
+++ b/tools/dtrace/upstairs_repair.d
@@ -36,17 +36,19 @@ dtrace:::BEGIN, tick-1s
  * Translate the longer state string into a shorter version
  */
 inline string short_state[string ss] =
-    ss == "active" ? "ACT" :
-    ss == "new" ? "NEW" :
-    ss == "live_repair_ready" ? "LRR" :
-    ss == "live_repair" ? "LR" :
-    ss == "faulted" ? "FLT" :
-    ss == "offline" ? "OFL" :
-    ss == "reconcile" ? "REC" :
-    ss == "wait_quorum" ? "WQ" :
-    ss == "wait_active" ? "WA" :
-    ss == "replaced" ? "RPL" :
-    ss == "connecting" ? "CON" :
+    ss == "Active" ? "ACT" :
+    ss == "WaitQuorum" ? "WQ" :
+    ss == "Reconcile" ? "REC" :
+    ss == "LiveRepairReady" ? "LRR" :
+    ss == "New" ? "NEW" :
+    ss == "Faulted" ? "FLT" :
+    ss == "Offline" ? "OFL" :
+    ss == "LiveRepair" ? "LR" :
+    ss == "Replacing" ? "RPC" :
+    ss == "Disabled" ? "DIS" :
+    ss == "Deactivated" ? "DAV" :
+    ss == "NegotiationFailed" ? "NF" :
+    ss == "Fault" ? "FLT" :
     ss;
 
 crucible_upstairs*:::up-status
@@ -56,13 +58,13 @@ crucible_upstairs*:::up-status
      * State for the three downstairs
      */
 
-    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0].type");
+    this->ds0state = json(copyinstr(arg1), "ok.ds_state[0]");
     this->d0 = short_state[this->ds0state];
 
-    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1].type");
+    this->ds1state = json(copyinstr(arg1), "ok.ds_state[1]");
     this->d1 = short_state[this->ds1state];
 
-    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2].type");
+    this->ds2state = json(copyinstr(arg1), "ok.ds_state[2]");
     this->d2 = short_state[this->ds2state];
 
     printf("%3s", this->d0);

--- a/tools/dtrace/upstairs_repair.d
+++ b/tools/dtrace/upstairs_repair.d
@@ -2,7 +2,7 @@
  * Display internal Upstairs live repair status.
  */
 #pragma D option quiet
-#pragma D option strsize=1k
+#pragma D option strsize=2k
 /*
  * Print the header right away
  */

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -805,6 +805,9 @@ where
 impl std::fmt::Display for DsState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            DsState::Active => {
+                write!(f, "Active")
+            }
             DsState::Connecting {
                 state: NegotiationState::WaitQuorum,
                 ..
@@ -822,9 +825,6 @@ impl std::fmt::Display for DsState {
                 ..
             } => {
                 write!(f, "LiveRepairReady")
-            }
-            DsState::Active => {
-                write!(f, "Active")
             }
             DsState::Connecting {
                 mode: ConnectionMode::New,
@@ -853,9 +853,23 @@ impl std::fmt::Display for DsState {
             DsState::LiveRepair => {
                 write!(f, "LiveRepair")
             }
-            DsState::Stopping(..) => {
-                write!(f, "Stopping")
-            }
+            DsState::Stopping(r) => match r {
+                ClientStopReason::Replacing => {
+                    write!(f, "Replacing")
+                }
+                ClientStopReason::Disabled => {
+                    write!(f, "Disabled")
+                }
+                ClientStopReason::Deactivated => {
+                    write!(f, "Deactivated")
+                }
+                ClientStopReason::NegotiationFailed(_) => {
+                    write!(f, "NegotiationFailed")
+                }
+                ClientStopReason::Fault(_) => {
+                    write!(f, "Faulted")
+                }
+            },
         }
     }
 }
@@ -1566,7 +1580,7 @@ pub struct DtraceInfo {
     /// Number of write bytes in flight
     pub write_bytes_out: u64,
     /// State of a downstairs
-    pub ds_state: [DsState; 3],
+    pub ds_state: [String; 3],
     /// Counters for each state of a downstairs job.
     pub ds_io_count: IOStateCount,
     /// Extents repaired during initial reconciliation.

--- a/upstairs/src/notify.rs
+++ b/upstairs/src/notify.rs
@@ -378,7 +378,7 @@ async fn notify_task_nexus(
             }
 
             Err(e) => {
-                error!(log, "failed to notify Nexus of {s}: {e}");
+                warn!(log, "failed to notify Nexus of {s}: {e}");
 
                 // If there's a problem notifying Nexus, it could be due to
                 // Nexus being gone before the DNS was updated. If this is the
@@ -442,7 +442,7 @@ pub(crate) async fn get_nexus_client(
             }
 
             Err(e) => {
-                error!(log, "lookup Nexus address failed: {e}");
+                warn!(log, "lookup Nexus address failed: {e}");
                 return None;
             }
         };

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -782,7 +782,9 @@ impl Upstairs {
                 next_job_id: self.downstairs.peek_next_id(),
                 write_bytes_out: self.downstairs.write_bytes_outstanding(),
                 ds_count: self.downstairs.active_count() as u32,
-                ds_state: self.downstairs.collect_stats(|c| c.state()),
+                ds_state: self
+                    .downstairs
+                    .collect_stats(|client| format!("{}", client.state())),
                 ds_io_count: self.downstairs.io_state_count(),
                 ds_reconciled: self.downstairs.reconcile_repaired(),
                 ds_reconcile_needed: self.downstairs.reconcile_repair_needed(),


### PR DESCRIPTION
Cleanup DTrace printing of downstairs state.

Convert the DsState type into a string before we stuff it into the DTrace probe.  We were treating it as a string already on the other side, so why not just send the string we want to begin with.  This avoids having to do more complicated processing inside the D scripts.  Updated all the DTraces scripts that were using the old method to now expect the new string that is returned for the default display of DsState type.

Updated the default display for DsState to provide a bit more info for states that were "Connecting".

Changed a few log messages from error to warn in the case where we can't send an update message to Nexus.

Fix for various bits in https://github.com/oxidecomputer/crucible/issues/1772

Here is some sample output from some of the DTrace scripts:
```
alan@etrium:crucible$ pfexec dtrace -Z -s tools/dtrace/up-info.d 
  PID     UUID  SESSION DS0 DS1 DS2   NEXT_JOB  DELTA CONN   ELR   ELC   ERR   ERN
12140 b088b7c5 2d9b1fec ACT ACT ACT       1004      0    3     0     0     0     0
12140 b088b7c5 2d9b1fec ACT ACT ACT       1004      0    3     0     0     0     0
12140 b088b7c5 2d9b1fec ACT ACT ACT       1004      0    3     0     0     0     0
12140 b088b7c5 2d9b1fec ACT ACT ACT       1004      0    3     0     0     0     0
12146 2d50ec4b 431c0edf ACT ACT ACT       1004      0    3     0     0     0     0
12146 2d50ec4b 431c0edf ACT ACT ACT       1004      0    3     0     0     0     0
12146 2d50ec4b 431c0edf ACT ACT ACT       1004      0    3     0     0     0     0
12146 2d50ec4b 431c0edf ACT ACT ACT       1004      0    3     0     0     0     0
12154 5f6d602e d8035684  WQ  WQ NEW       1000      0    2     0     0     0     0
12154 5f6d602e d8035684  WQ  WQ NEW       1000      0    2     0     0     0     0
12154 5f6d602e d8035684  WQ  WQ NEW       1000      0    2     0     0     0     0
12154 5f6d602e d8035684  WQ  WQ NEW       1000      0    2     0     0     0     0
12154 5f6d602e d8035684  WQ  WQ NEW       1000      0    2     0     0     0     0
12154 5f6d602e d8035684  WQ  WQ NEW       1000      0    2     0     0     0     0
12154 5f6d602e d8035684  WQ  WQ NEW       1000      0    2     0     0     0     0
12154 5f6d602e d8035684  WQ  WQ NEW       1000      0    2     0     0     0     0
12154 5f6d602e d8035684  WQ  WQ NEW       1000      0    2     0     0     0     0
12154 5f6d602e d8035684 REC REC REC       1000      0    3     0     0     2    18
12154 5f6d602e d8035684 ACT ACT ACT       1002      2    3     0     0    20     0
12154 5f6d602e d8035684 ACT ACT ACT       1002      0    3     0     0    20     0
12154 5f6d602e d8035684 ACT ACT ACT       1002      0    3     0     0    20     0
  PID     UUID  SESSION DS0 DS1 DS2   NEXT_JOB  DELTA CONN   ELR   ELC   ERR   ERN
12154 5f6d602e d8035684 ACT ACT ACT       1002      0    3     0     0    20     0
12179 0817aca3 2a0fd3d4 OFL ACT ACT       1401      0    3     0     0     0     0
12179 0817aca3 2a0fd3d4 OFL ACT ACT       1401      0    3     0     0     0     0
12179 0817aca3 2a0fd3d4 OFL ACT ACT       1401      0    3     0     0     0     0
```

I let the dtrace scripts run while running cargo test and I could see many of the states showing up.
Here is a bunch of noise from that:
```
alan@etrium:crucible$ pfexec dtrace -Z -s tools/dtrace/sled_upstairs_info.d
  PID     UUID  SESSION DS0 DS1 DS2   UPW   DSW  NEXT_JOB   WRITE_BO    IP0   IP1   IP2     D0    D1    D2     S0    S1    S2    ER0   ER1   ER2    EC0   EC1   EC2
12494 7dc3f943 1bb2b697 FLT ACT ACT     0     0      1498          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12491 861995a1 e6a231de OFL OFL OFL     0     0      1000          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12497 5bd17c94 fe8e0586 FLT ACT ACT     0     0      2201          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12492 34940348 dd0721be FLT ACT ACT     0   497      1497          0      0     0     0      0   497   497    497     0     0      0     0     0      0     0     0
12501 dbb21d8c 932671af OFL ACT ACT     0     0      1000          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12503 da39d261 17b1d5c7 OFL ACT ACT     0     0      1000          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12498 09e744d8 e1e347c0 FLT ACT ACT     0  1200      2200          0      0     0     0      0  1200  1200   1200     0     0      0     0     0      0     0     0
12502 4137d113 1912fce1 OFL ACT ACT     0     0      1000          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12965 5fed87cb 30bb4c55 ACT ACT ACT     1    40      1184    1048576      1     1     1     39    39    39      0     0     0      0     0     0      0     0     0
12494 7dc3f943 1bb2b697 FLT ACT ACT     0     0      1498          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12497 5bd17c94 fe8e0586 FLT ACT ACT     0     0      2201          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12492 34940348 dd0721be FLT ACT ACT     0   497      1497          0      0     0     0      0   497   497    497     0     0      0     0     0      0     0     0
12501 dbb21d8c 932671af OFL ACT ACT     0     0      1000          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12498 09e744d8 e1e347c0 FLT ACT ACT     0  1200      2200          0      0     0     0      0  1200  1200   1200     0     0      0     0     0      0     0     0
12965 5fed87cb 30bb4c55 ACT ACT ACT     1    43      1187    1048576      1     1     1     42    42    42      0     0     0      0     0     0      0     0     0
12494 7dc3f943 1bb2b697 FLT ACT ACT     0     0      1498          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12497 5bd17c94 fe8e0586 FLT ACT ACT     0     0      2201          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12492 34940348 dd0721be FLT ACT ACT     0   497      1497          0      0     0     0      0   497   497    497     0     0      0     0     0      0     0     0
12501 dbb21d8c 932671af OFL ACT ACT     0     0      1000          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12498 09e744d8 e1e347c0 FLT ACT ACT     0     0      2201          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12965 5fed87cb 30bb4c55 ACT ACT ACT     1    46      1190    1048576      1     1     1     45    45    45      0     0     0      0     0     0      0     0     0
  PID     UUID  SESSION DS0 DS1 DS2   UPW   DSW  NEXT_JOB   WRITE_BO    IP0   IP1   IP2     D0    D1    D2     S0    S1    S2    ER0   ER1   ER2    EC0   EC1   EC2
12494 7dc3f943 1bb2b697 FLT ACT ACT     0     0      1498          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12497 5bd17c94 fe8e0586 FLT ACT ACT     0     0      2201          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12492 34940348 dd0721be FLT ACT ACT     0     0      1498          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12501 dbb21d8c 932671af OFL ACT ACT     0     0      1000          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12498 09e744d8 e1e347c0 FLT ACT ACT     0     0      2201          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12494 7dc3f943 1bb2b697 FLT ACT ACT     0     0      1498          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12497 5bd17c94 fe8e0586 FLT ACT ACT     0     0      2201          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12492 34940348 dd0721be FLT ACT ACT     0     0      1498          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12501 dbb21d8c 932671af OFL ACT ACT     0     0      1000          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12498 09e744d8 e1e347c0 FLT ACT ACT     0     0      2201          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12494 7dc3f943 1bb2b697  LR ACT ACT    20   199      1699      17920     10    37    37     24   162   162    165     0     0      3     0     0      0     0     0
12497 5bd17c94 fe8e0586  LR ACT ACT    11   181      2384       8704     10    19    19     24   162   162    147     0     0      3     0     0      0     0     0
12492 34940348 dd0721be  LR ACT ACT     2   164      1664          0      2     2     2     24   162   162    138     0     0      3     0     0      0     0     0
12501 dbb21d8c 932671af OFL ACT ACT     0     0      1000          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12498 09e744d8 e1e347c0  LR ACT ACT     8   176      2379       6144     10    14    14     24   162   162    142     0     0      3     0     0      0     0     0
12501 dbb21d8c 932671af OFL ACT ACT     0     0      1000          0      0     0     0      0     0     0      0     0     0      0     0     0      0     0     0
12965 5fed87cb 30bb4c55 ACT ACT ACT     0    46      1190          0      0     0     0     46    46    46      0     0     0      0     0     0      0     0     0
12501 dbb21d8c 932671af ACT ACT ACT     0     1      1001        512      1     0     0      0     1     1      0     0     0      0     0     0      0     0     0
```
