### PR TITLE
Bump to 2024 edition

### DIFF
--- a/agent-antagonist/Cargo.toml
+++ b/agent-antagonist/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "agent-antagonist"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/agent-antagonist/src/main.rs
+++ b/agent-antagonist/src/main.rs
@@ -1,5 +1,5 @@
-use anyhow::bail;
 use anyhow::Result;
+use anyhow::bail;
 use clap::Parser;
 use crucible_common::build_logger;
 use futures::StreamExt;
@@ -11,14 +11,14 @@ use slog::{info, warn};
 use std::net::SocketAddr;
 use std::process::Command;
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc,
+    atomic::{AtomicBool, Ordering},
 };
 use uuid::Uuid;
 
 use crucible_agent_client::{
-    types::{CreateRegion, RegionId, State as RegionState},
     Client as CrucibleAgentClient,
+    types::{CreateRegion, RegionId, State as RegionState},
 };
 
 #[derive(Debug, Parser)]

--- a/agent-client/Cargo.toml
+++ b/agent-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crucible-agent-client"
 version = "0.0.1"
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow.workspace = true

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crucible-agent"
 version = "0.0.1"
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow.workspace = true

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1,10 +1,10 @@
 // Copyright 2021 Oxide Computer Company
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{Result, anyhow, bail};
 use clap::Parser;
 use crucible_agent_types::smf::SmfProperty;
 use dropshot::{ConfigLogging, ConfigLoggingIfExists, ConfigLoggingLevel};
-use slog::{debug, error, info, o, Logger};
+use slog::{Logger, debug, error, info, o};
 use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
