### PR TITLE
upstairs: validate subvolume coverage before IO dispatch

### DIFF
--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -455,6 +455,55 @@ impl VolumeInner {
         sv_vec
     }
 
+    fn checked_lba_end(start: u64, length: u64) -> Result<u64, CrucibleError> {
+        let Some(end) = start.checked_add(length) else {
+            crucible_bail!(OffsetInvalid);
+        };
+
+        Ok(end)
+    }
+
+    fn lba_ranges_fully_cover(
+        start: u64,
+        end: u64,
+        ranges: impl Iterator<Item = Range<u64>>,
+    ) -> bool {
+        if start >= end {
+            return false;
+        }
+
+        let mut next = start;
+
+        for range in ranges {
+            if range.start != next
+                || range.end <= range.start
+                || range.end > end
+            {
+                return false;
+            }
+
+            next = range.end;
+        }
+
+        next == end
+    }
+
+    fn check_lba_range_is_fully_covered(
+        start: u64,
+        end: u64,
+        affected_sub_volumes: &[(Range<u64>, &SubVolume)],
+    ) -> Result<(), CrucibleError> {
+        if !Self::lba_ranges_fully_cover(
+            start,
+            end,
+            affected_sub_volumes.iter().map(|(range, _)| range.clone()),
+        ) {
+            crucible_bail!(OffsetInvalid);
+        }
+
+        Ok(())
+    }
+
     #[allow(clippy::if_same_then_else)]
     pub fn read_only_parent_for_lba_range(
         &self,
@@ -508,14 +557,17 @@ impl VolumeInner {
 
         self.check_data_size(data.len()).await?;
 
-        let affected_sub_volumes = self.sub_volumes_for_lba_range(
-            offset.0,
-            data.len() as u64 / self.block_size,
-        );
+        let block_count = data.len() as u64 / self.block_size;
+        let end = Self::checked_lba_end(offset.0, block_count)?;
 
-        if affected_sub_volumes.is_empty() {
-            crucible_bail!(OffsetInvalid);
-        }
+        let affected_sub_volumes =
+            self.sub_volumes_for_lba_range(offset.0, block_count);
+
+        Self::check_lba_range_is_fully_covered(
+            offset.0,
+            end,
+            &affected_sub_volumes,
+        )?;
 
         // TODO parallel dispatch!
         for (coverage, sub_volume) in affected_sub_volumes {
@@ -960,14 +1012,17 @@ impl BlockIO for VolumeInner {
 
         let bs = self.check_data_size(data.len()).await? as usize;
 
-        let affected_sub_volumes = self.sub_volumes_for_lba_range(
-            offset.0,
-            data.len() as u64 / self.block_size,
-        );
+        let block_count = data.len() as u64 / self.block_size;
+        let end = Self::checked_lba_end(offset.0, block_count)?;
 
-        if affected_sub_volumes.is_empty() {
-            crucible_bail!(OffsetInvalid);
-        }
+        let affected_sub_volumes =
+            self.sub_volumes_for_lba_range(offset.0, block_count);
+
+        Self::check_lba_range_is_fully_covered(
+            offset.0,
+            end,
+            &affected_sub_volumes,
+        )?;
 
         // TODO parallel dispatch!
         let mut data_index = 0;
@@ -1018,7 +1073,10 @@ impl BlockIO for VolumeInner {
                 * self.block_size as usize;
         }
 
-        assert_eq!(data.len(), data_index);
+        debug_assert_eq!(data.len(), data_index);
+        if data.len() != data_index {
+            crucible_bail!(OffsetInvalid);
+        }
 
         cdt::volume__read__done!(|| (cc, self.uuid));
         Ok(())
@@ -1189,60 +1247,15 @@ impl SubVolume {
     ) -> Option<Range<u64>> {
         assert!(length >= 1);
 
-        let end = start + length - 1;
+        let end = start.checked_add(length)?;
 
-        // No coverage:
-        //
-        // lba_range:                  |-------------|
-        // argument range:  |-------|
-        // argument range:                                  |--------|
-        //
+        let overlap_start = std::cmp::max(start, self.lba_range.start);
+        let overlap_end = std::cmp::min(end, self.lba_range.end);
 
-        if end < self.lba_range.start {
-            return None;
-        }
-
-        if start >= self.lba_range.end {
-            return None;
-        }
-
-        // Total coverage:
-        //
-        // lba_range:                  |-------------|
-        // argument range:              |-------|
-        // argument range:                 |--------|
-
-        if self.lba_range.contains(&start) && self.lba_range.contains(&end) {
-            return Some(start..(start + length));
-        }
-
-        // Partial coverage:
-
-        if self.lba_range.contains(&start) {
-            assert!(!self.lba_range.contains(&end));
-
-            // lba_range:                  |-------------|
-            // argument range:                         |--------|
-            // coverage:                               ^^^
-
-            Some(start..self.lba_range.end)
-        } else if self.lba_range.contains(&end) {
-            assert!(!self.lba_range.contains(&start));
-
-            // lba_range:                  |-------------|
-            // argument range:          |-------|
-            // coverage:                   ^^^^^^
-            Some(self.lba_range.start..(end + 1))
-        } else if start < self.lba_range.start && end > self.lba_range.end {
-            // lba_range:                  |-------------|
-            // argument range:          |--------------------|
-            // coverage:                   ^^^^^^^^^^^^^^^
-            Some(self.lba_range.clone())
+        if overlap_start < overlap_end {
+            Some(overlap_start..overlap_end)
         } else {
-            panic!(
-                "should never get here! {:?} {} {}",
-                self.lba_range, start, length
-            );
+            None
         }
     }
 }
@@ -6100,11 +6113,11 @@ mod test {
 
 #[cfg(test)]
 mod volume_partial_coverage_tests {
+    use crate::volume::SubVolume;
     use crate::{
         BlockIO, BlockIndex, Buffer, BytesMut, CrucibleError, InMemoryBlockIO,
         Volume, VolumeBuilder,
     };
-    use crate::volume::SubVolume;
     use slog::Logger;
     use std::sync::Arc;
     use uuid::Uuid;

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -6097,3 +6097,135 @@ mod test {
         Volume::construct(vcr, None, csl()).await.unwrap_err();
     }
 }
+
+#[cfg(test)]
+mod volume_partial_coverage_tests {
+    use crate::{
+        BlockIO, BlockIndex, Buffer, BytesMut, CrucibleError, InMemoryBlockIO,
+        Volume, VolumeBuilder,
+    };
+    use crate::volume::SubVolume;
+    use slog::Logger;
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    async fn two_subvolume_volume(
+        block_size: usize,
+        blocks_per_subvolume: usize,
+    ) -> Volume {
+        let log = Logger::root(slog::Discard, slog::o!());
+        let mut builder = VolumeBuilder::new(block_size as u64, log);
+
+        for _ in 0..2 {
+            let block_io: Arc<dyn BlockIO + Send + Sync> =
+                Arc::new(InMemoryBlockIO::new(
+                    Uuid::new_v4(),
+                    block_size as u64,
+                    block_size * blocks_per_subvolume,
+                ));
+
+            builder.add_subvolume(block_io).await.unwrap();
+        }
+
+        builder.into()
+    }
+
+    #[test]
+    fn subvolume_lba_range_coverage_handles_request_covering_entire_subvolume()
+    {
+        let block_size = 512;
+        let block_io: Arc<dyn BlockIO + Send + Sync> =
+            Arc::new(InMemoryBlockIO::new(
+                Uuid::new_v4(),
+                block_size as u64,
+                2 * block_size,
+            ));
+
+        let sub_volume = SubVolume {
+            lba_range: 2..4,
+            block_io,
+        };
+
+        /*
+         * request:   [1, 5)
+         * subvolume: [2, 4)
+         *
+         * The request overlaps the entire subvolume.  The helper should return the
+         * subvolume's coverage range, not panic.
+         */
+        assert_eq!(sub_volume.lba_range_coverage(1, 4), Some(2..4));
+    }
+
+    #[tokio::test]
+    async fn write_rejects_partially_covered_range_before_dispatch() {
+        let block_size = 512;
+        let blocks_per_subvolume = 2;
+        let volume =
+            two_subvolume_volume(block_size, blocks_per_subvolume).await;
+
+        let last_valid_block =
+            BlockIndex((2 * blocks_per_subvolume - 1) as u64);
+
+        volume
+            .write(
+                last_valid_block,
+                BytesMut::from(&vec![0x11; block_size][..]),
+            )
+            .await
+            .unwrap();
+
+        let result = volume
+            .write(
+                last_valid_block,
+                BytesMut::from(&vec![0x22; 2 * block_size][..]),
+            )
+            .await;
+
+        assert!(matches!(result, Err(CrucibleError::OffsetInvalid)));
+
+        let mut after = Buffer::new(1, block_size);
+        volume.read(last_valid_block, &mut after).await.unwrap();
+
+        assert_eq!(&after[..], &vec![0x11; block_size][..]);
+    }
+
+    #[tokio::test]
+    async fn write_unwritten_rejects_partially_covered_range_before_dispatch() {
+        let block_size = 512;
+        let blocks_per_subvolume = 2;
+        let volume =
+            two_subvolume_volume(block_size, blocks_per_subvolume).await;
+
+        let last_valid_block =
+            BlockIndex((2 * blocks_per_subvolume - 1) as u64);
+
+        let result = volume
+            .write_unwritten(
+                last_valid_block,
+                BytesMut::from(&vec![0x33; 2 * block_size][..]),
+            )
+            .await;
+
+        assert!(matches!(result, Err(CrucibleError::OffsetInvalid)));
+    }
+
+    #[tokio::test]
+    async fn read_rejects_partially_covered_range() {
+        let block_size = 512;
+        let blocks_per_subvolume = 2;
+        let volume =
+            two_subvolume_volume(block_size, blocks_per_subvolume).await;
+
+        /*
+         * subvolumes:     [0, 2) [2, 4)
+         * requested read:    [1, 5)
+         *
+         * This intersects the existing subvolumes but is not fully covered by them.
+         */
+        let mut data = Buffer::new(4, block_size);
+        let result = volume.read(BlockIndex(1), &mut data).await;
+
+        assert!(matches!(result, Err(CrucibleError::OffsetInvalid)));
+        assert_eq!(&data[..], &vec![0; 4 * block_size][..]);
+    }
+}

--- a/upstairs/src/volume.rs
+++ b/upstairs/src/volume.rs
@@ -6118,6 +6118,7 @@ mod volume_partial_coverage_tests {
         BlockIO, BlockIndex, Buffer, BytesMut, CrucibleError, InMemoryBlockIO,
         Volume, VolumeBuilder,
     };
+    use proptest::prelude::*;
     use slog::Logger;
     use std::sync::Arc;
     use uuid::Uuid;
@@ -6143,6 +6144,22 @@ mod volume_partial_coverage_tests {
         builder.into()
     }
 
+    fn subvolume_for_test(lba_range: std::ops::Range<u64>) -> SubVolume {
+        let block_size = 512;
+        let block_count = lba_range.end - lba_range.start;
+        let block_io: Arc<dyn BlockIO + Send + Sync> =
+            Arc::new(InMemoryBlockIO::new(
+                Uuid::new_v4(),
+                block_size,
+                block_size as usize * block_count as usize,
+            ));
+
+        SubVolume {
+            lba_range,
+            block_io,
+        }
+    }
+
     #[test]
     fn subvolume_lba_range_coverage_handles_request_covering_entire_subvolume()
     {
@@ -6163,10 +6180,52 @@ mod volume_partial_coverage_tests {
          * request:   [1, 5)
          * subvolume: [2, 4)
          *
-         * The request overlaps the entire subvolume.  The helper should return the
+         * The request overlaps the entire subvolume. The helper should return the
          * subvolume's coverage range, not panic.
          */
         assert_eq!(sub_volume.lba_range_coverage(1, 4), Some(2..4));
+    }
+
+    proptest! {
+        #[test]
+        fn subvolume_lba_range_coverage_matches_block_intersection(
+            sub_start in 0u64..32,
+            sub_len in 1u64..32,
+            req_start in 0u64..64,
+            req_len in 1u64..64,
+        ) {
+            let sub_end = sub_start + sub_len;
+            let req_end = req_start + req_len;
+            let sub_volume = subvolume_for_test(sub_start..sub_end);
+
+            let universe_end = std::cmp::max(sub_end, req_end);
+
+            let covered: Vec<u64> = (0..universe_end)
+                .filter(|&block| {
+                    sub_start <= block
+                        && block < sub_end
+                        && req_start <= block
+                        && block < req_end
+                })
+                .collect();
+
+            let expected = covered.first().map(|first| {
+                let last = *covered.last().unwrap();
+                *first..(last + 1)
+            });
+
+            prop_assert_eq!(
+                sub_volume.lba_range_coverage(req_start, req_len),
+                expected,
+            );
+        }
+    }
+
+    #[test]
+    fn subvolume_lba_range_coverage_returns_none_when_request_end_overflows() {
+        let sub_volume = subvolume_for_test(2..4);
+
+        assert_eq!(sub_volume.lba_range_coverage(u64::MAX, 1), None,);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

For requests that start on a valid block but extend past the end of the volume, the existing code finds the valid prefix of the request, but does not appear to check that the entire requested range is covered before dispatch.

I am marking this as a draft because it is a boundary-condition change in storage range handling, and I would appreciate confirmation that returning `OffsetInvalid` for partially covered volume IO is the intended contract. I also want to get the CI signal before marking this ready for review.

This draft PR proposes a defensive range-validation in `upstairs/src/volume.rs`. I tried to keep the change narrow:

* the first commit adds failing regression tests;
* the second commit changes the subvolume-backed range handling so partially covered `read`, `write`, and `write_unwritten` requests return `OffsetInvalid`;
* the third commit adds focused property coverage for SubVolume::lba_range_coverage(), plus an explicit overflow case.

## Semantic changes

This PR intends the following behavior changes:

* `SubVolume::lba_range_coverage()` now computes the intersection of two half-open ranges directly, using checked arithmetic for the requested range end.
* `SubVolume::lba_range_coverage()` returns coverage for requests that fully cover a subvolume while extending outside it, instead of panicking.
* `Volume::write()` and `Volume::write_unwritten()` now reject partially covered requests before dispatching any write.
* `Volume::read()` now rejects partially covered requests on the subvolume-backed path before dispatching any subvolume read.
* The final read-buffer coverage check now returns `OffsetInvalid` as a defensive fallback instead of relying only on `assert_eq!`.

## Details

The tests build a small volume with two subvolumes:

```text
subvolume 0: [0, 2)  -> blocks 0, 1
subvolume 1: [2, 4)  -> blocks 2, 3
full volume: [0, 4)  -> blocks 0, 1, 2, 3
```

This setup is intentionally small, but it still exercises the multi-subvolume coverage path used by `Volume`.

For writes, the important boundary case is a request that starts at the final valid block and extends past the end:

```text
write 2 blocks starting at block 3

requested range: [3, 5)  -> blocks 3, 4
covered range:   [3, 4)  -> block 3
missing range:   [4, 5)  -> block 4, outside the volume
```

The old write path could treat the valid prefix `[3, 4)` as sufficient, dispatch that one-block write, and return success for the full two-block request. This PR changes the write path to verify full coverage before dispatch, so the request is rejected before block `3` is modified.

For reads, the two-subvolume setup also exposes a related coverage-calculation issue:

```text
read 4 blocks starting at block 1

requested range:      [1, 5)
subvolume 0 coverage: [1, 2)
subvolume 1 coverage: [2, 4)
missing range:              [4, 5)
```

This request has valid covered pieces, but it is still not fully covered by the volume. It should return `OffsetInvalid`.

The same read case also exercises `SubVolume::lba_range_coverage()` with this shape:

```text
request:   [1, 5)
subvolume: [2, 4)
coverage:  [2, 4)
```

That is a valid case where the request fully covers the subvolume while extending outside it. The helper should return `Some(2..4)`, not panic.

The proposal simplifies `SubVolume::lba_range_coverage()` to compute the intersection of two half-open ranges directly. On the subvolume-backed IO paths, `Volume` then checks that the collected coverage ranges exactly span the requested IO range before dispatching subvolume reads or writes. There is an explicit regression test for the request shape that previously reached the helper's panic path, and there is a property test that checks the helper against an independently derived block-by-block intersection over small bounded ranges. The property test is intended to document that the helper returns exactly the non-empty intersection of the requested half-open LBA range and the subvolume's half-open LBA range.

## Testing

I ran the following locally on Ubuntu under WSL on Windows:

* `cargo fmt --check`
* `cargo check --workspace`
* `cargo check --workspace --release`
* `cargo test --workspace`
* `cargo test --workspace --release`

## Contribution

I submit this contribution under the repository’s existing license terms, the Mozilla Public License Version 2.0, without any warranty.

**AI assistance disclosure:** I used ChatGPT (GPT-5.5 Thinking) throughout development of this patch, including reasoning about the issue, writing code and tests, reviewing the implementation, and writing commit and PR text. I guided the work and ran the listed checks.