### PR TITLE
Add VolumeInfo

### DIFF
--- a/crucible-client-types/src/lib.rs
+++ b/crucible-client-types/src/lib.rs
@@ -190,7 +190,7 @@ pub enum VolumeInfo {
     },
 }
 
-#[derive(Debug, Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum DownstairsInfoNegotiationStatus {
     WaitConnect,
@@ -200,7 +200,7 @@ pub enum DownstairsInfoNegotiationStatus {
     LiveRepairReady,
 }
 
-#[derive(Debug, Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum DownstairsInfoConnectionMode {
     New,
@@ -218,7 +218,7 @@ pub struct DownstairsInfo {
     pub state: DownstairsInfoStatus,
 }
 
-#[derive(Debug, Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema, PartialEq)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum DownstairsInfoStatus {
     Connecting {
@@ -230,7 +230,7 @@ pub enum DownstairsInfoStatus {
     Stopping,
 }
 
-#[derive(Debug, Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum UpstairsInfoStatus {
     Initializing,

--- a/crucible-client-types/src/lib.rs
+++ b/crucible-client-types/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 use base64::{Engine, engine};
 use schemars::JsonSchema;
@@ -165,6 +165,79 @@ pub struct RegionExtentInfo {
     pub blocks_per_extent: u64,
     /// Total number of extents that make up this region.
     pub extent_count: u32,
+}
+
+/// A tree representation of the info and status of all parts of a Volume.
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum VolumeInfo {
+    Volume {
+        sub_volumes: Vec<VolumeInfo>,
+        read_only_parent: Option<Box<VolumeInfo>>,
+    },
+
+    Upstairs {
+        state: UpstairsInfoStatus,
+        block_size: Option<u64>,
+        upstairs_id: Uuid,
+        session_id: Uuid,
+        generation: u64,
+        read_only: bool,
+        encrypted: bool,
+        reconcile_in_progress: bool,
+        live_repair_in_progress: bool,
+        targets: Vec<DownstairsInfo>,
+    },
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DownstairsInfoNegotiationStatus {
+    WaitConnect,
+    Negotiating,
+    WaitQuorum,
+    Reconcile,
+    LiveRepairReady,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DownstairsInfoConnectionMode {
+    New,
+    Offline,
+    Faulted,
+    Replaced,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct DownstairsInfo {
+    pub region_id: Option<Uuid>,
+    pub target_addr: Option<SocketAddr>,
+    pub repair_addr: Option<SocketAddr>,
+    pub state: DownstairsInfoStatus,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum DownstairsInfoStatus {
+    Connecting {
+        state: DownstairsInfoNegotiationStatus,
+        mode: DownstairsInfoConnectionMode,
+    },
+    Active,
+    LiveRepair,
+    Stopping,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum UpstairsInfoStatus {
+    Initializing,
+    GoActive,
+    Active,
+    Deactivating,
+    Disabled,
 }
 
 #[cfg(test)]

--- a/crutest/src/main.rs
+++ b/crutest/src/main.rs
@@ -1,4 +1,5 @@
-// Copyright 2023 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
+
 use anyhow::{Result, anyhow, bail};
 use bytes::Bytes;
 use clap::Parser;
@@ -32,7 +33,8 @@ mod protocol;
 mod stats;
 pub use stats::*;
 
-use crucible::volume::{VolumeBuilder, VolumeInfo};
+use crucible::volume::VolumeBuilder;
+use crucible::volume::VolumeExtentInfo;
 use crucible::*;
 use crucible_client_types::RegionExtentInfo;
 use crucible_protocol::CRUCIBLE_MESSAGE_VERSION;
@@ -411,7 +413,7 @@ impl BufferbloatConfig {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DiskInfo {
-    volume_info: VolumeInfo,
+    volume_info: VolumeExtentInfo,
     write_log: WriteLog,
     max_block_io: usize,
 }

--- a/crutest/src/protocol.rs
+++ b/crutest/src/protocol.rs
@@ -1,4 +1,5 @@
-// Copyright 2022 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
+
 use anyhow::bail;
 use bytes::{Buf, BufMut, BytesMut};
 use serde::{Deserialize, Serialize};
@@ -39,7 +40,7 @@ pub enum CliMessage {
     Flush,
     // Run the generic test
     Generic(usize, bool, bool),
-    Info(VolumeInfo),
+    Info(VolumeExtentInfo),
     InfoPlease,
     IsActive,
     MyUuid(Uuid),
@@ -221,7 +222,7 @@ mod tests {
 
     #[test]
     fn rt_info() -> Result<()> {
-        let vi = VolumeInfo {
+        let vi = VolumeExtentInfo {
             block_size: 512,
             volumes: Vec::new(),
         };

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -11,8 +11,12 @@ mod integration_tests {
     use base64::{Engine, engine};
     use crucible::volume::VolumeBuilder;
     use crucible::*;
+    use crucible_client_types::DownstairsInfo;
+    use crucible_client_types::DownstairsInfoStatus;
     use crucible_client_types::RegionExtentInfo;
+    use crucible_client_types::UpstairsInfoStatus;
     use crucible_client_types::VolumeConstructionRequest;
+    use crucible_client_types::VolumeInfo;
     use crucible_downstairs::*;
     use crucible_pantry::pantry::Pantry;
     use crucible_pantry_client::Client as CruciblePantryClient;
@@ -6343,5 +6347,200 @@ mod integration_tests {
             );
             assert_eq!(*state, DownstairsInfoStatus::Active);
         }
+    }
+
+    /// Validate the VolumeInfo for multiple sub-volumes and a read-only parent
+    #[tokio::test]
+    async fn test_volume_info_multiple_subvolumes() -> Result<()> {
+        const BLOCK_SIZE: usize = 512;
+
+        let tds1 = DefaultTestDownstairsSet::small(false).await?;
+        let tds2 = DefaultTestDownstairsSet::big(false).await?;
+        let tds3 = DefaultTestDownstairsSet::problem().await?;
+
+        let vcr = VolumeConstructionRequest::Volume {
+            id: Uuid::new_v4(),
+            block_size: BLOCK_SIZE as u64,
+            sub_volumes: vec![
+                VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds1.blocks_per_extent(),
+                    extent_count: tds1.extent_count(),
+                    opts: tds1.opts(),
+                    generation: 1,
+                },
+                VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds2.blocks_per_extent(),
+                    extent_count: tds2.extent_count(),
+                    opts: tds2.opts(),
+                    generation: 2,
+                },
+            ],
+            read_only_parent: Some(Box::new(
+                VolumeConstructionRequest::Region {
+                    block_size: BLOCK_SIZE as u64,
+                    blocks_per_extent: tds3.blocks_per_extent(),
+                    extent_count: tds3.extent_count(),
+                    opts: tds3.opts(),
+                    generation: 3,
+                },
+            )),
+        };
+
+        let volume = Volume::construct(vcr, None, csl()).await?;
+
+        volume.activate().await?;
+
+        // `problem` is 10M, so the total size should be `small` + `big`,
+        // meaning 5120 + 50M.
+
+        let sv1 = tds1.blocks_per_extent()
+            * tds1.extent_count() as u64
+            * BLOCK_SIZE as u64;
+
+        let sv2 = tds2.blocks_per_extent()
+            * tds2.extent_count() as u64
+            * BLOCK_SIZE as u64;
+
+        assert_eq!(volume.total_size().await?, sv1 + sv2);
+
+        // Verify the VolumeInfo for all three region sets
+
+        let info = volume.query_volume_info().await?;
+
+        let VolumeInfo::Volume {
+            sub_volumes,
+            read_only_parent,
+        } = info
+        else {
+            panic!("wrong variant!");
+        };
+
+        assert_eq!(sub_volumes.len(), 2);
+        assert!(read_only_parent.is_some());
+
+        // `small` downstairs set
+
+        let VolumeInfo::Upstairs {
+            state,
+            block_size: _,
+            upstairs_id: _,
+            session_id: _,
+            generation,
+            read_only,
+            encrypted,
+            reconcile_in_progress,
+            live_repair_in_progress,
+            targets,
+        } = &sub_volumes[0]
+        else {
+            panic!("wrong variant!");
+        };
+
+        assert_eq!(*state, UpstairsInfoStatus::Active);
+        assert_eq!(*generation, 1);
+        assert!(!(*read_only));
+        assert!(*encrypted);
+        assert!(!(*reconcile_in_progress));
+        assert!(!(*live_repair_in_progress));
+
+        let opts = tds1.opts();
+
+        for (i, target) in targets.iter().enumerate() {
+            let DownstairsInfo {
+                region_id: _,
+                target_addr,
+                repair_addr: _,
+                state,
+            } = &target;
+
+            assert_eq!(target_addr.as_ref(), Some(&opts.target[i]));
+            assert_eq!(*state, DownstairsInfoStatus::Active);
+        }
+
+        // `big` downstairs set
+
+        let VolumeInfo::Upstairs {
+            state,
+            block_size: _,
+            upstairs_id: _,
+            session_id: _,
+            generation,
+            read_only,
+            encrypted,
+            reconcile_in_progress,
+            live_repair_in_progress,
+            targets,
+        } = &sub_volumes[1]
+        else {
+            panic!("wrong variant!");
+        };
+
+        assert_eq!(*state, UpstairsInfoStatus::Active);
+        assert_eq!(*generation, 2);
+        assert!(!(*read_only));
+        assert!(*encrypted);
+        assert!(!(*reconcile_in_progress));
+        assert!(!(*live_repair_in_progress));
+
+        let opts = tds2.opts();
+
+        for (i, target) in targets.iter().enumerate() {
+            let DownstairsInfo {
+                region_id: _,
+                target_addr,
+                repair_addr: _,
+                state,
+            } = &target;
+
+            assert_eq!(target_addr.as_ref(), Some(&opts.target[i]));
+            assert_eq!(*state, DownstairsInfoStatus::Active);
+        }
+
+        // `problem` downstairs set
+
+        let Some(read_only_parent) = read_only_parent else {
+            panic!("should be Some");
+        };
+
+        let VolumeInfo::Upstairs {
+            state,
+            block_size: _,
+            upstairs_id: _,
+            session_id: _,
+            generation,
+            read_only,
+            encrypted,
+            reconcile_in_progress,
+            live_repair_in_progress,
+            targets,
+        } = &*read_only_parent
+        else {
+            panic!("wrong variant!");
+        };
+
+        assert_eq!(*state, UpstairsInfoStatus::Active);
+        assert_eq!(*generation, 3);
+        assert!(!(*read_only));
+        assert!(*encrypted);
+        assert!(!(*reconcile_in_progress));
+        assert!(!(*live_repair_in_progress));
+
+        let opts = tds3.opts();
+
+        for (i, target) in targets.iter().enumerate() {
+            let DownstairsInfo {
+                region_id: _,
+                target_addr,
+                repair_addr: _,
+                state,
+            } = &target;
+
+            assert_eq!(target_addr.as_ref(), Some(&opts.target[i]));
+            assert_eq!(*state, DownstairsInfoStatus::Active);
+        }
+
+        Ok(())
     }
 }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 #[cfg(test)]
 mod integration_tests {
@@ -6148,6 +6148,7 @@ mod integration_tests {
                 active: true,
                 seen_active: true,
                 num_job_handles: 0,
+                info: _,
             }
         ));
 
@@ -6181,6 +6182,7 @@ mod integration_tests {
                 active: false,
                 seen_active: true,
                 num_job_handles: 0,
+                info: _,
             }
         ));
     }
@@ -6270,5 +6272,76 @@ mod integration_tests {
         }
 
         Ok(())
+    }
+
+    /// Validate the VolumeInfo from the Pantry
+    #[tokio::test]
+    async fn test_pantry_get_volume_info() {
+        // Spin off three downstairs, build our Crucible struct.
+
+        let tds = DefaultTestDownstairsSet::big(false).await.unwrap();
+        let opts = tds.opts();
+
+        // Start a pantry, get the client for it, then use it to bulk_write
+        // in data
+        let (_pantry, volume_id, client) =
+            get_pantry_and_client_for_tds(&tds).await;
+
+        let status =
+            client.volume_status(&volume_id.to_string()).await.unwrap();
+
+        let crucible_pantry_client::types::VolumeStatus { info, .. } =
+            status.into_inner();
+
+        use crucible_pantry_client::types::DownstairsInfoStatus;
+        use crucible_pantry_client::types::UpstairsInfoStatus;
+
+        let crucible_pantry_client::types::VolumeInfo::Volume {
+            sub_volumes,
+            ..
+        } = info
+        else {
+            panic!("wrong variant");
+        };
+
+        assert_eq!(sub_volumes.len(), 1);
+
+        let crucible_pantry_client::types::VolumeInfo::Upstairs {
+            state,
+            block_size: _,
+            upstairs_id: _,
+            session_id: _,
+            generation,
+            read_only,
+            encrypted,
+            reconcile_in_progress,
+            live_repair_in_progress,
+            targets,
+        } = &sub_volumes[0]
+        else {
+            panic!("wrong variant!");
+        };
+
+        assert_eq!(*state, UpstairsInfoStatus::Active);
+        assert_eq!(*generation, 1);
+        assert!(!(*read_only));
+        assert!(*encrypted);
+        assert!(!(*reconcile_in_progress));
+        assert!(!(*live_repair_in_progress));
+
+        for (i, target) in targets.iter().enumerate() {
+            let crucible_pantry_client::types::DownstairsInfo {
+                region_id: _,
+                target_addr,
+                repair_addr: _,
+                state,
+            } = &target;
+
+            assert_eq!(
+                target_addr.as_ref().map(|x| x.parse().unwrap()),
+                Some(opts.target[i])
+            );
+            assert_eq!(*state, DownstairsInfoStatus::Active);
+        }
     }
 }

--- a/openapi/crucible-pantry/crucible-pantry-1.0.0-ad603f.json.gitstub
+++ b/openapi/crucible-pantry/crucible-pantry-1.0.0-ad603f.json.gitstub
@@ -1,0 +1,1 @@
+ef04744d2a7ba34d6036ec7c39abcc49eeec25ef:openapi/crucible-pantry/crucible-pantry-1.0.0-ad603f.json

--- a/openapi/crucible-pantry/crucible-pantry-2.0.0-9dbf85.json
+++ b/openapi/crucible-pantry/crucible-pantry-2.0.0-9dbf85.json
@@ -6,7 +6,7 @@
       "url": "https://oxide.computer",
       "email": "api@oxide.computer"
     },