@@ -1195,7 +1195,7 @@ mod test {
     use crate::snapshot_interface::TestSnapshotInterface;
 
     use crucible_agent_types::{region::*, snapshot::*};
-    use slog::{o, Drain, Logger};
+    use slog::{Drain, Logger, o};
     use std::collections::BTreeMap;
     use tempfile::*;
     use uuid::Uuid;

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -1,6 +1,6 @@
 // Copyright 2024 Oxide Computer Company
 use super::datafile::DataFile;
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use crucible_agent_api::*;
 use crucible_agent_types::{region, snapshot};
 use dropshot::{
@@ -8,7 +8,7 @@ use dropshot::{
     HttpResponseDeleted, HttpResponseOk, Path as TypedPath, RequestContext,
     TypedBody, VersionPolicy,
 };
-use slog::{o, Logger};
+use slog::{Logger, o};
 use std::net::SocketAddr;
 use std::result::Result as SResult;
 use std::sync::Arc;

--- a/agent/src/snapshot_interface.rs
+++ b/agent/src/snapshot_interface.rs
@@ -1,8 +1,8 @@
 // Copyright 2023 Oxide Computer Company
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use crucible_agent_types::snapshot::Snapshot;
-use slog::{error, info, Logger};
+use slog::{Logger, error, info};
 #[cfg(test)]
 use std::collections::HashSet;
 use std::process::Command;
@@ -113,9 +113,8 @@ impl SnapshotInterface for ZfsSnapshotInterface {
                 let cmd_stdout = String::from_utf8_lossy(&cmd.stdout);
 
                 // Remove newline
-                let cmd_stdout = cmd_stdout.trim_end().to_string();
 
-                cmd_stdout
+                cmd_stdout.trim_end().to_string()
             };
 
             if !cmd.status.success() {

--- a/cmon/Cargo.toml
+++ b/cmon/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cmon"
 version = "0.1.0"
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 clap.workspace = true

--- a/cmon/src/main.rs
+++ b/cmon/src/main.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::io::{self, BufRead};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 
 use crucible::DtraceInfo;
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -3,7 +3,7 @@ name = "crucible-common"
 version = "0.0.1"
 authors = ["Joshua M. Clulow <jmc@oxide.computer>", "Alan Hanson <alan@oxide.computer>"]
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow.workspace = true

--- a/common/src/impacted_blocks.rs
+++ b/common/src/impacted_blocks.rs
@@ -135,7 +135,7 @@ impl ImpactedBlocks {
     pub fn extents(
         &self,
         ddef: &RegionDefinition,
-    ) -> impl Iterator<Item = ExtentId> {
+    ) -> impl Iterator<Item = ExtentId> + use<'_> {
         let blocks_per_extent = ddef.extent_size().value;
         match self {
             ImpactedBlocks::Empty => None, /* empty range */
@@ -222,7 +222,7 @@ mod test {
     use proptest::prelude::*;
     use std::panic;
     use std::panic::UnwindSafe;
-    use test_strategy::{proptest, Arbitrary};
+    use test_strategy::{Arbitrary, proptest};
 
     fn basic_region_definition(
         extent_size: u32,
@@ -574,8 +574,8 @@ mod test {
 
     /// Generate a random region definition, and a single ImpactedBlocks range
     /// within it.
-    fn region_and_impacted_blocks_strategy(
-    ) -> impl Strategy<Value = (RegionDefinition, ImpactedBlocks)> {
+    fn region_and_impacted_blocks_strategy()
+    -> impl Strategy<Value = (RegionDefinition, ImpactedBlocks)> {
         any::<(ArbitraryRegionDefinition, ArbitraryImpactedBlocks)>().prop_map(
             |(test_ddef, test_iblocks)| {
                 let ddef = reify_region_definition(test_ddef);

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 use ErrorKind::NotFound;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use slog::Drain;
@@ -16,9 +16,9 @@ use tokio::time::Duration;
 
 mod region;
 pub use region::{
-    config_path, Block, BlockIndex, BlockOffset, ExtentId, RegionDefinition,
-    RegionOptions, DATABASE_READ_VERSION, DATABASE_WRITE_VERSION,
-    MAX_BLOCK_SIZE, MAX_SHIFT, MIN_BLOCK_SIZE, MIN_SHIFT,
+    Block, BlockIndex, BlockOffset, DATABASE_READ_VERSION,
+    DATABASE_WRITE_VERSION, ExtentId, MAX_BLOCK_SIZE, MAX_SHIFT,
+    MIN_BLOCK_SIZE, MIN_SHIFT, RegionDefinition, RegionOptions, config_path,
 };
 
 pub mod impacted_blocks;
@@ -225,9 +225,7 @@ pub enum NegotiationError {
     )]
     EncryptionMismatch { expected: bool, actual: bool },
 
-    #[error(
-        "Incompatible read-only settings: wanted {expected}, got {actual}"
-    )]
+    #[error("Incompatible read-only settings: wanted {expected}, got {actual}")]
     ReadOnlyMismatch { expected: bool, actual: bool },
 
     #[error("Incompatible upstairs ID: wanted {expected}, got {actual}")]

--- a/common/src/region.rs
+++ b/common/src/region.rs
@@ -1,5 +1,5 @@
 // Copyright 2021 Oxide Computer Company
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};

--- a/control-client/Cargo.toml
+++ b/control-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crucible-control-client"
 version = "0.0.1"
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow.workspace = true

--- a/crucible-client-types/Cargo.toml
+++ b/crucible-client-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crucible-client-types"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 base64.workspace = true

--- a/crucible-client-types/src/lib.rs
+++ b/crucible-client-types/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 Oxide Computer Company
 
-use base64::{engine, Engine};
+use base64::{Engine, engine};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -29,7 +29,8 @@ pub enum VolumeConstructionRequest {
         blocks_per_extent: u64,
         extent_count: u32,
         opts: CrucibleOpts,
-        gen: u64,
+        #[serde(rename = "gen")]
+        generation: u64,
     },
     File {
         id: Uuid,

--- a/crudd/Cargo.toml
+++ b/crudd/Cargo.toml
@@ -3,7 +3,7 @@ name = "crudd"
 version = "0.1.0"
 authors = ["Artemis Everfree <artemis@oxide.computer>"]
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow.workspace = true

--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -8,7 +8,7 @@ use std::os::unix::io::FromRawFd;
 use std::sync::Arc;
 use std::{cmp, io};
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use clap::Parser;
 use futures::stream::StreamExt;
 use itertools::Itertools;
@@ -41,7 +41,7 @@ pub struct Opt {
 
     /// Generation
     #[clap(short, long, default_value = "0", action)]
-    gen: u64,
+    generation: u64,
 
     /// TLS certificate
     #[clap(long, action)]
@@ -564,7 +564,7 @@ async fn main() -> Result<()> {
     let (guest, io) = Guest::new(None);
     let guest = Arc::new(guest);
 
-    let _join_handle = up_main(crucible_opts, opt.gen, None, io, None)?;
+    let _join_handle = up_main(crucible_opts, opt.generation, None, io, None)?;
     eprintln!("Crucible runtime is spawned");
 
     // IO time
@@ -596,7 +596,10 @@ async fn main() -> Result<()> {
             }
         }
         Err(e) => {
-            eprintln!("Encountered error while performing IO: {}. gracefully cleaning up.", e);
+            eprintln!(
+                "Encountered error while performing IO: {}. gracefully cleaning up.",
+                e
+            );
         }
     };
 

--- a/crutest/Cargo.toml
+++ b/crutest/Cargo.toml
@@ -3,7 +3,7 @@ name = "crutest"
 version = "0.1.0"
 authors = ["Joshua M. Clulow <jmc@oxide.computer>", "Alan Hanson <alan@oxide.computer"]
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow.workspace = true

--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -93,7 +93,7 @@ enum CliCommand {
     Activate {
         /// Specify this generation number to use when requesting activation.
         #[clap(long, short, default_value = "1", action)]
-        gen: u64,
+        generation: u64,
     },
     /// Send an activation message and don't wait for an answer.
     ///
@@ -102,7 +102,7 @@ enum CliCommand {
     ActivateRequest {
         /// Specify this generation number to use when requesting activation.
         #[clap(long, short, default_value = "1", action)]
-        gen: u64,
+        generation: u64,
     },
     /// Commit the current write_log data to the minimum expected counts.
     Commit,
@@ -466,11 +466,11 @@ async fn cmd_to_msg(
     dsc_client: &mut Option<dsc_client::Client>,
 ) -> Result<()> {
     match cmd {
-        CliCommand::Activate { gen } => {
-            fw.send(CliMessage::Activate(gen)).await?;
+        CliCommand::Activate { generation } => {
+            fw.send(CliMessage::Activate(generation)).await?;
         }
-        CliCommand::ActivateRequest { gen } => {
-            fw.send(CliMessage::ActivateRequest(gen)).await?;
+        CliCommand::ActivateRequest { generation } => {
+            fw.send(CliMessage::ActivateRequest(generation)).await?;
         }
         CliCommand::Commit => {
             fw.send(CliMessage::Commit).await?;
@@ -742,16 +742,16 @@ async fn process_cli_command(
     verify_output: Option<PathBuf>,
 ) -> Result<()> {
     match cmd {
-        CliMessage::Activate(gen) => {
-            match volume.activate_with_gen(gen).await {
+        CliMessage::Activate(generation) => {
+            match volume.activate_with_gen(generation).await {
                 Ok(_) => fw.send(CliMessage::DoneOk).await,
                 Err(e) => fw.send(CliMessage::Error(e)).await,
             }
         }
-        CliMessage::ActivateRequest(gen) => {
+        CliMessage::ActivateRequest(generation) => {
             let gc = volume.clone();
             let _handle = tokio::spawn(async move {
-                match gc.activate_with_gen(gen).await {
+                match gc.activate_with_gen(generation).await {
                     Ok(_) => {
                         println!("Activate Successful");
                     }
@@ -901,12 +901,9 @@ async fn process_cli_command(
                      * seems like once we go active we won't need to run
                      * it again.
                      */
-                    if !*wc_filled {
-                        if let Some(vi) = verify_input {
-                            load_write_log(volume, &mut new_di, vi, false)
-                                .await?;
-                            *wc_filled = true;
-                        }
+                    if !*wc_filled && let Some(vi) = verify_input {
+                        load_write_log(volume, &mut new_di, vi, false).await?;
+                        *wc_filled = true;
                     }
                     *di_option = Some(new_di.clone());
                     fw.send(CliMessage::Info(new_di.volume_info)).await

--- a/crutest/src/stats.rs
+++ b/crutest/src/stats.rs
@@ -1,6 +1,6 @@
 // Copyright 2024 Oxide Computer Company
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use omicron_common::api::internal::nexus::ProducerEndpoint;
 use omicron_common::api::internal::nexus::ProducerKind;
 use oximeter_producer::{

--- a/downstairs-api/Cargo.toml
+++ b/downstairs-api/Cargo.toml
@@ -2,8 +2,8 @@
 name = "crucible-downstairs-api"
 version = "0.1.0"
 license = "MPL-2.0"
-edition = "2021"
-rust-version = "1.81"
+edition = "2024"
+rust-version = "1.85"
 
 [dependencies]
 crucible-common.workspace = true

--- a/downstairs-types/Cargo.toml
+++ b/downstairs-types/Cargo.toml
@@ -2,8 +2,8 @@
 name = "crucible-downstairs-types"
 version = "0.1.0"
 license = "MPL-2.0"
-edition = "2021"
-rust-version = "1.81"
+edition = "2024"
+rust-version = "1.85"
 
 [dependencies]
 crucible-common.workspace = true

--- a/downstairs/Cargo.toml
+++ b/downstairs/Cargo.toml
@@ -3,8 +3,8 @@ name = "crucible-downstairs"
 version = "0.0.1"
 authors = ["Joshua M. Clulow <jmc@oxide.computer>", "Alan Hanson <alan@oxide.computer"]
 license = "MPL-2.0"
-edition = "2021"
-rust-version = "1.81"
+edition = "2024"
+rust-version = "1.85"
 
 [dependencies]
 anyhow.workspace = true

--- a/downstairs/src/admin.rs
+++ b/downstairs/src/admin.rs
@@ -58,7 +58,7 @@ impl CrucibleDownstairsAdminApi for CrucibleDownstairsAdminImpl {
                     "must provide all of cert_pem, key_pem, root_cert_pem \
                      if any are provided"
                         .to_owned(),
-                ))
+                ));
             }
         };
 

--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -1045,7 +1045,7 @@ pub fn extent_info(
     println!();
 
     // Calculate extent file layout details using RawLayout
-    use crate::extent_inner_raw::{RawLayout, BLOCK_CONTEXT_SLOT_SIZE_BYTES};
+    use crate::extent_inner_raw::{BLOCK_CONTEXT_SLOT_SIZE_BYTES, RawLayout};
     use crate::extent_inner_raw_common::BLOCK_META_SIZE_BYTES;
 
     let layout = RawLayout::new(def.extent_size());
@@ -1223,17 +1223,12 @@ pub fn extent_info(
         if start_byte == end_byte {
             println!(
                 "Active Context Bits:  0x{:08x} bits {}-{} (0 = Slot A, 1 = Slot B)",
-                active_context_start,
-                start_bit,
-                end_bit
+                active_context_start, start_bit, end_bit
             );
         } else {
             println!(
                 "Active Context Bits:  0x{:08x} bit {} - 0x{:08x} bit {} (0 = Slot A, 1 = Slot B)",
-                active_context_start,
-                start_bit,
-                active_context_end,
-                end_bit
+                active_context_start, start_bit, active_context_end, end_bit
             );
         }
 

--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -3,8 +3,8 @@ use std::convert::TryInto;
 use std::fmt::Debug;
 use std::fs::File;
 
-use anyhow::{anyhow, bail, Result};
-use nix::unistd::{sysconf, SysconfVar};
+use anyhow::{Result, anyhow, bail};
+use nix::unistd::{SysconfVar, sysconf};
 
 use tracing::instrument;
 
@@ -482,7 +482,7 @@ impl Extent {
                         return Err(CrucibleError::IoError(format!(
                             "raw extent {number} has unknown tag {i}"
                         ))
-                        .into())
+                        .into());
                     }
                 }
             }
@@ -505,11 +505,11 @@ impl Extent {
 
     /// Close an extent, returning a tuple of `(gen, flush, dirty)`
     pub fn close(self) -> Result<(u64, u64, bool), CrucibleError> {
-        let gen = self.inner.gen_number().unwrap();
+        let generation = self.inner.gen_number().unwrap();
         let flush = self.inner.flush_number().unwrap();
         let dirty = self.inner.dirty().unwrap();
 
-        Ok((gen, flush, dirty))
+        Ok((generation, flush, dirty))
     }
 
     /// Validates the extent data

--- a/downstairs/src/extent_inner_raw.rs
+++ b/downstairs/src/extent_inner_raw.rs
@@ -1,23 +1,22 @@
 // Copyright 2023 Oxide Computer Company
 use crate::{
-    cdt,
+    Block, CrucibleError, ExtentReadRequest, ExtentReadResponse, ExtentWrite,
+    JobId, RegionDefinition, cdt,
     extent::{
-        check_input, extent_path, DownstairsBlockContext, ExtentInner,
-        EXTENT_META_RAW,
+        DownstairsBlockContext, EXTENT_META_RAW, ExtentInner, check_input,
+        extent_path,
     },
     extent_inner_raw_common::{
-        pread_all, pwrite_all, OnDiskMeta, BLOCK_META_SIZE_BYTES,
+        BLOCK_META_SIZE_BYTES, OnDiskMeta, pread_all, pwrite_all,
     },
     integrity_hash, mkdir_for_file,
     region::JobOrReconciliationId,
-    Block, CrucibleError, ExtentReadRequest, ExtentReadResponse, ExtentWrite,
-    JobId, RegionDefinition,
 };
 use crucible_common::ExtentId;
 use crucible_protocol::ReadBlockContext;
 
 use itertools::Itertools;
-use slog::{error, Logger};
+use slog::{Logger, error};
 
 use std::collections::HashSet;
 use std::fs::{File, OpenOptions};
@@ -27,7 +26,7 @@ use std::path::Path;
 
 // Re-exports
 pub use crucible_raw_extent::{
-    OnDiskDownstairsBlockContext, BLOCK_CONTEXT_SLOT_SIZE_BYTES,
+    BLOCK_CONTEXT_SLOT_SIZE_BYTES, OnDiskDownstairsBlockContext,
 };
 
 /// Number of extra syscalls per read / write that triggers defragmentation
@@ -697,7 +696,7 @@ impl RawInner {
         layout.write_context_slots_contiguous(
             file,
             0,
-            std::iter::repeat(None).take(block_count),
+            std::iter::repeat_n(None, block_count),
             ContextSlot::B,
             0,
         )?;

--- a/downstairs/src/extent_inner_raw_common.rs
+++ b/downstairs/src/extent_inner_raw_common.rs
@@ -1,7 +1,7 @@
 use std::os::fd::AsFd;
 
 // Re-export from `crucible_raw_extent`
-pub use crucible_raw_extent::{OnDiskMeta, BLOCK_META_SIZE_BYTES};
+pub use crucible_raw_extent::{BLOCK_META_SIZE_BYTES, OnDiskMeta};
 
 /// Call `pread` repeatedly to read an entire buffer
 ///

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -1,20 +1,19 @@
 // Copyright 2023 Oxide Computer Company
 use crate::{
-    cdt,
-    extent::{check_input, extent_path, DownstairsBlockContext, ExtentInner},
+    Block, BlockContext, CrucibleError, ExtentReadRequest, ExtentReadResponse,
+    ExtentWrite, JobId, RegionDefinition, cdt,
+    extent::{DownstairsBlockContext, ExtentInner, check_input, extent_path},
     extent_inner_raw_common::pwrite_all,
     integrity_hash,
     region::JobOrReconciliationId,
-    Block, BlockContext, CrucibleError, ExtentReadRequest, ExtentReadResponse,
-    ExtentWrite, JobId, RegionDefinition,
 };
-use crucible_common::{crucible_bail, ExtentId};
+use crucible_common::{ExtentId, crucible_bail};
 use crucible_protocol::{EncryptionContext, ReadBlockContext};
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use itertools::Itertools;
-use rusqlite::{params, Connection, Transaction};
-use slog::{error, Logger};
+use rusqlite::{Connection, Transaction, params};
+use slog::{Logger, error};
 
 use std::collections::{BTreeMap, HashSet};
 use std::fs::{File, OpenOptions};
@@ -668,8 +667,7 @@ impl SqliteMoreInner {
         block: u64,
         count: u64,
     ) -> Result<Vec<Option<DownstairsBlockContext>>, SqliteMoreInnerError> {
-        let stmt =
-            "SELECT block, hash, nonce, tag, on_disk_hash FROM block_context \
+        let stmt = "SELECT block, hash, nonce, tag, on_disk_hash FROM block_context \
              WHERE block BETWEEN ?1 AND ?2";
         let mut stmt = self.metadb.prepare_cached(stmt)?;
 
@@ -785,7 +783,7 @@ impl SqliteMoreInner {
         extent_number: ExtentId,
     ) -> Result<Self> {
         use crate::{
-            extent::{ExtentMeta, EXTENT_META_SQLITE},
+            extent::{EXTENT_META_SQLITE, ExtentMeta},
             mkdir_for_file,
         };
         let mut path = extent_path(dir, extent_number);
@@ -1024,8 +1022,7 @@ impl SqliteMoreInner {
         &self,
         block_context: &DownstairsBlockContext,
     ) -> Result<(), SqliteMoreInnerError> {
-        let stmt =
-            "INSERT OR IGNORE INTO block_context (block, hash, nonce, tag, on_disk_hash) \
+        let stmt = "INSERT OR IGNORE INTO block_context (block, hash, nonce, tag, on_disk_hash) \
              VALUES (?1, ?2, ?3, ?4, ?5)";
 
         let (nonce, tag) = if let Some(encryption_context) =
@@ -1600,8 +1597,8 @@ mod test {
     /// We should never add contexts for blocks that haven't been written by
     /// an upstairs.
     #[test]
-    fn test_fully_rehash_and_clean_does_not_mark_blocks_as_written(
-    ) -> Result<()> {
+    fn test_fully_rehash_and_clean_does_not_mark_blocks_as_written()
+    -> Result<()> {
         let dir = tempdir()?;
         let mut inner = SqliteInner::create(
             dir.as_ref(),
@@ -1697,8 +1694,8 @@ mod test {
     /// but is distinct in that it call fully_rehash directly, without closing
     /// and re-opening the extent.
     #[test]
-    fn test_fully_rehash_marks_blocks_unwritten_if_data_never_hit_disk(
-    ) -> Result<()> {
+    fn test_fully_rehash_marks_blocks_unwritten_if_data_never_hit_disk()
+    -> Result<()> {
         let dir = tempdir()?;
         let mut inner = SqliteInner::create(
             dir.as_ref(),

--- a/downstairs/src/lib.rs
+++ b/downstairs/src/lib.rs
@@ -12,22 +12,21 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crucible_common::{
-    build_logger, integrity_hash, mkdir_for_file, Block, BlockIndex,
-    BlockOffset, CrucibleError, ExtentId, RegionDefinition, VerboseTimeout,
-    MAX_BLOCK_SIZE,
+    Block, BlockIndex, BlockOffset, CrucibleError, ExtentId, MAX_BLOCK_SIZE,
+    RegionDefinition, VerboseTimeout, build_logger, integrity_hash,
+    mkdir_for_file,
 };
 use crucible_protocol::{
-    BlockContext, CrucibleDecoder, JobId, Message, MessageWriter,
-    ReadBlockContext, ReconciliationId, SnapshotDetails,
-    CRUCIBLE_MESSAGE_VERSION,
+    BlockContext, CRUCIBLE_MESSAGE_VERSION, CrucibleDecoder, JobId, Message,
+    MessageWriter, ReadBlockContext, ReconciliationId, SnapshotDetails,
 };
 use repair_client::Client;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use bytes::BytesMut;
 use futures::StreamExt;
 use rand::prelude::*;
-use slog::{debug, error, info, o, warn, Logger};
+use slog::{Logger, debug, error, info, o, warn};
 use tokio::net::TcpListener;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::Instant;
@@ -863,7 +862,7 @@ async fn proc_stream(
 pub struct UpstairsConnection {
     upstairs_id: Uuid,
     session_id: Uuid,
-    gen: u64,
+    generation: u64,
 }
 
 /// Unique ID identifying a single connection
@@ -1728,8 +1727,12 @@ impl ActiveConnection {
                 debug!(
                     self.log,
                     "Flush     :{} extent_limit {:?} deps:{:?} res:{} f:{} g:{}",
-                    job_id, extent_limit, dependencies, result.is_ok(),
-                    flush_number, gen_number,
+                    job_id,
+                    extent_limit,
+                    dependencies,
+                    result.is_ok(),
+                    flush_number,
+                    gen_number,
                 );
 
                 Message::FlushAck {
@@ -2449,8 +2452,8 @@ impl Downstairs {
                     // Compare the new generaion number to what the existing
                     // connection is and take action based on that.
                     match upstairs_connection
-                        .gen
-                        .cmp(&active_upstairs_connection.gen)
+                        .generation
+                        .cmp(&active_upstairs_connection.generation)
                     {
                         Ordering::Less => {
                             // If the new connection has a lower generation
@@ -2458,8 +2461,8 @@ impl Downstairs {
                             // allow it to take over.
                             bail!(
                                 "Current gen {} is > requested gen of {}",
-                                active_upstairs_connection.gen,
-                                upstairs_connection.gen,
+                                active_upstairs_connection.generation,
+                                upstairs_connection.generation,
                             );
                         }
                         Ordering::Equal => {
@@ -2732,7 +2735,7 @@ impl Downstairs {
                 version,
                 upstairs_id,
                 session_id,
-                gen,
+                generation,
                 read_only,
                 encrypted,
                 alternate_versions,
@@ -2817,7 +2820,7 @@ impl Downstairs {
                 let upstairs_connection = UpstairsConnection {
                     upstairs_id,
                     session_id,
-                    gen,
+                    generation,
                 };
 
                 // Steal data from the connection state
@@ -2844,7 +2847,7 @@ impl Downstairs {
             Message::PromoteToActive {
                 upstairs_id,
                 session_id,
-                gen,
+                generation,
             } => {
                 let ConnectionState::Negotiating {
                     negotiated,
@@ -2880,16 +2883,16 @@ impl Downstairs {
                         session_id
                     );
                 } else {
-                    if upstairs_connection.gen != gen {
+                    if upstairs_connection.generation != generation {
                         warn!(
                             self.log,
                             "warning: generation number at negotiation was {} \
                              and {} at activation, updating",
-                            upstairs_connection.gen,
-                            gen,
+                            upstairs_connection.generation,
+                            generation,
                         );
 
-                        // Reborrow to update `upstairs_connection.gen`
+                        // Reborrow to update `upstairs_connection.generation`
                         let ConnectionState::Negotiating {
                             upstairs_connection,
                             ..
@@ -2897,7 +2900,7 @@ impl Downstairs {
                         else {
                             unreachable!()
                         };
-                        upstairs_connection.gen = gen;
+                        upstairs_connection.generation = generation;
                     }
 
                     self.promote_to_active(upstairs_connection, conn_id)?;
@@ -2915,12 +2918,12 @@ impl Downstairs {
                         unreachable!();
                     };
                     *negotiated = NegotiationState::PromotedToActive;
-                    upstairs_connection.gen = gen;
+                    upstairs_connection.generation = generation;
 
                     if let Err(e) = state.reply(Message::YouAreNowActive {
                         upstairs_id,
                         session_id,
-                        gen,
+                        generation,
                     }) {
                         bail!("Failed sending YouAreNewActive: {}", e);
                     }
@@ -3199,7 +3202,7 @@ impl Downstairs {
         if let Err(e) = state.reply(Message::YouAreNoLongerActive {
             new_upstairs_id: new_upstairs_connection.upstairs_id,
             new_session_id: new_upstairs_connection.session_id,
-            new_gen: new_upstairs_connection.gen,
+            new_gen: new_upstairs_connection.generation,
         }) {
             warn!(self.log, "Failed sending YouAreNoLongerActive: {e}");
         }
@@ -3762,7 +3765,7 @@ mod test {
     use bytes::Bytes;
     use rand_chacha::ChaCha20Rng;
     use std::net::Ipv4Addr;
-    use tempfile::{tempdir, TempDir};
+    use tempfile::{TempDir, tempdir};
     use tokio::net::TcpSocket;
 
     // Create a simple logger
@@ -3811,10 +3814,11 @@ mod test {
 
     fn complete(work: &mut Work, ds_id: JobId, job: IOop) {
         // validate that deps are done
-        assert!(job
-            .deps()
-            .iter()
-            .all(|dep| work.completed.is_complete(*dep)));
+        assert!(
+            job.deps()
+                .iter()
+                .all(|dep| work.completed.is_complete(*dep))
+        );
 
         // Flushes and barriers both guarantee that no future jobs will depend
         // on jobs that preceded them, so we reset the completed jobs list to
@@ -3887,7 +3891,7 @@ mod test {
         let upstairs_connection = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 10,
+            generation: 10,
         };
 
         // Dummy connection id
@@ -3982,7 +3986,7 @@ mod test {
         let upstairs_connection = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 10,
+            generation: 10,
         };
 
         // Dummy ConnectionId
@@ -4055,7 +4059,7 @@ mod test {
         let block_size: u64 = 512;
         let extent_size = 4;
         let dir = tempdir()?;
-        let gen = 10;
+        let generation = 10;
 
         let mut ds = create_test_downstairs(block_size, extent_size, 5, &dir)?;
 
@@ -4063,7 +4067,7 @@ mod test {
         let upstairs_connection = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen,
+            generation,
         };
 
         // Dummy ConnectionId
@@ -4081,7 +4085,7 @@ mod test {
             dependencies: vec![],
             extent: ExtentId(1),
             flush_number: 1,
-            gen_number: gen,
+            gen_number: generation,
         };
         ds.active_mut(conn_id).add_work(JobId(1001), rio);
 
@@ -4223,14 +4227,14 @@ mod test {
         let block_size: u64 = 512;
         let extent_size = 4;
         let dir = tempdir()?;
-        let gen = 10;
+        let generation = 10;
 
         let mut ds = create_test_downstairs(block_size, extent_size, 5, &dir)?;
 
         let upstairs_connection = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen,
+            generation,
         };
 
         let conn_id = ConnectionId(0);
@@ -4251,7 +4255,7 @@ mod test {
         let rio = IOop::Flush {
             dependencies: vec![JobId(1000)],
             flush_number: 3,
-            gen_number: gen,
+            gen_number: generation,
             snapshot_details: None,
             extent_limit: None,
         };
@@ -4331,14 +4335,14 @@ mod test {
         let block_size: u64 = 512;
         let extent_size = 4;
         let dir = tempdir()?;
-        let gen = 10;
+        let generation = 10;
 
         let mut ds = create_test_downstairs(block_size, extent_size, 5, &dir)?;
 
         let upstairs_connection = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen,
+            generation,
         };
 
         let conn_id = ConnectionId(0);
@@ -4434,7 +4438,7 @@ mod test {
         let block_size: u64 = 512;
         let extent_size = 4;
         let dir = tempdir()?;
-        let gen = 10;
+        let generation = 10;
 
         let mut ds = create_test_downstairs(block_size, extent_size, 5, &dir)?;
 
@@ -4442,7 +4446,7 @@ mod test {
         let upstairs_connection = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen,
+            generation,
         };
 
         // Dummy ConnectionId
@@ -4464,7 +4468,7 @@ mod test {
             dependencies: vec![JobId(1000)],
             extent: eid,
             flush_number: 3,
-            gen_number: gen,
+            gen_number: generation,
         };
         ds.active_mut(conn_id).add_work(JobId(1001), rio);
 
@@ -4516,7 +4520,7 @@ mod test {
                 assert_eq!(session_id, upstairs_connection.session_id);
                 assert_eq!(job_id, JobId(1001));
                 let (g, f, d) = result.as_ref().unwrap();
-                assert_eq!(*g, gen);
+                assert_eq!(*g, generation);
                 assert_eq!(*f, 3);
                 assert!(!*d);
             }
@@ -4543,13 +4547,13 @@ mod test {
         let block_size: u64 = 512;
         let extent_size = 4;
         let dir = tempdir()?;
-        let gen = 10;
+        let generation = 10;
 
         let mut ds = create_test_downstairs(block_size, extent_size, 5, &dir)?;
         let upstairs_connection = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen,
+            generation,
         };
 
         let conn_id = ConnectionId(0);
@@ -4580,7 +4584,7 @@ mod test {
             dependencies: vec![JobId(1000)],
             extent: eid_one,
             flush_number: 6,
-            gen_number: gen,
+            gen_number: generation,
         };
         ds.active_mut(conn_id).add_work(JobId(1002), rio);
 
@@ -4622,7 +4626,7 @@ mod test {
                 assert_eq!(session_id, upstairs_connection.session_id);
                 assert_eq!(job_id, JobId(1002));
                 let (g, f, d) = result.as_ref().unwrap();
-                assert_eq!(*g, gen);
+                assert_eq!(*g, generation);
                 assert_eq!(*f, 6);
                 assert!(!*d);
             }
@@ -5563,7 +5567,7 @@ mod test {
         let upstairs_connection = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
         };
 
         ds.add_fake_connection(upstairs_connection, ConnectionId(0));
@@ -5581,7 +5585,7 @@ mod test {
         let upstairs_connection = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
         };
 
         ds.add_fake_connection(upstairs_connection, ConnectionId(0));
@@ -5593,8 +5597,8 @@ mod test {
     }
 
     #[test]
-    fn test_promote_to_active_multi_read_write_different_uuid_same_gen(
-    ) -> Result<()> {
+    fn test_promote_to_active_multi_read_write_different_uuid_same_gen()
+    -> Result<()> {
         // Attempting to activate multiple read-write (where it's different
         // Upstairs) but with the same gen should be blocked
         let mut ds = build_test_downstairs(false)?;
@@ -5602,13 +5606,13 @@ mod test {
         let upstairs_connection_1 = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
         };
 
         let upstairs_connection_2 = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
         };
 
         let id1 = ConnectionId(1);
@@ -5638,8 +5642,8 @@ mod test {
     }
 
     #[test]
-    fn test_promote_to_active_multi_read_write_different_uuid_lower_gen(
-    ) -> Result<()> {
+    fn test_promote_to_active_multi_read_write_different_uuid_lower_gen()
+    -> Result<()> {
         // Attempting to activate multiple read-write (where it's different
         // Upstairs) but with a lower gen should be blocked.
         let mut ds = build_test_downstairs(false)?;
@@ -5647,13 +5651,13 @@ mod test {
         let upstairs_connection_1 = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 2,
+            generation: 2,
         };
 
         let upstairs_connection_2 = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
         };
 
         println!("ds1: {:?}", ds);
@@ -5696,13 +5700,13 @@ mod test {
         let upstairs_connection_1 = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
         };
 
         let upstairs_connection_2 = UpstairsConnection {
             upstairs_id: upstairs_connection_1.upstairs_id,
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
         };
 
         let id1 = ConnectionId(1);
@@ -5731,8 +5735,8 @@ mod test {
     }
 
     #[test]
-    fn test_promote_to_active_multi_read_write_same_uuid_larger_gen(
-    ) -> Result<()> {
+    fn test_promote_to_active_multi_read_write_same_uuid_larger_gen()
+    -> Result<()> {
         // Attempting to activate multiple read-write where it's the same
         // Upstairs, but a different session, and with a larger generation
         // should allow the new connection to take over.
@@ -5741,13 +5745,13 @@ mod test {
         let upstairs_connection_1 = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
         };
 
         let upstairs_connection_2 = UpstairsConnection {
             upstairs_id: upstairs_connection_1.upstairs_id,
             session_id: Uuid::new_v4(),
-            gen: 2,
+            generation: 2,
         };
 
         let id1 = ConnectionId(1);
@@ -5783,13 +5787,13 @@ mod test {
         let upstairs_connection_1 = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
         };
 
         let upstairs_connection_2 = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
         };
 
         let id1 = ConnectionId(1);
@@ -5824,13 +5828,13 @@ mod test {
         let upstairs_connection_1 = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
         };
 
         let upstairs_connection_2 = UpstairsConnection {
             upstairs_id: upstairs_connection_1.upstairs_id,
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
         };
 
         let id1 = ConnectionId(1);
@@ -5865,13 +5869,13 @@ mod test {
         let upstairs_connection_1 = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
         };
 
         let upstairs_connection_2 = UpstairsConnection {
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
         };
 
         let id1 = ConnectionId(1);
@@ -5977,7 +5981,7 @@ mod test {
             version: CRUCIBLE_MESSAGE_VERSION,
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
             read_only: false,
             encrypted: false,
             alternate_versions: Vec::new(),
@@ -6015,7 +6019,7 @@ mod test {
             version: CRUCIBLE_MESSAGE_VERSION - 1,
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
             read_only: false,
             encrypted: false,
             alternate_versions: vec![CRUCIBLE_MESSAGE_VERSION - 1],
@@ -6049,7 +6053,7 @@ mod test {
             version: CRUCIBLE_MESSAGE_VERSION + 1,
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
             read_only: false,
             encrypted: false,
             alternate_versions: vec![CRUCIBLE_MESSAGE_VERSION + 1],
@@ -6083,7 +6087,7 @@ mod test {
             version: CRUCIBLE_MESSAGE_VERSION + 1,
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
             read_only: false,
             encrypted: false,
             alternate_versions: vec![
@@ -6124,7 +6128,7 @@ mod test {
             version: CRUCIBLE_MESSAGE_VERSION + 4,
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
             read_only: false,
             encrypted: false,
             alternate_versions: vec![
@@ -6231,7 +6235,7 @@ mod test {
             version: CRUCIBLE_MESSAGE_VERSION,
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 1,
+            generation: 1,
             read_only: false,
             encrypted: false,
             alternate_versions: Vec::new(),

--- a/downstairs/src/main.rs
+++ b/downstairs/src/main.rs
@@ -3,17 +3,17 @@ use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::time::Duration;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use clap::Parser;
 use slog::info;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use uuid::Uuid;
 
-use crucible_common::{build_logger, ExtentId};
+use crucible_common::{ExtentId, build_logger};
 use crucible_downstairs::admin::*;
 use crucible_downstairs::*;
-use crucible_protocol::{JobId, CRUCIBLE_MESSAGE_VERSION};
+use crucible_protocol::{CRUCIBLE_MESSAGE_VERSION, JobId};
 
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/downstairs/src/repair.rs
+++ b/downstairs/src/repair.rs
@@ -11,7 +11,7 @@ use dropshot::{
 use hyper::{Response, StatusCode};
 
 use super::*;
-use crate::extent::{extent_dir, extent_file_name, extent_path, ExtentType};
+use crate::extent::{ExtentType, extent_dir, extent_file_name, extent_path};
 
 /**
  * Our context is the root of the region we want to serve.

--- a/downstairs/src/stats.rs
+++ b/downstairs/src/stats.rs
@@ -5,8 +5,8 @@ use super::*;
 use omicron_common::api::internal::nexus::ProducerEndpoint;
 use omicron_common::api::internal::nexus::ProducerKind;
 use oximeter::{
-    types::{Cumulative, Sample},
     Metric, MetricsError, Producer, Target,
+    types::{Cumulative, Sample},
 };
 use oximeter_producer::{
     Config, ConfigLogging, ConfigLoggingIfExists, ConfigLoggingLevel,

--- a/dsc-client/Cargo.toml
+++ b/dsc-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dsc-client"
 version = "0.0.1"
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow.workspace = true

--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dsc"
 version = "0.1.0"
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow.workspace = true

--- a/dsc/src/control.rs
+++ b/dsc/src/control.rs
@@ -1,5 +1,4 @@
 // Copyright 2022 Oxide Computer Company
-use dropshot::endpoint;
 use dropshot::ApiDescription;
 use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
@@ -9,6 +8,7 @@ use dropshot::HttpError;
 use dropshot::HttpServerStarter;
 use dropshot::Path;
 use dropshot::RequestContext;
+use dropshot::endpoint;
 use dropshot::{HttpResponseOk, HttpResponseUpdatedNoContent};
 use schemars::JsonSchema;
 use serde::Deserialize;

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use byte_unit::Byte;
 use clap::{Parser, Subcommand};
 use csv::WriterBuilder;
@@ -18,15 +18,15 @@ use serde::Deserialize;
 use serde::Serialize;
 use tokio::process::{Child, Command};
 use tokio::runtime::Builder;
-use tokio::sync::{mpsc, watch, Mutex};
-use tokio::time::{sleep_until, Duration, Instant};
+use tokio::sync::{Mutex, mpsc, watch};
+use tokio::time::{Duration, Instant, sleep_until};
 use uuid::Uuid;
 
 pub mod client;
 pub mod control;
-use client::{client_main, ClientCommand};
+use client::{ClientCommand, client_main};
 use crucible_client_types::RegionExtentInfo;
-use crucible_common::{config_path, read_json, RegionDefinition};
+use crucible_common::{RegionDefinition, config_path, read_json};
 
 /// dsc  DownStairs Controller
 #[derive(Debug, Parser)]
@@ -1654,7 +1654,7 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use tempfile::{tempdir, NamedTempFile};
+    use tempfile::{NamedTempFile, tempdir};
 
     // Create a temporary file.  Close the file but return the path
     // so it won't be deleted.

--- a/hammer/Cargo.toml
+++ b/hammer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crucible-hammer"
 version = "0.1.0"
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -2,7 +2,7 @@
 
 use std::net::SocketAddr;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use clap::Parser;
 use uuid::Uuid;
 
@@ -38,7 +38,7 @@ pub struct Opt {
     key: Option<String>,
 
     #[clap(short, long, default_value = "1", action)]
-    gen: u64,
+    generation: u64,
 
     /*
      * Number of upstairs to sequentially activate and handoff to
@@ -121,8 +121,9 @@ async fn main() -> Result<()> {
          */
         let (guest, io) = Guest::new(None);
 
-        let gen: u64 = i as u64 + opt.gen;
-        let _join_handle = up_main(crucible_opts.clone(), gen, None, io, None)?;
+        let generation: u64 = i as u64 + opt.generation;
+        let _join_handle =
+            up_main(crucible_opts.clone(), generation, None, io, None)?;
         println!("Crucible runtime is spawned");
 
         cpfs.push(crucible::CruciblePseudoFile::from(guest)?);

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "James MacMahon <james@oxide.computer>"
 ]
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -8,7 +8,7 @@ mod integration_tests {
     use std::sync::Arc;
 
     use anyhow::*;
-    use base64::{engine, Engine};
+    use base64::{Engine, engine};
     use crucible::volume::VolumeBuilder;
     use crucible::*;
     use crucible_client_types::RegionExtentInfo;
@@ -16,10 +16,10 @@ mod integration_tests {
     use crucible_downstairs::*;
     use crucible_pantry::pantry::Pantry;
     use crucible_pantry_client::Client as CruciblePantryClient;
-    use httptest::{matchers::*, responders::*, Expectation, Server};
+    use httptest::{Expectation, Server, matchers::*, responders::*};
     use repair_client::Client;
     use sha2::Digest;
-    use slog::{info, o, warn, Drain, Logger};
+    use slog::{Drain, Logger, info, o, warn};
     use tempfile::*;
     use tokio::sync::mpsc;
     use uuid::*;
@@ -351,14 +351,14 @@ mod integration_tests {
 
     impl<T: TestDownstairsDataset> Drop for TestDownstairs<T> {
         fn drop(&mut self) {
-            if self.dataset.stop_downstairs_during_drop() {
-                if let Some(downstairs) = self.downstairs.take() {
-                    tokio::task::block_in_place(move || {
-                        tokio::runtime::Handle::current()
-                            .block_on(async move { downstairs.stop().await })
-                            .unwrap();
-                    });
-                }
+            if self.dataset.stop_downstairs_during_drop()
+                && let Some(downstairs) = self.downstairs.take()
+            {
+                tokio::task::block_in_place(move || {
+                    tokio::runtime::Handle::current()
+                        .block_on(async move { downstairs.stop().await })
+                        .unwrap();
+                });
             }
         }
     }
@@ -744,7 +744,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts,
-                gen: 1,
+                generation: 1,
             }],
             read_only_parent: None,
         };
@@ -793,7 +793,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts,
-                gen: 1,
+                generation: 1,
             }],
             read_only_parent: None,
         };
@@ -849,7 +849,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts,
-                gen: 1,
+                generation: 1,
             }],
             read_only_parent: None,
         };
@@ -1000,7 +1000,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts,
-                gen: 1,
+                generation: 1,
             }],
             read_only_parent: None,
         };
@@ -1080,7 +1080,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts,
-                gen: 1,
+                generation: 1,
             }],
             read_only_parent: Some(Box::new(
                 VolumeConstructionRequest::Volume {
@@ -1139,7 +1139,7 @@ mod integration_tests {
                     blocks_per_extent: tds.blocks_per_extent(),
                     extent_count: tds.extent_count(),
                     opts,
-                    gen: 1,
+                    generation: 1,
                 },
             )),
         };
@@ -1183,7 +1183,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts,
-                gen: 1,
+                generation: 1,
             }],
             read_only_parent: None,
         };
@@ -1249,7 +1249,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts,
-                gen: 1,
+                generation: 1,
             }],
             read_only_parent: None,
         };
@@ -1317,7 +1317,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts,
-                gen: 1,
+                generation: 1,
             }],
             read_only_parent: None,
         };
@@ -1382,7 +1382,7 @@ mod integration_tests {
             blocks_per_extent: tds1.blocks_per_extent(),
             extent_count: tds1.extent_count(),
             opts,
-            gen: 1,
+            generation: 1,
         });
         let tds2 = DefaultTestDownstairsSet::small(false).await?;
         let opts = tds2.opts();
@@ -1391,7 +1391,7 @@ mod integration_tests {
             blocks_per_extent: tds2.blocks_per_extent(),
             extent_count: tds2.extent_count(),
             opts,
-            gen: 1,
+            generation: 1,
         });
 
         let vcr = VolumeConstructionRequest::Volume {
@@ -1439,8 +1439,8 @@ mod integration_tests {
     }
 
     #[tokio::test]
-    async fn integration_test_volume_write_unwritten_subvols_sparse(
-    ) -> Result<()> {
+    async fn integration_test_volume_write_unwritten_subvols_sparse()
+    -> Result<()> {
         // Test a single layer volume with two subvolumes,
         // verify a first write_unwritten that crosses the subvols
         // works as expected.
@@ -1464,7 +1464,7 @@ mod integration_tests {
             blocks_per_extent: tds1.blocks_per_extent(),
             extent_count: tds1.extent_count(),
             opts,
-            gen: 1,
+            generation: 1,
         });
         let tds2 = DefaultTestDownstairsSet::small(false).await?;
         let opts = tds2.opts();
@@ -1473,7 +1473,7 @@ mod integration_tests {
             blocks_per_extent: tds2.blocks_per_extent(),
             extent_count: tds2.extent_count(),
             opts,
-            gen: 1,
+            generation: 1,
         });
 
         let vcr = VolumeConstructionRequest::Volume {
@@ -1565,7 +1565,7 @@ mod integration_tests {
             blocks_per_extent: tds1.blocks_per_extent(),
             extent_count: tds1.extent_count(),
             opts,
-            gen: 1,
+            generation: 1,
         });
         let tds2 = DefaultTestDownstairsSet::small(false).await?;
         let opts = tds2.opts();
@@ -1574,7 +1574,7 @@ mod integration_tests {
             blocks_per_extent: tds2.blocks_per_extent(),
             extent_count: tds2.extent_count(),
             opts,
-            gen: 1,
+            generation: 1,
         });
 
         let vcr = VolumeConstructionRequest::Volume {
@@ -2112,7 +2112,7 @@ mod integration_tests {
             blocks_per_extent: tds1.blocks_per_extent(),
             extent_count: tds1.extent_count(),
             opts,
-            gen: 1,
+            generation: 1,
         });
         let tds2 = DefaultTestDownstairsSet::small(false).await?;
         let opts = tds2.opts();
@@ -2121,7 +2121,7 @@ mod integration_tests {
             blocks_per_extent: tds2.blocks_per_extent(),
             extent_count: tds2.extent_count(),
             opts,
-            gen: 1,
+            generation: 1,
         });
 
         let vcr = VolumeConstructionRequest::Volume {
@@ -2192,8 +2192,8 @@ mod integration_tests {
     }
 
     #[tokio::test]
-    async fn integration_test_volume_subvols_parent_scrub_sparse_2(
-    ) -> Result<()> {
+    async fn integration_test_volume_subvols_parent_scrub_sparse_2()
+    -> Result<()> {
         // Test a volume with two sub volumes, and 3/4th RO parent
         // Write a few spots, one spanning the sub vols.
         // Verify scrubber and everything works as expected.
@@ -2236,7 +2236,7 @@ mod integration_tests {
             blocks_per_extent: tds1.blocks_per_extent(),
             extent_count: tds1.extent_count(),
             opts,
-            gen: 1,
+            generation: 1,
         });
         let tds2 = DefaultTestDownstairsSet::small(false).await?;
         let opts = tds2.opts();
@@ -2245,7 +2245,7 @@ mod integration_tests {
             blocks_per_extent: tds2.blocks_per_extent(),
             extent_count: tds2.extent_count(),
             opts,
-            gen: 1,
+            generation: 1,
         });
 
         let vcr = VolumeConstructionRequest::Volume {
@@ -2348,7 +2348,7 @@ mod integration_tests {
                     blocks_per_extent: tds.blocks_per_extent(),
                     extent_count: tds.extent_count(),
                     opts: opts.clone(),
-                    gen: 1,
+                    generation: 1,
                 },
             )),
         };
@@ -2366,7 +2366,7 @@ mod integration_tests {
                     blocks_per_extent: tds.blocks_per_extent(),
                     extent_count: tds.extent_count(),
                     opts,
-                    gen: 1,
+                    generation: 1,
                 },
             )),
         };
@@ -2532,13 +2532,15 @@ mod integration_tests {
 
             assert_eq!(&buffer[..], random_buffer);
 
-            assert!(volume
-                .write(
-                    BlockIndex(0),
-                    BytesMut::from(vec![0u8; BLOCK_SIZE].as_slice()),
-                )
-                .await
-                .is_err());
+            assert!(
+                volume
+                    .write(
+                        BlockIndex(0),
+                        BytesMut::from(vec![0u8; BLOCK_SIZE].as_slice()),
+                    )
+                    .await
+                    .is_err()
+            );
 
             volume.flush(None).await?;
         }
@@ -2557,7 +2559,7 @@ mod integration_tests {
                 blocks_per_extent: top_layer_tds.blocks_per_extent(),
                 extent_count: top_layer_tds.extent_count(),
                 opts: top_layer_opts,
-                gen: 3,
+                generation: 3,
             }],
             read_only_parent: Some(Box::new(
                 VolumeConstructionRequest::Volume {
@@ -2569,7 +2571,7 @@ mod integration_tests {
                             .blocks_per_extent(),
                         extent_count: test_downstairs_set.extent_count(),
                         opts: bottom_layer_opts,
-                        gen: 3,
+                        generation: 3,
                     }],
                     read_only_parent: None,
                 },
@@ -2628,12 +2630,14 @@ mod integration_tests {
             DefaultTestDownstairsSet::small_sqlite(false).await?;
 
         // This must be a SQLite extent!
-        assert!(test_downstairs_set
-            .downstairs1
-            .path()
-            .unwrap()
-            .join("00/000/000.db")
-            .exists());
+        assert!(
+            test_downstairs_set
+                .downstairs1
+                .path()
+                .unwrap()
+                .join("00/000/000.db")
+                .exists()
+        );
 
         let mut builder = VolumeBuilder::new(BLOCK_SIZE as u64, csl());
         builder
@@ -2670,12 +2674,14 @@ mod integration_tests {
         test_downstairs_set.reboot_read_only().await?;
 
         // This must still be a SQLite backend!
-        assert!(test_downstairs_set
-            .downstairs1
-            .path()
-            .unwrap()
-            .join("00/000/000.db")
-            .exists());
+        assert!(
+            test_downstairs_set
+                .downstairs1
+                .path()
+                .unwrap()
+                .join("00/000/000.db")
+                .exists()
+        );
 
         // Validate that this now accepts reads and flushes, but rejects writes
         {
@@ -2704,13 +2710,15 @@ mod integration_tests {
 
             assert_eq!(&buffer[..], random_buffer);
 
-            assert!(volume
-                .write(
-                    BlockIndex(0),
-                    BytesMut::from(vec![0u8; BLOCK_SIZE].as_slice()),
-                )
-                .await
-                .is_err());
+            assert!(
+                volume
+                    .write(
+                        BlockIndex(0),
+                        BytesMut::from(vec![0u8; BLOCK_SIZE].as_slice()),
+                    )
+                    .await
+                    .is_err()
+            );
 
             volume.flush(None).await?;
         }
@@ -2722,12 +2730,14 @@ mod integration_tests {
         let bottom_layer_opts = test_downstairs_set.opts();
 
         // The new volume is **not** using the SQLite backend!
-        assert!(!top_layer_tds
-            .downstairs1
-            .path()
-            .unwrap()
-            .join("00/000/000.db")
-            .exists());
+        assert!(
+            !top_layer_tds
+                .downstairs1
+                .path()
+                .unwrap()
+                .join("00/000/000.db")
+                .exists()
+        );
 
         let vcr = VolumeConstructionRequest::Volume {
             id: Uuid::new_v4(),
@@ -2737,7 +2747,7 @@ mod integration_tests {
                 blocks_per_extent: top_layer_tds.blocks_per_extent(),
                 extent_count: top_layer_tds.extent_count(),
                 opts: top_layer_opts,
-                gen: 3,
+                generation: 3,
             }],
             read_only_parent: Some(Box::new(
                 VolumeConstructionRequest::Volume {
@@ -2749,7 +2759,7 @@ mod integration_tests {
                             .blocks_per_extent(),
                         extent_count: test_downstairs_set.extent_count(),
                         opts: bottom_layer_opts,
-                        gen: 3,
+                        generation: 3,
                     }],
                     read_only_parent: None,
                 },
@@ -2805,12 +2815,14 @@ mod integration_tests {
         let mut test_downstairs_set =
             DefaultTestDownstairsSet::small_sqlite(false).await?;
         // This must be a SQLite extent!
-        assert!(test_downstairs_set
-            .downstairs1
-            .path()
-            .unwrap()
-            .join("00/000/000.db")
-            .exists());
+        assert!(
+            test_downstairs_set
+                .downstairs1
+                .path()
+                .unwrap()
+                .join("00/000/000.db")
+                .exists()
+        );
 
         let mut builder = VolumeBuilder::new(BLOCK_SIZE as u64, csl());
         builder
@@ -2845,21 +2857,25 @@ mod integration_tests {
         drop(volume);
 
         // This must still be a SQLite extent!
-        assert!(test_downstairs_set
-            .downstairs1
-            .path()
-            .unwrap()
-            .join("00/000/000.db")
-            .exists());
+        assert!(
+            test_downstairs_set
+                .downstairs1
+                .path()
+                .unwrap()
+                .join("00/000/000.db")
+                .exists()
+        );
 
         test_downstairs_set.reboot_read_write().await?;
         // This should now be migrated, and the DB file should be deleted
-        assert!(!test_downstairs_set
-            .downstairs1
-            .path()
-            .unwrap()
-            .join("00/000/000.db")
-            .exists());
+        assert!(
+            !test_downstairs_set
+                .downstairs1
+                .path()
+                .unwrap()
+                .join("00/000/000.db")
+                .exists()
+        );
 
         let mut builder = VolumeBuilder::new(BLOCK_SIZE as u64, csl());
         builder
@@ -3060,12 +3076,14 @@ mod integration_tests {
             DefaultTestDownstairsSet::small_sqlite(false).await?;
 
         // This must be a SQLite extent!
-        assert!(test_downstairs_set
-            .downstairs1
-            .path()
-            .unwrap()
-            .join("00/000/000.db")
-            .exists());
+        assert!(
+            test_downstairs_set
+                .downstairs1
+                .path()
+                .unwrap()
+                .join("00/000/000.db")
+                .exists()
+        );
 
         let mut builder = VolumeBuilder::new(BLOCK_SIZE as u64, csl());
         builder
@@ -3794,8 +3812,8 @@ mod integration_tests {
     }
 
     #[tokio::test]
-    async fn integration_test_volume_replace_downstairs_then_takeover(
-    ) -> Result<()> {
+    async fn integration_test_volume_replace_downstairs_then_takeover()
+    -> Result<()> {
         let log = csl();
         // Replace a downstairs with a new one which will kick off
         // LiveRepair. Then spin up a new Upstairs with a newer
@@ -4515,8 +4533,8 @@ mod integration_tests {
     }
 
     #[tokio::test]
-    async fn integration_test_guest_downstairs_unwritten_sparse_mid(
-    ) -> Result<()> {
+    async fn integration_test_guest_downstairs_unwritten_sparse_mid()
+    -> Result<()> {
         // Test using the guest layer to verify a new region is
         // what we expect, and a write_unwritten and read work as expected,
         // this time with sparse writes where the middle block is written
@@ -4572,8 +4590,8 @@ mod integration_tests {
     }
 
     #[tokio::test]
-    async fn integration_test_guest_downstairs_unwritten_sparse_end(
-    ) -> Result<()> {
+    async fn integration_test_guest_downstairs_unwritten_sparse_end()
+    -> Result<()> {
         // Test write_unwritten and read work as expected,
         // this time with sparse writes where the last block is written
         const BLOCK_SIZE: usize = 512;
@@ -4821,7 +4839,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts: opts.clone(),
-                gen: 1,
+                generation: 1,
             }],
             read_only_parent: None,
         };
@@ -4924,7 +4942,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts: opts.clone(),
-                gen: 2,
+                generation: 2,
             }],
             read_only_parent: None,
         };
@@ -5024,7 +5042,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts: opts.clone(),
-                gen: 1,
+                generation: 1,
             }],
             read_only_parent: None,
         };
@@ -5077,7 +5095,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts,
-                gen: 3,
+                generation: 3,
             }],
             read_only_parent: None,
         };
@@ -5161,7 +5179,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts,
-                gen: 2,
+                generation: 2,
             }],
             read_only_parent: None,
         };
@@ -5220,7 +5238,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts,
-                gen: 2,
+                generation: 2,
             }],
             read_only_parent: None,
         };
@@ -5356,7 +5374,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts: opts.clone(),
-                gen: 1,
+                generation: 1,
             }],
             read_only_parent: read_only_parent.clone(),
         };
@@ -5398,7 +5416,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts: opts.clone(),
-                gen: 2,
+                generation: 2,
             }],
             read_only_parent,
         };
@@ -5447,7 +5465,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts,
-                gen: 3,
+                generation: 3,
             }],
             read_only_parent: None,
         };
@@ -5925,7 +5943,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts: opts.clone(),
-                gen: 2,
+                generation: 2,
             }],
             read_only_parent: None,
         };
@@ -5969,7 +5987,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts: new_opts.clone(),
-                gen: 3,
+                generation: 3,
             }],
             read_only_parent: None,
         };
@@ -6003,7 +6021,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts: opts.clone(),
-                gen: 1,
+                generation: 1,
             }],
             read_only_parent: None,
         };
@@ -6044,7 +6062,7 @@ mod integration_tests {
             blocks_per_extent: tds.blocks_per_extent(),
             extent_count: tds.extent_count(),
             opts: opts.clone(),
-            gen: 2,
+            generation: 2,
         });
 
         let new_sub_vol = vec![VolumeConstructionRequest::Region {
@@ -6052,7 +6070,7 @@ mod integration_tests {
             blocks_per_extent: sv_tds.blocks_per_extent(),
             extent_count: sv_tds.extent_count(),
             opts: sv_opts.clone(),
-            gen: 1,
+            generation: 1,
         }];
 
         let new_vol = VolumeConstructionRequest::Volume {
@@ -6081,7 +6099,7 @@ mod integration_tests {
             blocks_per_extent: tds.blocks_per_extent(),
             extent_count: tds.extent_count(),
             opts: new_opts.clone(),
-            gen: 3,
+            generation: 3,
         });
 
         // Our "new" VCR must have a new downstairs in the opts, and have
@@ -6143,7 +6161,7 @@ mod integration_tests {
                 blocks_per_extent: tds.blocks_per_extent(),
                 extent_count: tds.extent_count(),
                 opts,
-                gen: 2,
+                generation: 2,
             }],
             read_only_parent: None,
         };
@@ -6179,7 +6197,7 @@ mod integration_tests {
                 blocks_per_extent: child.blocks_per_extent(),
                 extent_count: child.extent_count(),
                 opts: child.opts(),
-                gen: 2,
+                generation: 2,
             }],
             read_only_parent: None,
         };
@@ -6217,7 +6235,7 @@ mod integration_tests {
                 blocks_per_extent: child.blocks_per_extent(),
                 extent_count: child.extent_count(),
                 opts: child.opts(),
-                gen: 2,
+                generation: 2,
             }],
             read_only_parent: None,
         };

--- a/measure_iops/Cargo.toml
+++ b/measure_iops/Cargo.toml
@@ -2,7 +2,7 @@
 name = "measure-iops"
 version = "0.0.1"
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow.workspace = true

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -3,7 +3,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use clap::Parser;
 use rand::Rng;
 use tokio::time::{Duration, Instant};
@@ -22,7 +22,7 @@ pub struct Opt {
     key: Option<String>,
 
     #[clap(short, long, default_value = "0", action)]
-    gen: u64,
+    generation: u64,
 
     #[clap(long, action)]
     cert_pem: Option<String>,
@@ -82,7 +82,7 @@ async fn main() -> Result<()> {
     let (guest, io) = Guest::new(None);
     let guest = Arc::new(guest);
 
-    let _join_handle = up_main(crucible_opts, opt.gen, None, io, None)?;
+    let _join_handle = up_main(crucible_opts, opt.generation, None, io, None)?;
     println!("Crucible runtime is spawned");
 
     guest.activate().await?;

--- a/nbd_server/Cargo.toml
+++ b/nbd_server/Cargo.toml
@@ -3,7 +3,7 @@ name = "crucible-nbd-server"
 version = "0.1.0"
 authors = ["Joshua M. Clulow <jmc@oxide.computer>", "Alan Hanson <alan@oxide.computer>", "James MacMahon <james@oxide.computer>"]
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow.workspace = true

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -1,12 +1,12 @@
 // Copyright 2021 Oxide Computer Company
 use std::net::SocketAddr;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use clap::Parser;
 
 use crucible::*;
 
-use nbd::server::{handshake, transmission, Export};
+use nbd::server::{Export, handshake, transmission};
 use std::net::{TcpListener, TcpStream as NetTcpStream};
 
 /*
@@ -38,7 +38,7 @@ pub struct Opt {
     key: Option<String>,
 
     #[clap(short, long, default_value = "0", action)]
-    gen: u64,
+    generation: u64,
 
     // TLS options
     #[clap(long, action)]
@@ -92,7 +92,7 @@ async fn main() -> Result<()> {
      */
     let (guest, io) = Guest::new(None);
 
-    let _join_handle = up_main(crucible_opts, opt.gen, None, io, None)?;
+    let _join_handle = up_main(crucible_opts, opt.generation, None, io, None)?;
     println!("Crucible runtime is spawned");
 
     // NBD server

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crucible-package"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow.workspace = true

--- a/pantry-api/Cargo.toml
+++ b/pantry-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crucible-pantry-api"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
 [dependencies]

--- a/pantry-client/Cargo.toml
+++ b/pantry-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crucible-pantry-client"
 version = "0.0.1"
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow.workspace = true

--- a/pantry-types/Cargo.toml
+++ b/pantry-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crucible-pantry-types"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
 [dependencies]

--- a/pantry/Cargo.toml
+++ b/pantry/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crucible-pantry"
 version = "0.0.1"
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow.workspace = true

--- a/pantry/src/lib.rs
+++ b/pantry/src/lib.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use dropshot::{ConfigLogging, ConfigLoggingIfExists, ConfigLoggingLevel};
-use slog::{info, o, Logger};
+use slog::{Logger, info, o};
 
 pub const PROG: &str = "crucible-pantry";
 

--- a/pantry/src/main.rs
+++ b/pantry/src/main.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 Oxide Computer Company
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use clap::Parser;
 use std::net::SocketAddr;
 

--- a/pantry/src/pantry.rs
+++ b/pantry/src/pantry.rs
@@ -6,16 +6,16 @@ use std::future::Future;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use anyhow::anyhow;
 use anyhow::Result;
+use anyhow::anyhow;
 use bytes::{Bytes, BytesMut};
 use dropshot::HttpError;
 use sha2::Digest;
 use sha2::Sha256;
+use slog::Logger;
 use slog::error;
 use slog::info;
 use slog::o;
-use slog::Logger;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use uuid::Uuid;
@@ -25,8 +25,8 @@ use crucible::ReplaceResult;
 use crucible::SnapshotDetails;
 use crucible::Volume;
 use crucible::VolumeConstructionRequest;
-use crucible_common::crucible_bail;
 use crucible_common::CrucibleError;
+use crucible_common::crucible_bail;
 use crucible_pantry_types::{ExpectedDigest, PantryStatus, VolumeStatus};
 
 pub enum ActiveObservation {

--- a/pantry/src/server.rs
+++ b/pantry/src/server.rs
@@ -4,8 +4,8 @@ use super::pantry::Pantry;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
-use base64::{engine, Engine};
+use anyhow::{Result, anyhow};
+use base64::{Engine, engine};
 use crucible_pantry_api::*;
 use crucible_pantry_types::*;
 use dropshot::{
@@ -13,7 +13,7 @@ use dropshot::{
     HttpResponseDeleted, HttpResponseOk, HttpResponseUpdatedNoContent,
     Path as TypedPath, RequestContext, TypedBody, VersionPolicy,
 };
-use slog::{info, o, Logger};
+use slog::{Logger, info, o};
 use std::result::Result as SResult;
 
 #[derive(Debug)]

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -3,7 +3,7 @@ name = "crucible-protocol"
 version = "0.0.0"
 authors = ["Joshua M. Clulow <jmc@oxide.computer>"]
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow.workspace = true

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -248,7 +248,7 @@ pub enum Message {
         // The unique UUID just for this running upstairs session
         session_id: Uuid,
         // Generation number (IGNORED)
-        gen: u64,
+        generation: u64,
         // If we expect the region to be read-only.
         read_only: bool,
         // If we expect the region to be  encrypted.
@@ -291,12 +291,12 @@ pub enum Message {
     PromoteToActive {
         upstairs_id: Uuid,
         session_id: Uuid,
-        gen: u64,
+        generation: u64,
     },
     YouAreNowActive {
         upstairs_id: Uuid,
         session_id: Uuid,
-        gen: u64,
+        generation: u64,
     },
     YouAreNoLongerActive {
         new_upstairs_id: Uuid,
@@ -1142,7 +1142,7 @@ mod tests {
             version: 2,
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 123,
+            generation: 123,
             read_only: false,
             encrypted: true,
             alternate_versions: Vec::new(),
@@ -1213,7 +1213,7 @@ mod tests {
             version: 0,
             upstairs_id: Uuid::new_v4(),
             session_id: Uuid::new_v4(),
-            gen: 23849183,
+            generation: 23849183,
             read_only: true,
             encrypted: false,
             alternate_versions: Vec::new(),
@@ -1285,7 +1285,7 @@ mod tests {
             version: 123,
             upstairs_id,
             session_id,
-            gen: 567,
+            generation: 567,
             read_only: true,
             encrypted: false,
             alternate_versions: vec![8, 9],

--- a/repair-client/Cargo.toml
+++ b/repair-client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "repair-client"
 version = "0.0.1"
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow.workspace = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
 max_width = 80
-edition = "2021"
+edition = "2024"

--- a/smf/Cargo.toml
+++ b/smf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crucible-smf"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 libc.workspace = true

--- a/smf/src/instance.rs
+++ b/smf/src/instance.rs
@@ -5,8 +5,8 @@ use std::ptr::NonNull;
 
 use super::scf_sys::*;
 use super::{
-    buf_for, str_from, Iter, PropertyGroup, PropertyGroups, Result, Scf,
-    ScfError, Service, Snapshot, Snapshots,
+    Iter, PropertyGroup, PropertyGroups, Result, Scf, ScfError, Service,
+    Snapshot, Snapshots, buf_for, str_from,
 };
 
 #[derive(Debug)]

--- a/smf/src/lib.rs
+++ b/smf/src/lib.rs
@@ -97,8 +97,8 @@ pub enum ScfError {
 
 impl From<u32> for ScfError {
     fn from(error: u32) -> Self {
-        use scf_error_t::*;
         use ScfError::*;
+        use scf_error_t::*;
 
         match scf_error_t::from_u32(error) {
             Some(SCF_ERROR_NONE) => None,

--- a/smf/src/property.rs
+++ b/smf/src/property.rs
@@ -4,8 +4,8 @@ use std::ptr::NonNull;
 
 use super::scf_sys::*;
 use super::{
-    buf_for, str_from, Iter, PropertyGroup, Result, Scf, ScfError, Value,
-    Values,
+    Iter, PropertyGroup, Result, Scf, ScfError, Value, Values, buf_for,
+    str_from,
 };
 
 #[derive(Debug)]

--- a/smf/src/propertygroup.rs
+++ b/smf/src/propertygroup.rs
@@ -5,8 +5,8 @@ use std::ptr::NonNull;
 
 use super::scf_sys::*;
 use super::{
-    buf_for, str_from, Instance, Iter, Properties, Property, Result, Scf,
-    ScfError, Service, Snapshot, Transaction,
+    Instance, Iter, Properties, Property, Result, Scf, ScfError, Service,
+    Snapshot, Transaction, buf_for, str_from,
 };
 
 #[derive(Debug)]

--- a/smf/src/scf_sys.rs
+++ b/smf/src/scf_sys.rs
@@ -120,7 +120,7 @@ pub const SCF_DECODE_FMRI_REQUIRE_NO_INSTANCE: c_int = 0x00000008;
 
 #[cfg(target_os = "illumos")]
 #[link(name = "scf")]
-extern "C" {
+unsafe extern "C" {
     pub fn scf_handle_create(version: scf_version_t) -> *mut scf_handle_t;
     pub fn scf_handle_destroy(handle: *mut scf_handle_t);
     pub fn scf_handle_bind(handle: *mut scf_handle_t) -> c_int;
@@ -293,7 +293,7 @@ extern "C" {
     ) -> c_int;
 
     pub fn scf_pg_create(handle: *mut scf_handle_t)
-        -> *mut scf_propertygroup_t;
+    -> *mut scf_propertygroup_t;
     pub fn scf_pg_destroy(pg: *mut scf_propertygroup_t);
 
     pub fn scf_pg_get_name(
@@ -420,7 +420,7 @@ extern "C" {
     ) -> c_int;
 
     pub fn smf_disable_instance(instance: *const c_char, flags: c_int)
-        -> c_int;
+    -> c_int;
     pub fn smf_enable_instance(instance: *const c_char, flags: c_int) -> c_int;
     pub fn smf_refresh_instance(instance: *const c_char) -> c_int;
 

--- a/smf/src/scope.rs
+++ b/smf/src/scope.rs
@@ -5,7 +5,7 @@ use std::ptr::NonNull;
 
 use super::scf_sys::*;
 use super::{
-    buf_for, str_from, Iter, Result, Scf, ScfError, Service, Services,
+    Iter, Result, Scf, ScfError, Service, Services, buf_for, str_from,
 };
 
 #[derive(Debug)]

--- a/smf/src/service.rs
+++ b/smf/src/service.rs
@@ -5,8 +5,8 @@ use std::ptr::NonNull;
 
 use super::scf_sys::*;
 use super::{
-    buf_for, str_from, Instance, Instances, Iter, PropertyGroups, Result, Scf,
-    ScfError, Scope,
+    Instance, Instances, Iter, PropertyGroups, Result, Scf, ScfError, Scope,
+    buf_for, str_from,
 };
 
 #[derive(Debug)]

--- a/smf/src/snapshot.rs
+++ b/smf/src/snapshot.rs
@@ -5,8 +5,8 @@ use std::ptr::NonNull;
 
 use super::scf_sys::*;
 use super::{
-    buf_for, str_from, Instance, Iter, PropertyGroup, PropertyGroups, Result,
-    ScfError,
+    Instance, Iter, PropertyGroup, PropertyGroups, Result, ScfError, buf_for,
+    str_from,
 };
 
 #[derive(Debug)]

--- a/smf/src/value.rs
+++ b/smf/src/value.rs
@@ -6,7 +6,7 @@ use std::ptr::NonNull;
 use num_traits::cast::FromPrimitive;
 
 use super::scf_sys::*;
-use super::{buf_for, str_from, Iter, Property, Result, Scf, ScfError};
+use super::{Iter, Property, Result, Scf, ScfError, buf_for, str_from};
 
 #[derive(Debug)]
 pub struct Value<'a> {

--- a/upstairs/Cargo.toml
+++ b/upstairs/Cargo.toml
@@ -3,8 +3,8 @@ name = "crucible"
 version = "0.0.1"
 authors = ["Joshua M. Clulow <jmc@oxide.computer>", "Alan Hanson <alan@oxide.computer"]
 license = "MPL-2.0"
-edition = "2021"
-rust-version = "1.81"
+edition = "2024"
+rust-version = "1.85"
 
 [lib]
 name = "crucible"

--- a/upstairs/src/active_jobs.rs
+++ b/upstairs/src/active_jobs.rs
@@ -4,8 +4,8 @@ use crucible_common::{BlockIndex, ExtentId, RegionDefinition};
 use crucible_protocol::JobId;
 
 use crate::{
-    extent_to_impacted_blocks, DownstairsIO, ExtentRepairIDs, IOop,
-    ImpactedBlocks,
+    DownstairsIO, ExtentRepairIDs, IOop, ImpactedBlocks,
+    extent_to_impacted_blocks,
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -91,10 +91,9 @@ impl ActiveJobs {
                 // Other live repair jobs aren't recorded, because they're
                 // immediately masked by the ExtentLiveReopen (which is the final
                 // operation in the repair job).
-                assert!(!self
-                    .block_to_active
-                    .job_to_range
-                    .contains_key(&job_id))
+                assert!(
+                    !self.block_to_active.job_to_range.contains_key(&job_id)
+                )
             }
         };
         self.jobs.insert(job_id, io);

--- a/upstairs/src/block_io.rs
+++ b/upstairs/src/block_io.rs
@@ -141,8 +141,8 @@ impl BlockIO for FileBlockIO {
 }
 
 // Implement BlockIO over an HTTP(S) url
-use reqwest::header::{CONTENT_LENGTH, RANGE};
 use reqwest::Client;
+use reqwest::header::{CONTENT_LENGTH, RANGE};
 use std::str::FromStr;
 
 pub struct ReqwestBlockIO {

--- a/upstairs/src/control.rs
+++ b/upstairs/src/control.rs
@@ -1,5 +1,4 @@
 // Copyright 2022 Oxide Computer Company
-use dropshot::endpoint;
 use dropshot::ApiDescription;
 use dropshot::ConfigDropshot;
 use dropshot::HandlerTaskMode;
@@ -7,6 +6,7 @@ use dropshot::HttpError;
 use dropshot::HttpResponseOk;
 use dropshot::HttpServerStarter;
 use dropshot::RequestContext;
+use dropshot::endpoint;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;

--- a/upstairs/src/deferred.rs
+++ b/upstairs/src/deferred.rs
@@ -3,18 +3,18 @@
 use std::sync::Arc;
 
 use crate::{
-    client::ConnectionId, io_limits::IOLimitGuard, upstairs::UpstairsConfig,
     BlockContext, BlockOp, ClientId, ImpactedBlocks, Message, RawWrite,
+    client::ConnectionId, io_limits::IOLimitGuard, upstairs::UpstairsConfig,
 };
 use bytes::BytesMut;
-use crucible_common::{integrity_hash, CrucibleError, RegionDefinition};
+use crucible_common::{CrucibleError, RegionDefinition, integrity_hash};
 use crucible_protocol::{ReadBlockContext, ReadResponseHeader};
 use futures::{
-    future::{ready, Either, Ready},
-    stream::FuturesOrdered,
     StreamExt,
+    future::{Either, Ready, ready},
+    stream::FuturesOrdered,
 };
-use slog::{error, Logger};
+use slog::{Logger, error};
 use tokio::sync::oneshot;
 
 /// Future stored in a [`DeferredQueue`]

--- a/upstairs/src/live_repair.rs
+++ b/upstairs/src/live_repair.rs
@@ -89,10 +89,10 @@ pub mod repair_test {
         client::ClientAction,
         downstairs::DownstairsAction,
         upstairs::{
+            Upstairs, UpstairsAction,
             test::{
                 create_test_upstairs, start_up_and_repair, to_live_repair_ready,
             },
-            Upstairs, UpstairsAction,
         },
     };
 

--- a/upstairs/src/mend.rs
+++ b/upstairs/src/mend.rs
@@ -25,7 +25,7 @@ impl RegionMetadata {
                 .iter()
                 .enumerate()
                 .map(|(i, g)| ExtentMetadata {
-                    gen: *g,
+                    generation: *g,
                     flush: flush_numbers[i],
                     dirty: dirty[i],
                 })
@@ -56,7 +56,7 @@ impl RegionMetadata {
 /// works to pick the highest-priority extent.
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub(crate) struct ExtentMetadata {
-    pub gen: u64,
+    pub generation: u64,
     pub flush: u64,
     pub dirty: bool,
 }
@@ -123,11 +123,7 @@ impl DownstairsMend {
             }
         }
 
-        if dsm.mend.is_empty() {
-            None
-        } else {
-            Some(dsm)
-        }
+        if dsm.mend.is_empty() { None } else { Some(dsm) }
     }
 }
 
@@ -1156,7 +1152,7 @@ mod test {
         // first and second rows with a 1 in the third row.
         // Generation and dirty bits are the same for all downstairs.
 
-        let gen = vec![1, 1, 1, 1, 1, 1, 1, 1, 1];
+        let gens = vec![1, 1, 1, 1, 1, 1, 1, 1, 1];
 
         // Extent --------  0  1  2  3  4  5  6  7  8
         let flush0 = vec![1, 2, 3, 1, 2, 3, 1, 2, 3];
@@ -1167,9 +1163,9 @@ mod test {
             false, false, false, false, false, false, false, false, false,
         ];
 
-        let d0 = RegionMetadata::new(&gen, &flush0, &dirty);
-        let d1 = RegionMetadata::new(&gen, &flush1, &dirty);
-        let d2 = RegionMetadata::new(&gen, &flush2, &dirty);
+        let d0 = RegionMetadata::new(&gens, &flush0, &dirty);
+        let d1 = RegionMetadata::new(&gens, &flush1, &dirty);
+        let d2 = RegionMetadata::new(&gens, &flush2, &dirty);
 
         let mut meta = ClientMap::new();
         meta.insert(ClientId::new(0), &d0);
@@ -1248,7 +1244,7 @@ mod test {
         // first and second rows with a 2 in the third row.
         // Generation and dirty bits are the same for all downstairs.
 
-        let gen = vec![1, 1, 1, 1, 1, 1, 1, 1, 1];
+        let gens = vec![1, 1, 1, 1, 1, 1, 1, 1, 1];
         // Extent --------- 0  1  2  3  4  5  6  7  8
         let flush0 = vec![1, 2, 3, 1, 2, 3, 1, 2, 3];
         let flush1 = vec![1, 1, 1, 2, 2, 2, 3, 3, 3];
@@ -1258,9 +1254,9 @@ mod test {
             false, false, false, false, false, false, false, false, false,
         ];
 
-        let d0 = RegionMetadata::new(&gen, &flush0, &dirty);
-        let d1 = RegionMetadata::new(&gen, &flush1, &dirty);
-        let d2 = RegionMetadata::new(&gen, &flush2, &dirty);
+        let d0 = RegionMetadata::new(&gens, &flush0, &dirty);
+        let d1 = RegionMetadata::new(&gens, &flush1, &dirty);
+        let d2 = RegionMetadata::new(&gens, &flush2, &dirty);
 
         let mut meta = ClientMap::new();
         meta.insert(ClientId::new(0), &d0);
@@ -1339,7 +1335,7 @@ mod test {
         // first and second rows with 3 in the third row.
         // Generation and dirty bits are the same for all downstairs.
 
-        let gen = vec![1, 1, 1, 1, 1, 1, 1, 1, 1];
+        let gens = vec![1, 1, 1, 1, 1, 1, 1, 1, 1];
 
         // Extent --------- 0  1  2  3  4  5  6  7  8
         let flush0 = vec![1, 2, 3, 1, 2, 3, 1, 2, 3];
@@ -1350,9 +1346,9 @@ mod test {
             false, false, false, false, false, false, false, false, false,
         ];
 
-        let d0 = RegionMetadata::new(&gen, &flush0, &dirty);
-        let d1 = RegionMetadata::new(&gen, &flush1, &dirty);
-        let d2 = RegionMetadata::new(&gen, &flush2, &dirty);
+        let d0 = RegionMetadata::new(&gens, &flush0, &dirty);
+        let d1 = RegionMetadata::new(&gens, &flush1, &dirty);
+        let d2 = RegionMetadata::new(&gens, &flush2, &dirty);
 
         let mut meta = ClientMap::new();
         meta.insert(ClientId::new(0), &d0);

--- a/upstairs/src/notify.rs
+++ b/upstairs/src/notify.rs
@@ -6,7 +6,7 @@
 
 use chrono::{DateTime, Utc};
 use rand::prelude::*;
-use slog::{debug, error, info, o, warn, Logger};
+use slog::{Logger, debug, error, info, o, warn};
 use std::net::{Ipv6Addr, SocketAddr};
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -251,13 +251,13 @@ async fn notify_task_nexus(
                 upstairs_id,
                 repair_id,
                 session_id,
-                ref repairs,
+                repairs,
             }
             | NotifyRequest::ReconcileStart {
                 upstairs_id,
                 repair_id,
                 session_id,
-                ref repairs,
+                repairs,
             } => {
                 let upstairs_id = TypedUuid::from_untyped_uuid(*upstairs_id);
                 let (description, repair_type) =
@@ -332,14 +332,14 @@ async fn notify_task_nexus(
                 repair_id,
                 session_id,
                 aborted,
-                ref repairs,
+                repairs,
             }
             | NotifyRequest::ReconcileFinish {
                 upstairs_id,
                 repair_id,
                 session_id,
                 aborted,
-                ref repairs,
+                repairs,
             } => {
                 let upstairs_id = TypedUuid::from_untyped_uuid(*upstairs_id);
                 let (description, repair_type) =

--- a/upstairs/src/pseudo_file.rs
+++ b/upstairs/src/pseudo_file.rs
@@ -212,9 +212,9 @@ impl<T: BlockIO> CruciblePseudoFile<T> {
     }
     pub async fn activate_with_gen(
         &mut self,
-        gen: u64,
+        generation: u64,
     ) -> Result<(), CrucibleError> {
-        self.block_io.activate_with_gen(gen).await?;
+        self.block_io.activate_with_gen(generation).await?;
         self.sz = self.block_io.total_size().await?;
         self.block_size = self.block_io.get_block_size().await?;
         self.uuid = self.block_io.get_uuid().await?;

--- a/upstairs/src/stats.rs
+++ b/upstairs/src/stats.rs
@@ -2,8 +2,8 @@
 use super::*;
 
 use oximeter::{
-    types::{Cumulative, Sample},
     Metric, MetricsError, Producer, Target,
+    types::{Cumulative, Sample},
 };
 
 // These structs are used to construct the desired stats for Oximeter.

--- a/upstairs/src/test.rs
+++ b/upstairs/src/test.rs
@@ -51,7 +51,7 @@ pub(crate) mod up_test {
         upstairs::Upstairs,
     };
 
-    use base64::{engine, Engine};
+    use base64::{Engine, engine};
     use pseudo_file::IOSpan;
 
     // Create a simple logger
@@ -398,8 +398,8 @@ pub(crate) mod up_test {
 
     // Validate that reading a blank block works
     #[test]
-    pub fn test_upstairs_validate_encrypted_read_response_blank_block(
-    ) -> Result<()> {
+    pub fn test_upstairs_validate_encrypted_read_response_blank_block()
+    -> Result<()> {
         // Set up the encryption context
         let mut key = vec![0u8; 32];
         rand::fill(&mut key[..]);
@@ -446,8 +446,8 @@ pub(crate) mod up_test {
     }
 
     #[test]
-    pub fn test_upstairs_validate_unencrypted_read_response_blank_block(
-    ) -> Result<()> {
+    pub fn test_upstairs_validate_unencrypted_read_response_blank_block()
+    -> Result<()> {
         let mut data = BytesMut::with_capacity(512);
         data.resize(512, 0u8);
 

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -6,7 +6,7 @@
 name = "crucible-workspace-hack"
 version = "0.1.0"
 description = "workspace-hack package, managed by hakari"
-edition = "2021"
+edition = "2024"
 # You can choose to publish this crate: see https://docs.rs/cargo-hakari/latest/cargo_hakari/publishing.
 publish = false
 


### PR DESCRIPTION
I got tired of my editor's LSP complaining about `gen`, and decided to update everything to Rust 2024.

This was mostly mechanical renaming of `gen` → `generation`, Clippy fixes, and `rustfmt`.

`VolumeConstructionRequest` has to have a `#[serde(rename = "gen")]` annotation, because it's been stored on disk.