### PR TITLE
Remove a Volume's jobs when detaching

### DIFF
--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -5923,6 +5923,56 @@ mod integration_tests {
         client.detach(&volume_id.to_string()).await.unwrap();
     }
 
+    // Test attaching and detaching the same volume multiple times
+    #[tokio::test]
+    async fn test_pantry_attach_detach_multiple() {
+        const BLOCK_SIZE: usize = 512;
+
+        // Spin off three downstairs, build our Crucible struct.
+
+        let tds = DefaultTestDownstairsSet::small(false).await.unwrap();
+
+        // Start a pantry, get the client for it
+        let (_pantry, volume_id, client) =
+            get_pantry_and_client_for_tds(&tds).await;
+
+        client.detach(&volume_id.to_string()).await.unwrap();
+
+        // Attach it again
+
+        let vcr = VolumeConstructionRequest::Volume {
+            id: volume_id,
+            block_size: BLOCK_SIZE as u64,
+            sub_volumes: vec![VolumeConstructionRequest::Region {
+                block_size: BLOCK_SIZE as u64,
+                blocks_per_extent: tds.blocks_per_extent(),
+                extent_count: tds.extent_count(),
+                opts: tds.opts(),
+                generation: 1,
+            }],
+            read_only_parent: None,
+        };
+
+        client
+            .attach(
+                &volume_id.to_string(),
+                &crucible_pantry_client::types::AttachRequest {
+                    // the type here is
+                    // crucible_pantry_client::types::VolumeConstructionRequest,
+                    // not
+                    // crucible::VolumeConstructionRequest, but they are the
+                    // same thing! take a trip through JSON
+                    // to get to the right type
+                    volume_construction_request: serde_json::from_str(
+                        &serde_json::to_string(&vcr).unwrap(),
+                    )
+                    .unwrap(),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
     #[tokio::test]
     async fn test_volume_replace_vcr() {
         // Test of a replacement of a downstairs given two

--- a/pantry/src/pantry.rs
+++ b/pantry/src/pantry.rs
@@ -578,6 +578,16 @@ impl PantryJobs {
 
         job
     }
+
+    pub fn gc_jobs_for_volume_id(&mut self, volume_id: &str) {
+        let Some(job_ids) = self.volume_id_to_job_ids.remove(volume_id) else {
+            return;
+        };
+
+        for job_id in job_ids {
+            self.job_handles.remove(&job_id);
+        }
+    }
 }
 
 /// Pantry stores opened Volumes in-memory
@@ -1033,7 +1043,10 @@ impl Pantry {
 
         match entry.detach().await {
             Ok(()) | Err(CrucibleError::UpstairsInactive) => {
-                // Ok, remove from entries list
+                // Remove all jobs related to this volume
+                self.jobs.lock().await.gc_jobs_for_volume_id(&volume_id);
+
+                // Remove the volume from the entries list
                 self.entries.lock().await.remove(&volume_id);
             }
 


### PR DESCRIPTION
When detaching a Volume from the Pantry, garbage-collect all the related jobs. A previous commit changed the implementation of `attach` to be implemented in terms of `attach_activate_background`, and this used the volume_id as the supplied job_id, This caused a problem because the re-use of a job_id isn't allowed, meaning that clients of the Pantry could only attach a volume once!