-    "version": "1.0.0"
+    "version": "2.0.0"
   },
   "paths": {
     "/crucible/pantry/0": {
@@ -665,6 +665,117 @@
           "target"
         ]
       },
+      "DownstairsInfo": {
+        "type": "object",
+        "properties": {
+          "region_id": {
+            "nullable": true,
+            "type": "string",
+            "format": "uuid"
+          },
+          "repair_addr": {
+            "nullable": true,
+            "type": "string"
+          },
+          "state": {
+            "$ref": "#/components/schemas/DownstairsInfoStatus"
+          },
+          "target_addr": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "state"
+        ]
+      },
+      "DownstairsInfoConnectionMode": {
+        "type": "string",
+        "enum": [
+          "new",
+          "offline",
+          "faulted",
+          "replaced"
+        ]
+      },
+      "DownstairsInfoNegotiationStatus": {
+        "type": "string",
+        "enum": [
+          "wait_connect",
+          "negotiating",
+          "wait_quorum",
+          "reconcile",
+          "live_repair_ready"
+        ]
+      },
+      "DownstairsInfoStatus": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "$ref": "#/components/schemas/DownstairsInfoConnectionMode"
+              },
+              "state": {
+                "$ref": "#/components/schemas/DownstairsInfoNegotiationStatus"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "connecting"
+                ]
+              }
+            },
+            "required": [
+              "mode",
+              "state",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "active"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "live_repair"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "stopping"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      },
       "Error": {
         "description": "Error information from a response.",
         "type": "object",
@@ -815,6 +926,16 @@
         },
         "required": [
           "snapshot_id"
+        ]
+      },
+      "UpstairsInfoStatus": {
+        "type": "string",
+        "enum": [
+          "initializing",
+          "go_active",
+          "active",
+          "deactivating",
+          "disabled"
         ]
       },
       "ValidateRequest": {
@@ -989,12 +1110,116 @@
           }
         ]
       },
