### PR TITLE
Remove cargo nextest from github workflow, out of space

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Test build documentation
       run: cargo doc
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
The github provided ubuntu image/host/container has a limited amount of space, and we have apparently hit that limit.  We could figure it out and update it, but this test is already a duplicate of what we do in buildomat, so I just pulled out the test part, so now it just does cargo fmt/build/check.