### PR TITLE
Background read-only region creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +927,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1213,7 @@ name = "crucible-agent"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "async-channel",
  "chrono",
  "clap",
  "crucible-agent-api",
@@ -2524,6 +2546,27 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -5380,6 +5423,12 @@ dependencies = [
  "fnv",
  "unicode-width 0.1.14",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ resolver = "2"
 # crates.io
 aes-gcm-siv = "0.11.1"
 anyhow = "1"
+async-channel = "2.5.0"
 async-recursion = "1.1.1"
 async-trait = "0.1.89"
 atty = "0.2.14"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 
 [dependencies]
 anyhow.workspace = true
+async-channel.workspace = true
 chrono.workspace = true
 clap.workspace = true
 crucible-agent-api.workspace = true

--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -980,7 +980,7 @@ impl DataFile {
                             // requested and may exist. According to zfs list,
                             // it does not yet. How was a snapshot taken?
                             bail!(
-                                "region {} (maybe?) does not exist yet! {e}",
+                                "region {} not found in zfs list! {e}",
                                 request.id.0
                             );
                         }

--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -1,6 +1,6 @@
 // Copyright 2021 Oxide Computer Company
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result, bail};
 use crucible_agent_types::region::CreateRegion;
 use crucible_agent_types::region::RegionId;
 use crucible_agent_types::snapshot::CreateRunningSnapshotRequest;
@@ -9,8 +9,9 @@ use crucible_agent_types::snapshot::DeleteSnapshotRequest;
 use crucible_agent_types::snapshot::Snapshot;
 use crucible_common::write_json;
 use crucible_smf::scf_type_t::*;
+use dropshot::HttpError;
 use serde::{Deserialize, Serialize};