+      "VolumeInfo": {
+        "description": "A tree representation of the info and status of all parts of a Volume.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "volume": {
+                "type": "object",
+                "properties": {
+                  "read_only_parent": {
+                    "nullable": true,
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/VolumeInfo"
+                      }
+                    ]
+                  },
+                  "sub_volumes": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/VolumeInfo"
+                    }
+                  }
+                },
+                "required": [
+                  "sub_volumes"
+                ]
+              }
+            },
+            "required": [
+              "volume"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "upstairs": {
+                "type": "object",
+                "properties": {
+                  "block_size": {
+                    "nullable": true,
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0
+                  },
+                  "encrypted": {
+                    "type": "boolean"
+                  },
+                  "generation": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0
+                  },
+                  "live_repair_in_progress": {
+                    "type": "boolean"
+                  },
+                  "read_only": {
+                    "type": "boolean"
+                  },
+                  "reconcile_in_progress": {
+                    "type": "boolean"
+                  },
+                  "session_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "state": {
+                    "$ref": "#/components/schemas/UpstairsInfoStatus"
+                  },
+                  "targets": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/DownstairsInfo"
+                    }
+                  },
+                  "upstairs_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
+                "required": [
+                  "encrypted",
+                  "generation",
+                  "live_repair_in_progress",
+                  "read_only",
+                  "reconcile_in_progress",
+                  "session_id",
+                  "state",
+                  "targets",
+                  "upstairs_id"
+                ]
+              }
+            },
+            "required": [
+              "upstairs"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
       "VolumeStatus": {
         "type": "object",
         "properties": {
           "active": {
             "description": "Is the Volume currently active?",
             "type": "boolean"
+          },
+          "info": {
+            "$ref": "#/components/schemas/VolumeInfo"
           },
           "num_job_handles": {
             "description": "How many job handles are there for this Volume?",
@@ -1009,6 +1234,7 @@
         },
         "required": [
           "active",
+          "info",
           "num_job_handles",
           "seen_active"
         ]

--- a/openapi/crucible-pantry/crucible-pantry-latest.json
+++ b/openapi/crucible-pantry/crucible-pantry-latest.json
@@ -1,1 +1,1 @@
-crucible-pantry-1.0.0-ad603f.json
+crucible-pantry-2.0.0-9dbf85.json

--- a/pantry-api/src/lib.rs
+++ b/pantry-api/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2026 Oxide Computer Company
 
 use crucible_pantry_types_versions::latest;
+use crucible_pantry_types_versions::v1;
 use dropshot::{
     HttpError, HttpResponseDeleted, HttpResponseOk,
     HttpResponseUpdatedNoContent, Path, RequestContext, TypedBody,
@@ -19,6 +20,7 @@ api_versions!([
     // |  example for the next person.
     // v
     // (next_int, IDENT),
+    (2, VOLUME_INFO_ENUM),
     (1, INITIAL),
 ]);
 
@@ -51,11 +53,27 @@ pub trait CruciblePantryApi {
     #[endpoint {
         method = GET,
         path = "/crucible/pantry/0/volume/{id}",
+        versions = VERSION_VOLUME_INFO_ENUM..,
     }]
     async fn volume_status(
         rqctx: RequestContext<Self::Context>,
         path: Path<latest::pantry::VolumePath>,
     ) -> Result<HttpResponseOk<latest::pantry::VolumeStatus>, HttpError>;
+
+    #[endpoint {
+        method = GET,
+        path = "/crucible/pantry/0/volume/{id}",
+        versions = VERSION_INITIAL..VERSION_VOLUME_INFO_ENUM,
+        operation_id = "volume_status",
+    }]
+    async fn volume_status_v1(
+        rqctx: RequestContext<Self::Context>,
+        path: Path<latest::pantry::VolumePath>,
+    ) -> Result<HttpResponseOk<v1::pantry::VolumeStatus>, HttpError> {
+        Self::volume_status(rqctx, path)
+            .await
+            .map(|response| response.map(Into::into))
+    }
 
     /// Construct a volume from a VolumeConstructionRequest, storing the result in
     /// the Pantry.

--- a/pantry-client/src/lib.rs
+++ b/pantry-client/src/lib.rs
@@ -5,4 +5,8 @@ use progenitor::generate_api;
 generate_api!(
     spec = "../openapi/crucible-pantry/crucible-pantry-latest.json",
     derives = [schemars::JsonSchema],
+    patch = {
+        DownstairsInfoStatus = { derives = [PartialEq, Eq] },
+        UpstairsInfoStatus = { derives = [PartialEq, Eq] },
+    },
 );

--- a/pantry-types/versions/src/impls/pantry.rs
+++ b/pantry-types/versions/src/impls/pantry.rs
@@ -1,0 +1,14 @@
+// Copyright 2026 Oxide Computer Company
+
+use crate::latest;
+use crate::v1;
+
+impl From<latest::pantry::VolumeStatus> for v1::pantry::VolumeStatus {
+    fn from(latest: latest::pantry::VolumeStatus) -> v1::pantry::VolumeStatus {
+        v1::pantry::VolumeStatus {
+            active: latest.active,
+            seen_active: latest.seen_active,
+            num_job_handles: latest.num_job_handles,
+        }
+    }
+}

--- a/pantry-types/versions/src/latest.rs
+++ b/pantry-types/versions/src/latest.rs
@@ -20,7 +20,7 @@ pub mod pantry {
     pub use crate::v1::pantry::ValidateRequest;
     pub use crate::v1::pantry::ValidateResponse;
     pub use crate::v1::pantry::VolumePath;
-    pub use crate::v1::pantry::VolumeStatus;
+    pub use crate::v2::pantry::VolumeStatus;
 
     // Re-export ReplaceResult from crucible_client_types since the pantry API
     // uses it.

--- a/pantry-types/versions/src/lib.rs
+++ b/pantry-types/versions/src/lib.rs
@@ -31,3 +31,5 @@ mod impls;
 pub mod latest;
 #[path = "initial/mod.rs"]
 pub mod v1;
+#[path = "volume_info_enum/mod.rs"]
+pub mod v2;

--- a/pantry-types/versions/src/volume_info_enum/mod.rs
+++ b/pantry-types/versions/src/volume_info_enum/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2026 Oxide Computer Company
 
-//! Functional code for the latest versions of types.
+//! Version `VOLUME_INFO_ENUM` of the Crucible Pantry API.
 
 pub mod pantry;

--- a/pantry-types/versions/src/volume_info_enum/pantry.rs
+++ b/pantry-types/versions/src/volume_info_enum/pantry.rs
@@ -1,0 +1,18 @@
+// Copyright 2026 Oxide Computer Company
+
+use schemars::JsonSchema;
+use serde::Serialize;
+
+#[derive(Serialize, JsonSchema)]
+pub struct VolumeStatus {
+    /// Is the Volume currently active?
+    pub active: bool,
+
+    /// Has the Pantry ever seen this Volume active?
+    pub seen_active: bool,
+
+    /// How many job handles are there for this Volume?
+    pub num_job_handles: usize,
+
+    pub info: crucible_client_types::VolumeInfo,
+}

--- a/pantry/src/pantry.rs
+++ b/pantry/src/pantry.rs
@@ -883,6 +883,7 @@ impl Pantry {
             active,
             seen_active,
             num_job_handles: jobs.num_job_handles_for_volume(&volume_id),
+            info: entry.volume.query_volume_info().await?,
         })
     }
 

