### PR TITLE
Add VolumeInfo to crutest-cli

### DIFF
--- a/crutest/src/cli.rs
+++ b/crutest/src/cli.rs
@@ -197,6 +197,8 @@ enum CliCommand {
     },
     /// Get the upstairs UUID
     Uuid,
+    /// Request volume info as JSON
+    VolumeInfo,
 }
 
 /*
@@ -546,6 +548,9 @@ async fn cmd_to_msg(
         CliCommand::WriteUnwritten { offset } => {
             fw.send(CliMessage::WriteUnwritten(offset)).await?;
         }
+        CliCommand::VolumeInfo => {
+            fw.send(CliMessage::VolumeInfoPlease).await?;
+        }
     }
     /*
      * Now, wait for our response
@@ -557,6 +562,9 @@ async fn cmd_to_msg(
         }
         Some(CliMessage::Info(vi)) => {
             println!("Got info: {:?}", vi);
+        }
+        Some(CliMessage::VolumeInfoJson(json)) => {
+            println!("{}", json);
         }
         Some(CliMessage::DoneOk) => {
             println!("Ok");
@@ -988,6 +996,15 @@ async fn process_cli_command(
         CliMessage::Uuid => {
             let uuid = volume.get_uuid().await?;
             fw.send(CliMessage::MyUuid(uuid)).await
+        }
+        CliMessage::VolumeInfoPlease => {
+            match volume.query_volume_info().await {
+                Ok(vi) => {
+                    let json = serde_json::to_string_pretty(&vi).unwrap();
+                    fw.send(CliMessage::VolumeInfoJson(json)).await
+                }
+                Err(e) => fw.send(CliMessage::Error(e)).await,
+            }
         }
         CliMessage::Verify => {
             if let Some(di) = di_option {

--- a/crutest/src/protocol.rs
+++ b/crutest/src/protocol.rs
@@ -58,6 +58,8 @@ pub enum CliMessage {
     WriteUnwritten(usize),
     Unknown(u32, BytesMut),
     Uuid,
+    VolumeInfoPlease,
+    VolumeInfoJson(String),
 }
 
 #[derive(Debug)]
@@ -313,6 +315,20 @@ mod tests {
     #[test]
     fn rt_generic() -> Result<()> {
         let input = CliMessage::Generic(2, true, true);
+        assert_eq!(input, round_trip(&input)?);
+        Ok(())
+    }
+
+    #[test]
+    fn rt_volume_info_please() -> Result<()> {
+        let input = CliMessage::VolumeInfoPlease;
+        assert_eq!(input, round_trip(&input)?);
+        Ok(())
+    }
+
+    #[test]
+    fn rt_volume_info_json() -> Result<()> {
+        let input = CliMessage::VolumeInfoJson(r#"{"volume": {}}"#.to_string());
         assert_eq!(input, round_trip(&input)?);
         Ok(())
     }


### PR DESCRIPTION
Added the volume-info command to crutest cli.
This will get the VolumeInfo, make it json, and send it over to the CLI.

Here is an example of it in action:
```
>> volume-info                                                                  
{                                                                               
  "volume": {                                                                   
    "sub_volumes": [                                                            
      {                                 
        "upstairs": {   
          "state": "active",            
          "block_size": 4096,           
          "upstairs_id": "7d6c7fbe-9dbc-4a80-9626-fb61e9228aae",
          "session_id": "a2bd3329-4ed2-413b-8f46-007adafc8b15",                 
          "generation": 1,                                                      
          "read_only": false,                                                   
          "encrypted": false, 
          "reconcile_in_progress": false,                   
          "live_repair_in_progress": false,                            
          "targets": [                
            {                                                                   
              "region_id": "12345678-0000-0000-0000-000000008810",              
              "target_addr": "127.0.0.1:8810",
              "repair_addr": "0.0.0.0:12810",                   
              "state": {
                "type": "active"
              }                         
            },                                                                  
            {                                                                   
              "region_id": "12345678-0000-0000-0000-000000008820",              
              "target_addr": "127.0.0.1:8820",
              "repair_addr": "0.0.0.0:12820",
              "state": {     
                "type": "active"       
              }                         
            },                          
            { 
              "region_id": "12345678-0000-0000-0000-000000008830",
              "target_addr": "127.0.0.1:8830",
              "repair_addr": "0.0.0.0:12830",
              "state": {  
                "type": "active"
              }                         
            }                           
          ]                                                                     
        }                               
      }                                                                         
    ],              
>>
```