### PR TITLE
bump vergen-v9 version too

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -33,5 +33,5 @@ proptest.workspace = true
 test-strategy.workspace = true
 
 [build-dependencies]
-vergen = { version = "9.0.6", features = ["cargo", "rustc"] }
+vergen = { version = "9.1.0", features = ["cargo", "rustc"] }
 vergen-git2 = "9.1.0"


### PR DESCRIPTION
see my comment on [vergen issue 478](https://github.com/rustyhorde/vergen/issues/478#issuecomment-4025776422) for more, but keeping vergen at 9.1.0 across the board avoids some versioning issues in that crate across v9.

since we've got `vergen-git2 = 9.1.0` we can just bump Crucible in Propolis to fix https://github.com/oxidecomputer/propolis/issues/1070, but seems good to keep Crucible internally consistent (using `vergen = { version = "=9.0.6" }` would cause that same error in building Crucible today).