### PR TITLE
Print file name for extents

### DIFF
--- a/downstairs/src/dump.rs
+++ b/downstairs/src/dump.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 Oxide Computer Company
 use super::*;
-use crate::extent::ExtentMeta;
+use crate::extent::{ExtentMeta, ExtentType, extent_file_name};
 use rayon::prelude::*;
 use std::convert::TryInto;
 
@@ -53,7 +53,12 @@ pub fn verify_region(
 
     if !errors.is_empty() {
         for (number, err) in &errors {
-            println!("validation failed for extent {}: {:?}", number, err);
+            println!(
+                "validation failed for extent {} (file {}): {:?}",
+                number,
+                extent_file_name(*number, ExtentType::Data),
+                err
+            );
         }
         bail!("Region failed to verify");
     }

--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -480,7 +480,9 @@ impl Extent {
                     }
                     i => {
                         return Err(CrucibleError::IoError(format!(
-                            "raw extent {number} has unknown tag {i}"
+                            "raw extent {number} (file {}) has unknown \
+                            tag {i}",
+                            extent_file_name(number, ExtentType::Data)
                         ))
                         .into());
                     }


### PR DESCRIPTION
When debugging extent issues, it's nice to know both the extent number and the name of the extent file.

Some examples:
```
BRM23230018 # cd /pool/ext/15bf0fb1-9b75-49b6-81f1-1a7e86bc4f52/crypt/zone/oxz_crucible_ea22fb71-b24a-4a6d-abce-6b93d5b713e6/root/data/regions/c6d6ed4f-dd2a-424b-9e40-6da8afb82a89/      
BRM23230018 # /tmp/crucible-downstairs verify -d .
Error: IO Error: raw extent 308 (file 134) has unknown tag 0
```
Another:
```
BRM23230018 # cd /pool/ext/7e4b532a-f18f-4cf5-9c74-1783466e4e46/crypt/zone/oxz_crucible_0e8fef9a-5905-460d-9cb7-89a8300300c4/root/data/regions/99b7b406-ca63-44c4-8762-d63a18b631a8/
BRM23230018 # /tmp/crucible-downstairs verify -d .
validation failed for extent 272 (file 110): GenericError("block 0 has an active slot with mismatched hash")
validation failed for extent 773 (file 305): GenericError("block 0 has an active slot with mismatched hash")
validation failed for extent 900 (file 384): GenericError("block 0 has an active slot with mismatched hash")
Error: Region failed to verify
```