### PR TITLE
Print out the extent name in the format that matches what the file name will be.

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -145,7 +145,9 @@ pub enum CrucibleError {
     #[error("Invalid downstairs replace {0}")]
     ReplaceRequestInvalid(String),
 
-    #[error("missing context slot for block {block} in extent {extent} ({extent:03X})")]
+    #[error(
+        "missing context slot for block {block} in extent {extent} ({extent:03X})"
+    )]
     MissingContextSlot { block: u64, extent: u32 },
 
     #[error("metadata deserialization failed: {0}")]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -145,7 +145,7 @@ pub enum CrucibleError {
     #[error("Invalid downstairs replace {0}")]
     ReplaceRequestInvalid(String),
 
-    #[error("missing context slot for block {block} in extent {extent}")]
+    #[error("missing context slot for block {block} in extent {extent} ({extent:03X})")]
     MissingContextSlot { block: u64, extent: u32 },
 
     #[error("metadata deserialization failed: {0}")]


### PR DESCRIPTION
Print more helpful info if this condition arises.

The extent number if printed as uppercase hex with 3 digits is how the extent file will be named, so print this out as well to help someone doing debug.