--- a/upstairs/src/client.rs
+++ b/upstairs/src/client.rs
@@ -1780,6 +1780,14 @@ impl DownstairsClient {
     pub(crate) fn id(&self) -> Option<Uuid> {
         self.region_uuid
     }
+
+    pub(crate) fn target_addr(&self) -> Option<SocketAddr> {
+        self.target_addr
+    }
+
+    pub(crate) fn repair_addr(&self) -> Option<SocketAddr> {
+        self.repair_addr
+    }
 }
 
 /// Tracks client negotiation progress

--- a/upstairs/src/downstairs.rs
+++ b/upstairs/src/downstairs.rs
@@ -1068,6 +1068,11 @@ impl Downstairs {
         }
     }
 
+    /// Checks whether a reconciliation is in progress
+    pub(crate) fn reconcile_in_progress(&self) -> bool {
+        self.reconcile.is_some()
+    }
+
     /// Checks whether a live-repair is in progress
     pub(crate) fn live_repair_in_progress(&self) -> bool {
         // A live-repair is in progress if any client is in the LiveRepair

--- a/upstairs/src/guest.rs
+++ b/upstairs/src/guest.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use crucible_client_types::CrucibleOpts;
 use crucible_client_types::RegionExtentInfo;
+use crucible_client_types::VolumeInfo;
 use crucible_common::{BlockIndex, CrucibleError, build_logger};
 use crucible_protocol::SnapshotDetails;
 use oximeter::types::ProducerRegistry;
@@ -294,6 +295,14 @@ impl BlockIO for Guest {
             .send_and_wait(|done| BlockOp::QueryExtentInfo { done })
             .await?;
         Ok(Some(ei))
+    }
+
+    async fn query_volume_info(&self) -> Result<VolumeInfo, CrucibleError> {
+        let status = self
+            .send_and_wait(|done| BlockOp::QueryVolumeInfo { done })
+            .await?;
+
+        Ok(status)
     }
 
     async fn total_size(&self) -> Result<u64, CrucibleError> {

--- a/upstairs/src/lib.rs
+++ b/upstairs/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 #![allow(clippy::mutex_atomic)]
 
 use std::clone::Clone;
@@ -11,9 +11,11 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
-pub use crucible_client_types::{
-    CrucibleOpts, RegionExtentInfo, ReplaceResult, VolumeConstructionRequest,
-};
+pub use crucible_client_types::CrucibleOpts;
+pub use crucible_client_types::RegionExtentInfo;
+pub use crucible_client_types::ReplaceResult;
+pub use crucible_client_types::VolumeConstructionRequest;
+pub use crucible_client_types::VolumeInfo;
 pub use crucible_common::*;
 pub use crucible_protocol::*;
 
@@ -140,6 +142,17 @@ pub trait BlockIO: Sync {
         &self,
     ) -> Result<Option<RegionExtentInfo>, CrucibleError>;
     async fn query_work_queue(&self) -> Result<WQCounts, CrucibleError>;
+
+    /// Return a VolumeInfo object.
+    ///
+    /// This only make sense for Volume, Subvolume, and Guest, so it is only
+    /// implemented for those.
+    async fn query_volume_info(&self) -> Result<VolumeInfo, CrucibleError> {
+        crucible_bail!(
+            Unsupported,
+            "query_volume_info not implemented for this type"
+        );
+    }
 
     // Total bytes of Volume
     async fn total_size(&self) -> Result<u64, CrucibleError>;
@@ -1537,6 +1550,9 @@ pub(crate) enum BlockOp {
     },
     QueryUpstairsUuid {
         done: BlockRes<Uuid>,
+    },
+    QueryVolumeInfo {
+        done: BlockRes<VolumeInfo>,
     },
     // Begin testing options.
     QueryExtentInfo {

--- a/upstairs/src/upstairs.rs
+++ b/upstairs/src/upstairs.rs
@@ -1,9 +1,12 @@
-// Copyright 2023 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
+
 //! Data structures specific to Crucible's `struct Upstairs`
+
 use crate::{
     BlockOp, BlockRes, Buffer, ClientId, ClientMap, ConnectionMode,
-    CrucibleOpts, DsState, EncryptionContext, GuestIoHandle, Message,
-    RegionDefinition, RegionDefinitionStatus, SnapshotDetails, WQCounts, cdt,
+    CrucibleOpts, DsState, DsStateData, EncryptionContext, GuestIoHandle,
+    Message, NegotiationStateData, RegionDefinition, RegionDefinitionStatus,
+    SnapshotDetails, WQCounts, cdt,
     client::{
         ClientAction, ClientNegotiationFailed, ClientRunResult,
         ClientStopReason, NegotiationResult, NegotiationState,
@@ -19,6 +22,7 @@ use crate::{
     stats::UpStatOuter,
 };
 use crucible_client_types::RegionExtentInfo;
+use crucible_client_types::VolumeInfo;
 use crucible_common::{BlockIndex, CrucibleError};
 use serde::{Deserialize, Serialize};
 
@@ -1094,6 +1098,10 @@ impl Upstairs {
                         ));
                     }
                 };
+            }
+            BlockOp::QueryVolumeInfo { done } => {
+                let status = self.get_volume_info();
+                done.send_ok(status);
             }
             // Testing options
             BlockOp::QueryExtentInfo { done } => {
@@ -2251,6 +2259,99 @@ impl Upstairs {
     #[cfg(test)]
     pub(crate) fn ds_state(&self, client_id: ClientId) -> DsState {
         self.downstairs.clients[client_id].state()
+    }
+
+    pub fn get_volume_info(&self) -> VolumeInfo {
+        use crucible_client_types::DownstairsInfoConnectionMode;
+        use crucible_client_types::DownstairsInfoNegotiationStatus;
+        use crucible_client_types::DownstairsInfoStatus;
+        use crucible_client_types::UpstairsInfoStatus;
+
+        let mut targets = Vec::with_capacity(3);
+
+        for client in self.downstairs.clients.iter() {
+            let state = match client.state_data() {
+                DsStateData::Connecting { state, mode } => {
+                    DownstairsInfoStatus::Connecting {
+                        state: match state {
+                            NegotiationStateData::WaitConnect(_) => {
+                                DownstairsInfoNegotiationStatus::WaitConnect
+                            }
+
+                            NegotiationStateData::Start
+                            | NegotiationStateData::WaitForPromote
+                            | NegotiationStateData::WaitForRegionInfo
+                            | NegotiationStateData::GetExtentVersions => {
+                                DownstairsInfoNegotiationStatus::Negotiating
+                            }
+
+                            NegotiationStateData::WaitQuorum(_) => {
+                                DownstairsInfoNegotiationStatus::WaitQuorum
+                            }
+
+                            NegotiationStateData::Reconcile => {
+                                DownstairsInfoNegotiationStatus::Reconcile
+                            }
+
+                            NegotiationStateData::LiveRepairReady(_) => {
+                                DownstairsInfoNegotiationStatus::LiveRepairReady
+                            }
+                        },
+
+                        mode: match mode {
+                            ConnectionMode::New => {
+                                DownstairsInfoConnectionMode::New
+                            }
+                            ConnectionMode::Offline => {
+                                DownstairsInfoConnectionMode::Offline
+                            }
+                            ConnectionMode::Faulted => {
+                                DownstairsInfoConnectionMode::Faulted
+                            }
+                            ConnectionMode::Replaced => {
+                                DownstairsInfoConnectionMode::Replaced
+                            }
+                        },
+                    }
+                }
+
+                DsStateData::Active => DownstairsInfoStatus::Active,
+
+                DsStateData::LiveRepair => DownstairsInfoStatus::LiveRepair,
+
+                DsStateData::Stopping(_) => DownstairsInfoStatus::Stopping,
+            };
+
+            let target = crucible_client_types::DownstairsInfo {
+                region_id: client.id(),
+                target_addr: client.target_addr(),
+                repair_addr: client.repair_addr(),
+                state,
+            };
+
+            targets.push(target);
+        }
+
+        VolumeInfo::Upstairs {
+            state: match self.state {
+                UpstairsState::Initializing => UpstairsInfoStatus::Initializing,
+                UpstairsState::GoActive(_) => UpstairsInfoStatus::GoActive,
+                UpstairsState::Active => UpstairsInfoStatus::Active,
+                UpstairsState::Deactivating(_) => {
+                    UpstairsInfoStatus::Deactivating
+                }
+                UpstairsState::Disabled(_) => UpstairsInfoStatus::Disabled,
+            },
+            block_size: self.ddef.get_def().map(|ddef| ddef.block_size()),
+            upstairs_id: self.cfg.upstairs_id,
+            session_id: self.cfg.session_id,
+            generation: self.cfg.generation(),
+            read_only: self.cfg.read_only,
+            encrypted: self.cfg.encrypted(),
+            reconcile_in_progress: self.downstairs.reconcile_in_progress(),
+            live_repair_in_progress: self.downstairs.live_repair_in_progress(),
+            targets,
+        }
     }
 }
 

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -13,6 +13,7 @@ use tokio::time::Instant;
 use crucible_client_types::RegionExtentInfo;
 use crucible_client_types::ReplacementRequestCheck;
 use crucible_client_types::VolumeConstructionRequest;
+use crucible_client_types::VolumeInfo;
 
 /// Creates a `RegionDefinition` from a set of parameters in a region
 /// construction request.
@@ -710,7 +711,7 @@ impl Volume {
 
     pub async fn volume_extent_info(
         &self,
-    ) -> Result<VolumeInfo, CrucibleError> {
+    ) -> Result<VolumeExtentInfo, CrucibleError> {
         // A volume has multiple levels of extent info, not just one.
         let mut volumes = Vec::new();
 
@@ -721,7 +722,7 @@ impl Volume {
                     // it, we verify that the block sizes match, so we never
                     // expect there to be a mismatch.
                     assert_eq!(self.block_size, ei.block_size);
-                    let svi = SubVolumeInfo {
+                    let svi = SubVolumeExtentInfo {
                         blocks_per_extent: ei.blocks_per_extent,
                         extent_count: ei.extent_count,
                     };
@@ -737,7 +738,7 @@ impl Volume {
             }
         }
 
-        Ok(VolumeInfo {
+        Ok(VolumeExtentInfo {
             block_size: self.block_size,
             volumes,
         })
@@ -873,6 +874,28 @@ impl BlockIO for VolumeInner {
         }
 
         Ok(true)
+    }
+
+    async fn query_volume_info(&self) -> Result<VolumeInfo, CrucibleError> {
+        Ok(VolumeInfo::Volume {
+            sub_volumes: {
+                let mut statuses = Vec::with_capacity(self.sub_volumes.len());
+
+                for sub_volume in &self.sub_volumes {
+                    statuses.push(sub_volume.query_volume_info().await?);
+                }
+
+                statuses
+            },
+
+            read_only_parent: {
+                if let Some(rop) = &self.read_only_parent {
+                    Some(Box::new(rop.query_volume_info().await?))
+                } else {
+                    None
+                }
+            },
+        })
     }
 
     async fn total_size(&self) -> Result<u64, CrucibleError> {
@@ -1111,18 +1134,20 @@ impl BlockIO for VolumeInner {
     }
 }
 
+// TODO eventually put this in VolumeInfo?
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct VolumeInfo {
+pub struct VolumeExtentInfo {
     pub block_size: u64,
-    pub volumes: Vec<SubVolumeInfo>,
+    pub volumes: Vec<SubVolumeExtentInfo>,
 }
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct SubVolumeInfo {
+pub struct SubVolumeExtentInfo {
     pub blocks_per_extent: u64,
     pub extent_count: u32,
 }
 
-impl VolumeInfo {
+impl VolumeExtentInfo {
     pub fn total_size(&self) -> u64 {
         self.block_size * (self.total_blocks() as u64)
     }
@@ -1248,6 +1273,10 @@ impl BlockIO for SubVolume {
 
     async fn query_is_active(&self) -> Result<bool, CrucibleError> {
         self.block_io.query_is_active().await
+    }
+
+    async fn query_volume_info(&self) -> Result<VolumeInfo, CrucibleError> {
+        self.block_io.query_volume_info().await
     }
 
     async fn total_size(&self) -> Result<u64, CrucibleError> {


### PR DESCRIPTION
Add a new VolumeInfo enum that will be returned and provide a richer tree of information that matches the shape of the Volume. The intended consumer of this is the control plane in a few areas:

- when performing region replacement or region snapshot replacement, the control plane needs to know when to consider the live repair or reconciliation successful, ultimately proceeding to cleaning up the temporary resources and continuing with another replacement. The upstairs has always been the source of this answer but the plan is to move from using activation as this signal to using this introduced enum

- when activating with only 2 out of 3 downstairs available, the control plane needs to know the difference between an unhealthy volume and one that activated early with 2 out of 3 but eventually had all 3 mirrors online.

- in the future, the control plane could query for health when performing updates or sled reboots, pausing until impacted Volumes become healthy again

The VolumeInfo enum already existed so this PR renames that to VolumeExtentInfo. Eventually we should probably combine the two.