### PR TITLE
Add two repair tests to agent-antagonist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,13 +58,16 @@ name = "agent-antagonist"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "camino-tempfile",
  "clap",
  "crucible-agent-client",
  "crucible-common",
+ "crucible-downstairs",
  "crucible-workspace-hack",
  "futures",
  "futures-core",
  "rand 0.9.2",
+ "repair-client",
  "reqwest",
  "serde",
  "signal-hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ bincode = "1.3"
 byte-unit = "5.1.6"
 bytes = { version = "1", features = ["serde"] }
 camino = { version = "1.1", features = ["serde1"] }
+camino-tempfile = "1.4.1"
 cfg-if = { version = "1" }
 chrono = { version = "0.4", features = [ "serde" ] }
 clap = { version = "4.5", features = ["derive", "env", "wrap_help"] }

--- a/agent-antagonist/Cargo.toml
+++ b/agent-antagonist/Cargo.toml
@@ -7,19 +7,22 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
+camino-tempfile.workspace = true
 clap.workspace = true
 crucible-agent-client.workspace = true
 crucible-common.workspace = true
+crucible-downstairs.workspace = true
 crucible-workspace-hack.workspace = true
 futures-core.workspace = true
 futures.workspace = true
 rand.workspace = true
+repair-client.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 signal-hook-tokio.workspace = true
 signal-hook.workspace = true
-slog.workspace = true
-slog-term.workspace = true
 slog-bunyan.workspace = true
+slog-term.workspace = true
+slog.workspace = true
 tokio.workspace = true
 uuid.workspace = true

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -54,6 +54,8 @@ use region::Region;
 pub use admin::run_dropshot;
 pub use dump::{dump_region, verify_region};
 pub use dynamometer::*;
+pub use extent::extent_path;
+pub use extent::Extent;
 pub use stats::{DsCountStat, DsStatOuter};
 
 /// Single IO operation


### PR DESCRIPTION
Discussing possible causes for the zeroes appearing at the beginning of an extent file (#1788), one theory that came up was that the Extent was being repaired, and those zeroes came from reading the Extent from the repair API, not from the disk itself: only _one_ Region's Extents were bad, not all of them.

In order to test this theory, add two new tests, both of which will contact an Agent to get a Region's details, then use the repair API to read Extent data files and either look for a block of zeroes at the beginning or write that to a temporary file and use the new `Extent::validate` routine.