### PR TITLE
Do single-block validation after live-repair and when opening extent

### DIFF
--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -35,6 +35,7 @@ pub(crate) trait ExtentInner: Send + Sync + Debug {
     fn flush_number(&self) -> Result<u64, CrucibleError>;
     fn dirty(&self) -> Result<bool, CrucibleError>;
     fn validate(&self) -> Result<(), CrucibleError>;
+    fn validate_block(&self, i: u64) -> Result<(), CrucibleError>;
 
     /// Performs any metadata updates needed before a flush
     fn pre_flush(
@@ -250,7 +251,22 @@ pub fn extent_dir<P: AsRef<Path>>(dir: P, number: ExtentId) -> PathBuf {
  * anchored under "dir".
  */
 pub fn extent_path<P: AsRef<Path>>(dir: P, number: ExtentId) -> PathBuf {
-    extent_dir(dir, number).join(extent_file_name(number, ExtentType::Data))
+    let e = extent_file_name(number, ExtentType::Data);
+
+    // XXX terrible hack: if someone has already provided a full directory tree
+    // ending in `.copy`, then just append the extent file name.  This lets us
+    // open individual extent files during live-repair.
+    if dir
+        .as_ref()
+        .iter()
+        .next_back()
+        .and_then(|s| s.to_str())
+        .is_some_and(|s| s.ends_with(".copy"))
+    {
+        dir.as_ref().join(e)
+    } else {
+        extent_dir(dir, number).join(e)
+    }
 }
 
 /**
@@ -487,6 +503,11 @@ impl Extent {
                 }
             }
         };
+
+        // XXX debug validation after opening the extent
+        if let Err(e) = inner.validate_block(0) {
+            panic!("could not validate extent {number}: {e:#?}");
+        }
 
         let extent = Extent {
             number,

--- a/downstairs/src/extent_inner_sqlite.rs
+++ b/downstairs/src/extent_inner_sqlite.rs
@@ -103,9 +103,13 @@ impl ExtentInner for SqliteInner {
     }
 
     fn validate(&self) -> Result<(), CrucibleError> {
-        Err(CrucibleError::GenericError(
-            "`validate` is not implemented for Sqlite extent".to_owned(),
-        ))
+        // We don't implement validation for SQLite extents
+        Ok(())
+    }
+
+    fn validate_block(&self, _i: u64) -> Result<(), CrucibleError> {
+        // We don't implement validation for SQLite extents
+        Ok(())
     }
 
     #[cfg(test)]

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -682,6 +682,22 @@ impl Region {
             );
         }
 
+        // XXX debug code
+        // Open the extent that we just received, which checks block 0.  We do
+        // this before copying it, to check what was received on the wire.
+        info!(self.log, "Verifying extent {eid} on reception");
+        if let Err(e) = Extent::open(
+            &copy_dir,
+            &self.def(),
+            eid,
+            true, // read-only
+            &self.log.clone(),
+        ) {
+            panic!(
+                "Failed to open live-repair extent {eid} in {copy_dir:?}: {e:?}"
+            );
+        }
+
         // After we have all files: move the repair dir.
         info!(
             self.log,


### PR DESCRIPTION
This is a draft for debugging purposes