### PR TITLE
Use an explicit rev for oxidecomputer git deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 [[package]]
 name = "api_identity"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "bootstore"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "bytes",
  "camino",
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "bootstrap-agent-lockstep-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "anyhow",
  "omicron-common",
@@ -932,7 +932,7 @@ dependencies = [
 [[package]]
 name = "clickhouse-admin-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "clickhouse-admin-types-versions",
  "omicron-workspace-hack",
@@ -941,7 +941,7 @@ dependencies = [
 [[package]]
 name = "clickhouse-admin-types-versions"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "anyhow",
  "atomicwrites",
@@ -1020,7 +1020,7 @@ checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 [[package]]
 name = "cockroach-admin-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "cockroach-admin-types-versions",
  "omicron-workspace-hack",
@@ -1030,7 +1030,7 @@ dependencies = [
 [[package]]
 name = "cockroach-admin-types-versions"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "chrono",
  "csv",
@@ -2728,7 +2728,7 @@ dependencies = [
 [[package]]
 name = "ereport-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "dropshot",
  "omicron-uuid-kinds",
@@ -3072,7 +3072,7 @@ dependencies = [
 [[package]]
 name = "gateway-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3114,7 +3114,7 @@ dependencies = [
 [[package]]
 name = "gateway-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "gateway-types-versions",
  "omicron-workspace-hack",
@@ -3123,7 +3123,7 @@ dependencies = [
 [[package]]
 name = "gateway-types-versions"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "daft",
  "dropshot",
@@ -3217,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "gfss"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "digest",
  "omicron-workspace-hack",
@@ -3977,7 +3977,7 @@ dependencies = [
 [[package]]
 name = "illumos-utils"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4132,7 +4132,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "internal-dns-resolver"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "futures",
  "hickory-proto 0.25.2",
@@ -4150,7 +4150,7 @@ dependencies = [
 [[package]]
 name = "internal-dns-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4166,7 +4166,7 @@ dependencies = [
 [[package]]
 name = "internal-dns-types-versions"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4358,7 +4358,7 @@ dependencies = [
 [[package]]
 name = "key-manager-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "omicron-workspace-hack",
  "secrecy",
@@ -4806,7 +4806,7 @@ dependencies = [
 [[package]]
 name = "nexus-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "chrono",
  "futures",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "nexus-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "anyhow",
  "api_identity",
@@ -4905,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "nexus-types-versions"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "anyhow",
  "api_identity",
@@ -5188,7 +5188,7 @@ dependencies = [
 [[package]]
 name = "omicron-common"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "anyhow",
  "api_identity",
@@ -5235,7 +5235,7 @@ dependencies = [
 [[package]]
 name = "omicron-ledger"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "async-trait",
  "camino",
@@ -5251,7 +5251,7 @@ dependencies = [
 [[package]]
 name = "omicron-passwords"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "argon2",
  "omicron-workspace-hack",
@@ -5266,7 +5266,7 @@ dependencies = [
 [[package]]
 name = "omicron-uuid-kinds"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "daft",
  "newtype-uuid",
@@ -5332,7 +5332,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "openapi-lint"
 version = "0.4.0"
-source = "git+https://github.com/oxidecomputer/openapi-lint?branch=main#ef442ee4343e97b6d9c217d3e7533962fe7d7236"
+source = "git+https://github.com/oxidecomputer/openapi-lint?rev=ef442ee4343e97b6d9c217d3e7533962fe7d7236#ef442ee4343e97b6d9c217d3e7533962fe7d7236"
 dependencies = [
  "heck 0.4.1",
  "indexmap 2.14.0",
@@ -5569,7 +5569,7 @@ dependencies = [
 [[package]]
 name = "oximeter"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5588,7 +5588,7 @@ dependencies = [
 [[package]]
 name = "oximeter-db"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -5643,7 +5643,7 @@ dependencies = [
 [[package]]
 name = "oximeter-macro-impl"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "omicron-workspace-hack",
  "proc-macro2",
@@ -5654,7 +5654,7 @@ dependencies = [
 [[package]]
 name = "oximeter-producer"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "chrono",
  "dropshot",
@@ -5679,7 +5679,7 @@ dependencies = [
 [[package]]
 name = "oximeter-producer-api"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "dropshot",
  "omicron-workspace-hack",
@@ -5689,7 +5689,7 @@ dependencies = [
 [[package]]
 name = "oximeter-schema"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5710,7 +5710,7 @@ dependencies = [
 [[package]]
 name = "oximeter-timeseries-macro"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "omicron-workspace-hack",
  "oximeter-schema",
@@ -5723,7 +5723,7 @@ dependencies = [
 [[package]]
 name = "oximeter-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "omicron-workspace-hack",
  "oximeter-types-versions",
@@ -5732,7 +5732,7 @@ dependencies = [
 [[package]]
 name = "oximeter-types-versions"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "bytes",
  "chrono",
@@ -5752,7 +5752,7 @@ dependencies = [
 [[package]]
 name = "oxlog"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "anyhow",
  "camino",
@@ -5781,7 +5781,7 @@ dependencies = [
 [[package]]
 name = "oxql-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7859,7 +7859,7 @@ dependencies = [
 [[package]]
 name = "sled-agent-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7889,7 +7889,7 @@ dependencies = [
 [[package]]
 name = "sled-agent-types-versions"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7928,7 +7928,7 @@ dependencies = [
 [[package]]
 name = "sled-hardware-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "daft",
  "omicron-workspace-hack",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "trust-quorum-protocol"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "bootstore",
  "bytes",
@@ -9106,7 +9106,7 @@ dependencies = [
 [[package]]
 name = "trust-quorum-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "omicron-workspace-hack",
  "trust-quorum-types-versions",
@@ -9115,7 +9115,7 @@ dependencies = [
 [[package]]
 name = "trust-quorum-types-versions"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "byte-wrapper",
  "daft",
@@ -9331,7 +9331,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 [[package]]
 name = "update-engine"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/omicron?branch=main#fa779b29af7a8656657ccca6ec531446188d916c"
+source = "git+https://github.com/oxidecomputer/omicron?rev=fa779b29af7a8656657ccca6ec531446188d916c#fa779b29af7a8656657ccca6ec531446188d916c"
 dependencies = [
  "anyhow",
  "cancel-safe-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,14 +134,15 @@ usdt = "0.6.0"
 uuid = { version = "1", features = [ "serde", "v4" ] }
 
 # git
-omicron-common = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
-nexus-client = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
-internal-dns-resolver = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
-internal-dns-types = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
-omicron-uuid-kinds = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
-openapi-lint = { git = "https://github.com/oxidecomputer/openapi-lint", branch = "main" }
-oximeter = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
-oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", branch = "main" }
+omicron-common = { git = "https://github.com/oxidecomputer/omicron", rev = "fa779b29af7a8656657ccca6ec531446188d916c" }
+nexus-client = { git = "https://github.com/oxidecomputer/omicron", rev = "fa779b29af7a8656657ccca6ec531446188d916c" }
+internal-dns-resolver = { git = "https://github.com/oxidecomputer/omicron", rev = "fa779b29af7a8656657ccca6ec531446188d916c" }
+internal-dns-types = { git = "https://github.com/oxidecomputer/omicron", rev = "fa779b29af7a8656657ccca6ec531446188d916c" }
+omicron-uuid-kinds = { git = "https://github.com/oxidecomputer/omicron", rev = "fa779b29af7a8656657ccca6ec531446188d916c" }
+oximeter = { git = "https://github.com/oxidecomputer/omicron", rev = "fa779b29af7a8656657ccca6ec531446188d916c" }
+oximeter-producer = { git = "https://github.com/oxidecomputer/omicron", rev = "fa779b29af7a8656657ccca6ec531446188d916c" }
+
+openapi-lint = { git = "https://github.com/oxidecomputer/openapi-lint", rev = "ef442ee4343e97b6d9c217d3e7533962fe7d7236" }
 
 # local path
 crucible = { path = "./upstairs" }


### PR DESCRIPTION
Chasing down a cargo build failure in propolis caused by multiple versions of the same package lead to the discovery that rev of omicron that is in propolis' lock file is old, about 700 commits behind main. Once propolis was updated to the same rev of omicron that crucible uses, cargo no longer hit that same build error.

Use explicit git revs in Cargo.toml: this doesn't change the version in the lock file but does make it explicit what is being used. Propolis will be updated shortly to pull this commit in (a no-op, as the lockfile version doesn't change), and will be updated to use explicit revs in the same way.