### PR TITLE
dsc: add --oximeter flag to publish downstairs metrics

### DIFF
--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -188,6 +188,12 @@ enum Action {
         #[clap(long, default_value = "15", action)]
         extent_count: u32,
 
+        /// Registration address of an Oximeter collector. When set, each
+        /// downstairs is started with `--oximeter <addr>` and publishes
+        /// metrics to that collector.
+        #[clap(long, action)]
+        oximeter: Option<SocketAddr>,
+
         /// Downstairs will all be started read only (default: false)
         #[clap(long, action, default_value = "false")]
         read_only: bool,
@@ -234,6 +240,9 @@ struct DownstairsInfo {
     output_file: PathBuf,
     client_id: usize,
     read_only: bool,
+    /// Registration address of an Oximeter collector. When set, the spawned
+    /// downstairs is told to register and publish metrics (`--oximeter`).
+    oximeter: Option<SocketAddr>,
 }
 
 impl DownstairsInfo {
@@ -247,6 +256,7 @@ impl DownstairsInfo {
         output_file: PathBuf,
         client_id: usize,
         read_only: bool,
+        oximeter: Option<SocketAddr>,
     ) -> DownstairsInfo {
         DownstairsInfo {
             ds_bin,
@@ -257,6 +267,7 @@ impl DownstairsInfo {
             output_file,
             client_id,
             read_only,
+            oximeter,
         }
     }
 
@@ -275,16 +286,21 @@ impl DownstairsInfo {
         };
 
         let region_dir = self.region_dir.clone();
+        let mut args = vec![
+            "run".to_string(),
+            "-p".to_string(),
+            port_value,
+            "-d".to_string(),
+            region_dir.clone(),
+            "--mode".to_string(),
+            mode,
+        ];
+        if let Some(oximeter) = self.oximeter {
+            args.push("--oximeter".to_string());
+            args.push(oximeter.to_string());
+        }
         let cmd = Command::new(self.ds_bin.clone())
-            .args([
-                "run",
-                "-p",
-                &port_value,
-                "-d",
-                &region_dir,
-                "--mode",
-                &mode,
-            ])
+            .args(&args)
             .stdout(Stdio::from(outputs))
             .stderr(Stdio::from(errors))
             .spawn()
@@ -324,6 +340,8 @@ pub struct DscInfo {
     work: Mutex<DscWork>,
     /// If the downstairs are started read only
     read_only: bool,
+    /// Oximeter collector registration address passed to each downstairs
+    oximeter: Option<SocketAddr>,
 }
 
 impl DscInfo {
@@ -337,6 +355,7 @@ impl DscInfo {
         port_base: u32,
         region_count: usize,
         read_only: bool,
+        oximeter: Option<SocketAddr>,
     ) -> Result<Arc<Self>> {
         // Verify the downstairs binary exists as is a file
         if !Path::new(&downstairs_bin).exists() {
@@ -453,6 +472,7 @@ impl DscInfo {
             rs: mrs,
             work,
             read_only,
+            oximeter,
         }))
     }
 
@@ -598,6 +618,7 @@ impl DscInfo {
             output_path,
             ds_id,
             self.read_only,
+            self.oximeter,
         );
         rs.ds.push(Arc::new(dsi));
 
@@ -693,6 +714,7 @@ impl DscInfo {
                 output_path,
                 ds_id,
                 self.read_only,
+                self.oximeter,
             );
             rs.ds.push(Arc::new(dsi));
             port += rs.port_step;
@@ -1569,6 +1591,7 @@ fn main() -> Result<()> {
                 port_base,
                 region_count,
                 false,
+                None,
             )?;
 
             runtime.block_on(dsci.create_regions(
@@ -1587,7 +1610,8 @@ fn main() -> Result<()> {
             region_dir,
         } => {
             let dsci = DscInfo::new(
-                ds_bin, output_dir, region_dir, notify_tx, true, 8810, 3, false,
+                ds_bin, output_dir, region_dir, notify_tx, true, 8810, 3,
+                false, None,
             )?;
             runtime.block_on(region_create_test(&dsci, long, csv_out))
         }
@@ -1600,6 +1624,7 @@ fn main() -> Result<()> {
             encrypted,
             extent_size,
             extent_count,
+            oximeter,
             output_dir,
             port_base,
             read_only,
@@ -1628,6 +1653,7 @@ fn main() -> Result<()> {
                 port_base,
                 region_count,
                 read_only,
+                oximeter,
             )?;
 
             if create {
@@ -1683,6 +1709,7 @@ mod test {
             8810,
             3,
             false,
+            None,
         );
         assert!(res.is_ok());
         assert!(Path::new(&dir).exists());
@@ -1708,6 +1735,7 @@ mod test {
             8810,
             3,
             false,
+            None,
         );
         assert!(res.is_ok());
         assert!(Path::new(&dir).exists());
@@ -1727,8 +1755,9 @@ mod test {
         let r2 = tempdir().unwrap().as_ref().to_path_buf();
         let region_vec = vec![r1, r2];
         let (tx, _) = watch::channel(0);
-        let res =
-            DscInfo::new(ds_bin, dir, region_vec, tx, true, 8810, 3, false);
+        let res = DscInfo::new(
+            ds_bin, dir, region_vec, tx, true, 8810, 3, false, None,
+        );
         assert!(res.is_err());
     }
 
@@ -1744,8 +1773,9 @@ mod test {
         let r3 = tempdir().unwrap().as_ref().to_path_buf();
         let region_vec = vec![r1, r2, r3];
         let (tx, _) = watch::channel(0);
-        let res =
-            DscInfo::new(ds_bin, dir, region_vec, tx, true, 8810, 2, false);
+        let res = DscInfo::new(
+            ds_bin, dir, region_vec, tx, true, 8810, 2, false, None,
+        );
         assert!(res.is_err());
     }
 
@@ -1770,6 +1800,7 @@ mod test {
             8810,
             4,
             false,
+            None,
         );
         assert!(res.is_ok());
         assert!(Path::new(&dir).exists());
@@ -1795,6 +1826,7 @@ mod test {
             8810,
             3,
             false,
+            None,
         );
 
         assert!(res.is_err());
@@ -1820,13 +1852,14 @@ mod test {
             8810,
             3,
             false,
+            None,
         )
         .unwrap();
 
         // Now, create them again and expect an error.
         let (tx, _) = watch::channel(0);
         let res = DscInfo::new(
-            ds_bin, output_dir, region_vec, tx, true, 8810, 3, false,
+            ds_bin, output_dir, region_vec, tx, true, 8810, 3, false, None,
         );
         assert!(res.is_err());
     }
@@ -1839,9 +1872,10 @@ mod test {
         let dir = tempdir().unwrap().as_ref().to_path_buf();
         let region_vec = vec![dir.clone()];
         let (tx, _) = watch::channel(0);
-        let dsci =
-            DscInfo::new(ds_bin, dir, region_vec, tx, true, 8810, 3, false)
-                .unwrap();
+        let dsci = DscInfo::new(
+            ds_bin, dir, region_vec, tx, true, 8810, 3, false, None,
+        )
+        .unwrap();
 
         let res = dsci.delete_ds_region(0).await;
         println!("res is {:?}", res);
@@ -1859,9 +1893,10 @@ mod test {
         let r3 = tempdir().unwrap().as_ref().to_path_buf();
         let region_vec = vec![r1.clone(), r2, r3];
         let (tx, _) = watch::channel(0);
-        let dsci =
-            DscInfo::new(ds_bin, dir, region_vec, tx, true, 8810, 3, false)
-                .unwrap();
+        let dsci = DscInfo::new(
+            ds_bin, dir, region_vec, tx, true, 8810, 3, false, None,
+        )
+        .unwrap();
 
         // Manually create the first region directory.
         let ds_region_dir =
@@ -1895,6 +1930,7 @@ mod test {
             8810,
             3,
             false,
+            None,
         )
         .unwrap();
 
@@ -1927,6 +1963,7 @@ mod test {
             8810,
             3,
             false,
+            None,
         )
         .unwrap();
         assert!(Path::new(&dir).exists());
@@ -1969,6 +2006,7 @@ mod test {
             8810,
             4,
             false,
+            None,
         )
         .unwrap();
         assert!(Path::new(&dir).exists());
@@ -2012,6 +2050,7 @@ mod test {
             8810,
             3,
             false,
+            None,
         )
         .unwrap();
         assert!(Path::new(&dir).exists());
@@ -2050,6 +2089,7 @@ mod test {
             8810,
             4,
             false,
+            None,
         )
         .unwrap();
         assert!(Path::new(&dir).exists());


### PR DESCRIPTION
## Summary

`dsc` spawns `crucible-downstairs` instances but never passes `--oximeter`, so a `dsc`-managed fleet emits no Oximeter metrics — there's no way to wire the downstairs producer endpoints up to a collector.

This adds an optional `--oximeter <addr>` flag to `dsc start`. When set, the address is threaded through to every downstairs `dsc` spawns (`crucible-downstairs run ... --oximeter <addr>`), mirroring how the existing `read_only` option is propagated through `DownstairsInfo`/`DscInfo`. When unset, behavior is unchanged.

This makes it possible to point a `dsc` test fleet at an Oximeter collector (or a Nexus-compatible registration endpoint) for metrics collection.

## Implementation

- `DownstairsInfo` and `DscInfo` gain an `oximeter: Option<SocketAddr>` field, propagated from the `Start` subcommand.
- `DownstairsInfo::start()` appends `--oximeter <addr>` to the spawned command's args only when the option is set.
- Non-`Start` paths (`Create`, `RegionPerf`) pass `None`.

## Test plan

- [x] `cargo fmt -p dsc --check` — clean
- [x] `cargo clippy -p dsc --all-targets -- -D warnings` — clean
- [x] `cargo test -p dsc` — all 16 tests pass
- [x] Manually verified end-to-end: `dsc start --create --oximeter <addr>` causes each spawned downstairs to register with and publish metrics to the collector at `<addr>`.