-use slog::{Logger, crit, error, info};
+use slog::{Logger, crit, error, info, warn};
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::path::Path;
@@ -38,6 +39,8 @@ pub struct DataFile {
 #[derive(Debug, PartialEq, Clone)]
 pub enum RegionState {
     Requested,
+    /// Region creation is occuring in the background
+    Creating,
     Created,
     Tombstoned,
     Destroyed,
@@ -48,6 +51,33 @@ impl From<RegionState> for crucible_agent_types::region::State {
     fn from(s: RegionState) -> crucible_agent_types::region::State {
         match s {
             RegionState::Requested => {
+                crucible_agent_types::region::State::Requested
+            }
+            RegionState::Creating => {
+                // The Crucible agent will only read the data file on startup,
+                // either after being updated or after crashing. There's a few
+                // considerations here that all conclude that Creating should be
+                // converted here to Requested:
+                //
+                // If this is a newer Crucible Agent that supports background
+                // creation and the in-memory type's state is Creating, then
+                // background creation of that region was occurring when the
+                // update or crash occurred, and the Agent should start again
+                // from the beginning.  Starting from the beginning is
+                // equivalent by running the worker thread and starting again
+                // from Requested.
+                //
+                // If this is an older Crucible Agent that does _not_ support
+                // background creation is the one reading the data file, it
+                // should also start from Requested in order to start over.
+                //
+                // If this From path is being invoked as part of an API
+                // response, then users of the API only care that the Region is
+                // Requested and not yet in state Created, as they have always,
+                // not what the Agent is doing behind the scenes. Said another
+                // way: a Nexus that is polling an older or newer Crucible Agent
+                // is not aware of whether or not the region creation is
+                // occurring in the background.
                 crucible_agent_types::region::State::Requested
             }
             RegionState::Created => {
@@ -945,7 +975,17 @@ impl DataFile {
                             return Ok(());
                         }
 
-                        RegionState::Requested | RegionState::Created => {
+                        RegionState::Requested | RegionState::Creating => {
+                            // According to the agent's datafile, the region was
+                            // requested and may exist. According to zfs list,
+                            // it does not yet. How was a snapshot taken?
+                            bail!(
+                                "region {} (maybe?) does not exist yet! {e}",
+                                request.id.0
+                            );
+                        }
+
+                        RegionState::Created => {
                             // This is a bug: according to the agent's datafile,
                             // the region exists, but according to zfs list, it
                             // does not
@@ -1045,7 +1085,8 @@ impl DataFile {
         let r = inner.regions.get_mut(id).unwrap();
         let nstate = RegionState::Created;
         match &r.state {
-            RegionState::Requested => (),
+            RegionState::Requested | RegionState::Creating => (),
+
             RegionState::Tombstoned => {
                 /*
                  * Nexus requested that we destroy this region before we
@@ -1053,6 +1094,7 @@ impl DataFile {
                  */
                 return Ok(());
             }
+
             x => bail!("created region in weird state {:?}", x),
         }
 
@@ -1147,8 +1189,10 @@ impl DataFile {
         let r = inner.regions.get_mut(id).unwrap();
         let nstate = RegionState::Destroyed;
         match &r.state {
-            RegionState::Requested => (),
+            RegionState::Requested | RegionState::Creating => (),
+
             RegionState::Tombstoned => (),
+
             x => bail!("region to destroy in weird state {:?}", x),
         }
 
@@ -1200,13 +1244,15 @@ impl DataFile {
     /**
      * Nexus has requested that we destroy this particular region.
      */
-    pub fn destroy(&self, id: &RegionId) -> Result<()> {
+    pub fn destroy(&self, id: &RegionId) -> Result<(), HttpError> {
         let mut inner = self.inner.lock().unwrap();
 
-        let r = inner
-            .regions
-            .get_mut(id)
-            .ok_or_else(|| anyhow!("region {} does not exist", id.0))?;
+        let r = inner.regions.get_mut(id).ok_or_else(|| {
+            HttpError::for_not_found(
+                None,
+                format!("region {} does not exist", id.0),
+            )
+        })?;
 
         match r.state {
             RegionState::Tombstoned | RegionState::Destroyed => {
@@ -1216,6 +1262,24 @@ impl DataFile {
                  * - Already destroyed; no more work to do.
                  */
             }
+
+            RegionState::Creating => {
+                // `Creating` means that some processing is occurring in the
+                // background in a region creation thread, and if we set this
+                // region's state to `Tombstoned` and allow the worker thread to
+                // operate on it, this would conflict and lead to chaos.
+                // Restrict this with a 503.
+
+                let m = format!(
+                    "cannot destroy region {:?} in state {:?}",
+                    r.id.0, r.state,
+                );
+
+                warn!(self.log, "{m}");
+
+                return Err(HttpError::for_unavail(None, m));
+            }
+
             RegionState::Requested
             | RegionState::Created
             | RegionState::Failed => {
@@ -1305,6 +1369,7 @@ impl DataFile {
 
         match region.state {
             RegionState::Requested
+            | RegionState::Creating
             | RegionState::Destroyed
             | RegionState::Tombstoned
             | RegionState::Failed => {
@@ -1335,6 +1400,27 @@ impl DataFile {
             .get_snapshots_for_dataset(dataset.dataset())?;
 
         Ok(results)
+    }
+
+    /**
+     * Mark a particular region as provisioning in the background.
+     */
+    pub fn creating(&self, id: &RegionId) {
+        let mut inner = self.inner.lock().unwrap();
+
+        let r = inner.regions.get_mut(id).unwrap();
+        let nstate = RegionState::Creating;
+        if r.state == nstate {
+            return;
+        }
+
+        info!(
+            self.log,
+            "region {} state: {:?} -> {:?}", r.id.0, r.state, nstate,
+        );
+        r.state = nstate;
+
+        self.store(inner);
     }
 }
 

--- a/agent/src/datafile.rs
+++ b/agent/src/datafile.rs
@@ -59,25 +59,16 @@ impl From<RegionState> for crucible_agent_types::region::State {
                 // considerations here that all conclude that Creating should be
                 // converted here to Requested:
                 //
-                // If this is a newer Crucible Agent that supports background
-                // creation and the in-memory type's state is Creating, then
-                // background creation of that region was occurring when the
-                // update or crash occurred, and the Agent should start again
-                // from the beginning.  Starting from the beginning is
-                // equivalent by running the worker thread and starting again
-                // from Requested.
-                //
-                // If this is an older Crucible Agent that does _not_ support
-                // background creation is the one reading the data file, it
-                // should also start from Requested in order to start over.
+                // If the region was in state Creating, then background creation
+                // of that region was occurring when the update or crash
+                // occurred, and the Agent should start again from the
+                // beginning. Starting from the beginning is equivalent by
+                // running the worker thread and starting again from Requested.
                 //
                 // If this From path is being invoked as part of an API
                 // response, then users of the API only care that the Region is
                 // Requested and not yet in state Created, as they have always,
-                // not what the Agent is doing behind the scenes. Said another
-                // way: a Nexus that is polling an older or newer Crucible Agent
-                // is not aware of whether or not the region creation is
-                // occurring in the background.
+                // not what the Agent is doing behind the scenes.
                 crucible_agent_types::region::State::Requested
             }
             RegionState::Created => {

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -37,6 +37,11 @@ const SERVICE: &str = "oxide/crucible/downstairs";
 const RESERVATION_FACTOR: f64 = 1.25;
 const QUOTA_FACTOR: u64 = 3;
 
+// The number of tasks spawned to handle region clone operations.
+//
+// TODO does this need to be variable?
+const WORKER_COUNT: usize = 64;
+
 mod datafile;
 mod resource;
 mod server;
@@ -75,7 +80,7 @@ enum Args {
     },
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ZFSDataset {
     dataset: String,
 }
@@ -315,7 +320,7 @@ async fn main() -> Result<()> {
              */
             let log0 = log.new(o!("component" => "worker"));
             let df0 = Arc::clone(&df);
-            std::thread::spawn(|| {
+            tokio::spawn(async {
                 worker(
                     log0,
                     df0,
@@ -324,6 +329,7 @@ async fn main() -> Result<()> {
                     downstairs_prefix,
                     snapshot_prefix,
                 )
+                .await
             });
 
             server::run_server(&log, listen, df).await
@@ -809,7 +815,7 @@ where
  *
  * For region with state Requested, create the region.
  */
-fn worker(
+async fn worker(
     log: Logger,
     df: Arc<datafile::DataFile>,
     regions_dataset: ZFSDataset,
@@ -826,6 +832,39 @@ fn worker(
             );
         }
     };
+
+    // Note that this channel is unbounded as the number of concurrent region
+    // creation requests will be controlled by Nexus.
+    let (region_create_tx, region_create_rx) = async_channel::unbounded();
+
+    for tid in 0..WORKER_COUNT {
+        let df = df.clone();
+        let regions_dataset = regions_dataset.clone();
+        let regions_dataset_path = regions_dataset_path.clone();
+        let downstairs_program = downstairs_program.clone();
+        let downstairs_prefix = downstairs_prefix.clone();
+        let snapshot_prefix = snapshot_prefix.clone();
+
+        let region_create_rx = region_create_rx.clone();
+        let log = log.new(o!("agent_region_create" => tid));
+
+        tokio::spawn(async move {
+            loop {
+                while let Ok(region) = region_create_rx.recv().await {
+                    agent_region_create(
+                        &log,
+                        &df,
+                        &regions_dataset,
+                        &regions_dataset_path,
+                        &downstairs_program,
+                        &downstairs_prefix,
+                        &snapshot_prefix,
+                        region,
+                    );
+                }
+            }
+        });
+    }
 
     loop {
         /*
@@ -858,102 +897,50 @@ fn worker(
                  * then we finish up destroying the region.
                  */
                 match &r.state {
-                    RegionState::Requested => 'requested: {
-                        /*
-                         * Compute the actual size required for a full region,
-                         * then add our metadata overhead to that.
-                         */
-                        let region_size = r.block_size
-                            * r.extent_size
-                            * r.extent_count as u64;
-                        let reservation =
-                            (region_size as f64 * RESERVATION_FACTOR).round()
-                                as u64;
-                        let quota = region_size * QUOTA_FACTOR;
+                    RegionState::Requested => {
+                        let read_only = r.source.is_some();
 
-                        info!(
-                            log,
-                            "Region size:{} reservation:{} quota:{}",
-                            region_size,
-                            reservation,
-                            quota,
-                        );
+                        if read_only {
+                            // If the region we're requesting is read-only then
+                            // background the creation as it will involve
+                            // cloning from a remote address, and this could
+                            // take a long while.
+                            let region_id = r.id.clone();
 
-                        // If regions need to be created, do that before
-                        // apply_smf.
-                        let region_dataset = match regions_dataset
-                            .ensure_child_dataset(
-                                &r.id.0,
-                                Some(reservation),
-                                Some(quota),
-                                &log,
-                            ) {
-                            Ok(region_dataset) => region_dataset,
-                            Err(e) => {
+                            // Set the region's ID to creating before enqueuing
+                            // the region for background creation to avoid
+                            // racing with how the background tasks can change
+                            // the region's state.
+                            //
+                            // Note the additional state `Creating` was required
+                            // because if it did not exist then another
+                            // iteration of this worker loop would see the same
+                            // Region in Requested and repeatedly enqueue region
+                            // create requests.
+                            df.creating(&region_id);
+
+                            if let Err(e) = region_create_tx.send(r).await {
                                 error!(
                                     log,
-                                    "Dataset {} creation failed: {}",
-                                    &r.id.0,
-                                    e,
+                                    "could not send region for creation: {:?}",
+                                    e
                                 );
-                                df.fail(&r.id);
-                                break 'requested;
+
+                                std::process::exit(1);
                             }
-                        };
-
-                        let dataset_path = match region_dataset.path() {
-                            Ok(dataset_path) => dataset_path,
-                            Err(e) => {
-                                error!(
-                                    log,
-                                    "Failed to find path for dataset {}: {}",
-                                    &r.id.0,
-                                    e,
-                                );
-                                df.fail(&r.id);
-                                break 'requested;
-                            }
-                        };
-
-                        // It's important that a region transition to "Created"
-                        // only after it has been created as a dataset:
-                        // after the crucible agent restarts, `apply_smf` will
-                        // only start downstairs services for those in
-                        // "Created". If the `df.created` is moved to after this
-                        // function's `apply_smf` call, and there is a crash
-                        // before that moved `df.created` is set, then the agent
-                        // will not start a downstairs service for this region
-                        // when rebooted.
-                        let res = worker_region_create(
-                            &log,
-                            &downstairs_program,
-                            &r,
-                            &dataset_path,
-                        )
-                        .and_then(|_| df.created(&r.id));
-
-                        if let Err(e) = res {
-                            error!(
-                                log,
-                                "region {:?} create failed: {:?}", r.id.0, e
-                            );
-                            df.fail(&r.id);
-                            break 'requested;
-                        }
-
-                        info!(log, "applying SMF actions post create...");
-                        let result = apply_smf(
-                            &log,
-                            &df,
-                            regions_dataset_path.clone(),
-                            &downstairs_prefix,
-                            &snapshot_prefix,
-                        );
-
-                        if let Err(e) = result {
-                            error!(log, "SMF application failure: {:?}", e);
                         } else {
-                            info!(log, "SMF ok!");
+                            // If the region we're creating is not read-only,
+                            // then create it right here.
+                            agent_region_create(
+                                &log,
+                                &df,
+                                &regions_dataset,
+                                &regions_dataset_path,
+                                &downstairs_program,
+                                &downstairs_prefix,
+                                &snapshot_prefix,
+                                r,
+                            );
                         }
                     }
 
@@ -1083,6 +1070,88 @@ fn worker(
                 }
             }
         }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn agent_region_create(
+    log: &Logger,
+    df: &Arc<datafile::DataFile>,
+    regions_dataset: &ZFSDataset,
+    regions_dataset_path: &Path,
+    downstairs_program: &Path,
+    downstairs_prefix: &str,
+    snapshot_prefix: &str,
+    r: Region,
+) {
+    /*
+     * Compute the actual size required for a full region, then add our metadata
+     * overhead to that.
+     */
+    let region_size = r.block_size * r.extent_size * r.extent_count as u64;
+    let reservation = (region_size as f64 * RESERVATION_FACTOR).round() as u64;
+    let quota = region_size * QUOTA_FACTOR;
+
+    info!(
+        log,
+        "Region size:{} reservation:{} quota:{}",
+        region_size,
+        reservation,
+        quota,
+    );
+
+    // If regions need to be created, do that before apply_smf.
+    let region_dataset = match regions_dataset.ensure_child_dataset(
+        &r.id.0,
+        Some(reservation),
+        Some(quota),
+        log,
+    ) {
+        Ok(region_dataset) => region_dataset,
+        Err(e) => {
+            error!(log, "Dataset {} creation failed: {}", &r.id.0, e,);
+            df.fail(&r.id);
+            return;
+        }
+    };
+
+    let dataset_path = match region_dataset.path() {
+        Ok(dataset_path) => dataset_path,
+        Err(e) => {
+            error!(log, "Failed to find path for dataset {}: {}", &r.id.0, e,);
+            df.fail(&r.id);
+            return;
+        }
+    };
+
+    // It's important that a region transition to "Created" only after it has
+    // been created as a dataset: after the crucible agent restarts, `apply_smf`
+    // will only start downstairs services for those in "Created". If the
+    // `df.created` is moved to after this function's `apply_smf` call, and
+    // there is a crash before that moved `df.created` is set, then the agent
+    // will not start a downstairs service for this region when rebooted.
+    let res = worker_region_create(log, downstairs_program, &r, &dataset_path)
+        .and_then(|_| df.created(&r.id));
+
+    if let Err(e) = res {
+        error!(log, "region {:?} create failed: {:?}", r.id.0, e);
+        df.fail(&r.id);
+        return;
+    }
+
+    info!(log, "applying SMF actions post create...");
+    let result = apply_smf(
+        log,
+        df,
+        regions_dataset_path.to_path_buf(),
+        downstairs_prefix,
+        snapshot_prefix,
+    );
+
+    if let Err(e) = result {
+        error!(log, "SMF application failure: {:?}", e);
+    } else {
+        info!(log, "SMF ok!");
     }
 }
 

--- a/agent/src/server.rs
+++ b/agent/src/server.rs
@@ -85,10 +85,9 @@ impl CrucibleAgentApi for CrucibleAgentImpl {
             ));
         }
 
-        match rc.context().destroy(&p.id) {
-            Ok(_) => Ok(HttpResponseDeleted()),
-            Err(e) => Err(HttpError::for_bad_request(None, e.to_string())),
-        }
+        rc.context().destroy(&p.id)?;
+
+        Ok(HttpResponseDeleted())
     }
 
     async fn region_get_snapshots(


### PR DESCRIPTION
When the Crucible Agent is requested to create a read-only region from a remote Downstairs source, this currently blocks the worker thread as region creation is performed in the worker loop, and it cannot respond to other state changes.

This commit spawns region creation threads that the main worker thread can send requests to, and sends all read-only region creation requests there.

This builds on the previous work to separate the serialized on-disk types from the in-memory types: a `Creating` state is added to the in-memory type and used while this background creation is occurring.