### PR TITLE
Fix warnings

### DIFF
--- a/downstairs/src/extent.rs
+++ b/downstairs/src/extent.rs
@@ -581,7 +581,7 @@ impl Extent {
     /// returned.  Otherwise, the value in `ExtentReadResponse::data` is
     /// guaranteed to be fully initialized and of the requested length.
     #[instrument]
-    pub fn read(
+    pub(crate) fn read(
         &mut self,
         job_id: JobId,
         req: ExtentReadRequest,
@@ -597,7 +597,7 @@ impl Extent {
     }
 
     #[instrument]
-    pub fn write(
+    pub(crate) fn write(
         &mut self,
         job_id: JobId,
         write: &ExtentWrite,

--- a/downstairs/src/region.rs
+++ b/downstairs/src/region.rs
@@ -788,7 +788,7 @@ impl Region {
     }
 
     #[instrument]
-    pub fn region_write(
+    pub(crate) fn region_write(
         &mut self,
         writes: &RegionWrite,
         job_id: JobId,
@@ -832,7 +832,7 @@ impl Region {
     }
 
     #[instrument]
-    pub fn region_read(
+    pub(crate) fn region_read(
         &mut self,
         req: &RegionReadRequest,
         job_id: JobId,

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -604,7 +604,7 @@ impl Downstairs {
         }
 
         if self.gw_active.remove(&ds_id) {
-            self.acked_ids.push(ds_id);
+            self.acked_ids.enqueue(ds_id);
         } else {
             panic!("job {ds_id} not on gw_active list");
         }
@@ -2405,7 +2405,7 @@ impl Downstairs {
         );
 
         if acked {
-            self.acked_ids.push(ds_id)
+            self.acked_ids.enqueue(ds_id);
         } else {
             self.gw_active.insert(ds_id);
         }
@@ -2922,9 +2922,9 @@ impl Downstairs {
                 assert!(job.acked);
 
                 retired.push(id);
-                self.retired_ids.push(id);
+                self.retired_ids.enqueue(id);
                 let summary = job.io_summarize(id);
-                self.retired_jobs.push(summary);
+                self.retired_jobs.enqueue(summary);
                 for cid in ClientId::iter() {
                     self.clients[cid].retire_job(job);
                 }


### PR DESCRIPTION
- `ringbuffer::RingBuffer::push` is deprecated
- Fix warning about returned values being less public than functions, by making the functions less public
