### PR TITLE
Remove old field from dtrace action script

### DIFF
--- a/tools/dtrace/upstairs_action.d
+++ b/tools/dtrace/upstairs_action.d
@@ -2,7 +2,7 @@
  * Display internal Upstairs status.
  */
 #pragma D option quiet
-#pragma D option strsize=1k
+#pragma D option strsize=2k
 /*
  * Print the header right away
  */
@@ -19,7 +19,7 @@ tick-1s
 /show > 20/
 {
     printf("%9s %9s %9s", "APPLY", "DOWN_S", "GUEST");
-    printf(" %9s %9s %9s", "DFR_BLK", "DFR_MSG", "LEAK_CHK");
+    printf(" %9s %9s", "DFR_BLK", "DFR_MSG");
     printf(" %9s %9s", "FLUSH_CHK", "STAT_CHK");
     printf(" %9s %9s", "CTRL_CHK", "NOOP");
     printf("\n");
@@ -34,7 +34,6 @@ crucible_upstairs*:::up-status
     printf(" %9s", json(copyinstr(arg1), "ok.up_counters.action_guest"));
     printf(" %9s", json(copyinstr(arg1), "ok.up_counters.action_deferred_block"));
     printf(" %9s", json(copyinstr(arg1), "ok.up_counters.action_deferred_message"));
-    printf(" %9s", json(copyinstr(arg1), "ok.up_counters.action_leak_check"));
     printf(" %9s", json(copyinstr(arg1), "ok.up_counters.action_flush_check"));
     printf(" %9s", json(copyinstr(arg1), "ok.up_counters.action_stat_check"));
     printf(" %9s", json(copyinstr(arg1), "ok.up_counters.action_control_check"));


### PR DESCRIPTION
The `upstairs_action.d` script had a reference to a field that no longer
existed.  Remove that field from the script.

Fixes https://github.com/oxidecomputer/crucible/issues/1916