### PR TITLE
Restore `--gen` argument for binaries

### DIFF
--- a/crudd/src/main.rs
+++ b/crudd/src/main.rs
@@ -40,7 +40,7 @@ pub struct Opt {
     key: Option<String>,
 
     /// Generation
-    #[clap(short, long, default_value = "0", action)]
+    #[clap(short, long = "gen", default_value = "0", action)]
     generation: u64,
 
     /// TLS certificate

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -174,7 +174,7 @@ pub struct Opt {
     #[clap(long, global = true, action)]
     flush_timeout: Option<f32>,
 
-    #[clap(short, global = true, long, default_value_t = 0, action)]
+    #[clap(short, global = true, long = "gen", default_value_t = 0, action)]
     generation: u64,
 
     /// The key for an encrypted downstairs.

--- a/hammer/src/main.rs
+++ b/hammer/src/main.rs
@@ -37,7 +37,7 @@ pub struct Opt {
     #[clap(short, long, action)]
     key: Option<String>,
 
-    #[clap(short, long, default_value = "1", action)]
+    #[clap(short, long = "gen", default_value = "1", action)]
     generation: u64,
 
     /*

--- a/measure_iops/src/main.rs
+++ b/measure_iops/src/main.rs
@@ -21,7 +21,7 @@ pub struct Opt {
     #[clap(short, long, action)]
     key: Option<String>,
 
-    #[clap(short, long, default_value = "0", action)]
+    #[clap(short, long = "gen", default_value = "0", action)]
     generation: u64,
 
     #[clap(long, action)]

--- a/nbd_server/src/main.rs
+++ b/nbd_server/src/main.rs
@@ -37,7 +37,7 @@ pub struct Opt {
     #[clap(short, long, action)]
     key: Option<String>,
 
-    #[clap(short, long, default_value = "0", action)]
+    #[clap(short, long = "gen", default_value = "0", action)]
     generation: u64,
 
     // TLS options


### PR DESCRIPTION
#1799 renamed `gen` → `generation`, because the former is a reserved word in Rust 2024.  That PR special-cased the `generation` field in the volume construction request, because it's serialized to disk; however, we should also special-case CLI arguments to avoid breaking existing scripts.