### PR TITLE
pantest, a pantry test program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5797,6 +5797,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pantest"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "crucible-common",
+ "crucible-pantry-client",
+ "crucible-workspace-hack",
+ "dsc-client",
+ "slog",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "papergrid"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "repair-client",
     "smf",
     "upstairs",
+    "pantest",
     "workspace-hack",
     "xtask",
     "agent-antagonist",

--- a/dsc/src/client.rs
+++ b/dsc/src/client.rs
@@ -50,6 +50,8 @@ pub enum ClientCommand {
         #[clap(long, short, action)]
         cid: u32,
     },
+    /// Show whether downstairs are running read-only
+    ReadOnly,
     /// Get count of regions.
     RegionCount,
     /// Get region info.
@@ -127,6 +129,10 @@ pub async fn client_main(server: String, cmd: ClientCommand) -> Result<()> {
         }
         ClientCommand::Port { cid } => {
             let res = dsc.dsc_get_port(cid).await.unwrap();
+            println!("{:?}", res);
+        }
+        ClientCommand::ReadOnly => {
+            let res = dsc.dsc_get_read_only().await.unwrap();
             println!("{:?}", res);
         }
         ClientCommand::RegionCount => {

--- a/dsc/src/control.rs
+++ b/dsc/src/control.rs
@@ -24,6 +24,7 @@ pub(crate) fn build_api() -> ApiDescription<Arc<DownstairsControl>> {
     api.register(dsc_get_ds_state).unwrap();
     api.register(dsc_get_pid).unwrap();
     api.register(dsc_get_port).unwrap();
+    api.register(dsc_get_read_only).unwrap();
     api.register(dsc_get_region_count).unwrap();
     api.register(dsc_get_region_info).unwrap();
     api.register(dsc_get_uuid).unwrap();
@@ -511,6 +512,20 @@ async fn dsc_get_region_info(
         })?;
 
     Ok(HttpResponseOk(region_info))
+}
+
+/**
+ * Return true if downstairs were started read-only
+ */
+#[endpoint {
+    method = GET,
+    path = "/readonly",
+}]
+async fn dsc_get_read_only(
+    rqctx: RequestContext<Arc<DownstairsControl>>,
+) -> Result<HttpResponseOk<bool>, HttpError> {
+    let api_context = rqctx.context();
+    Ok(HttpResponseOk(api_context.dsci.read_only))
 }
 
 /**

--- a/openapi/dsc-control.json
+++ b/openapi/dsc-control.json
@@ -318,6 +318,31 @@
         }
       }
     },
+    "/readonly": {
+      "get": {
+        "summary": "Return true if downstairs were started read-only",
+        "operationId": "dsc_get_read_only",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Boolean",
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/regioncount": {
       "get": {
         "summary": "Get the count of regions.",

--- a/pantest/Cargo.toml
+++ b/pantest/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "pantest"
+version = "0.1.0"
+license = "MPL-2.0"
+edition = "2024"
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+crucible-pantry-client.workspace = true
+dsc-client.workspace = true
+slog.workspace = true
+tokio.workspace = true
+uuid.workspace = true
+crucible-common.workspace = true
+crucible-workspace-hack.workspace = true

--- a/pantest/README.md
+++ b/pantest/README.md
@@ -1,0 +1,32 @@
+# pantest - Crucible Pantry Test Tool
+
+A CLI tool for testing the Crucible pantry outside of the full
+control plane. Similar to how crutest exercises the upstairs
+directly, pantest exercises the pantry through its HTTP API.
+
+## Usage
+
+Requires a pantry and (for most commands) a dsc server running
+separately.
+
+```
+# Get pantry status
+pantest -p 127.0.0.1:9999 status
+
+# Attach a volume (builds VCR from dsc region info)
+pantest -p 127.0.0.1:9999 -d 127.0.0.1:9998 attach
+
+# Attach with a specific generation number
+pantest -p 127.0.0.1:9999 -d 127.0.0.1:9998 attach --generation 5
+
+# Get volume status
+pantest -p 127.0.0.1:9999 volume-status <volume-uuid>
+
+# Detach a volume
+pantest -p 127.0.0.1:9999 detach <volume-uuid>
+```
+
+The `attach` command queries dsc for region info, port numbers,
+and the volume UUID (from downstairs client ID 0), then
+constructs a VolumeConstructionRequest and sends it to the
+pantry.

--- a/pantest/README.md
+++ b/pantest/README.md
@@ -14,10 +14,11 @@ separately.
 pantest -p 127.0.0.1:9999 status
 
 # Attach a volume (builds VCR from dsc region info)
-pantest -p 127.0.0.1:9999 -d 127.0.0.1:9998 attach
+pantest -p 127.0.0.1:9999 attach --dsc 127.0.0.1:9998
 
-# Attach with a specific generation number
-pantest -p 127.0.0.1:9999 -d 127.0.0.1:9998 attach --generation 5
+# Attach with a specific volume ID and generation number
+pantest -p 127.0.0.1:9999 attach --dsc 127.0.0.1:9998 \
+    --volume-id <uuid> --generation 5
 
 # Get volume status
 pantest -p 127.0.0.1:9999 volume-status <volume-uuid>
@@ -27,6 +28,6 @@ pantest -p 127.0.0.1:9999 detach <volume-uuid>
 ```
 
 The `attach` command queries dsc for region info, port numbers,
-and the volume UUID (from downstairs client ID 0), then
-constructs a VolumeConstructionRequest and sends it to the
-pantry.
+and read-only status, then constructs a
+VolumeConstructionRequest and sends it to the pantry. A volume
+ID is auto-generated if not provided.

--- a/pantest/README.md
+++ b/pantest/README.md
@@ -20,6 +20,10 @@ pantest -p 127.0.0.1:9999 attach --dsc 127.0.0.1:9998
 pantest -p 127.0.0.1:9999 attach --dsc 127.0.0.1:9998 \
     --volume-id <uuid> --generation 5
 
+# Attach with encryption
+pantest -p 127.0.0.1:9999 attach --dsc 127.0.0.1:9998 \
+    --key $(openssl rand -base64 32)
+
 # Get volume status
 pantest -p 127.0.0.1:9999 volume-status <volume-uuid>
 

--- a/pantest/src/main.rs
+++ b/pantest/src/main.rs
@@ -19,10 +19,6 @@ struct Args {
     #[clap(short, long)]
     pantry: std::net::SocketAddr,
 
-    /// IP:Port for a dsc server
-    #[clap(short, long)]
-    dsc: Option<std::net::SocketAddr>,
-
     #[clap(subcommand)]
     cmd: Cmd,
 }
@@ -34,6 +30,10 @@ enum Cmd {
 
     /// Attach a volume constructed from dsc info
     Attach {
+        /// IP:Port for a dsc server
+        #[clap(short, long)]
+        dsc: std::net::SocketAddr,
+
         /// Generation number
         #[clap(short, long, default_value_t = 1)]
         generation: u64,
@@ -62,10 +62,9 @@ async fn main() -> Result<()> {
 
     match args.cmd {
         Cmd::Status => cmd_status(&log, &pantry).await?,
-        Cmd::Attach { generation } => {
-            let dsc_addr = require_dsc(&args.dsc)?;
-            let dsc = DscClient::new(&format!("http://{}", dsc_addr));
-            cmd_attach(&log, &pantry, &dsc, dsc_addr, generation).await?;
+        Cmd::Attach { dsc, generation } => {
+            let dsc_client = DscClient::new(&format!("http://{}", dsc));
+            cmd_attach(&log, &pantry, &dsc_client, dsc, generation).await?;
         }
         Cmd::Detach { volume_id } => {
             cmd_detach(&log, &pantry, volume_id).await?;
@@ -76,12 +75,6 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
-}
-
-fn require_dsc(
-    dsc: &Option<std::net::SocketAddr>,
-) -> Result<std::net::SocketAddr> {
-    dsc.ok_or_else(|| anyhow::anyhow!("--dsc is required for this command"))
 }
 
 /// Query dsc for region info and downstairs targets, then build

--- a/pantest/src/main.rs
+++ b/pantest/src/main.rs
@@ -1,6 +1,6 @@
 // Copyright 2026 Oxide Computer Company
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use clap::Parser;
 use crucible_pantry_client::Client;
 use crucible_pantry_client::types::{
@@ -114,7 +114,7 @@ async fn build_vcr_from_dsc(
     let ri = dsc
         .dsc_get_region_info()
         .await
-        .map_err(|e| anyhow::anyhow!("get region info: {}", e))?
+        .context("get region info")?
         .into_inner();
 
     info!(
@@ -127,7 +127,7 @@ async fn build_vcr_from_dsc(
     let region_count = dsc
         .dsc_get_region_count()
         .await
-        .map_err(|e| anyhow::anyhow!("get region count: {}", e))?
+        .context("get region count")?
         .into_inner();
 
     if region_count < 3 {
@@ -150,7 +150,7 @@ async fn build_vcr_from_dsc(
     let read_only = dsc
         .dsc_get_read_only()
         .await
-        .map_err(|e| anyhow::anyhow!("get read_only: {}", e))?
+        .context("get read_only")?
         .into_inner();
 
     if read_only {
@@ -165,9 +165,7 @@ async fn build_vcr_from_dsc(
             let port = dsc
                 .dsc_get_port(cid)
                 .await
-                .map_err(|e| {
-                    anyhow::anyhow!("get port for cid {}: {}", cid, e,)
-                })?
+                .with_context(|| format!("get port for cid {cid}"))?
                 .into_inner();
             let addr =
                 std::net::SocketAddr::new(dsc_addr.ip(), port.try_into()?);
@@ -213,7 +211,7 @@ async fn cmd_status(log: &Logger, pantry: &Client) -> Result<()> {
     let status = pantry
         .pantry_status()
         .await
-        .map_err(|e| anyhow::anyhow!("Failed to get pantry status: {}", e))?
+        .context("get pantry status")?
         .into_inner();
 
     info!(log, "Pantry status:");
@@ -250,7 +248,7 @@ async fn cmd_attach(
             },
         )
         .await
-        .map_err(|e| anyhow::anyhow!("attach failed: {}", e))?
+        .context("attach")?
         .into_inner();
 
     info!(log, "Attached volume"; "id" => result.id);
@@ -266,10 +264,7 @@ async fn cmd_detach(
     let volume_id_str = volume_id.to_string();
     info!(log, "Detaching volume {}", volume_id_str);
 
-    pantry
-        .detach(&volume_id_str)
-        .await
-        .map_err(|e| anyhow::anyhow!("detach failed: {}", e))?;
+    pantry.detach(&volume_id_str).await.context("detach")?;
 
     info!(log, "Detached volume {}", volume_id_str);
 
@@ -284,7 +279,7 @@ async fn cmd_volume_status(
     let status = pantry
         .volume_status(&volume_id.to_string())
         .await
-        .map_err(|e| anyhow::anyhow!("volume status failed: {}", e))?
+        .context("volume status")?
         .into_inner();
 
     info!(log, "Volume status for {}", volume_id);

--- a/pantest/src/main.rs
+++ b/pantest/src/main.rs
@@ -38,6 +38,11 @@ enum Cmd {
         #[clap(short, long)]
         volume_id: Option<Uuid>,
 
+        /// Encryption key (base64-encoded, 32 bytes).
+        /// Generate one with: $(openssl rand -base64 32)
+        #[clap(short, long)]
+        key: Option<String>,
+
         /// Generation number
         #[clap(short, long, default_value_t = 1)]
         generation: u64,
@@ -69,12 +74,21 @@ async fn main() -> Result<()> {
         Cmd::Attach {
             dsc,
             volume_id,
+            key,
             generation,
         } => {
             let volume_id = volume_id.unwrap_or_else(Uuid::new_v4);
-            let dsc_client = DscClient::new(&format!("http://{}", dsc));
-            cmd_attach(&log, &pantry, &dsc_client, dsc, volume_id, generation)
-                .await?;
+            let dsc_client = DscClient::new(&format!("http://{dsc}"));
+            cmd_attach(
+                &log,
+                &pantry,
+                &dsc_client,
+                dsc,
+                volume_id,
+                key,
+                generation,
+            )
+            .await?;
         }
         Cmd::Detach { volume_id } => {
             cmd_detach(&log, &pantry, volume_id).await?;
@@ -94,6 +108,7 @@ async fn build_vcr_from_dsc(
     dsc: &DscClient,
     dsc_addr: std::net::SocketAddr,
     volume_id: Uuid,
+    key: Option<String>,
     generation: u64,
 ) -> Result<VolumeConstructionRequest> {
     let ri = dsc
@@ -175,7 +190,7 @@ async fn build_vcr_from_dsc(
                 lossy: false,
                 read_only,
                 flush_timeout: None,
-                key: None,
+                key: key.clone(),
                 cert_pem: None,
                 key_pem: None,
                 root_cert_pem: None,
@@ -214,10 +229,15 @@ async fn cmd_attach(
     dsc: &DscClient,
     dsc_addr: std::net::SocketAddr,
     volume_id: Uuid,
+    key: Option<String>,
     generation: u64,
 ) -> Result<()> {
+    if key.is_some() {
+        info!(log, "Encryption enabled");
+    }
     let vcr =
-        build_vcr_from_dsc(log, dsc, dsc_addr, volume_id, generation).await?;
+        build_vcr_from_dsc(log, dsc, dsc_addr, volume_id, key, generation)
+            .await?;
 
     let volume_id_str = volume_id.to_string();
     info!(log, "Attaching volume {}", volume_id_str);

--- a/pantest/src/main.rs
+++ b/pantest/src/main.rs
@@ -134,6 +134,16 @@ async fn build_vcr_from_dsc(
         .map_err(|e| anyhow::anyhow!("get uuid for cid 0: {}", e))?
         .into_inner();
 
+    let read_only = dsc
+        .dsc_get_read_only()
+        .await
+        .map_err(|e| anyhow::anyhow!("get read_only: {}", e))?
+        .into_inner();
+
+    if read_only {
+        info!(log, "dsc reports read-only mode");
+    }
+
     let mut sub_volumes = Vec::new();
     let mut cid = 0u32;
 
@@ -167,7 +177,7 @@ async fn build_vcr_from_dsc(
                 id: Uuid::new_v4(),
                 target: targets,
                 lossy: false,
-                read_only: false,
+                read_only,
                 flush_timeout: None,
                 key: None,
                 cert_pem: None,

--- a/pantest/src/main.rs
+++ b/pantest/src/main.rs
@@ -1,0 +1,328 @@
+// Copyright 2026 Oxide Computer Company
+
+use anyhow::{Result, bail};
+use clap::Parser;
+use crucible_pantry_client::Client;
+use crucible_pantry_client::types::{
+    AttachRequest, CrucibleOpts, VolumeConstructionRequest, VolumeInfo,
+};
+use dsc_client::Client as DscClient;
+use slog::{Logger, info, warn};
+use uuid::Uuid;
+
+use crucible_common::build_logger;
+
+#[derive(Debug, Parser)]
+#[clap(name = "pantest", about = "Crucible Pantry test program")]
+struct Args {
+    /// IP:Port for the pantry server
+    #[clap(short, long)]
+    pantry: std::net::SocketAddr,
+
+    /// IP:Port for a dsc server
+    #[clap(short, long)]
+    dsc: Option<std::net::SocketAddr>,
+
+    #[clap(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Debug, Parser)]
+enum Cmd {
+    /// Get pantry status
+    Status,
+
+    /// Attach a volume constructed from dsc info
+    Attach {
+        /// Generation number
+        #[clap(short, long, default_value_t = 1)]
+        generation: u64,
+    },
+
+    /// Detach a volume
+    Detach {
+        /// Volume ID to detach
+        volume_id: Uuid,
+    },
+
+    /// Get status of an attached volume
+    VolumeStatus {
+        /// Volume ID to query
+        volume_id: Uuid,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    let log = build_logger();
+
+    let pantry_url = format!("http://{}", args.pantry);
+    let pantry = Client::new(&pantry_url);
+
+    match args.cmd {
+        Cmd::Status => cmd_status(&log, &pantry).await?,
+        Cmd::Attach { generation } => {
+            let dsc_addr = require_dsc(&args.dsc)?;
+            let dsc = DscClient::new(&format!("http://{}", dsc_addr));
+            cmd_attach(&log, &pantry, &dsc, dsc_addr, generation).await?;
+        }
+        Cmd::Detach { volume_id } => {
+            cmd_detach(&log, &pantry, volume_id).await?;
+        }
+        Cmd::VolumeStatus { volume_id } => {
+            cmd_volume_status(&log, &pantry, volume_id).await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn require_dsc(
+    dsc: &Option<std::net::SocketAddr>,
+) -> Result<std::net::SocketAddr> {
+    dsc.ok_or_else(|| anyhow::anyhow!("--dsc is required for this command"))
+}
+
+/// Query dsc for region info and downstairs targets, then build
+/// a VolumeConstructionRequest suitable for the pantry.
+async fn build_vcr_from_dsc(
+    log: &Logger,
+    dsc: &DscClient,
+    dsc_addr: std::net::SocketAddr,
+    generation: u64,
+) -> Result<(Uuid, VolumeConstructionRequest)> {
+    let ri = dsc
+        .dsc_get_region_info()
+        .await
+        .map_err(|e| anyhow::anyhow!("get region info: {}", e))?
+        .into_inner();
+
+    info!(
+        log, "Region info from dsc";
+        "block_size" => ri.block_size,
+        "blocks_per_extent" => ri.blocks_per_extent,
+        "extent_count" => ri.extent_count,
+    );
+
+    let region_count = dsc
+        .dsc_get_region_count()
+        .await
+        .map_err(|e| anyhow::anyhow!("get region count: {}", e))?
+        .into_inner();
+
+    if region_count < 3 {
+        bail!("Need at least 3 regions, dsc reports {}", region_count,);
+    }
+
+    let sv_count = region_count / 3;
+    let remainder = region_count % 3;
+    info!(
+        log,
+        "dsc has {} regions, {} sub-volumes", region_count, sv_count,
+    );
+    if remainder != 0 {
+        warn!(
+            log,
+            "{} regions will not be part of any sub-volume", remainder,
+        );
+    }
+
+    let volume_id = dsc
+        .dsc_get_uuid(0)
+        .await
+        .map_err(|e| anyhow::anyhow!("get uuid for cid 0: {}", e))?
+        .into_inner();
+
+    let mut sub_volumes = Vec::new();
+    let mut cid = 0u32;
+
+    for sv in 0..sv_count {
+        let mut targets = Vec::new();
+        for _ in 0..3 {
+            let port = dsc
+                .dsc_get_port(cid)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!("get port for cid {}: {}", cid, e,)
+                })?
+                .into_inner();
+            let addr =
+                std::net::SocketAddr::new(dsc_addr.ip(), port.try_into()?);
+            targets.push(addr.to_string());
+            cid += 1;
+        }
+
+        info!(
+            log, "Sub-volume {sv}";
+            "targets" => ?targets,
+        );
+
+        sub_volumes.push(VolumeConstructionRequest::Region {
+            block_size: ri.block_size,
+            blocks_per_extent: ri.blocks_per_extent,
+            extent_count: ri.extent_count,
+            gen_: generation,
+            opts: CrucibleOpts {
+                id: Uuid::new_v4(),
+                target: targets,
+                lossy: false,
+                read_only: false,
+                flush_timeout: None,
+                key: None,
+                cert_pem: None,
+                key_pem: None,
+                root_cert_pem: None,
+                control: None,
+            },
+        });
+    }
+
+    let vcr = VolumeConstructionRequest::Volume {
+        id: volume_id,
+        block_size: ri.block_size,
+        sub_volumes,
+        read_only_parent: None,
+    };
+
+    Ok((volume_id, vcr))
+}
+
+async fn cmd_status(log: &Logger, pantry: &Client) -> Result<()> {
+    let status = pantry
+        .pantry_status()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to get pantry status: {}", e))?
+        .into_inner();
+
+    info!(log, "Pantry status:");
+    info!(log, "  Volumes: {:?}", status.volumes);
+    info!(log, "  Job handles: {}", status.num_job_handles);
+
+    Ok(())
+}
+
+async fn cmd_attach(
+    log: &Logger,
+    pantry: &Client,
+    dsc: &DscClient,
+    dsc_addr: std::net::SocketAddr,
+    generation: u64,
+) -> Result<()> {
+    let (volume_id, vcr) =
+        build_vcr_from_dsc(log, dsc, dsc_addr, generation).await?;
+
+    let volume_id_str = volume_id.to_string();
+    info!(log, "Attaching volume {}", volume_id_str);
+
+    let result = pantry
+        .attach(
+            &volume_id_str,
+            &AttachRequest {
+                volume_construction_request: vcr,
+            },
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("attach failed: {}", e))?
+        .into_inner();
+
+    info!(log, "Attached volume"; "id" => result.id);
+
+    Ok(())
+}
+
+async fn cmd_detach(
+    log: &Logger,
+    pantry: &Client,
+    volume_id: Uuid,
+) -> Result<()> {
+    let volume_id_str = volume_id.to_string();
+    info!(log, "Detaching volume {}", volume_id_str);
+
+    pantry
+        .detach(&volume_id_str)
+        .await
+        .map_err(|e| anyhow::anyhow!("detach failed: {}", e))?;
+
+    info!(log, "Detached volume {}", volume_id_str);
+
+    Ok(())
+}
+
+async fn cmd_volume_status(
+    log: &Logger,
+    pantry: &Client,
+    volume_id: Uuid,
+) -> Result<()> {
+    let status = pantry
+        .volume_status(&volume_id.to_string())
+        .await
+        .map_err(|e| anyhow::anyhow!("volume status failed: {}", e))?
+        .into_inner();
+
+    info!(log, "Volume status for {}", volume_id);
+    info!(log, "  Active: {}", status.active);
+    info!(log, "  Seen active: {}", status.seen_active);
+    info!(log, "  Job handles: {}", status.num_job_handles);
+    print_volume_info(log, &status.info, 1);
+
+    Ok(())
+}
+
+fn print_volume_info(log: &Logger, info: &VolumeInfo, depth: usize) {
+    let indent = "  ".repeat(depth);
+    match info {
+        VolumeInfo::Volume {
+            sub_volumes,
+            read_only_parent,
+        } => {
+            info!(log, "{}Volume:", indent);
+            for (i, sv) in sub_volumes.iter().enumerate() {
+                info!(log, "{}  Sub-volume {}:", indent, i);
+                print_volume_info(log, sv, depth + 2);
+            }
+            if let Some(rop) = read_only_parent {
+                info!(log, "{}  Read-only parent:", indent);
+                print_volume_info(log, rop, depth + 2);
+            }
+        }
+        VolumeInfo::Upstairs {
+            upstairs_id,
+            session_id,
+            generation,
+            state,
+            read_only,
+            encrypted,
+            live_repair_in_progress,
+            reconcile_in_progress,
+            targets,
+            block_size,
+        } => {
+            info!(log, "{}Upstairs: {}", indent, upstairs_id);
+            info!(log, "{}  Session: {}", indent, session_id);
+            info!(log, "{}  Generation: {}", indent, generation);
+            info!(log, "{}  State: {:?}", indent, state);
+            info!(log, "{}  Read-only: {}", indent, read_only);
+            info!(log, "{}  Encrypted: {}", indent, encrypted);
+            if let Some(bs) = block_size {
+                info!(log, "{}  Block size: {}", indent, bs);
+            }
+            if *live_repair_in_progress {
+                warn!(log, "{}  Live repair in progress!", indent);
+            }
+            if *reconcile_in_progress {
+                warn!(log, "{}  Reconcile in progress!", indent);
+            }
+            for (i, ds) in targets.iter().enumerate() {
+                info!(
+                    log,
+                    "{}  Downstairs [{}]: {:?} addr={:?}",
+                    indent,
+                    i,
+                    ds.state,
+                    ds.target_addr,
+                );
+            }
+        }
+    }
+}

--- a/pantest/src/main.rs
+++ b/pantest/src/main.rs
@@ -131,19 +131,19 @@ async fn build_vcr_from_dsc(
         .into_inner();
 
     if region_count < 3 {
-        bail!("Need at least 3 regions, dsc reports {}", region_count,);
+        bail!("Need at least 3 regions, dsc reports {region_count}");
     }
 
     let sv_count = region_count / 3;
     let remainder = region_count % 3;
     info!(
         log,
-        "dsc has {} regions, {} sub-volumes", region_count, sv_count,
+        "dsc has {region_count} regions, {sv_count} sub-volumes",
     );
     if remainder != 0 {
         warn!(
             log,
-            "{} regions will not be part of any sub-volume", remainder,
+            "{remainder} regions will not be part of any sub-volume",
         );
     }
 
@@ -238,7 +238,7 @@ async fn cmd_attach(
             .await?;
 
     let volume_id_str = volume_id.to_string();
-    info!(log, "Attaching volume {}", volume_id_str);
+    info!(log, "Attaching volume {volume_id_str}");
 
     let result = pantry
         .attach(
@@ -262,11 +262,11 @@ async fn cmd_detach(
     volume_id: Uuid,
 ) -> Result<()> {
     let volume_id_str = volume_id.to_string();
-    info!(log, "Detaching volume {}", volume_id_str);
+    info!(log, "Detaching volume {volume_id_str}");
 
     pantry.detach(&volume_id_str).await.context("detach")?;
 
-    info!(log, "Detached volume {}", volume_id_str);
+    info!(log, "Detached volume {volume_id_str}");
 
     Ok(())
 }
@@ -282,7 +282,7 @@ async fn cmd_volume_status(
         .context("volume status")?
         .into_inner();
 
-    info!(log, "Volume status for {}", volume_id);
+    info!(log, "Volume status for {volume_id}");
     info!(log, "  Active: {}", status.active);
     info!(log, "  Seen active: {}", status.seen_active);
     info!(log, "  Job handles: {}", status.num_job_handles);
@@ -298,13 +298,13 @@ fn print_volume_info(log: &Logger, info: &VolumeInfo, depth: usize) {
             sub_volumes,
             read_only_parent,
         } => {
-            info!(log, "{}Volume:", indent);
+            info!(log, "{indent}Volume:");
             for (i, sv) in sub_volumes.iter().enumerate() {
-                info!(log, "{}  Sub-volume {}:", indent, i);
+                info!(log, "{indent}  Sub-volume {i}:");
                 print_volume_info(log, sv, depth + 2);
             }
             if let Some(rop) = read_only_parent {
-                info!(log, "{}  Read-only parent:", indent);
+                info!(log, "{indent}  Read-only parent:");
                 print_volume_info(log, rop, depth + 2);
             }
         }
@@ -320,27 +320,25 @@ fn print_volume_info(log: &Logger, info: &VolumeInfo, depth: usize) {
             targets,
             block_size,
         } => {
-            info!(log, "{}Upstairs: {}", indent, upstairs_id);
-            info!(log, "{}  Session: {}", indent, session_id);
-            info!(log, "{}  Generation: {}", indent, generation);
-            info!(log, "{}  State: {:?}", indent, state);
-            info!(log, "{}  Read-only: {}", indent, read_only);
-            info!(log, "{}  Encrypted: {}", indent, encrypted);
+            info!(log, "{indent}Upstairs: {upstairs_id}");
+            info!(log, "{indent}  Session: {session_id}");
+            info!(log, "{indent}  Generation: {generation}");
+            info!(log, "{indent}  State: {state:?}");
+            info!(log, "{indent}  Read-only: {read_only}");
+            info!(log, "{indent}  Encrypted: {encrypted}");
             if let Some(bs) = block_size {
-                info!(log, "{}  Block size: {}", indent, bs);
+                info!(log, "{indent}  Block size: {bs}");
             }
             if *live_repair_in_progress {
-                warn!(log, "{}  Live repair in progress!", indent);
+                warn!(log, "{indent}  Live repair in progress!");
             }
             if *reconcile_in_progress {
-                warn!(log, "{}  Reconcile in progress!", indent);
+                warn!(log, "{indent}  Reconcile in progress!");
             }
             for (i, ds) in targets.iter().enumerate() {
                 info!(
                     log,
-                    "{}  Downstairs [{}]: {:?} addr={:?}",
-                    indent,
-                    i,
+                    "{indent}  Downstairs [{i}]: {:?} addr={:?}",
                     ds.state,
                     ds.target_addr,
                 );

--- a/pantest/src/main.rs
+++ b/pantest/src/main.rs
@@ -34,6 +34,10 @@ enum Cmd {
         #[clap(short, long)]
         dsc: std::net::SocketAddr,
 
+        /// Volume ID (auto-generated if not provided)
+        #[clap(short, long)]
+        volume_id: Option<Uuid>,
+
         /// Generation number
         #[clap(short, long, default_value_t = 1)]
         generation: u64,
@@ -62,9 +66,15 @@ async fn main() -> Result<()> {
 
     match args.cmd {
         Cmd::Status => cmd_status(&log, &pantry).await?,
-        Cmd::Attach { dsc, generation } => {
+        Cmd::Attach {
+            dsc,
+            volume_id,
+            generation,
+        } => {
+            let volume_id = volume_id.unwrap_or_else(Uuid::new_v4);
             let dsc_client = DscClient::new(&format!("http://{}", dsc));
-            cmd_attach(&log, &pantry, &dsc_client, dsc, generation).await?;
+            cmd_attach(&log, &pantry, &dsc_client, dsc, volume_id, generation)
+                .await?;
         }
         Cmd::Detach { volume_id } => {
             cmd_detach(&log, &pantry, volume_id).await?;
@@ -83,8 +93,9 @@ async fn build_vcr_from_dsc(
     log: &Logger,
     dsc: &DscClient,
     dsc_addr: std::net::SocketAddr,
+    volume_id: Uuid,
     generation: u64,
-) -> Result<(Uuid, VolumeConstructionRequest)> {
+) -> Result<VolumeConstructionRequest> {
     let ri = dsc
         .dsc_get_region_info()
         .await
@@ -121,12 +132,6 @@ async fn build_vcr_from_dsc(
         );
     }
 
-    let volume_id = dsc
-        .dsc_get_uuid(0)
-        .await
-        .map_err(|e| anyhow::anyhow!("get uuid for cid 0: {}", e))?
-        .into_inner();
-
     let read_only = dsc
         .dsc_get_read_only()
         .await
@@ -138,11 +143,10 @@ async fn build_vcr_from_dsc(
     }
 
     let mut sub_volumes = Vec::new();
-    let mut cid = 0u32;
 
     for sv in 0..sv_count {
         let mut targets = Vec::new();
-        for _ in 0..3 {
+        for cid in (sv * 3)..(sv * 3 + 3) {
             let port = dsc
                 .dsc_get_port(cid)
                 .await
@@ -153,7 +157,6 @@ async fn build_vcr_from_dsc(
             let addr =
                 std::net::SocketAddr::new(dsc_addr.ip(), port.try_into()?);
             targets.push(addr.to_string());
-            cid += 1;
         }
 
         info!(
@@ -188,7 +191,7 @@ async fn build_vcr_from_dsc(
         read_only_parent: None,
     };
 
-    Ok((volume_id, vcr))
+    Ok(vcr)
 }
 
 async fn cmd_status(log: &Logger, pantry: &Client) -> Result<()> {
@@ -210,10 +213,11 @@ async fn cmd_attach(
     pantry: &Client,
     dsc: &DscClient,
     dsc_addr: std::net::SocketAddr,
+    volume_id: Uuid,
     generation: u64,
 ) -> Result<()> {
-    let (volume_id, vcr) =
-        build_vcr_from_dsc(log, dsc, dsc_addr, generation).await?;
+    let vcr =
+        build_vcr_from_dsc(log, dsc, dsc_addr, volume_id, generation).await?;
 
     let volume_id_str = volume_id.to_string();
     info!(log, "Attaching volume {}", volume_id_str);


### PR DESCRIPTION
This provides a pantry test program and a few basic commands to talk to a running pantry server.  
It allows some exercise of the pantry outside of omicron.
Initial support for attach, detach, status, and volume-status. 
The pantest program uses dsc to get information and from that constructs a VCR to use with the pantry.

Some example commands (after starting a pantry and dsc with three downstairs)
```
newexit:crucible$ ./target/release/pantest -p 127.0.0.1:17000 status
Jun 09 21:23:12.177 INFO Pantry status:
Jun 09 21:23:12.177 INFO   Volumes: []
Jun 09 21:23:12.177 INFO   Job handles: 0

newexit:crucible$ ./target/release/pantest -p 127.0.0.1:17000 attach --dsc 127.0.0.1:9998
Jun 09 21:37:51.194 INFO Region info from dsc, extent_count: 15, blocks_per_extent: 100, block_size: 4096
Jun 09 21:37:51.194 INFO dsc has 3 regions, 1 sub-volumes
Jun 09 21:37:51.195 INFO Sub-volume 0, targets: ["127.0.0.1:8810", "127.0.0.1:8820", "127.0.0.1:8830"]
Jun 09 21:37:51.195 INFO Attaching volume 12345678-0000-0000-0000-000000008810
Jun 09 21:37:51.200 INFO Attached volume, id: 12345678-0000-0000-0000-000000008810

newexit:crucible$ ./target/release/pantest -p 127.0.0.1:17000 status
Jun 09 21:38:25.738 INFO Pantry status:
Jun 09 21:38:25.738 INFO   Volumes: ["12345678-0000-0000-0000-000000008810"]
Jun 09 21:38:25.738 INFO   Job handles: 0

newexit:crucible$ ./target/release/pantest -p 127.0.0.1:17000 volume-status 12345678-0000-0000-0000-000000008810
Jun 09 21:40:44.544 INFO Volume status for 12345678-0000-0000-0000-000000008810
Jun 09 21:40:44.544 INFO   Active: true
Jun 09 21:40:44.544 INFO   Seen active: true
Jun 09 21:40:44.544 INFO   Job handles: 0
Jun 09 21:40:44.544 INFO   Volume:
Jun 09 21:40:44.544 INFO     Sub-volume 0:
Jun 09 21:40:44.544 INFO       Upstairs: 96a31b41-3728-48e2-879f-522ecc20dfc6
Jun 09 21:40:44.544 INFO         Session: bffb32ab-da32-4cbd-8d17-756f64250835
Jun 09 21:40:44.544 INFO         Generation: 1
Jun 09 21:40:44.544 INFO         State: Active
Jun 09 21:40:44.545 INFO         Read-only: false
Jun 09 21:40:44.545 INFO         Encrypted: false
Jun 09 21:40:44.545 INFO         Block size: 4096
Jun 09 21:40:44.545 INFO         Downstairs [0]: Active addr=Some("127.0.0.1:8810")
Jun 09 21:40:44.545 INFO         Downstairs [1]: Active addr=Some("127.0.0.1:8820")
Jun 09 21:40:44.545 INFO         Downstairs [2]: Active addr=Some("127.0.0.1:8830")

newexit:crucible$ ./target/release/pantest -p 127.0.0.1:17000 detach 12345678-0000-0000-0000-000000008810
Jun 09 21:41:33.071 INFO Detaching volume 12345678-0000-0000-0000-000000008810
Jun 09 21:41:33.073 INFO Detached volume 12345678-0000-0000-0000-000000008810

newexit:crucible$ ./target/release/pantest -p 127.0.0.1:17000 status
Jun 09 21:43:06.581 INFO Pantry status:
Jun 09 21:43:06.581 INFO   Volumes: []
Jun 09 21:43:06.581 INFO   Job handles: 0
```

This also adds a "readonly" endpoint to dsc.  This allows us to get everything we need from the dsc server to create a volume and attach it to the pantry.  