### PR TITLE
make Crucible APIs versioned

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,6 +1149,7 @@ dependencies = [
  "crucible-agent-types",
  "crucible-workspace-hack",
  "dropshot",
+ "dropshot-api-manager-types",
  "schemars",
  "serde",
 ]
@@ -1309,6 +1310,7 @@ dependencies = [
  "crucible-downstairs-types",
  "crucible-workspace-hack",
  "dropshot",
+ "dropshot-api-manager-types",
  "hyper",
  "schemars",
  "serde",
@@ -1472,6 +1474,7 @@ dependencies = [
  "crucible-pantry-types",
  "crucible-workspace-hack",
  "dropshot",
+ "dropshot-api-manager-types",
  "schemars",
  "serde",
 ]
@@ -2074,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "dropshot-api-manager"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f448e29400392b55ed2c0133c79841e1bc1bc771e6e20841cb1a5c70a77ef65"
+checksum = "6d0c9a9b3587eb5c7da419466203773307767124fa20e84068d9dd06ee34caa9"
 dependencies = [
  "anyhow",
  "atomicwrites",
@@ -2104,9 +2107,9 @@ dependencies = [
 
 [[package]]
 name = "dropshot-api-manager-types"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b913840b90fcccce6afbdb146acf39aa3243b8510e255a70572e53a964fc96a"
+checksum = "00be3e4459aae391b88805e9f735c7cf9cf4ed6aad02bc0e92b224b590af39ab"
 dependencies = [
  "anyhow",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,8 @@ clearscreen = "4.0.2"
 crossterm = { version = "0.28.1" }
 crucible-workspace-hack = "0.1.0"  # see [patch.crates-io.crucible-workspace-hack] for more
 csv = "1.3.1"
-dropshot-api-manager = "0.2.1"
-dropshot-api-manager-types = "0.2.1"
+dropshot-api-manager = "0.2.2"
+dropshot-api-manager-types = "0.2.2"
 expectorate = "1.1.0"
 fakedata_generator = "0.5"
 futures = "0.3"

--- a/agent-api/Cargo.toml
+++ b/agent-api/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2024"
 crucible-agent-types.workspace = true
 crucible-workspace-hack.workspace = true
 dropshot.workspace = true
+dropshot-api-manager-types.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/agent-api/src/lib.rs
+++ b/agent-api/src/lib.rs
@@ -10,8 +10,36 @@ use dropshot::{
     HttpError, HttpResponseDeleted, HttpResponseOk, Path, RequestContext,
     TypedBody,
 };
+use dropshot_api_manager_types::api_versions;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+api_versions!([
+    // WHEN CHANGING THE API (part 1 of 2):
+    //
+    // +- Pick a new semver and define it in the list below.  The list MUST
+    // |  remain sorted, which generally means that your version should go at
+    // |  the very top.
+    // |
+    // |  Duplicate this line, uncomment the *second* copy, update that copy for
+    // |  your new API version, and leave the first copy commented out as an
+    // |  example for the next person.
+    // v
+    // (next_int, IDENT),
+    (1, INITIAL),
+]);
+
+// WHEN CHANGING THE API (part 2 of 2):
+//
+// The call to `api_versions!` above defines constants of type
+// `semver::Version` that you can use in your Dropshot API definition to specify
+// the version when a particular endpoint was added or removed.  For example, if
+// you used:
+//
+//     (1, INITIAL)
+//
+// Then you could use `VERSION_INITIAL` as the version in which endpoints were
+// added or removed.
 
 #[dropshot::api_description]
 pub trait CrucibleAgentApi {

--- a/downstairs-api/Cargo.toml
+++ b/downstairs-api/Cargo.toml
@@ -10,6 +10,7 @@ crucible-common.workspace = true
 crucible-downstairs-types.workspace = true
 crucible-workspace-hack.workspace = true
 dropshot.workspace = true
+dropshot-api-manager-types.workspace = true
 hyper.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/downstairs-api/src/lib.rs
+++ b/downstairs-api/src/lib.rs
@@ -8,10 +8,38 @@ use dropshot::{
     Body, HttpError, HttpResponseCreated, HttpResponseOk, Path, RequestContext,
     TypedBody,
 };
+use dropshot_api_manager_types::api_versions;
 use hyper::Response;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+api_versions!([
+    // WHEN CHANGING THE API (part 1 of 2):
+    //
+    // +- Pick a new semver and define it in the list below.  The list MUST
+    // |  remain sorted, which generally means that your version should go at
+    // |  the very top.
+    // |
+    // |  Duplicate this line, uncomment the *second* copy, update that copy for
+    // |  your new API version, and leave the first copy commented out as an
+    // |  example for the next person.
+    // v
+    // (next_int, IDENT),
+    (1, INITIAL),
+]);
+
+// WHEN CHANGING THE API (part 2 of 2):
+//
+// The call to `api_versions!` above defines constants of type
+// `semver::Version` that you can use in your Dropshot API definition to specify
+// the version when a particular endpoint was added or removed.  For example, if
+// you used:
+//
+//     (1, INITIAL)
+//
+// Then you could use `VERSION_INITIAL` as the version in which endpoints were
+// added or removed.
 
 /// API trait for the downstairs admin server.
 #[dropshot::api_description]

--- a/dropshot-apis/src/main.rs
+++ b/dropshot-apis/src/main.rs
@@ -38,8 +38,8 @@ pub fn all_apis() -> anyhow::Result<ManagedApis> {
     let apis = vec![
         ManagedApiConfig {
             ident: "crucible-agent",
-            versions: Versions::Lockstep {
-                version: semver::Version::new(0, 0, 1),
+            versions: Versions::Versioned {
+                supported_versions: crucible_agent_api::supported_versions(),
             },
             title: "Crucible Agent",
             metadata: ManagedApiMetadata {
@@ -52,8 +52,8 @@ pub fn all_apis() -> anyhow::Result<ManagedApis> {
         },
         ManagedApiConfig {
             ident: "crucible-pantry",
-            versions: Versions::Lockstep {
-                version: semver::Version::new(0, 0, 1),
+            versions: Versions::Versioned {
+                supported_versions: crucible_pantry_api::supported_versions(),
             },
             title: "Crucible Pantry",
             metadata: ManagedApiMetadata {
@@ -66,8 +66,9 @@ pub fn all_apis() -> anyhow::Result<ManagedApis> {
         },
         ManagedApiConfig {
             ident: "downstairs-repair",
-            versions: Versions::Lockstep {
-                version: semver::Version::new(0, 0, 1),
+            versions: Versions::Versioned {
+                supported_versions: crucible_downstairs_api::supported_versions(
+                ),
             },
             title: "Downstairs Repair",
             metadata: ManagedApiMetadata {

--- a/pantry-api/Cargo.toml
+++ b/pantry-api/Cargo.toml
@@ -9,5 +9,6 @@ crucible-client-types.workspace = true
 crucible-pantry-types.workspace = true
 crucible-workspace-hack.workspace = true
 dropshot.workspace = true
+dropshot-api-manager-types.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/pantry-api/src/lib.rs
+++ b/pantry-api/src/lib.rs
@@ -6,8 +6,36 @@ use dropshot::{
     HttpError, HttpResponseDeleted, HttpResponseOk,
     HttpResponseUpdatedNoContent, Path, RequestContext, TypedBody,
 };
+use dropshot_api_manager_types::api_versions;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+api_versions!([
+    // WHEN CHANGING THE API (part 1 of 2):
+    //
+    // +- Pick a new semver and define it in the list below.  The list MUST
+    // |  remain sorted, which generally means that your version should go at
+    // |  the very top.
+    // |
+    // |  Duplicate this line, uncomment the *second* copy, update that copy for
+    // |  your new API version, and leave the first copy commented out as an
+    // |  example for the next person.
+    // v
+    // (next_int, IDENT),
+    (1, INITIAL),
+]);
+
+// WHEN CHANGING THE API (part 2 of 2):
+//
+// The call to `api_versions!` above defines constants of type
+// `semver::Version` that you can use in your Dropshot API definition to specify
+// the version when a particular endpoint was added or removed.  For example, if
+// you used:
+//
+//     (1, INITIAL)
+//
+// Then you could use `VERSION_INITIAL` as the version in which endpoints were
+// added or removed.
 
 #[dropshot::api_description]
 pub trait CruciblePantryApi {


### PR DESCRIPTION
Last part of https://github.com/oxidecomputer/omicron/issues/8922. There are three APIs that are part of the Omicron API dependency graph; make all of them versioned.
