### PR TITLE
Handle errors in get-up-state.sh

### DIFF
--- a/tools/dtrace/get-up-state.sh
+++ b/tools/dtrace/get-up-state.sh
@@ -4,10 +4,10 @@ set -o pipefail
 
 filename='/tmp/get-up-state.out'
 final='/tmp/get-up-state.final'
-rm -f $final
+echo "" > $final
 
 # Gather our output first.
-dtrace -s /opt/oxide/crucible_dtrace/get-up-state.d | awk 'NF' > "$filename"
+dtrace -Z -s /opt/oxide/crucible_dtrace/get-up-state.d | awk 'NF' > "$filename"
 if [[ $? -ne 0 ]]; then
     exit 1
 fi


### PR DESCRIPTION
Fix for https://github.com/oxidecomputer/crucible/issues/1786

Handle errors if no dtrace probes are found in get-up-state.sh